### PR TITLE
Revert "config: Skip chrome2 until the configuration is in place in csc"

### DIFF
--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -2,7 +2,7 @@ const { resolve } = require('path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
-    skipChrome2: true,
+    skipChrome2: false,
 });
 
 plugins.push(


### PR DESCRIPTION
This reverts commit 688291386a869887bfe0da3a8e657b9809b7e826.

---

We can reenable this now, since the csc PR got merged.