### PR TITLE
Add link to google cloud

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const ImageLink = (props) => {
+    const uploadStatus = props.imageStatus ? props.imageStatus.upload_status : undefined;
+    if (uploadStatus) {
+        let url = '';
+        if (uploadStatus.type === 'gcp') {
+            url = 'https://console.cloud.google.com/compute/imagesDetail/projects/' +
+                uploadStatus.options.project_id +
+                '/global/images/' +
+                uploadStatus.options.image_name;
+        }
+
+        return (
+            <Button
+                component="a"
+                target="_blank"
+                variant="link"
+                icon={ <ExternalLinkAltIcon /> }
+                iconPosition="right"
+                isInline
+                href={ url }>
+                    View uploaded image
+            </Button>
+        );
+    }
+
+    return null;
+};
+
+ImageLink.propTypes = {
+    imageStatus: PropTypes.object,
+};
+
+export default ImageLink;

--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -14,6 +14,7 @@ import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import ImageBuildStatus from './ImageBuildStatus';
 import Release from './Release';
 import Upload from './Upload';
+import ImageLink from './ImageLink';
 class ImagesTable extends Component {
     constructor(props) {
         super(props);
@@ -95,6 +96,7 @@ class ImagesTable extends Component {
             'Release',
             'Target',
             'Status',
+            ''
         ];
 
         // the state.page is not an index so must be reduced by 1 get the starting index
@@ -110,6 +112,7 @@ class ImagesTable extends Component {
                     { title: <Release release={ compose.request.distribution } /> },
                     { title: <Upload uploadType={ compose.request.image_requests[0].upload_request.type } /> },
                     { title: <ImageBuildStatus status={ compose.image_status ? compose.image_status.status : '' } /> },
+                    { title: <ImageLink imageStatus={ compose.image_status } /> },
                 ]
             };
         });

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -4,6 +4,7 @@ import { renderWithReduxRouter } from '../../testUtils';
 import ImagesTable from '../../../Components/ImagesTable/ImagesTable';
 import ImageBuildStatus from '../../../Components/ImagesTable/ImageBuildStatus';
 import Upload from '../../../Components/ImagesTable/Upload';
+import ImageLink from '../../../Components/ImagesTable/ImageLink';
 import '@testing-library/jest-dom';
 
 const store = {
@@ -22,6 +23,34 @@ const store = {
             '77fa8b03-7efb-4120-9a20-da66d68c4494',
         ],
         byId: {
+            'ca03f120-9840-4959-871e-94a5cb49d1f2': {
+                id: 'ca03f120-9840-4959-871e-94a5cb49d1f2',
+                created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
+                request: {
+                    distribution: 'rhel-8',
+                    image_requests: [
+                        {
+                            architecture: 'x86_64',
+                            image_type: 'vhd',
+                            upload_request: {
+                                type: 'gcp',
+                                options: {}
+                            }
+                        }
+                    ],
+                },
+                image_status: {
+                    status: 'success',
+                    upload_status: {
+                        options: {
+                            image_name: 'composer-api-d446d8cb-7c16-4756-bf7d-706293785b05',
+                            project_id: 'red-hat-image-builder'
+                        },
+                        status: 'success',
+                        type: 'gcp'
+                    }
+                },
+            },
             // kept "running" for backward compatibility
             'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa': {
                 id: 'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa',
@@ -171,34 +200,6 @@ const store = {
                     status: 'failure',
                 },
             },
-            'ca03f120-9840-4959-871e-94a5cb49d1f2': {
-                id: 'ca03f120-9840-4959-871e-94a5cb49d1f2',
-                created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
-                request: {
-                    distribution: 'rhel-8',
-                    image_requests: [
-                        {
-                            architecture: 'x86_64',
-                            image_type: 'vhd',
-                            upload_request: {
-                                type: 'gcp',
-                                options: {}
-                            }
-                        }
-                    ],
-                },
-                image_status: {
-                    status: 'success',
-                    upload_status: {
-                        options: {
-                            image_name: 'composer-api-d446d8cb-7c16-4756-bf7d-706293785b05',
-                            project_id: 'red-hat-image-builder'
-                        },
-                        status: 'success',
-                        type: 'gcp'
-                    }
-                },
-            },
             '551de6f6-1533-4b46-a69f-7924051f9bc6': {
                 id: '551de6f6-1533-4b46-a69f-7924051f9bc6',
                 created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
@@ -282,6 +283,10 @@ describe('Images Table', () => {
             // render the expected <ImageBuildStatus /> and compare the text content
             render(<ImageBuildStatus status={ compose.image_status.status } />, { container: testElement });
             expect(row.cells[4]).toHaveTextContent(testElement.textContent);
+
+            // render the expected <ImageLink /> and compare the text content
+            render(<ImageLink imageStatus={ compose.image_status } />, { container: testElement });
+            expect(row.cells[5]).toHaveTextContent(testElement.textContent);
         }
     });
 });


### PR DESCRIPTION
The images list now contains a link to the uploaded image. Only google cloud images platform images currently display the link following a successful upload.

This does not match the complete designs for the page but I would prefer to wait to implement the full design. There is no support for multiple uploads and the status information is still fairly limited. 

![imageLink](https://user-images.githubusercontent.com/11712857/118001505-1584b280-b347-11eb-9997-ea397bba0e2b.png)
