### PR TITLE
CreateImageWizard: improve packages step

### DIFF
--- a/src/Components/CreateImageWizard/WizardStepPackages.js
+++ b/src/Components/CreateImageWizard/WizardStepPackages.js
@@ -6,6 +6,7 @@ import { Button, DualListSelector, Text, TextContent, Title } from '@patternfly/
 import { actions } from '../../store/actions';
 import api from '../../api.js';
 
+import './WizardStepPackages.scss';
 class WizardStepPackages extends Component {
     constructor(props) {
         super(props);
@@ -86,14 +87,16 @@ class WizardStepPackages extends Component {
             <>
                 <TextContent>
                     <Title headingLevel="h2" size="xl">Additional packages</Title>
-                    <Text>Optionally add additional packages to your <strong>{this.props.release.distro}</strong> image</Text>
+                    <Text>Add optional additional packages to your image by searching available packages.</Text>
                 </TextContent>
                 <DualListSelector
                     className="pf-u-mt-sm"
                     isSearchable
                     availableOptionsActions={ availableOptionsActions }
                     availableOptions={ this.state.packagesAvailableComponents }
+                    availableOptionsTitle={ 'Available packages' }
                     chosenOptions={ this.state.packagesFilteredComponents }
+                    chosenOptionsTitle={ 'Chosen packages' }
                     addSelected={ this.packageListChange }
                     removeSelected={ this.packageListChange }
                     addAll={ this.packageListChange }

--- a/src/Components/CreateImageWizard/WizardStepPackages.scss
+++ b/src/Components/CreateImageWizard/WizardStepPackages.scss
@@ -1,0 +1,3 @@
+.pf-c-dual-list-selector__menu {
+    --pf-c-dual-list-selector__menu--MinHeight: 20.5rem
+}

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -289,7 +289,7 @@ describe('Step Registration', () => {
         const [ next, , ] = verifyButtons();
         next.click();
 
-        screen.getByText('Optionally add additional packages to your image');
+        screen.getByText('Add optional additional packages to your image by searching available packages.');
     });
 
     test('clicking Back loads Upload to AWS', () => {
@@ -426,7 +426,7 @@ describe('Step Review', () => {
         const back = screen.getByRole('button', { name: /Back/ });
         back.click();
 
-        screen.getByText('Optionally add additional packages to your image');
+        screen.getByText('Add optional additional packages to your image by searching available packages.');
     });
 
     test('clicking Cancel loads landing page', () => {
@@ -488,7 +488,7 @@ describe('Click through all steps', () => {
                 });
             });
 
-        screen.getByText('Optionally add additional packages to your image');
+        screen.getByText('Add optional additional packages to your image by searching available packages.');
         userEvent.type(screen.getByRole('searchbox', { name: /Available search input/ }), 'test');
         screen.getByTestId('search-pkgs-button').click();
         await expect(getPackages).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Update the text description and replace "options" with "packages". Also, add styling to increase the size of the available and chosen packages list.

This fixes some of the differences between the designs and the current work. Additional improvements will take more considerable work so this PR should close #188 in favor of #210 #211 #212 #213