### PR TITLE
CreateImageWizard: use your image instead of the image

### DIFF
--- a/src/Components/CreateImageWizard/WizardStepReview.js
+++ b/src/Components/CreateImageWizard/WizardStepReview.js
@@ -108,7 +108,7 @@ class WizardStepReview extends Component {
                 <TextContent>
                     <Text component={ TextVariants.small }>
                     Review the information and click the Create button
-                    to create the image using the following criteria.
+                    to create your image using the following criteria.
                     </Text>
                     <Text component={ TextVariants.h3 }>Image output</Text>
                     <TextList component={ TextListVariants.dl } data-testid='review-image-output'>

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -372,7 +372,7 @@ describe('Step Packages', () => {
         const [ next, , ] = verifyButtons();
         next.click();
 
-        screen.getByText('Review the information and click the Create button to create the image using the following criteria.');
+        screen.getByText('Review the information and click the Create button to create your image using the following criteria.');
     });
 
     test('clicking Back loads Register', () => {
@@ -498,7 +498,7 @@ describe('Click through all steps', () => {
 
         // review
         await screen.
-            findByText('Review the information and click the Create button to create the image using the following criteria.');
+            findByText('Review the information and click the Create button to create your image using the following criteria.');
         const main = screen.getByRole('main', { name: 'Create image' });
         within(main).getByText('Amazon Web Services');
         within(main).getByText('Google Cloud Platform');
@@ -621,7 +621,7 @@ describe('Click through all steps', () => {
         reviewStep.click();
 
         await screen.
-            findByText('Review the information and click the Create button to create the image using the following criteria.');
+            findByText('Review the information and click the Create button to create your image using the following criteria.');
         const main = screen.getByRole('main', { name: 'Create image' });
         within(main).getByText('Amazon Web Services');
         await screen.findByText('Register the system on first boot');
@@ -656,7 +656,7 @@ describe('Click through all steps', () => {
         reviewStep.click();
 
         await screen.
-            findByText('Review the information and click the Create button to create the image using the following criteria.');
+            findByText('Review the information and click the Create button to create your image using the following criteria.');
         const main = screen.getByRole('main', { name: 'Create image' });
         within(main).getByText('Amazon Web Services');
         await screen.findByText('Register the system on first boot');


### PR DESCRIPTION
This fixes #190. I left the term "the image" for the google and aws steps since we already specify it as "your image" and duplicate wording sounds weird.