### PR TITLE
ImagesTable: add azure image link

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -6,24 +6,42 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 const ImageLink = (props) => {
     const uploadStatus = props.imageStatus ? props.imageStatus.upload_status : undefined;
-    if (uploadStatus && uploadStatus.type === 'aws') {
-        const url = 'https://console.aws.amazon.com/ec2/v2/home?region=' +
-                uploadStatus.options.region +
-                '#LaunchInstanceWizard:ami=' +
-                uploadStatus.options.ami;
-
-        return (
-            <Button
-                component="a"
-                target="_blank"
-                variant="link"
-                icon={ <ExternalLinkAltIcon /> }
-                iconPosition="right"
-                isInline
-                href={ url }>
-                    Launch instance
-            </Button>
-        );
+    if (uploadStatus) {
+        if (uploadStatus.type === 'aws') {
+            const url = 'https://console.aws.amazon.com/ec2/v2/home?region=' +
+                    uploadStatus.options.region +
+                    '#LaunchInstanceWizard:ami=' +
+                    uploadStatus.options.ami;
+            return (
+                <Button
+                    component="a"
+                    target="_blank"
+                    variant="link"
+                    icon={ <ExternalLinkAltIcon /> }
+                    iconPosition="right"
+                    isInline
+                    href={ url }>
+                        Launch instance
+                </Button>
+            );
+        } else if (uploadStatus.type === 'azure') {
+            const url = 'https://portal.azure.com/#@' + props.uploadOptions.tenant_id +
+            '/resource/subscriptions/' + props.uploadOptions.subscription_id +
+            '/resourceGroups/' + props.uploadOptions.resource_group +
+            '/providers/Microsoft.Compute/images/' + uploadStatus.options.image_name;
+            return (
+                <Button
+                    component="a"
+                    target="_blank"
+                    variant="link"
+                    icon={ <ExternalLinkAltIcon /> }
+                    iconPosition="right"
+                    isInline
+                    href={ url }>
+                        View uploaded image
+                </Button>
+            );
+        }
     }
 
     return null;
@@ -31,6 +49,7 @@ const ImageLink = (props) => {
 
 ImageLink.propTypes = {
     imageStatus: PropTypes.object,
+    uploadOptions: PropTypes.object,
 };
 
 export default ImageLink;

--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -112,7 +112,9 @@ class ImagesTable extends Component {
                     { title: <Release release={ compose.request.distribution } /> },
                     { title: <Upload uploadType={ compose.request.image_requests[0].upload_request.type } /> },
                     { title: <ImageBuildStatus status={ compose.image_status ? compose.image_status.status : '' } /> },
-                    { title: <ImageLink imageStatus={ compose.image_status } /> },
+                    { title: <ImageLink
+                        imageStatus={ compose.image_status }
+                        uploadOptions={ compose.request.image_requests[0].upload_request.options } /> },
                 ]
             };
         });

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -231,7 +231,11 @@ const store = {
                             image_type: 'vhd',
                             upload_request: {
                                 type: 'azure',
-                                options: {}
+                                options: {
+                                    tenant_id: 'test-tenant-id',
+                                    subscription_id: 'test-subscription-id',
+                                    resource_group: 'test-resource-group'
+                                }
                             }
                         }
                     ],
@@ -284,8 +288,11 @@ describe('Images Table', () => {
             render(<ImageBuildStatus status={ compose.image_status.status } />, { container: testElement });
             expect(row.cells[4]).toHaveTextContent(testElement.textContent);
 
-            // render the expected <ImageLink /> and compare the text content for an aws link
-            render(<ImageLink imageStatus={ compose.image_status } />, { container: testElement });
+            // render the expected <ImageLink /> and compare the text content for a link
+            render(
+                <ImageLink imageStatus={ compose.image_status } uploadOptions={ compose.request.image_requests[0].upload_request.options }  />,
+                { container: testElement }
+            );
             expect(row.cells[5]).toHaveTextContent(testElement.textContent);
         }
     });


### PR DESCRIPTION
When an azure image is successfully uploaded the user is provided a link to view the image in the azure web portal.

![azure](https://user-images.githubusercontent.com/11712857/120342270-ed5df300-c2f7-11eb-9f56-2a6f81864bd0.png)
