### PR TITLE
src: Rename RHEL 8.3 to just RHEL 8

### DIFF
--- a/src/Components/CreateImageWizard/WizardStepImageOutput.js
+++ b/src/Components/CreateImageWizard/WizardStepImageOutput.js
@@ -28,7 +28,7 @@ class WizardStepImageOutput extends Component {
 
     render() {
         const releaseOptions = [
-            { value: 'rhel-8', label: 'Red Hat Enterprise Linux (RHEL) 8.3' },
+            { value: 'rhel-8', label: 'Red Hat Enterprise Linux (RHEL) 8' },
             { value: 'centos-8', label: 'CentOS Stream 8' },
         ];
 

--- a/src/Components/CreateImageWizard/WizardStepReview.js
+++ b/src/Components/CreateImageWizard/WizardStepReview.js
@@ -18,7 +18,7 @@ class WizardStepReview extends Component {
 
     render() {
         const releaseLabels = {
-            'rhel-8': 'Red Hat Enterprise Linux (RHEL) 8.3',
+            'rhel-8': 'Red Hat Enterprise Linux (RHEL) 8',
             'centos-8': 'CentOS Stream 8'
         };
 

--- a/src/Components/ImagesTable/Release.js
+++ b/src/Components/ImagesTable/Release.js
@@ -5,7 +5,7 @@ import { Label } from '@patternfly/react-core';
 
 const Release = (props) => {
     const releaseOptions = {
-        'rhel-8': 'RHEL 8.3',
+        'rhel-8': 'RHEL 8',
         'centos-8': 'CentOS Stream 8'
     };
     const release = releaseOptions[props.release] ? releaseOptions[props.release] : props.release;


### PR DESCRIPTION
We should pull these labels/descriptions from the service, but let's do
that separately.