### PR TITLE
Remove registration step for CentOS images

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -271,13 +271,16 @@ class CreateImageWizard extends Component {
             steps: uploadDestinationSteps
         };
 
+        const StepImageRegistration = {
+            name: 'Registration',
+            component: <WizardStepRegistration
+                isValidSubscription={ this.state.isValidSubscription } />
+        };
+
         const steps = [
             StepImageOutput,
             ...(StepTargetEnv.steps.length > 0 ? [ StepTargetEnv ] : []),
-            {
-                name: 'Registration',
-                component: <WizardStepRegistration
-                    isValidSubscription={ this.state.isValidSubscription } /> },
+            ...(this.props.release.distro === 'rhel-8' ? [ StepImageRegistration ] : []),
             {
                 name: 'Packages',
                 component: <WizardStepPackages /> },

--- a/src/Components/CreateImageWizard/WizardStepReview.js
+++ b/src/Components/CreateImageWizard/WizardStepReview.js
@@ -113,7 +113,7 @@ class WizardStepReview extends Component {
                     <Text component={ TextVariants.h3 }>Image output</Text>
                     <TextList component={ TextListVariants.dl } data-testid='review-image-output'>
                         <TextListItem component={ TextListItemVariants.dt }>Release</TextListItem>
-                        <TextListItem component={ TextListItemVariants.dd }>{releaseLabels[this.props.release]}</TextListItem>
+                        <TextListItem component={ TextListItemVariants.dd }>{releaseLabels[this.props.release.distro]}</TextListItem>
                     </TextList>
                     <Text component={ TextVariants.h3 }>Target environment</Text>
                     {this.props.uploadDestinations.aws && awsReview }
@@ -131,6 +131,7 @@ class WizardStepReview extends Component {
 
 function mapStateToProps(state) {
     return {
+        release: state.pendingCompose.release,
         uploadDestinations: state.pendingCompose.uploadDestinations,
         uploadAWS: state.pendingCompose.uploadAWS,
         uploadAzure: state.pendingCompose.uploadAzure,

--- a/src/Components/CreateImageWizard/WizardStepReview.js
+++ b/src/Components/CreateImageWizard/WizardStepReview.js
@@ -99,6 +99,16 @@ class WizardStepReview extends Component {
             </>);
         }
 
+        const registrationReview = (
+            <>
+                <Text component={ TextVariants.h3 }>Registration</Text>
+                <TextList component={ TextListVariants.dl } data-testid='review-image-registration'>
+                    <TextListItem component={ TextListItemVariants.dt }>Subscription</TextListItem>
+                    { subscriptionReview }
+                </TextList>
+            </>
+        );
+
         return (
             <>
                 { (Object.keys(this.props.uploadAWSErrors).length > 0 ||
@@ -118,11 +128,7 @@ class WizardStepReview extends Component {
                     <Text component={ TextVariants.h3 }>Target environment</Text>
                     {this.props.uploadDestinations.aws && awsReview }
                     {this.props.uploadDestinations.google && googleReview }
-                    <Text component={ TextVariants.h3 }>Registration</Text>
-                    <TextList component={ TextListVariants.dl } data-testid='review-image-registration'>
-                        <TextListItem component={ TextListItemVariants.dt }>Subscription</TextListItem>
-                        { subscriptionReview }
-                    </TextList>
+                    {this.props.release.distro === 'rhel-8' && registrationReview }
                 </TextContent>
             </>
         );


### PR DESCRIPTION
Registration is only enabled for RHEL images now. Also, the release/distro was not being properly displayed in the review screen. 

Fixes #139 #117 

![registrationReview](https://user-images.githubusercontent.com/11712857/120995139-68565c00-c785-11eb-9b24-27d8ad12e64a.png)


