### PR TITLE
Add missing modules entry to webpack config.

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -7,8 +7,8 @@ const { config: webpackConfig, plugins } = config({
     debug: true,
     port: 8002,
     useFileHash: false,
-    sassPrefix: '.image-builder, body',
-    skipChrome2: true,
+    modules: [ 'image_builder' ],
+    sassPrefix: '.image-builder, body'
 });
 
 plugins.push(

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,6 +5,7 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
     skipChrome2: false,
+    modules: [ 'image_builder' ],
     sassPrefix: '.image-builder, body',
 });
 


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-15320

### Changes
- add missing modules configuration to webpack config

The build was generating empy `fed-mods.json` file. This file is used by chrome to handle webpack container loading. If you use custom `moduleName` in the federated modules plugin, you also have to add that same string to the base webpack config. Otherwise, the config will be looking for different module names and creates an incorrect metadata file

Fixes this issue: 

![Screenshot from 2021-07-15 14-22-32](https://user-images.githubusercontent.com/22619452/125787319-06546c72-93fe-476f-9152-11523b71125b.png)

cc @ochosi @Gundersanne 

