### PR TITLE
Fix review page

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -39,22 +39,23 @@ const ReviewStep = () => {
                     </TextListItem>
                 </TextList>
             </>}
-            {getState()?.values?.['register-system'] === 'subscribe-now-radio' && <>
-                <Text component={ TextVariants.h3 }>Registration</Text>
-                <TextList component={ TextListVariants.dl } data-testid='review-image-registration'>
-                    <TextListItem component={ TextListItemVariants.dt }>Subscription</TextListItem>
-                    <TextListItem component={ TextListItemVariants.dd }>
-                        {getState()?.values?.['register-system'] === 'subscribe-now-radio' ?
-                            'Register the system on first boot' :
-                        registerValues?.[getState()?.values?.['register-system']?.title]
-                        }
-                    </TextListItem>
-                    <TextListItem component={ TextListItemVariants.dt }>Activation key</TextListItem>
-                    <TextListItem component={ TextListItemVariants.dd } type="password">
-                        {'*'.repeat(getState()?.values?.['subscription-activation']?.length)}
-                    </TextListItem>
-                </TextList>
-            </>}
+            {getState()?.values?.['register-system'] === 'subscribe-now-radio' &&
+             getState()?.values?.release.includes('rhel') && <>
+                    <Text component={ TextVariants.h3 }>Registration</Text>
+                    <TextList component={ TextListVariants.dl } data-testid='review-image-registration'>
+                        <TextListItem component={ TextListItemVariants.dt }>Subscription</TextListItem>
+                        <TextListItem component={ TextListItemVariants.dd }>
+                            {getState()?.values?.['register-system'] === 'subscribe-now-radio' ?
+                                'Register the system on first boot' :
+                            registerValues?.[getState()?.values?.['register-system']?.title]
+                            }
+                        </TextListItem>
+                        <TextListItem component={ TextListItemVariants.dt }>Activation key</TextListItem>
+                        <TextListItem component={ TextListItemVariants.dd } type="password">
+                            {'*'.repeat(getState()?.values?.['subscription-activation']?.length)}
+                        </TextListItem>
+                    </TextList>
+                </>}
         </TextContent>
     );
 };


### PR DESCRIPTION
Previously one could trick the state machine into showing the subscription section by first filling in the subscription information, then going back to the image type and changing it to CentOS.

Now we check if "rhel" is part of the image type (to hopefully also cover future RHEL offerings).
This may have to be extended in case RHEL for Edge or some other offering doesn't contain the "rhel" string.