### PR TITLE
.travis.yml: Only build the main and prod-beta branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 sudo: required
+branches:
+  only:
+  - main
+  - prod-beta
 notifications:
   email: false
 node_js:


### PR DESCRIPTION
This avoids double builds on the npm-update PRs.