### PR TITLE
CreateImageWizard: add gcp email validation

### DIFF
--- a/src/Components/CreateImageWizard/steps/googleCloud.js
+++ b/src/Components/CreateImageWizard/steps/googleCloud.js
@@ -106,6 +106,11 @@ export default {
                 {
                     type: validatorTypes.REQUIRED,
                 },
+                {
+                    type: validatorTypes.PATTERN,
+                    pattern: '[a-z0-9._%+-]+@[a-z0-9.-]+.[a-z]{2,}$',
+                    message: 'Please enter a valid email address'
+                }
             ],
         },
         {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -224,6 +224,16 @@ describe('Step Upload to Google', () => {
         expect(accessKeyId).toBeEnabled();
         // expect(accessKeyId).toBeRequired(); // DDf does not support required value
     });
+
+    test('the google email field must be a valid email', () => {
+        const [ next, , ] = verifyButtons();
+        userEvent.type(screen.getByTestId('input-google-email'), 'a');
+        expect(next).toHaveClass('pf-m-disabled');
+        expect(next).toBeDisabled();
+        userEvent.type(screen.getByTestId('input-google-email'), 'test@test.com');
+        expect(next).not.toHaveClass('pf-m-disabled');
+        expect(next).toBeEnabled();
+    });
 });
 
 describe('Step Upload to Azure', () => {


### PR DESCRIPTION
Email address input validation to GCP step in CreateImageWizard.
Closes #260