### PR TITLE
CreateImageWizard: add creation failure alert

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -136,6 +136,15 @@ const CreateImageWizard = () => {
                     }));
 
                     setIsSaving(false);
+                })
+                .catch((err) => {
+                    dispatch(addNotification({
+                        variant: 'danger',
+                        title: 'Your image could not be created',
+                        description: 'Status code ' + err.response.status + ': ' + err.response.statusText,
+                    }));
+
+                    setIsSaving(false);
                 });
         } }
         defaultArch="x86_64"


### PR DESCRIPTION
When image creation failed to start the wizard would get stuck in the saving state with no notice to the user. Now the user will get an error alert contain the status code and message. The wizard no longer gets stuck in the saving state.

Fixes #270 

![Screenshot from 2021-10-21 18-26-49](https://user-images.githubusercontent.com/11712857/138318922-7a38eed5-b7c5-4ee8-b070-99aaece5ec94.png)
