### PR TITLE
CreateImageWizard: fix packages addAll button

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -63,7 +63,7 @@ const Packages = ({ defaultArch, ...props }) => {
         chosenOptionsTitle="Chosen packages"
         addSelected={ packageListChange }
         removeSelected={ packageListChange }
-        addAll={ packageListChange }
+        addAll={ (available, chosen) => packageListChange([], chosen.concat(available)) }
         removeAll= { (newAvailablePackages) => packageListChange(
             newAvailablePackages,
             packagesSelected.filter((item) => !mapComponentToPackage(item)?.name?.includes(filterSelected))


### PR DESCRIPTION
When clicking the packages add all button the list of available packages did not get added to the list of chosen packages. Now
the chosen packages and available packages are concatenated together.

Fixes #255

The behavior of the addAll callback is not as expected so I have opened https://github.com/patternfly/patternfly-react/issues/6495