### PR TITLE
codecov.yml: reset comment to default

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,7 @@ coverage:
         threshold: 5%
 codecov:
   require_ci_to_pass: no
-comment: no
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
The comment configuration is now set to codecov.yml's default values. This allows codecov comments on our PRs.

Fixes #243