### PR TITLE
CreateImageWizard: decrease aws account id field length

### DIFF
--- a/src/Components/CreateImageWizard/steps/aws.js
+++ b/src/Components/CreateImageWizard/steps/aws.js
@@ -24,6 +24,7 @@ export default {
         {
             component: componentTypes.TEXT_FIELD,
             name: 'aws-account-id',
+            className: 'pf-u-w-25',
             'data-testid': 'aws-account-id',
             type: 'text',
             label: 'AWS account ID',


### PR DESCRIPTION
![Screenshot from 2021-11-10 18-39-23](https://user-images.githubusercontent.com/11712857/141164614-a4493e8d-6b48-4cfc-b716-e4bf2f935da4.png)

Fixes #182 