### PR TITLE
devel: update the 

### DIFF
--- a/devel/.env
+++ b/devel/.env
@@ -1,5 +1,5 @@
 COMPOSE_PROJECT_NAME=image-builder
-STATE_DIR=./state
+CERT_DIR=./state/x509
 COMPOSER_CONFIG_DIR=./config/composer
 WORKER_CONFIG_DIR=./config/worker
 SPANDX_CONFIG=./config/spandx/local-frontend-and-api.js

--- a/devel/.env
+++ b/devel/.env
@@ -3,3 +3,4 @@ CERT_DIR=./state/x509
 COMPOSER_CONFIG_DIR=./config/composer
 WORKER_CONFIG_DIR=./config/worker
 SPANDX_CONFIG=./config/spandx/local-frontend-and-api.js
+COMPOSER_OFFLINE_TOKEN=someOfflineToken

--- a/devel/config/backend/quotas.json
+++ b/devel/config/backend/quotas.json
@@ -1,0 +1,6 @@
+{
+  "default":{
+      "quota":200,
+      "slidingWindow":1209600000000000
+  }
+}

--- a/devel/config/composer/acl.yml
+++ b/devel/config/composer/acl.yml
@@ -1,0 +1,4 @@
+## hack since oauth server is
+## using http
+- claim: typ
+  pattern: ^Bearer$

--- a/devel/config/composer/osbuild-composer.toml
+++ b/devel/config/composer/osbuild-composer.toml
@@ -1,7 +1,16 @@
 [worker]
+request_job_timeout = "40s"
 allowed_domains = [ "localhost", "worker.osbuild.org" ]
+enable_mtls = false
+enable_jwt = true
+jwt_keys_url = "http://fauxauth:8888/certs"
+jwt_acl_file = "/etc/osbuild-composer/acl.yml"
 ca = "/etc/osbuild-composer/ca-crt.pem"
 
 [koji]
 allowed_domains = [ "client.osbuild.org" ]
+enable_mtls = false
+enable_jwt = true
+jwt_keys_url = "http://fauxauth:8888/certs"
+jwt_acl_file = "/etc/osbuild-composer/acl.yml"
 ca = "/etc/osbuild-composer/ca-crt.pem"

--- a/devel/config/grafana/dashboards/dashboard.yml
+++ b/devel/config/grafana/dashboards/dashboard.yml
@@ -8,11 +8,3 @@ providers:
     editable: true
     options:
       path: /etc/grafana/provisioning/dashboards
-  - name: 'grafana-dashboard-image-builder-composer-general'
-    orgId: 1
-    folder: ''
-    type: file
-    disableDeletion: false
-    editable: true
-    options:
-      path: /etc/grafana/provisioning/dashboards

--- a/devel/config/worker/osbuild-worker.toml
+++ b/devel/config/worker/osbuild-worker.toml
@@ -1,0 +1,3 @@
+[authentication]
+oauth_url = "http://fauxauth:8888/token"
+offline_token = "/etc/osbuild-worker/token"

--- a/devel/config/worker/token
+++ b/devel/config/worker/token
@@ -1,0 +1,1 @@
+someOfflineToken

--- a/devel/docker-compose.yml
+++ b/devel/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       timeout: 2s
       retries: 10
     volumes:
+      - ./config/backend/quotas.json:/config/quotas.json:z
       - ${STATE_DIR}/x509/ca-crt.pem:/etc/image-builder/ca-crt.pem:z
       - ${STATE_DIR}/x509/client-crt.pem:/etc/image-builder/client-crt.pem:z
       - ${STATE_DIR}/x509/client-key.pem:/etc/image-builder/client-key.pem:z
@@ -81,6 +82,7 @@ services:
       - OSBUILD_CERT_PATH=/etc/image-builder/client-crt.pem
       - OSBUILD_KEY_PATH=/etc/image-builder/client-key.pem
       - OSBUILD_CA_PATH=/etc/image-builder/ca-crt.pem
+      - QUOTA_FILE=/config/quotas.json
     networks:
       net:
         ipv4_address: 172.31.0.40

--- a/devel/docker-compose.yml
+++ b/devel/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       dockerfile: ./distribution/Dockerfile-ubi
     volumes:
       - ${COMPOSER_CONFIG_DIR}/osbuild-composer.toml:/etc/osbuild-composer/osbuild-composer.toml:z
-      - ${STATE_DIR}/x509/ca-crt.pem:/etc/osbuild-composer/ca-crt.pem:z
-      - ${STATE_DIR}/x509/composer-crt.pem:/etc/osbuild-composer/composer-crt.pem:z
-      - ${STATE_DIR}/x509/composer-key.pem:/etc/osbuild-composer/composer-key.pem:z
+      - ${CERT_DIR}/ca-crt.pem:/etc/osbuild-composer/ca-crt.pem:z
+      - ${CERT_DIR}/composer-crt.pem:/etc/osbuild-composer/composer-crt.pem:z
+      - ${CERT_DIR}/composer-key.pem:/etc/osbuild-composer/composer-key.pem:z
     ports: 
       - 8080:8700
     networks:
@@ -23,9 +23,9 @@ services:
     # override the entrypoint to specify composer hostname and port
     entrypoint: [ "/usr/libexec/osbuild-composer/osbuild-worker", "composer:8700" ]
     volumes:
-      - ${STATE_DIR}/x509/ca-crt.pem:/etc/osbuild-composer/ca-crt.pem:z
-      - ${STATE_DIR}/x509/worker-crt.pem:/etc/osbuild-composer/worker-crt.pem:z
-      - ${STATE_DIR}/x509/worker-key.pem:/etc/osbuild-composer/worker-key.pem:z
+      - ${CERT_DIR}/ca-crt.pem:/etc/osbuild-composer/ca-crt.pem:z
+      - ${CERT_DIR}/worker-crt.pem:/etc/osbuild-composer/worker-crt.pem:z
+      - ${CERT_DIR}/worker-key.pem:/etc/osbuild-composer/worker-key.pem:z
     environment:
       - CACHE_DIRECTORY=/var/cache/osbuild-composer
     cap_add:
@@ -65,9 +65,9 @@ services:
       retries: 10
     volumes:
       - ./config/backend/quotas.json:/config/quotas.json:z
-      - ${STATE_DIR}/x509/ca-crt.pem:/etc/image-builder/ca-crt.pem:z
-      - ${STATE_DIR}/x509/client-crt.pem:/etc/image-builder/client-crt.pem:z
-      - ${STATE_DIR}/x509/client-key.pem:/etc/image-builder/client-key.pem:z
+      - ${CERT_DIR}/ca-crt.pem:/etc/image-builder/ca-crt.pem:z
+      - ${CERT_DIR}/client-crt.pem:/etc/image-builder/client-crt.pem:z
+      - ${CERT_DIR}/client-key.pem:/etc/image-builder/client-key.pem:z
     environment:
       - LISTEN_ADDRESS=backend:8086
       - LOG_LEVEL=DEBUG
@@ -127,9 +127,9 @@ services:
       - "9000:9090"
     volumes:
       - ./config/prometheus:/config
-      - ${STATE_DIR}/x509/ca-crt.pem:/etc/image-builder/ca-crt.pem:z
-      - ${STATE_DIR}/x509/client-crt.pem:/etc/image-builder/client-crt.pem:z
-      - ${STATE_DIR}/x509/client-key.pem:/etc/image-builder/client-key.pem:z
+      - ${CERT_DIR}/ca-crt.pem:/etc/image-builder/ca-crt.pem:z
+      - ${CERT_DIR}/client-crt.pem:/etc/image-builder/client-crt.pem:z
+      - ${CERT_DIR}/client-key.pem:/etc/image-builder/client-key.pem:z
     restart: unless-stopped
     networks:
       net:

--- a/devel/docker-compose.yml
+++ b/devel/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - ${WORKER_CONFIG_DIR}/token:/etc/osbuild-worker/token:z
     environment:
       - CACHE_DIRECTORY=/var/cache/osbuild-composer
+    privileged: true
     cap_add:
       - MKNOD
       - SYS_ADMIN

--- a/devel/docker-compose.yml
+++ b/devel/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: ./distribution/Dockerfile-ubi
     volumes:
       - ${COMPOSER_CONFIG_DIR}/osbuild-composer.toml:/etc/osbuild-composer/osbuild-composer.toml:z
+      - ${COMPOSER_CONFIG_DIR}/acl.yml:/etc/osbuild-composer/acl.yml:z
       - ${CERT_DIR}/ca-crt.pem:/etc/osbuild-composer/ca-crt.pem:z
       - ${CERT_DIR}/composer-crt.pem:/etc/osbuild-composer/composer-crt.pem:z
       - ${CERT_DIR}/composer-key.pem:/etc/osbuild-composer/composer-key.pem:z
@@ -24,8 +25,8 @@ services:
     entrypoint: [ "/usr/libexec/osbuild-composer/osbuild-worker", "composer:8700" ]
     volumes:
       - ${CERT_DIR}/ca-crt.pem:/etc/osbuild-composer/ca-crt.pem:z
-      - ${CERT_DIR}/worker-crt.pem:/etc/osbuild-composer/worker-crt.pem:z
-      - ${CERT_DIR}/worker-key.pem:/etc/osbuild-composer/worker-key.pem:z
+      - ${WORKER_CONFIG_DIR}/osbuild-worker.toml:/etc/osbuild-worker/osbuild-worker.toml:z
+      - ${WORKER_CONFIG_DIR}/token:/etc/osbuild-worker/token:z
     environment:
       - CACHE_DIRECTORY=/var/cache/osbuild-composer
     cap_add:
@@ -77,11 +78,11 @@ services:
       - PGDATABASE=postgres
       - PGUSER=postgres
       - PGPASSWORD=postgres
-      - OSBUILD_URL=https://composer:8080
+      - COMPOSER_URL=https://composer:8080
+      - COMPOSER_TOKEN_URL=http://fauxauth:8888/token
+      - COMPOSER_OFFLINE_TOKEN=${COMPOSER_OFFLINE_TOKEN}
+      - COMPOSER_CA_PATH=/etc/image-builder/ca-crt.pem
       - DISTRIBUTIONS_DIR=/app/distributions
-      - OSBUILD_CERT_PATH=/etc/image-builder/client-crt.pem
-      - OSBUILD_KEY_PATH=/etc/image-builder/client-key.pem
-      - OSBUILD_CA_PATH=/etc/image-builder/ca-crt.pem
       - QUOTA_FILE=/config/quotas.json
     networks:
       net:
@@ -148,6 +149,19 @@ services:
         ipv4_address: 172.31.0.80
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=foobar
+  fauxauth:
+    image: local/osbuild-fauxauth
+    build:
+      context: ../../osbuild-composer
+      dockerfile: ./distribution/Dockerfile-fauxauth
+    entrypoint: [ "/opt/fauxauth.py", "-a", "0.0.0.0", "-p", "8888" ]
+    volumes:
+      - ${CERT_DIR}/:/etc/osbuild-composer/:z
+    ports:
+      - "8888:8888"
+    networks:
+      net:
+        ipv4_address: 172.31.0.90
 networks:
   net:
     ipam:


### PR DESCRIPTION
- make changes to use the `image-builder` composer client
- add a mock oauth server to simulate SSO `offline_token` exchange
- provide worker container with privileges (needed for loopback devices)
- add quota file
- remove duplicate grafana dashboard (causing errors in logs)

Note: this PR relies on the following PR https://github.com/osbuild/osbuild-composer/pull/2003