### PR TITLE
ci: Extract Coverity Scan tools in /tmp

### DIFF
--- a/.github/workflows/coverity_scan.yml
+++ b/.github/workflows/coverity_scan.yml
@@ -23,10 +23,10 @@ jobs:
           curl -o /tmp/cov-analysis-linux64.tgz https://scan.coverity.com/download/linux64 \
             --form project="$COVERITY_SCAN_PROJECT_NAME" \
             --form token="$COVERITY_SCAN_TOKEN"
-          tar xzvf /tmp/cov-analysis-linux64.tgz
+          pushd /tmp && tar xzvf cov-analysis-linux64.tgz && popd
 
           mkdir bin
-          ./cov-analysis-linux64-*/bin/cov-build --dir cov-int --no-command --fs-capture-search ./
+          /tmp/cov-analysis-linux64-*/bin/cov-build --dir cov-int --no-command --fs-capture-search ./
           tar czvf cov-int.tar.gz cov-int
 
           echo "Uploading coverity scan result to http://scan.coverity.com"


### PR DESCRIPTION
this will prevent the tool from scanning itself