### PR TITLE
CreateImageWizard: insert new compose on top of images list

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -126,7 +126,7 @@ const CreateImageWizard = () => {
                     ...response,
                     request,
                     image_status: { status: 'pending' }
-                }));
+                }, true));
             })))
                 .then(() => {
                     history.push('/landing');

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -733,7 +733,7 @@ describe('Click through all steps', () => {
                     id = 'edbae1c2-62bc-42c1-ae0c-3110ab718f58';
                 }
 
-                ids.push(id);
+                ids.unshift(id);
                 return Promise.resolve({ id });
             });
 


### PR DESCRIPTION
The composeAdded action includes a field 'insert'. When set to true `insert` will place the added compose at the beginning of the images list. The test is modified so the new composes are added to the beginning of the list.

Fixes #161 