### PR TITLE
CreateImageWizard: show previously chosen packages

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -31,6 +31,14 @@ const Packages = ({ defaultArch, ...props }) => {
     const [ filterChosen, setFilterChosen ] = useState('');
     const [ focus, setFocus ] = useState('');
 
+    // this effect only triggers on mount
+    useEffect(() => {
+        const selectedPackages = getState()?.values?.['selected-packages'];
+        if (selectedPackages) {
+            setPackagesChosen(selectedPackages);
+        }
+    }, []);
+
     const searchResultsComparator = useCallback((searchTerm) => {
         return (a, b) => {
             // check exact match first


### PR DESCRIPTION
If a user choses packages and then changes to a different step, the packagesChosen state is wiped. These packages are now stored in the form state under 'selected-packages'. When the packages step is mounted, if there are 'selected-packages', these are the initial state for packagesChosen.

Fixes #441 