### PR TITLE
CreateImageWizard: fix Enter key for packages search

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -107,10 +107,10 @@ const Packages = ({ defaultArch, ...props }) => {
     };
 
     useEffect(() => {
-        document.addEventListener('keydown', keydownHandler, false);
+        document.addEventListener('keydown', keydownHandler, true);
 
         return () => {
-            document.removeEventListener('keydown', keydownHandler, false);
+            document.removeEventListener('keydown', keydownHandler, true);
         };
     });
 


### PR DESCRIPTION
The addEventListener call needs to have the useCapture field set to true. The data-driven-forms patternfly 4 wizard will continue to the next step when the Enter key is pressed. If we add our keydownHandler as an event listener with useCapture set to True, the keydownHandler will trigger before the wizards handler. This will effectively override the wizard's handling of the Enter key so that it can be used to search when the user has either package search bar in focus.

Fixes #448 

See: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener