### PR TITLE
CreateImageWizard: fix add all packages

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -143,16 +143,19 @@ const Packages = ({ defaultArch, ...props }) => {
 
     // move all packages
     const moveAll = (fromAvailable) => {
+        let chosenPackages = [];
         if (fromAvailable) {
-            setPackagesChosen([ ...packagesAvailable.filter(pack => !pack.isHidden), ...packagesChosen ]);
+            chosenPackages = [ ...packagesAvailable.filter(pack => !pack.isHidden), ...packagesChosen ];
+            setPackagesChosen(chosenPackages);
             sortPackages([ ...packagesAvailable.filter(pack => pack.isHidden) ]);
         } else {
+            chosenPackages = [ ...packagesChosen.filter(pack => pack.isHidden) ];
             sortPackages([ ...packagesChosen.filter(pack => !pack.isHidden), ...packagesAvailable ]);
-            setPackagesChosen([ ...packagesChosen.filter(pack => pack.isHidden) ]);
+            setPackagesChosen(chosenPackages);
         }
 
         // set the steps field to the current chosen packages list
-        change(input.name, removePackagesDisplayFields(packagesChosen));
+        change(input.name, removePackagesDisplayFields(chosenPackages));
     };
 
     const onOptionSelect = (event, index, isChosen) => {


### PR DESCRIPTION
When adding all packages we no longer depend on the state update. Instead, we initialize an object with the chosen packages and pass that to both the step's state and the form's state. Using the step state to set the form's state was causing the form's state to be set from the prior step state and not the state with the new package list.

Fixes #447 