### PR TITLE
CreateImageWizard: don't obscure activation key

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -127,8 +127,8 @@ const ReviewStep = () => {
                                 <TextListItem component={ TextListItemVariants.dt }>
                                     Activation key
                                 </TextListItem>
-                                <TextListItem component={ TextListItemVariants.dd }>
-                                    {'*'.repeat(getState()?.values?.['subscription-activation']?.length)}
+                                <TextListItem component={ TextListItemVariants.dd } data-testid='subscription-activation-review'>
+                                    {getState()?.values?.['subscription-activation']}
                                 </TextListItem>
                             </TextList>
                         </TextContent>

--- a/src/Components/CreateImageWizard/steps/registration.js
+++ b/src/Components/CreateImageWizard/steps/registration.js
@@ -47,7 +47,7 @@ export default (user) => ({
             name: 'subscription-activation',
             'data-testid': 'subscription-activation',
             required: true,
-            type: 'password',
+            type: 'text',
             label: 'Activation key',
             condition: {
                 or: [

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -369,6 +369,7 @@ describe('Step Registration', () => {
         screen.getByRole('button', { name: /Next/ }).click();
         screen.getByRole('button', { name: /Next/ }).click();
         await screen.findByText('Register the system on first boot');
+        await screen.findAllByText('012345678901');
     });
 
     test('should hide input fields when clicking Register the system later', async () => {


### PR DESCRIPTION
Activation key was previously obscured by stars, instead just show it
(both in the input and in the review step) as it isn't secret.