### PR TITLE
CreateImageWizard: Fix move selected packages

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -125,7 +125,7 @@ const Packages = ({ defaultArch, ...props }) => {
     // move selected packages
     const moveSelected = (fromAvailable) => {
         const sourcePackages = fromAvailable ? packagesAvailable : packagesChosen;
-        const destinationPackages = fromAvailable ? packagesChosen : packagesAvailable;
+        const destinationPackages = fromAvailable ? packagesChosen : (packagesAvailable || []);
 
         const updatedSourcePackages = sourcePackages.filter((pack) => {
             if (pack.selected) {


### PR DESCRIPTION
If fromAvailable is false, packagesavailable can be undefined if it's
the first package that's being moved over.