### PR TITLE
Router: Replace landing with catch-all route

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -117,7 +117,7 @@ const CreateImageWizard = () => {
         })();
     }, []);
     return user ? <ImageCreator
-        onClose={ () => navigate('/landing') }
+        onClose={ () => navigate('/') }
         onSubmit={ ({ values, setIsSaving }) => {
             setIsSaving(() => true);
             const requests = onSave(values);
@@ -129,7 +129,7 @@ const CreateImageWizard = () => {
                 }, true));
             })))
                 .then(() => {
-                    navigate('/landing');
+                    navigate('/');
                     dispatch(addNotification({
                         variant: 'success',
                         title: 'Your image is being created',

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,5 +1,5 @@
 import React, { lazy } from 'react';
-import { Route, Routes, Navigate } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 
 const LandingPage = lazy(() => import('./Components/LandingPage/LandingPage'));
 const CreateImageWizard = lazy(() => import('./Components/CreateImageWizard/CreateImageWizard'));
@@ -7,9 +7,8 @@ const CreateImageWizard = lazy(() => import('./Components/CreateImageWizard/Crea
 export const Router = () => {
     return (
         <Routes>
-            <Route path='/landing/*' element={ <LandingPage /> } />
             <Route path='/imagewizard/*' element={ <CreateImageWizard /> } />
-            <Route path='/' element={ <Navigate replace to='/landing' /> } />
+            <Route path='*' element={ <LandingPage /> } />
         </Routes>
     );
 };

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -23,7 +23,7 @@ function verifyButtons() {
 function verifyCancelButton(cancel, history) {
     cancel.click();
 
-    expect(history.location.pathname).toBe('/landing');
+    expect(history.location.pathname).toBe('/');
 }
 
 // packages
@@ -860,7 +860,7 @@ describe('Click through all steps', () => {
         await expect(composeImage).toHaveBeenCalledTimes(3);
 
         // returns back to the landing page
-        await waitFor(() => expect(history.location.pathname).toBe('/landing'));
+        await waitFor(() => expect(history.location.pathname).toBe('/'));
         expect(store.getStore().getState().composes.allIds).toEqual(ids);
     });
 


### PR DESCRIPTION
This also mitigates the issue where clicking the image-builder nav link
would redirect you to `image-builder/image-builder` if image-builder was
already opened. And `/` didn't catch that path.