### PR TITLE
ImagesTable: align gcp image details with other instance text

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -72,7 +72,8 @@ const ImageLink = (props) => {
                     <Button
                         component="a"
                         target="_blank"
-                        variant="link">
+                        variant="link"
+                        isInline>
                             Image details
                     </Button>
                 </Popover>


### PR DESCRIPTION
The link for the gcp Instance description was not set to isInline. Fixing this aligns the text with the rest of the instance links.

![Screenshot from 2022-01-07 01-41-08](https://user-images.githubusercontent.com/11712857/148472630-92f8dd13-7944-4c2c-b47c-9da0ae1b2a5e.png)
