### PR TITLE
CreateImageWizard: validate azure resource group

### DIFF
--- a/src/Components/CreateImageWizard/steps/msAzure.js
+++ b/src/Components/CreateImageWizard/steps/msAzure.js
@@ -98,6 +98,12 @@ export default {
                 {
                     type: validatorTypes.REQUIRED,
                 },
+                {
+                    type: validatorTypes.PATTERN,
+                    pattern: /^[-\w._()]+[-\w_()]$/,
+                    message: 'Resource group names only allow alphanumeric characters, ' +
+                        'periods, underscores, hyphens, and parenthesis and cannot end in a period',
+                },
             ],
         }
         // TODO check oauth2 thing too here?


### PR DESCRIPTION
Resource group names only allow alphanumeric characters, periods, underscores, hyphens, and parenthesis and cannot end in a period. A regex validation is now added to ensure this.

Documented by azure here: https://docs.microsoft.com/en-us/rest/api/resources/resource-groups/create-or-update

Fixes #488 