### PR TITLE
CreateImageWizard: Get all matching packages from package search

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -43,31 +43,34 @@ const Packages = ({ defaultArch, ...props }) => {
 
     const searchResultsComparator = useCallback((searchTerm) => {
         return (a, b) => {
+            a = a.name.toLowerCase();
+            b = b.name.toLowerCase();
+
             // check exact match first
-            if (a.name === searchTerm) {
+            if (a === searchTerm) {
                 return -1;
             }
 
-            if (b.name === searchTerm) {
+            if (b === searchTerm) {
                 return 1;
             }
 
             // check for packages that start with the search term
-            if (a.name.startsWith(searchTerm) && !b.name.startsWith(searchTerm)) {
+            if (a.startsWith(searchTerm) && !b.startsWith(searchTerm)) {
                 return -1;
             }
 
-            if (b.name.startsWith(searchTerm) && !a.name.startsWith(searchTerm)) {
+            if (b.startsWith(searchTerm) && !a.startsWith(searchTerm)) {
                 return 1;
             }
 
             // if both (or neither) start with the search term
             // sort alphabetically
-            if (a.name < b.name) {
+            if (a < b) {
                 return -1;
             }
 
-            if (b.name < a.name) {
+            if (b < a) {
                 return 1;
             }
 

--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -114,6 +114,7 @@ const Packages = ({ defaultArch, ...props }) => {
             sortPackages(packagesAvailableFiltered);
             setPackagesAvailableFound(true);
         } else {
+            setPackagesAvailable([]);
             setPackagesAvailableFound(false);
         }
     };

--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -88,15 +88,26 @@ const Packages = ({ defaultArch, ...props }) => {
         });
     });
 
-    // call api to list available packages
-    const handlePackagesAvailableSearch = async () => {
-        const { data } = await api.getPackages(
+    const getAllPackages = async () => {
+        const args = [
             getState()?.values?.release,
             getState()?.values?.architecture || defaultArch,
             packagesSearchName.current
-        );
-        if (data) {
-            const packagesAvailableFiltered = filterPackagesAvailable(data);
+        ];
+        let { data, meta } = await api.getPackages(...args);
+        if (data?.length === meta.count) {
+            return data;
+        } else if (data) {
+            ({ data } = await api.getPackages(...args, meta.count));
+            return data;
+        }
+    };
+
+    // call api to list available packages
+    const handlePackagesAvailableSearch = async () => {
+        const packageList = await getAllPackages();
+        if (packageList) {
+            const packagesAvailableFiltered = filterPackagesAvailable(packageList);
             sortPackages(packagesAvailableFiltered);
             setPackagesAvailableFound(true);
         } else {

--- a/src/api.js
+++ b/src/api.js
@@ -28,12 +28,13 @@ async function getComposeStatus(id) {
     return request.data;
 }
 
-async function getPackages(distribution, architecture, search) {
+async function getPackages(distribution, architecture, search, limit) {
     const params = new URLSearchParams({
         distribution,
         architecture,
         search,
     });
+    limit && params.append('limit', limit);
     let path = '/packages?' + params.toString();
     const request = await axios.get(IMAGE_BUILDER_API.concat(path));
     return request.data;

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -49,6 +49,28 @@ const mockPkgResult = {
     ]
 };
 
+const mockPkgResultAlpha = {
+    meta: { count: 3 },
+    links: { first: '', last: '' },
+    data: [
+        {
+            name: 'lib-test',
+            summary: 'lib-test package summary',
+            version: '1.0',
+        },
+        {
+            name: 'Z-test',
+            summary: 'Z-test package summary',
+            version: '1.0',
+        },
+        {
+            name: 'test',
+            summary: 'summary for test package',
+            version: '1.0',
+        }
+    ]
+};
+
 const mockPkgResultPartial = {
     meta: { count: 132 },
     links: { first: '', last: '' },
@@ -767,6 +789,30 @@ describe('Step Packages', () => {
         const availablePackagesList = screen.getByTestId('available-pkgs-list');
         const availablePackagesItems = within(availablePackagesList).getAllByRole('option');
         expect(availablePackagesItems).toHaveLength(132);
+    });
+
+    test('search results should be sorted alphabetically', async () => {
+        await setUp();
+
+        const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
+
+        searchbox.click();
+
+        const getPackages = jest
+            .spyOn(api, 'getPackages')
+            .mockImplementation(() => Promise.resolve(mockPkgResultAlpha));
+
+        await searchForAvailablePackages(searchbox, 'test');
+        expect(getPackages).toHaveBeenCalledTimes(1);
+
+        const availablePackagesList = screen.getByTestId('available-pkgs-list');
+        const availablePackagesItems = within(availablePackagesList).getAllByRole('option');
+        expect(availablePackagesItems).toHaveLength(3);
+
+        const [ firstItem, secondItem, thirdItem ] = availablePackagesItems;
+        expect(firstItem).toHaveTextContent('testsummary for test package');
+        expect(secondItem).toHaveTextContent('lib-testlib-test package summary');
+        expect(thirdItem).toHaveTextContent('Z-testZ-test package summary');
     });
 });
 

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -705,6 +705,29 @@ describe('Step Packages', () => {
         screen.getByText('No packages found');
     });
 
+    test('should display empty available state on failed search after a successful search', async () => {
+        await setUp();
+
+        const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
+
+        searchbox.click();
+
+        let getPackages = jest
+            .spyOn(api, 'getPackages')
+            .mockImplementation(() => Promise.resolve(mockPkgResult));
+
+        await searchForAvailablePackages(searchbox, 'test');
+
+        getPackages = jest
+            .spyOn(api, 'getPackages')
+            .mockImplementation(() => Promise.resolve(mockPkgResultEmpty));
+
+        await searchForAvailablePackages(searchbox, 'asdf');
+
+        expect(getPackages).toHaveBeenCalledTimes(2);
+        screen.getByText('No packages found');
+    });
+
     test('should display empty chosen state on failed search', async () => {
         await setUp();
 


### PR DESCRIPTION
When searching for a package, all matching packages are now returned. First an
attempt is made using the api's default limit and if there are more
matching packages than the default limit a second request is made with
an increased limit. To facilitate this, api.getPackages() now accepts an
optional limit parameter. Retrieving all matching packages is necessary
because of the sorting logic.