### PR TITLE
package.json: add run script for stage env

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Make sure you have npm@7 and node 15+ installed. If you need multiple versions o
 
 3. open browser at `https://prod.foo.redhat.com:1337/beta/insights/image-builder`
 
+### Webpack proxy (staging) -- *Runs with image-builder's stage deployment*
+
+1. run `npm ci`
+
+2. run `npm run stage`. This command uses a stage-beta env by default. Configure your
+   environment by the `env` attribute in `dev.webpack.config.js`.
+
+3. open browser at `https://stage.foo.redhat.com:1337/beta/insights/image-builder`
+
 ### Insights proxy (deprecated)
 
 1. Clone the insights proxy: https://github.com/RedHatInsights/insights-proxy

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -8,7 +8,7 @@ const webpackProxy = {
     useProxy: true,
     proxyVerbose: true,
     debug: true,
-    env: `prod-${process.env.BETA ? 'beta' : 'stable'}`,
+    env: `${process.env.STAGE ? 'stage' : 'prod'}-${process.env.BETA ? 'beta' : 'stable'}`,
     appUrl: process.env.BETA ? '/beta/insights/image-builder' : '/insights/image-builder',
 };
 

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "nightly": "npm run travis:verify",
     "prod": "NODE_ENV=production BETA=true webpack serve --config config/dev.webpack.config.js",
     "server:ctr": "node src/server/generateServerKey.js",
+    "stage": "STAGE=true npm run start:proxy:beta",
     "start": "NODE_ENV=development webpack serve --config config/dev.webpack.config.js",
     "start:beta": "NODE_ENV=development BETA=true webpack serve --config config/dev.webpack.config.js",
     "start:proxy": "PROXY=true npm run start",


### PR DESCRIPTION
A developer can now run `npm run stage` which will run the UI against
the staging environment on crc.