### PR TITLE
CreateImageWizard: prefocus aws input field

### DIFF
--- a/src/Components/CreateImageWizard/steps/aws.js
+++ b/src/Components/CreateImageWizard/steps/aws.js
@@ -27,6 +27,7 @@ export default {
             type: 'text',
             label: 'AWS account ID',
             isRequired: true,
+            autoFocus: true,
             validate: [
                 {
                     type: validatorTypes.REQUIRED,


### PR DESCRIPTION
Autofocus the input field in the aws step of the CreateImageWizard modal.
Fixes #599 