### PR TITLE
Spur/image output instructions

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -2,8 +2,7 @@ import React from 'react';
 import ImageCreator from './ImageCreator';
 import { useNavigate } from 'react-router-dom';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import { Button } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import DocumentationButton from '../sharedComponents/DocumentationButton';
 import './CreateImageWizard.scss';
 import { useDispatch } from 'react-redux';
 import api from '../../api';
@@ -246,18 +245,7 @@ const CreateImageWizard = () => {
                     showTitles: true,
                     title: 'Create image',
                     crossroads: [ 'target-environment', 'release' ],
-                    description: <>Create a RHEL image and push it to cloud providers. <Button
-                        component="a"
-                        target="_blank"
-                        variant="link"
-                        icon={ <ExternalLinkAltIcon /> }
-                        iconPosition="right"
-                        isInline
-                        href="
-https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/uploading_a_customized_rhel_system_image_to_cloud_environments/index
-            ">
-                Documentation
-                    </Button></>,
+                    description: <>Image builder allows you to create a custom image and push it to target environments. <DocumentationButton /></>,
                     // order in this array does not reflect order in wizard nav, this order is managed inside
                     // of each step by `nextStep` property!
                     fields: [

--- a/src/Components/CreateImageWizard/steps/imageOutput.js
+++ b/src/Components/CreateImageWizard/steps/imageOutput.js
@@ -1,7 +1,10 @@
+import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import nextStepMapper from './imageOutputStepMapper';
 import { RHEL_8 } from '../../../constants.js';
+import { Text } from '@patternfly/react-core';
+import DocumentationButton from '../../sharedComponents/DocumentationButton';
 
 export const releaseValues = {
     [RHEL_8]: 'Red Hat Enterprise Linux (RHEL) 8',
@@ -14,6 +17,11 @@ export default {
     name: 'image-output',
     nextStep: ({ values }) => nextStepMapper(values),
     fields: [
+        {
+            component: componentTypes.PLAIN_TEXT,
+            name: 'image-output-plain-text',
+            label: <Text>Image builder allows you to create a custom image and push it to target environments.<br /><DocumentationButton /></Text>
+        },
         {
             component: componentTypes.SELECT,
             label: 'Release',

--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -4,13 +4,13 @@ import { connect } from 'react-redux';
 import { actions } from '../../store/actions';
 import { Link } from 'react-router-dom';
 import { Table, TableHeader, TableBody } from '@patternfly/react-table';
-import { Button,
-    EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody, EmptyStateSecondaryActions,
+import { EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody, EmptyStateSecondaryActions,
     Pagination,
     Toolbar, ToolbarContent, ToolbarItem,
     Title } from '@patternfly/react-core';
-import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 
+import DocumentationButton from '../sharedComponents/DocumentationButton';
 import ImageBuildStatus from './ImageBuildStatus';
 import Release from './Release';
 import Target from './Target';
@@ -140,18 +140,7 @@ class ImagesTable extends Component {
                         Create image
                         </Link>
                         <EmptyStateSecondaryActions>
-                            <Button
-                                component="a"
-                                target="_blank"
-                                variant="link"
-                                icon={ <ExternalLinkAltIcon /> }
-                                iconPosition="right"
-                                isInline
-                                href="
-https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/uploading_a_customized_rhel_system_image_to_cloud_environments/index
-                                ">
-                                    Documentation
-                            </Button>
+                            <DocumentationButton />
                         </EmptyStateSecondaryActions>
                     </EmptyState>
                 ) || (

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -5,10 +5,11 @@ import React, { Component } from 'react';
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 
 import { Button, Popover, TextContent, Text } from '@patternfly/react-core';
-import { ExternalLinkAltIcon, GithubIcon, HelpIcon } from '@patternfly/react-icons';
+import { GithubIcon, HelpIcon } from '@patternfly/react-icons';
 
 import ImagesTable from '../ImagesTable/ImagesTable';
 import './LandingPage.scss';
+import DocumentationButton from '../sharedComponents/DocumentationButton';
 
 class LandingPage extends Component {
     constructor(props) {
@@ -27,18 +28,7 @@ class LandingPage extends Component {
                                         Image Builder is a service that allows you to create RHEL images
                                         and push them to cloud environments.
                             </Text>
-                            <Button
-                                component="a"
-                                target="_blank"
-                                variant="link"
-                                icon={ <ExternalLinkAltIcon /> }
-                                iconPosition="right"
-                                isInline
-                                href="
-https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/uploading_a_customized_rhel_system_image_to_cloud_environments/index
-                                ">
-                                    Documentation
-                            </Button>
+                            <DocumentationButton />
                             <br />
                             <Button
                                 component="a"

--- a/src/Components/sharedComponents/DocumentationButton.js
+++ b/src/Components/sharedComponents/DocumentationButton.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const DocumentationButton = () => {
+    const documentationURL =
+'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/uploading_a_customized_rhel_system_image_to_cloud_environments/index';
+
+    return (
+        <Button
+            component="a"
+            target="_blank"
+            variant="link"
+            icon={ <ExternalLinkAltIcon /> }
+            iconPosition="right"
+            isInline
+            href={ documentationURL }>Documentation</Button>
+    );
+};
+
+export default DocumentationButton;


### PR DESCRIPTION
Resolves #596

Got a little ahead of myself with what I thought would be a simple fix... I realized we use the documentation button a lot. Four times currently and it is possible to imagine more in the future. It's a lot of code for a simple button so I refactored it into its own component; this helps dry the code and improves the form schema readability. Should also make maintaining it easier in the future if the URL changes, and if we need separate documentation URLs at some point in the future it should be easier to add that functionality as well.

Couple of questions:
1. Do we have any 'standard' for our imports? They don't seem to be in any order... If chaos rules, that's fine, just want to check and make sure.
2. If we like the idea of having this as a component, where should it live? Right now it is in CreateImageWizard/formComponents but I would also like to use it in the ImagesTable and LandingPage as well. Is it okay for ImagesTable and LandingPage to import form components from CreateImageWizard or should the component live in a higher level directory? Maybe we need to make a directory for shared components?