### PR TITLE
App: fix tab title

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ const App = (props) => {
     useEffect(() => {
         const registry = getRegistry();
         registry.register({ notifications: notificationsReducer });
+        document.title = 'Image Builder | Red Hat Insights';
         insights.chrome.init();
         insights.chrome.identifyApp('image-builder');
         const unregister = insights.chrome.on('APP_NAVIGATION', (event) =>


### PR DESCRIPTION
The tab title for image builder in crc was being diplayed as `image_builder`.
This commit fixes issue #617

![tab_title](https://user-images.githubusercontent.com/20438192/157033662-266c8e56-1b6b-4e5b-9dad-3fbc18341a28.png)

