### PR TITLE
LandingPage: Fix insights page title

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ const App = (props) => {
     useEffect(() => {
         const registry = getRegistry();
         registry.register({ notifications: notificationsReducer });
-        document.title = 'Image Builder | Red Hat Insights';
+        document.title = 'Image Builder - Red Hat Insights';
         insights.chrome.init();
         insights.chrome.identifyApp('image-builder');
         const unregister = insights.chrome.on('APP_NAVIGATION', (event) =>

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -16,6 +16,10 @@ class LandingPage extends Component {
         super(props);
     }
 
+    async componentDidMount() {
+        document.title = 'Image Builder - Red Hat Insights';
+    }
+
     render() {
         return (
             <React.Fragment>


### PR DESCRIPTION
This should change the default page title once it is loaded.
![Screenshot from 2022-03-21 21-22-29](https://user-images.githubusercontent.com/261436/159357487-c92e0c08-aa34-4039-859a-1e5dcc079ef6.png)

Inspired by https://github.com/RedHatInsights/ros-frontend/blob/main/src/Routes/RosPage/RosPage.js#L60

