### PR TITLE
LandingPage: tighten space between status icon and text

### DIFF
--- a/src/Components/ImagesTable/ImageBuildStatus.js
+++ b/src/Components/ImagesTable/ImageBuildStatus.js
@@ -57,7 +57,7 @@ const ImageBuildStatus = (props) => {
             {messages[props.status] &&
                 messages[props.status].map((message, key) => (
                     <Flex key={ key } className="pf-u-align-items-baseline pf-m-nowrap">
-                        <div>{message.icon}</div>
+                        <div className="pf-u-mr-sm">{message.icon}</div>
                         <small>{message.text}</small>
                     </Flex>
                 ))


### PR DESCRIPTION
Tighten the space between the status icon and the status text.

Fixes #595