### PR TITLE
CreateImageWizard: fix label spacing

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/TargetEnvironment.scss
+++ b/src/Components/CreateImageWizard/formComponents/TargetEnvironment.scss
@@ -1,3 +1,7 @@
+.pf-c-form__group-label {
+    --pf-c-form__group-label--PaddingBottom: var(--pf-global--spacer--xs);
+}
+
 .tiles {
     display: flex;
 }


### PR DESCRIPTION
Decrease the spacing below labels from 8px to 4px in accordance with the mocks.
Fixes #597