### PR TITLE
ImagesTable: Show UUID in expandable details row

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.scss
+++ b/src/Components/ImagesTable/ImagesTable.scss
@@ -1,0 +1,10 @@
+@media only screen and (min-width: 768px) {
+    .pf-c-table__expandable-row td:first-child {
+        // Align with expand/collapse button by duplicating its padding
+        padding-left: calc(var(--pf-c-table--cell--first-last-child--PaddingLeft) + var(--pf-global--spacer--md));
+    }
+}
+.pf-m-expanded tr:first-child {
+    // Remove border between a compose and its expanded detail
+    border-bottom-style: none;
+}

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -364,17 +364,17 @@ describe('Images Table', () => {
         // remove first row from list since it is just header labels
         const header = rows.shift();
         // test the header has correct labels
-        expect(header.cells[0]).toHaveTextContent('Image name');
-        expect(header.cells[1]).toHaveTextContent('Created');
-        expect(header.cells[2]).toHaveTextContent('Release');
-        expect(header.cells[3]).toHaveTextContent('Target');
-        expect(header.cells[4]).toHaveTextContent('Status');
-        expect(header.cells[5]).toHaveTextContent('Instance');
+        expect(header.cells[1]).toHaveTextContent('Image name');
+        expect(header.cells[2]).toHaveTextContent('Created');
+        expect(header.cells[3]).toHaveTextContent('Release');
+        expect(header.cells[4]).toHaveTextContent('Target');
+        expect(header.cells[5]).toHaveTextContent('Status');
+        expect(header.cells[6]).toHaveTextContent('Instance');
 
         // 10 rows for 10 images
         expect(rows).toHaveLength(10);
         for (const row of rows) {
-            const col1 = row.cells[0].textContent;
+            const col1 = row.cells[1].textContent;
 
             const composes = Object.values(store.composes.byId);
             // find compose with either the user defined image name or the uuid
@@ -382,25 +382,25 @@ describe('Images Table', () => {
             expect(compose).toBeTruthy();
 
             // date should match the month day and year of the timestamp.
-            expect(row.cells[1]).toHaveTextContent('Apr 27, 2021');
+            expect(row.cells[2]).toHaveTextContent('Apr 27, 2021');
 
             // render the expected <ImageBuildStatus /> and compare the text content
             let testElement = document.createElement('testElement');
             render(<Target
                 imageType={ compose.request.image_requests[0].image_type }
                 uploadType={ compose.request.image_requests[0].upload_request.type } />, { container: testElement });
-            expect(row.cells[3]).toHaveTextContent(testElement.textContent);
+            expect(row.cells[4]).toHaveTextContent(testElement.textContent);
 
             // render the expected <ImageBuildStatus /> and compare the text content
             render(<ImageBuildStatus status={ compose.image_status.status } />, { container: testElement });
-            expect(row.cells[4]).toHaveTextContent(testElement.textContent);
+            expect(row.cells[5]).toHaveTextContent(testElement.textContent);
 
             // render the expected <ImageLink /> and compare the text content for a link
             render(
                 <ImageLink imageStatus={ compose.image_status } uploadOptions={ compose.request.image_requests[0].upload_request.options }  />,
                 { container: testElement }
             );
-            expect(row.cells[5]).toHaveTextContent(testElement.textContent);
+            expect(row.cells[6]).toHaveTextContent(testElement.textContent);
         }
     });
 
@@ -413,7 +413,7 @@ describe('Images Table', () => {
         const rows = getAllByRole('row');
 
         // first row is header so look at index 1
-        const imageId = rows[1].cells[0].textContent;
+        const imageId = rows[1].cells[1].textContent;
 
         const actionsButton =  within(rows[1]).getByRole('button', {
             name: 'Actions'
@@ -427,6 +427,22 @@ describe('Images Table', () => {
         expect(history.location.pathname).toBe('/imagewizard');
         expect(history.location.state.composeRequest).toStrictEqual(store.composes.byId[imageId].request);
         expect(history.location.state.initialStep).toBe('review');
+    });
+
+    test('check expandable row toggle', () => {
+        renderWithReduxRouter(<ImagesTable />, store);
+
+        const table = screen.getByTestId('images-table');
+        const { getAllByRole } = within(table);
+        const rows = getAllByRole('row');
+
+        const toggleButton = within(rows[6]).getByRole('button', { name: /details/i });
+
+        expect(screen.getAllByText(/1579d95b-8f1d-4982-8c53-8c2afa4ab04c/i)[1]).not.toBeVisible();
+        userEvent.click(toggleButton);
+        expect(screen.getAllByText(/1579d95b-8f1d-4982-8c53-8c2afa4ab04c/i)[1]).toBeVisible();
+        userEvent.click(toggleButton);
+        expect(screen.getAllByText(/1579d95b-8f1d-4982-8c53-8c2afa4ab04c/i)[1]).not.toBeVisible();
     });
 });
 


### PR DESCRIPTION
This commit displays the UUID in an expandable details row. This is
necessary because if an image was named, the UUID was not displayed.
It is important that a user know the UUID for troubleshooting, for
example in the case of requesting help with an image.

To facilitate this, the original Table component was converted to a
TableComposable component. TableComposable is newer and recommended over
the older Table by PatternFly.