### PR TITLE
.travis: Introduce simplified custom release script

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -ex
+
+if [ "${TRAVIS_BRANCH}" = "main" ]; then
+    .travis/release.sh "stage-beta"
+fi
+
+if [ "${TRAVIS_BRANCH}" = "stage-stable" ]; then
+    .travis/release.sh "stage-stable"
+fi
+
+if [ "${TRAVIS_BRANCH}" = "prod-beta" ]; then
+    .travis/release.sh "prod-beta"
+fi
+
+if [ "${TRAVIS_BRANCH}" = "prod-stable" ]; then
+    .travis/release.sh "prod-stable"
+fi


### PR DESCRIPTION
The default release script doesn't push `main` to stage-beta.