### PR TITLE
CreateImageWizard: fix validation for activation keys

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ActivationKeys.js
+++ b/src/Components/CreateImageWizard/formComponents/ActivationKeys.js
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormGroup, Spinner, Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import api from '../../../api';
 
-const ActivationKeys = ({ label, isRequired }) => {
+const ActivationKeys = ({ label, isRequired, ...props }) => {
     const { change, getState } = useFormApi();
+    const { input } = useFieldApi(props);
     const [ activationKeys, setActivationKeys ] = useState([]);
     const [ isOpen, setIsOpen ] = useState(false);
     const [ isLoading, setIsLoading ] = useState(false);
@@ -23,12 +25,12 @@ const ActivationKeys = ({ label, isRequired }) => {
     const setActivationKey = (_, selection) => {
         selectActivationKey(selection);
         setIsOpen(false);
-        change('subscription-activation-key', selection);
+        change(input.name, selection);
     };
 
     const handleClear = () => {
         selectActivationKey();
-        change('subscription-activation-key', undefined);
+        change(input.name, undefined);
     };
 
     return (

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1536,6 +1536,9 @@ describe('Keyboard accessibility', () => {
         await screen.findByRole('textbox', {
             name: 'Select activation key'
         });
+        // skip registration
+        const registerLaterRadio = screen.getByLabelText('Register later');
+        userEvent.click(registerLaterRadio);
 
         clickNext();
 
@@ -1563,7 +1566,6 @@ describe('Keyboard accessibility', () => {
         // Review
         const targetEnvironmentTab = screen.getByTestId('tab-target');
         expect(targetEnvironmentTab).toHaveFocus();
-        await screen.findByTestId('organization-id');
     });
 
     test('pressing Esc closes the wizard', async () => {


### PR DESCRIPTION
The validators are passed values by the useFieldApi hook. Adding this to the activation key component allows the `required` validation to work.

Fixes #624 