### PR TITLE
.github: Sync branches workflow

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,0 +1,79 @@
+name: Sync branches
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      source:
+        description: Source ref (branch or sha)
+        required: true
+        type: string
+      target:
+        description: Target branch
+        required: true
+        type: choice
+        options:
+          - production
+          - stage-stable
+
+
+jobs:
+  check:
+    name: Check source and target validity
+    timeout-minutes: 1
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.source }}
+          fetch-depth: 0
+
+      - name: Check ancestry
+        if: ${{ github.event.inputs.target == 'production' }}
+        run: |
+          if ! git merge-base --is-ancestor ${{ github.event.inputs.source }} origin/main; then
+            echo "Target is production and source ref isn't an ancestor of main"
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor ${{ github.event.inputs.source }} origin/stage-stable; then
+            echo "Target is production and source ref isn't deployed in stage-stable"
+            echo "The main and stage-stable branches should be in sync, please fix"
+            exit 1
+          fi
+
+      - name: Check stage-stable manual sync
+        if: ${{ github.event.inputs.target == 'stage-stable' }}
+        run: |
+          if [ $(git rev-parse ${{ github.event.inputs.source }}) != $(git rev-parse origin/main) ]; then
+            echo "Target is stage-stable and source ref isn't main"
+            exit 1
+          fi
+
+
+  sync:
+    name: Sync source and target refs
+    needs: check
+    if: ${{ github.event_name == 'push' || success() }}
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.source }}
+          fetch-depth: 0
+
+      - name: Release to production
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'production' }}
+        run: |
+          git push origin ${{ github.event.inputs.source }}:refs/heads/prod-beta
+          git push origin ${{ github.event.inputs.source }}:refs/heads/prod-stable
+
+      - name: Sync main to stage-stable
+        if: ${{ github.event_name == 'push' || github.event.inputs.target == 'stage-stable' }}
+        run: |
+          git push origin origin/main:refs/heads/stage-stable


### PR DESCRIPTION

    This workflow syncs the main branch with the stage-stable branch.
    
    It also includes a production target which needs to be dispatched
    manually. The production target pushes the input ref to both prod-beta
    and prod-stable branches.
    
    This results in the main branch always being deployed on stage-beta and
    stage-stable, and the prod-beta and prod-stable branches being synced on
    release.

---

~~With 4 different branches now (main, stage-stable, prod-beta, prod-stable), we should have a more formal way of releasing to a specific target.~~

~~Should we have prod-beta == stage-stable always?~~

---

On push to main main -> stage-beta sync.

Release sync $sourc ref -> prod-beta == prod-stable