### PR TITLE
CreateImageWizard: Use 'gcp' image type for gcp

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -110,7 +110,7 @@ const onSave = (values) => {
             image_requests: [
                 {
                     architecture: 'x86_64',
-                    image_type: 'vhd',
+                    image_type: 'gcp',
                     upload_request: {
                         type: 'gcp',
                         options: {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1292,7 +1292,7 @@ describe('Click through all steps', () => {
                         image_name: 'MyImageName',
                         image_requests: [{
                             architecture: 'x86_64',
-                            image_type: 'vhd',
+                            image_type: 'gcp',
                             upload_request: {
                                 type: 'gcp',
                                 options: {


### PR DESCRIPTION
The vhd alias for gcp was dropped, as image-builder includes extra repos
for gcp.