### PR TITLE
CreateImageWizard: CentOS Speedbump

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -54,3 +54,7 @@
 	--pf-c-expandable-section__toggle--focus--Color: var(--pf-global--Color--100);
     --pf-c-expandable-section__toggle--m-expanded--Color: var(--pf-global--Color--100);
 }
+
+.pf-c-select__menu-item.pf-m-load {
+    --pf-c-select__menu-item--Color: var(--pf-global--Color--100);
+}

--- a/src/Components/CreateImageWizard/ImageCreator.js
+++ b/src/Components/CreateImageWizard/ImageCreator.js
@@ -15,6 +15,7 @@ import Select from '@data-driven-forms/pf4-component-mapper/select';
 import FileSystemConfiguration from './formComponents/FileSystemConfiguration';
 import FileSystemConfigToggle from './formComponents/FileSystemConfigToggle';
 import ImageOutputReleaseSelect from './formComponents/ImageOutputReleaseSelect';
+import CentOSAcknowledgement from './formComponents/CentOSAcknowledgement';
 
 const ImageCreator = ({
   schema,
@@ -53,6 +54,7 @@ const ImageCreator = ({
         'file-system-config-toggle': FileSystemConfigToggle,
         'file-system-configuration': FileSystemConfiguration,
         'image-output-release-select': ImageOutputReleaseSelect,
+        'centos-acknowledgement': CentOSAcknowledgement,
         ...customComponentMapper,
       }}
       onCancel={onClose}

--- a/src/Components/CreateImageWizard/formComponents/CentOSAcknowledgement.js
+++ b/src/Components/CreateImageWizard/formComponents/CentOSAcknowledgement.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Alert, Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const DeveloperProgramButton = () => {
+  return (
+    <Button
+      component="a"
+      target="_blank"
+      variant="link"
+      icon={<ExternalLinkAltIcon />}
+      iconPosition="right"
+      isInline
+      href={'https://developers.redhat.com/about'}
+    >
+      Red Hat Developer Program
+    </Button>
+  );
+};
+
+const CentOSAcknowledgement = () => {
+  return (
+    <Alert
+      variant="info"
+      isPlain
+      isInline
+      title={
+        <>
+          CentOS Stream builds may only be used for the development of
+          RHEL-Next.
+        </>
+      }
+    >
+      <p>
+        For other applications, use a RHEL distribution.
+        <br />
+        For those without subscriptions, join the Red Hat Developer program and
+        get cost-free RHEL: <DeveloperProgramButton />
+      </p>
+    </Alert>
+  );
+};
+
+export default CentOSAcknowledgement;

--- a/src/Components/CreateImageWizard/formComponents/ImageOutputReleaseSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/ImageOutputReleaseSelect.js
@@ -15,6 +15,7 @@ const ImageOutputReleaseSelect = ({ label, isRequired, ...props }) => {
   const { change, getState } = useFormApi();
   const { input } = useFieldApi(props);
   const [isOpen, setIsOpen] = useState(false);
+  const [showDevelopmentOptions, setShowDevelopmentOptions] = useState(false);
 
   const setRelease = (_, selection) => {
     change(input.name, selection);
@@ -23,6 +24,11 @@ const ImageOutputReleaseSelect = ({ label, isRequired, ...props }) => {
 
   const handleClear = () => {
     change(input.name, null);
+    setShowDevelopmentOptions(false);
+  };
+
+  const handleExpand = () => {
+    setShowDevelopmentOptions(true);
   };
 
   return (
@@ -34,11 +40,18 @@ const ImageOutputReleaseSelect = ({ label, isRequired, ...props }) => {
         onClear={handleClear}
         selections={RELEASES[getState()?.values?.[input.name]]}
         isOpen={isOpen}
+        {...(insights.chrome.isBeta() &&
+          !showDevelopmentOptions && {
+            loadingVariant: {
+              text: 'Show options for further development of RHEL',
+              onClick: handleExpand,
+            },
+          })}
       >
         {Object.entries(RELEASES)
           .filter(([key]) => {
-            // Only show non-RHEL distros in beta
-            if (insights.chrome.isBeta()) {
+            // Only show non-RHEL distros if expanded
+            if (showDevelopmentOptions) {
               return true;
             }
 

--- a/src/Components/CreateImageWizard/steps/imageOutput.js
+++ b/src/Components/CreateImageWizard/steps/imageOutput.js
@@ -39,6 +39,14 @@ export default {
       ],
     },
     {
+      component: 'centos-acknowledgement',
+      name: 'centos-acknowledgement',
+      condition: {
+        when: 'release',
+        pattern: /centos-*/,
+      },
+    },
+    {
       component: 'output',
       name: 'target-environment',
       label: 'Select target environments',

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -242,7 +242,7 @@ describe('Step Image output', () => {
     expect(next).toBeDisabled();
   });
 
-  test('expected releases are present on beta', async () => {
+  test('expect only RHEL releases before expansion', async () => {
     setUp();
 
     const releaseMenu = screen.getByRole('button', {
@@ -256,11 +256,70 @@ describe('Step Image output', () => {
     await screen.findByRole('option', {
       name: 'Red Hat Enterprise Linux (RHEL) 9',
     });
+    await screen.findByRole('button', {
+      name: 'Show options for further development of RHEL',
+    });
+
+    userEvent.click(releaseMenu);
+  });
+
+  test('expect all releases after expansion', async () => {
+    setUp();
+
+    const releaseMenu = screen.getByRole('button', {
+      name: /options menu/i,
+    });
+    userEvent.click(releaseMenu);
+
+    const showOptionsButton = screen.getByRole('button', {
+      name: 'Show options for further development of RHEL',
+    });
+    userEvent.click(showOptionsButton);
+
+    await screen.findByRole('option', {
+      name: 'Red Hat Enterprise Linux (RHEL) 8',
+    });
+    await screen.findByRole('option', {
+      name: 'Red Hat Enterprise Linux (RHEL) 9',
+    });
     await screen.findByRole('option', {
       name: 'CentOS Stream 8',
     });
     await screen.findByRole('option', {
       name: 'CentOS Stream 9',
+    });
+
+    expect(showOptionsButton).not.toBeInTheDocument();
+
+    userEvent.click(releaseMenu);
+  });
+
+  test('clear button resets to initial state (unexpanded)', async () => {
+    setUp();
+
+    const releaseMenu = screen.getByRole('button', {
+      name: /options menu/i,
+    });
+    userEvent.click(releaseMenu);
+
+    const showOptionsButton = screen.getByRole('button', {
+      name: 'Show options for further development of RHEL',
+    });
+    userEvent.click(showOptionsButton);
+
+    const clearAllButton = screen.getByRole('button', {
+      name: /clear all/i,
+    });
+    userEvent.click(clearAllButton);
+
+    await screen.findByRole('option', {
+      name: 'Red Hat Enterprise Linux (RHEL) 8',
+    });
+    await screen.findByRole('option', {
+      name: 'Red Hat Enterprise Linux (RHEL) 9',
+    });
+    await screen.findByRole('button', {
+      name: 'Show options for further development of RHEL',
     });
 
     userEvent.click(releaseMenu);
@@ -1125,6 +1184,12 @@ describe('Step Review', () => {
       name: /options menu/i,
     });
     userEvent.click(releaseMenu);
+
+    const showOptionsButton = screen.getByRole('button', {
+      name: 'Show options for further development of RHEL',
+    });
+    userEvent.click(showOptionsButton);
+
     const centos = screen.getByRole('option', {
       name: 'CentOS Stream 8',
     });

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -324,6 +324,29 @@ describe('Step Image output', () => {
 
     userEvent.click(releaseMenu);
   });
+
+  test('CentOS acknowledgement appears', async () => {
+    setUp();
+
+    const releaseMenu = screen.getByRole('button', {
+      name: /options menu/i,
+    });
+    userEvent.click(releaseMenu);
+
+    const showOptionsButton = screen.getByRole('button', {
+      name: 'Show options for further development of RHEL',
+    });
+    userEvent.click(showOptionsButton);
+
+    const centOSButton = screen.getByRole('option', {
+      name: 'CentOS Stream 9',
+    });
+    userEvent.click(centOSButton);
+
+    await screen.findByText(
+      'CentOS Stream builds may only be used for the development of RHEL-Next.'
+    );
+  });
 });
 
 describe('Step Upload to AWS', () => {


### PR DESCRIPTION
Adds an info alert that reads `The CentOS Stream distribution is enabled for
community use and not eligible for Red Hat Support. To learn more, visit
CentOS Stream.` to the image output step when CentOS Stream 8 or CentOS
Stream 9 is selected as the release. This is necessary to ensure
customers understand the role CentOS plays with respect to RHEL.