### PR TITLE
ImagesTable: support additional image type labels

### DIFF
--- a/src/Components/ImagesTable/Target.js
+++ b/src/Components/ImagesTable/Target.js
@@ -28,7 +28,7 @@ const Target = ({ composeId }) => {
     target = targetOptions[compose.uploadType];
   }
 
-  return <>{target}</>;
+  return <>{target ? target : compose.imageType}</>;
 };
 
 Target.propTypes = {


### PR DESCRIPTION
The rhel-edge-commit and rhel-edge-installer image types had no target label. This is now added. Also, if other image types are created that do not have a descriptive label then default to using the image type.