### PR TITLE
.github: Rename sync-branches workflow ref check job

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   check:
-    name: Check source and target validity
+    name: Validate source and target refs
     timeout-minutes: 1
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
Make the name of the check job more like the name of the sync job.

---

very important patch, it just annoyed me suddenly .-.