### PR TITLE
CreateImageWizard: Add /tmp mountpoint

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/MountPoint.js
+++ b/src/Components/CreateImageWizard/formComponents/MountPoint.js
@@ -13,7 +13,7 @@ import path from 'path';
 
 const MountPoint = ({ ...props }) => {
     // check '/' last!
-    const validPrefixes = [ '/home', '/opt', '/srv', '/usr', '/usr/local', '/var', '/app', '/data', '/' ];
+    const validPrefixes = [ '/app', '/data', '/home', '/opt', '/srv', '/tmp', '/usr', '/usr/local', '/var', '/' ];
     const [ isOpen, setIsOpen ] = useState(false);
     const [ prefix, setPrefix ] = useState('/');
     const [ suffix, setSuffix ] = useState('');


### PR DESCRIPTION
/tmp was added to the list of valid mountpoints in the filesystem
customization step.

No validation is necessary at this time because rhel-86, centos-8, and
centos-9 all support a /tmp mountpoint.