### PR TITLE
devel/gen-dashboard: use python3 explicitly in the shebang

### DIFF
--- a/devel/gen-dashboards
+++ b/devel/gen-dashboards
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import argparse, sys, yaml
 
 TEMPLATE_DIR="../../image-builder/templates/dashboards/grafana-dashboard-insights-image-builder-general.configmap.yml"


### PR DESCRIPTION
So people don't have to install python-unversioned-command on Fedora. It saves you 11 kB of disk space, worth it. :P