### PR TITLE
ImagesTable: add option to download a raw compose request

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -128,6 +128,18 @@ const ImagesTable = () => {
           state: { composeRequest: compose.request, initialStep: 'review' },
         }),
     },
+    {
+      title: (
+        <a
+          href={`data:text/plain;charset=utf-8,${encodeURIComponent(
+            JSON.stringify(compose.request)
+          )}`}
+          download="request.json"
+        >
+          Download compose request (.json)
+        </a>
+      ),
+    },
   ];
 
   // the state.page is not an index so must be reduced by 1 get the starting index

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -448,6 +448,41 @@ describe('Images Table', () => {
     expect(history.location.state.initialStep).toBe('review');
   });
 
+  test('check download compose request action', () => {
+    renderWithReduxRouter(<ImagesTable />, store);
+
+    // get rows
+    const table = screen.getByTestId('images-table');
+    const { getAllByRole } = within(table);
+    const rows = getAllByRole('row');
+
+    // first row is header so look at index 1
+    const imageId = rows[1].cells[1].textContent;
+    const expectedRequest = store.composes.byId[imageId].request;
+
+    const actionsButton = within(rows[1]).getByRole('button', {
+      name: 'Actions',
+    });
+    userEvent.click(actionsButton);
+
+    const downloadButton = screen.getByRole('button', {
+      name: 'Download compose request (.json)',
+    });
+
+    // No actual clicking because downloading is hard to test.
+    // Instead, we just check href and download properties of the <a> element.
+    const downloadLink = within(downloadButton).getByRole('link');
+    expect(downloadLink.download).toBe('request.json');
+
+    const hrefParts = downloadLink.href.split(',');
+    expect(hrefParts.length).toBe(2);
+    const [header, encodedRequest] = hrefParts;
+    expect(header).toBe('data:text/plain;charset=utf-8');
+    expect(encodedRequest).toBe(
+      encodeURIComponent(JSON.stringify(expectedRequest))
+    );
+  });
+
   test('check expandable row toggle', () => {
     renderWithReduxRouter(<ImagesTable />, store);
 


### PR DESCRIPTION
In order to help people transition from using GUI to use the API directly,
it's helpful to give them an easy way to inspect the whole raw compose
request.

This commit adds a new button next to each compose that simply downloads
the original compose request in a json format. This request can then be
directly piped into the IB API to build a new image.

## Notes

Manipulation DOM directly when using React? Crazy, right? It works though but I'm open to suggestions.

## Demo
https://www.youtube.com/watch?v=pr-6evaue_4
(I failed to embed gif, sry.)

## Static picture
![image](https://user-images.githubusercontent.com/119861/182806879-58b6fac5-a102-4f04-ad5d-70af6166cc79.png)




Original idea by Troy Dawson