### PR TITLE
Wizard: Add clarification to AWS and GCP environment steps

### DIFF
--- a/src/Components/CreateImageWizard/steps/aws.js
+++ b/src/Components/CreateImageWizard/steps/aws.js
@@ -25,7 +25,8 @@ export default {
         <p>
           Your image will be uploaded to AWS and shared with the account you
           provide below. <br />
-          The image should be copied to your account within 14 days.
+          The shared image will expire within 14 days. To keep the image longer,
+          copy it to your AWS account.
         </p>
       ),
     },

--- a/src/Components/CreateImageWizard/steps/googleCloud.js
+++ b/src/Components/CreateImageWizard/steps/googleCloud.js
@@ -98,8 +98,9 @@ export default {
       label: (
         <Text>
           Your image will be uploaded to Google Cloud Platform and shared with
-          the email you provide below. <br />
-          The image should be copied to your account within 14 days.
+          the account you provide below. <br />
+          The shared image will expire within 14 days. To keep the image longer,
+          copy it to your Google Cloud Platform account.
         </Text>
       ),
     },


### PR DESCRIPTION
Fixes #770. This clarifies that the user is responsible for copying the AWS/GCP image to their account before the image expires.