### PR TITLE
Wizard: Improve file system configuration error messaging

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfigButtons.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfigButtons.js
@@ -1,0 +1,59 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import { Button } from '@patternfly/react-core';
+import WizardContext from '@data-driven-forms/react-form-renderer/wizard-context';
+import PropTypes from 'prop-types';
+
+const FileSystemConfigButtons = ({ nextStep }) => {
+  const { handleNext, handlePrev, formOptions } = useContext(WizardContext);
+  const { change, getState } = useFormApi();
+  const [hasErrors, setHasErrors] = useState(
+    getState()?.errors?.['file-system-configuration'] ? true : false
+  );
+  const [nextHasBeenClicked, setNextHasBeenClicked] = useState(false);
+
+  useEffect(() => {
+    const errors = getState()?.errors?.['file-system-configuration'];
+    errors ? setHasErrors(true) : setHasErrors(false);
+
+    if (!errors) {
+      setNextHasBeenClicked(false);
+      change('file-system-config-show-errors', false);
+    }
+  });
+
+  const handleClick = () => {
+    if (!hasErrors) {
+      return handleNext(nextStep);
+    }
+
+    setNextHasBeenClicked(true);
+    change('file-system-config-show-errors', true);
+  };
+
+  return (
+    <>
+      <Button
+        variant="primary"
+        isDisabled={hasErrors && nextHasBeenClicked}
+        onClick={handleClick}
+      >
+        Next
+      </Button>
+      <Button variant="secondary" onClick={handlePrev}>
+        Back
+      </Button>
+      <div className="pf-c-wizard__footer-cancel">
+        <Button type="button" variant="link" onClick={formOptions.onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </>
+  );
+};
+
+FileSystemConfigButtons.propTypes = {
+  nextStep: PropTypes.string,
+};
+
+export default FileSystemConfigButtons;

--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -25,6 +25,7 @@ import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import { v4 as uuidv4 } from 'uuid';
 
+import { FormSpy } from '@data-driven-forms/react-form-renderer';
 import MountPoint from './MountPoint';
 import SizeUnit from './SizeUnit';
 import { UNIT_GIB } from '../../../constants';
@@ -70,6 +71,9 @@ const FileSystemConfiguration = ({ ...props }) => {
     setRows(newRows);
     setItemOrder(newOrder);
   }, []);
+
+  const showErrors = () =>
+    getState()?.values?.['file-system-config-show-errors'];
 
   useEffect(() => {
     change(
@@ -238,143 +242,154 @@ const FileSystemConfiguration = ({ ...props }) => {
   };
 
   return (
-    <>
-      <TextContent>
-        <Text component={TextVariants.h3}>Configure partitions</Text>
-      </TextContent>
-      {rows.length > 1 &&
-        getState()?.errors?.['file-system-configuration']?.duplicates && (
-          <Alert
-            variant="danger"
-            isInline
-            title="Duplicate mount points: All mount points must be unique. Remove the duplicate or choose a new mount point."
-          />
-        )}
-      {rows.length >= 1 &&
-        getState()?.errors?.['file-system-configuration']?.root === false && (
-          <Alert
-            variant="danger"
-            isInline
-            title="No root partition configured."
-          />
-        )}
-      <TextContent>
-        <Text>
-          Partitions have been generated and given default values based on best
-          practices from Red Hat, and your selections in previous steps of the
-          wizard.
-        </Text>
-      </TextContent>
-      <TableComposable
-        aria-label="File system table"
-        className={isDragging && styles.modifiers.dragOver}
-        variant="compact"
-      >
-        <Thead>
-          <Tr>
-            <Th />
-            <Th>Mount point</Th>
-            <Th>Type</Th>
-            <Th>
-              Minimum size
-              <Popover
-                hasAutoWidth
-                bodyContent={
-                  <TextContent>
-                    <Text>
-                      Image Builder may extend this size based on requirements,
-                      selected packages, and configurations.
-                    </Text>
-                  </TextContent>
-                }
-              >
-                <Button
-                  variant="plain"
-                  aria-label="File system configuration info"
-                  aria-describedby="file-system-configuration-info"
-                  className="pf-c-form__group-label-help"
-                >
-                  <HelpIcon />
-                </Button>
-              </Popover>
-            </Th>
-            <Th />
-          </Tr>
-        </Thead>
-        <Tbody
-          ref={bodyref}
-          onDragOver={onDragOver}
-          onDrop={onDragOver}
-          onDragLeave={onDragLeave}
-          data-testid="file-system-configuration-tbody"
-        >
-          {rows.map((row, rowIndex) => (
-            <Tr
-              key={rowIndex}
-              id={row.id}
-              draggable
-              onDrop={onDrop}
-              onDragEnd={onDragEnd}
-              onDragStart={onDragStart}
-            >
-              <Td
-                draggableRow={{
-                  id: `draggable-row-${row.id}`,
-                }}
+    <FormSpy>
+      {() => (
+        <>
+          <TextContent>
+            <Text component={TextVariants.h3}>Configure partitions</Text>
+          </TextContent>
+          {rows.length > 1 &&
+            getState()?.errors?.['file-system-configuration']?.duplicates
+              ?.length !== 0 &&
+            showErrors() && (
+              <Alert
+                variant="danger"
+                isInline
+                title="Duplicate mount points: All mount points must be unique. Remove the duplicate or choose a new mount point."
+                data-testid="fsc-warning"
               />
-              <Td className="pf-m-width-30">
-                <MountPoint
-                  key={row.id + '-mountpoint'}
-                  mountpoint={row.mountpoint}
-                  onChange={(mp) => setMountpoint(row.id, mp)}
-                />
-                {getState().errors['file-system-configuration']?.duplicates &&
-                  getState().errors[
-                    'file-system-configuration'
-                  ]?.duplicates.indexOf(row.mountpoint) !== -1 && (
-                    <Alert
-                      variant="danger"
-                      isInline
-                      isPlain
-                      title="Duplicate mount point."
+            )}
+          {rows.length >= 1 &&
+            getState()?.errors?.['file-system-configuration']?.root === false &&
+            showErrors() && (
+              <Alert
+                variant="danger"
+                isInline
+                title="No root partition configured."
+              />
+            )}
+          <TextContent>
+            <Text>
+              Partitions have been generated and given default values based on
+              best practices from Red Hat, and your selections in previous steps
+              of the wizard.
+            </Text>
+          </TextContent>
+          <TableComposable
+            aria-label="File system table"
+            className={isDragging && styles.modifiers.dragOver}
+            variant="compact"
+          >
+            <Thead>
+              <Tr>
+                <Th />
+                <Th>Mount point</Th>
+                <Th>Type</Th>
+                <Th>
+                  Minimum size
+                  <Popover
+                    hasAutoWidth
+                    bodyContent={
+                      <TextContent>
+                        <Text>
+                          Image Builder may extend this size based on
+                          requirements, selected packages, and configurations.
+                        </Text>
+                      </TextContent>
+                    }
+                  >
+                    <Button
+                      variant="plain"
+                      aria-label="File system configuration info"
+                      aria-describedby="file-system-configuration-info"
+                      className="pf-c-form__group-label-help"
+                    >
+                      <HelpIcon />
+                    </Button>
+                  </Popover>
+                </Th>
+                <Th />
+              </Tr>
+            </Thead>
+            <Tbody
+              ref={bodyref}
+              onDragOver={onDragOver}
+              onDrop={onDragOver}
+              onDragLeave={onDragLeave}
+              data-testid="file-system-configuration-tbody"
+            >
+              {rows.map((row, rowIndex) => (
+                <Tr
+                  key={rowIndex}
+                  id={row.id}
+                  draggable
+                  onDrop={onDrop}
+                  onDragEnd={onDragEnd}
+                  onDragStart={onDragStart}
+                >
+                  <Td
+                    draggableRow={{
+                      id: `draggable-row-${row.id}`,
+                    }}
+                  />
+                  <Td className="pf-m-width-30">
+                    <MountPoint
+                      key={row.id + '-mountpoint'}
+                      mountpoint={row.mountpoint}
+                      onChange={(mp) => setMountpoint(row.id, mp)}
                     />
-                  )}
-              </Td>
-              <Td className="pf-m-width-20">
-                {/* always xfs */}
-                {row.fstype}
-              </Td>
-              <Td className="pf-m-width-30">
-                <SizeUnit
-                  key={row.id + '-sizeunit'}
-                  size={row.size}
-                  unit={row.unit}
-                  onChange={(s, u) => setSize(row.id, s, u)}
-                />
-              </Td>
-              <Td className="pf-m-width-10">
-                <Button
-                  variant="link"
-                  icon={<MinusCircleIcon />}
-                  onClick={() => removeRow(row.id)}
-                />
-              </Td>
-            </Tr>
-          ))}
-        </Tbody>
-      </TableComposable>
-      <TextContent>
-        <Button
-          data-testid="file-system-add-partition"
-          className="pf-u-text-align-left"
-          variant="link"
-          icon={<PlusCircleIcon />}
-          onClick={addRow}
-        >
-          Add partition
-        </Button>
-      </TextContent>
-    </>
+                    {getState().errors['file-system-configuration']?.duplicates
+                      .length !== 0 &&
+                      getState().errors[
+                        'file-system-configuration'
+                      ]?.duplicates.indexOf(row.mountpoint) !== -1 &&
+                      showErrors() && (
+                        <Alert
+                          variant="danger"
+                          isInline
+                          isPlain
+                          title="Duplicate mount point."
+                        />
+                      )}
+                  </Td>
+                  <Td className="pf-m-width-20">
+                    {/* always xfs */}
+                    {row.fstype}
+                  </Td>
+                  <Td className="pf-m-width-30">
+                    <SizeUnit
+                      key={row.id + '-sizeunit'}
+                      size={row.size}
+                      unit={row.unit}
+                      onChange={(s, u) => setSize(row.id, s, u)}
+                    />
+                  </Td>
+                  <Td className="pf-m-width-10">
+                    <Button
+                      variant="link"
+                      icon={<MinusCircleIcon />}
+                      onClick={() => removeRow(row.id)}
+                      data-testid="remove-mount-point"
+                    />
+                  </Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+          <TextContent>
+            <Button
+              data-testid="file-system-add-partition"
+              className="pf-u-text-align-left"
+              variant="link"
+              icon={<PlusCircleIcon />}
+              onClick={addRow}
+            >
+              Add partition
+            </Button>
+          </TextContent>
+        </>
+      )}
+    </FormSpy>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
@@ -2,14 +2,15 @@ import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
 import { Text } from '@patternfly/react-core';
-
 import StepTemplate from './stepTemplate';
+import FileSystemConfigButtons from '../formComponents/FileSystemConfigButtons';
 
 export default {
   StepTemplate,
   id: 'wizard-systemconfiguration-filesystem',
   title: 'File system configuration',
   name: 'File system configuration',
+  buttons: FileSystemConfigButtons,
   substepOf: 'System configuration',
   nextStep: 'packages',
   fields: [

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -17,13 +17,19 @@ import { RHEL_8 } from '../../../constants.js';
 let history = undefined;
 let store = undefined;
 
-function verifyButtons() {
-  // these buttons exist everywhere
-  const next = screen.getByRole('button', { name: /Next/ });
+function getBackButton() {
   const back = screen.getByRole('button', { name: /Back/ });
-  const cancel = screen.getByRole('button', { name: /Cancel/ });
+  return back;
+}
 
-  return [next, back, cancel];
+function getNextButton() {
+  const next = screen.getByRole('button', { name: /Next/ });
+  return next;
+}
+
+function getCancelButton() {
+  const cancel = screen.getByRole('button', { name: /Cancel/ });
+  return cancel;
 }
 
 function verifyCancelButton(cancel, history) {
@@ -200,8 +206,7 @@ describe('Step Image output', () => {
   test('clicking Next loads Upload to AWS', () => {
     setUp();
 
-    const [next, ,] = verifyButtons();
-    next.click();
+    getNextButton().click();
 
     screen.getByText('AWS account ID');
   });
@@ -209,7 +214,7 @@ describe('Step Image output', () => {
   test('clicking Cancel loads landing page', () => {
     setUp();
 
-    const [, , cancel] = verifyButtons();
+    const cancel = getCancelButton();
     verifyCancelButton(cancel, history);
   });
 
@@ -225,8 +230,6 @@ describe('Step Image output', () => {
   test('selecting and deselecting a tile disables the next button', () => {
     setUp();
 
-    const [next, ,] = verifyButtons();
-
     const awsTile = screen.getByTestId('upload-aws');
     // this has already been clicked once in the setup function
     awsTile.click(); // deselect
@@ -239,7 +242,7 @@ describe('Step Image output', () => {
     azureTile.click(); // select
     azureTile.click(); // deselect
 
-    expect(next).toBeDisabled();
+    expect(getNextButton()).toBeDisabled();
   });
 
   test('expect only RHEL releases before expansion', async () => {
@@ -352,13 +355,12 @@ describe('Step Image output', () => {
 describe('Step Upload to AWS', () => {
   const setUp = () => {
     history = renderWithReduxRouter(<CreateImageWizard />).history;
-    const [next, ,] = verifyButtons();
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
     awsTile.click();
 
-    next.click();
+    getNextButton().click();
 
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Target environment - Amazon Web Service'
@@ -369,8 +371,7 @@ describe('Step Upload to AWS', () => {
     setUp();
 
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
-    const [next, ,] = verifyButtons();
-    next.click();
+    getNextButton().click();
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -382,8 +383,7 @@ describe('Step Upload to AWS', () => {
   test('clicking Back loads Release', () => {
     setUp();
 
-    const [, back] = verifyButtons();
-    back.click();
+    getBackButton().click();
 
     screen.getByTestId('upload-aws');
   });
@@ -391,7 +391,7 @@ describe('Step Upload to AWS', () => {
   test('clicking Cancel loads landing page', () => {
     setUp();
 
-    const [, , cancel] = verifyButtons();
+    const cancel = getCancelButton();
     verifyCancelButton(cancel, history);
   });
 
@@ -408,13 +408,12 @@ describe('Step Upload to AWS', () => {
 describe('Step Upload to Google', () => {
   const setUp = () => {
     history = renderWithReduxRouter(<CreateImageWizard />).history;
-    const [next, ,] = verifyButtons();
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-google');
     awsTile.click();
 
-    next.click();
+    getNextButton().click();
 
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Target environment - Google Cloud Platform'
@@ -425,8 +424,7 @@ describe('Step Upload to Google', () => {
     setUp();
 
     userEvent.type(screen.getByTestId('input-google-email'), 'test@test.com');
-    const [next, ,] = verifyButtons();
-    next.click();
+    getNextButton().click();
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -438,8 +436,7 @@ describe('Step Upload to Google', () => {
   test('clicking Back loads Release', () => {
     setUp();
 
-    const [, back] = verifyButtons();
-    back.click();
+    getBackButton().click();
 
     screen.getByTestId('upload-google');
   });
@@ -447,7 +444,7 @@ describe('Step Upload to Google', () => {
   test('clicking Cancel loads landing page', () => {
     setUp();
 
-    const [, , cancel] = verifyButtons();
+    const cancel = getCancelButton();
     verifyCancelButton(cancel, history);
   });
 
@@ -463,25 +460,23 @@ describe('Step Upload to Google', () => {
   test('the google email field must be a valid email', () => {
     setUp();
 
-    const [next, ,] = verifyButtons();
     userEvent.type(screen.getByTestId('input-google-email'), 'a');
-    expect(next).toHaveClass('pf-m-disabled');
-    expect(next).toBeDisabled();
+    expect(getNextButton()).toHaveClass('pf-m-disabled');
+    expect(getNextButton()).toBeDisabled();
     userEvent.type(screen.getByTestId('input-google-email'), 'test@test.com');
-    expect(next).not.toHaveClass('pf-m-disabled');
-    expect(next).toBeEnabled();
+    expect(getNextButton()).not.toHaveClass('pf-m-disabled');
+    expect(getNextButton()).toBeEnabled();
   });
 });
 
 describe('Step Upload to Azure', () => {
   const setUp = () => {
     history = renderWithReduxRouter(<CreateImageWizard />).history;
-    const [next, ,] = verifyButtons();
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-azure');
     awsTile.click();
-    next.click();
+    getNextButton().click();
 
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Target environment - Microsoft Azure'
@@ -504,8 +499,7 @@ describe('Step Upload to Azure', () => {
       'testResourceGroup'
     );
 
-    const [next, ,] = verifyButtons();
-    next.click();
+    getNextButton().click();
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -517,8 +511,7 @@ describe('Step Upload to Azure', () => {
   test('clicking Back loads Release', () => {
     setUp();
 
-    const [, back] = verifyButtons();
-    back.click();
+    getBackButton().click();
 
     screen.getByTestId('upload-azure');
   });
@@ -526,7 +519,7 @@ describe('Step Upload to Azure', () => {
   test('clicking Cancel loads landing page', () => {
     setUp();
 
-    const [, , cancel] = verifyButtons();
+    const cancel = getCancelButton();
     verifyCancelButton(cancel, history);
   });
 
@@ -553,16 +546,15 @@ describe('Step Upload to Azure', () => {
 describe('Step Registration', () => {
   const setUp = async () => {
     history = renderWithReduxRouter(<CreateImageWizard />).history;
-    const [next, ,] = verifyButtons();
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
     awsTile.click();
 
-    next.click();
+    getNextButton().click();
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
 
-    next.click();
+    getNextButton().click();
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -575,8 +567,7 @@ describe('Step Registration', () => {
     const registerLaterRadio = screen.getByLabelText('Register later');
     userEvent.click(registerLaterRadio);
 
-    const [next, ,] = verifyButtons();
-    next.click();
+    getNextButton().click();
 
     screen.getByTestId('fsc-paritioning-toggle');
   });
@@ -584,8 +575,7 @@ describe('Step Registration', () => {
   test('clicking Back loads Upload to AWS', async () => {
     await setUp();
 
-    const [, back] = verifyButtons();
-    back.click();
+    getBackButton().click();
 
     screen.getByText('AWS account ID');
   });
@@ -593,7 +583,7 @@ describe('Step Registration', () => {
   test('clicking Cancel loads landing page', async () => {
     await setUp();
 
-    const [, , cancel] = verifyButtons();
+    const cancel = getCancelButton();
     verifyCancelButton(cancel, history);
   });
 
@@ -682,16 +672,15 @@ describe('Step Registration', () => {
 describe('Step Packages', () => {
   const setUp = async () => {
     history = renderWithReduxRouter(<CreateImageWizard />).history;
-    const [next, ,] = verifyButtons();
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
     awsTile.click();
-    next.click();
+    getNextButton().click();
 
     // aws step
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
-    next.click();
+    getNextButton().click();
     // skip registration
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -699,17 +688,16 @@ describe('Step Packages', () => {
 
     const registerLaterRadio = screen.getByLabelText('Register later');
     userEvent.click(registerLaterRadio);
-    next.click();
+    getNextButton().click();
 
     // skip fsc
-    next.click();
+    getNextButton().click();
   };
 
   test('clicking Next loads Image name', async () => {
     await setUp();
 
-    const [next, ,] = verifyButtons();
-    next.click();
+    getNextButton().click();
 
     screen.getByRole('heading', {
       name: 'Name image',
@@ -728,7 +716,7 @@ describe('Step Packages', () => {
   test('clicking Cancel loads landing page', async () => {
     await setUp();
 
-    const [, , cancel] = verifyButtons();
+    const cancel = getCancelButton();
     verifyCancelButton(cancel, history);
   });
 
@@ -1119,16 +1107,15 @@ describe('Step Packages', () => {
 describe('Step Details', () => {
   const setUp = async () => {
     history = renderWithReduxRouter(<CreateImageWizard />).history;
-    const [next, ,] = verifyButtons();
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
     awsTile.click();
-    next.click();
+    getNextButton().click();
 
     // aws step
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
-    next.click();
+    getNextButton().click();
     // skip registration
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -1136,18 +1123,16 @@ describe('Step Details', () => {
 
     const registerLaterRadio = screen.getByLabelText('Register later');
     userEvent.click(registerLaterRadio);
-    next.click();
+    getNextButton().click();
 
     // skip fsc
-    next.click();
+    getNextButton().click();
     // skip packages
-    next.click();
+    getNextButton().click();
   };
 
   test('image name invalid for more than 100 chars', async () => {
     await setUp();
-
-    const [next, ,] = verifyButtons();
 
     // Enter image name
     const nameInput = screen.getByRole('textbox', {
@@ -1156,28 +1141,27 @@ describe('Step Details', () => {
     // 101 character name
     const invalidName = 'a'.repeat(101);
     userEvent.type(nameInput, invalidName);
-    expect(next).toHaveClass('pf-m-disabled');
-    expect(next).toBeDisabled();
+    expect(getNextButton()).toHaveClass('pf-m-disabled');
+    expect(getNextButton()).toBeDisabled();
     userEvent.clear(nameInput);
     userEvent.type(nameInput, 'validName');
-    expect(next).not.toHaveClass('pf-m-disabled');
-    expect(next).toBeEnabled();
+    expect(getNextButton()).not.toHaveClass('pf-m-disabled');
+    expect(getNextButton()).toBeEnabled();
   });
 });
 
 describe('Step Review', () => {
   const setUp = async () => {
     history = renderWithReduxRouter(<CreateImageWizard />).history;
-    const [next, ,] = verifyButtons();
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
     awsTile.click();
-    next.click();
+    getNextButton().click();
 
     // aws step
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
-    next.click();
+    getNextButton().click();
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -1186,22 +1170,20 @@ describe('Step Review', () => {
     // skip registration
     const registerLaterRadio = screen.getByLabelText('Register later');
     userEvent.click(registerLaterRadio);
-    next.click();
+    getNextButton().click();
 
     // skip fsc
-    next.click();
+    getNextButton().click();
 
     // skip packages
-    next.click();
+    getNextButton().click();
     // skip name
-    next.click();
+    getNextButton().click();
   };
 
   // eslint-disable-next-line no-unused-vars
   const setUpCentOS = () => {
     history = renderWithReduxRouter(<CreateImageWizard />).history;
-
-    const [next, ,] = verifyButtons();
 
     const releaseMenu = screen.getByRole('button', {
       name: /options menu/i,
@@ -1221,19 +1203,19 @@ describe('Step Review', () => {
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
     awsTile.click();
-    next.click();
+    getNextButton().click();
 
     // aws step
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
-    next.click();
+    getNextButton().click();
 
     // skip fsc
-    next.click();
+    getNextButton().click();
 
     // skip packages
-    next.click();
+    getNextButton().click();
     // skip name
-    next.click();
+    getNextButton().click();
   };
 
   test('has 3 buttons', async () => {
@@ -1349,8 +1331,6 @@ describe('Click through all steps', () => {
   test('with valid values', async () => {
     await setUp();
 
-    const next = screen.getByRole('button', { name: /Next/ });
-
     // select image output
     const releaseMenu = screen.getByRole('button', {
       name: /options menu/i,
@@ -1414,7 +1394,7 @@ describe('Click through all steps', () => {
     userEvent.click(activationKey);
     screen.getByDisplayValue('name0');
 
-    next.click();
+    getNextButton().click();
 
     // fsc
     const toggle = await screen.findByTestId(
@@ -1427,6 +1407,7 @@ describe('Click through all steps', () => {
     const tbody = screen.getByTestId('file-system-configuration-tbody');
     const rows = within(tbody).getAllByRole('row');
     expect(rows).toHaveLength(3);
+    getNextButton().click();
     // set mountpoint of final row to /var/tmp
     within(rows[2]).getAllByRole('button', { name: 'Options menu' })[0].click();
     within(rows[2]).getByRole('option', { name: '/var' }).click();
@@ -1449,7 +1430,7 @@ describe('Click through all steps', () => {
     );
     within(rows[2]).getAllByRole('button', { name: 'Options menu' })[1].click();
     within(rows[2]).getByRole('option', { name: 'MiB' }).click();
-    next.click();
+    getNextButton().click();
 
     // packages
     const getPackages = jest
@@ -1468,14 +1449,14 @@ describe('Click through all steps', () => {
       .getByRole('option', { name: /testPkg test package summary/ })
       .click();
     screen.getByRole('button', { name: /Add selected/ }).click();
-    next.click();
+    getNextButton().click();
 
     // Enter image name
     const nameInput = screen.getByRole('textbox', {
       name: 'Image name',
     });
     userEvent.type(nameInput, 'MyImageName');
-    next.click();
+    getNextButton().click();
 
     // review
     await screen.findByText(


### PR DESCRIPTION
This commit improves the file system configuration step's error handling
by performing validation only when the next button is clicked. This
allows an invalid state to temporarily exist while the user is modifying
the mountpoints without bothersome error messages needlessly appearing.

Broadly speaking there were two options for the implementation: (1)
delay the validation, performing validation only upon clicking the next
button -or- (2) perform validation immediately as normal but hide error
messages until the next button is clicked. Option (1) proved to be
untenable - Data Driven Forms does provide `pauseValidation()` and
`resumeValidation()` functions from React Final Form which theoretically
would make this option possible... However, we need to call
`resumeValidation()` in the next button's click handler and then
immediately make a decision based on the validation results either to
remain on the step and display the errors or move to the next step.
When we tried implmenting this we found that `resumeValidation()` does
not immediately peform validation - validation only resumes after
exiting the handler. Therefore, this approach was not considered and
option (2) was used.

In order to gain control over the behavior of the next button, custom
buttons are implemented for this step. Sharing state between the custom
buttons and the form was a challenge. With pure React it would have been
as simple as moving the relevant state to the parent component, but that
was not possible due to Data Driven Forms. Instead, state is shared
using the form state. A new property,
`'file-system-config-show-errors'`, in the form state is used to
determine whether or not error messages should be displayed.

In order to cause a re-render upon a change in
`'file-system-config-show-errors'`, the file system configuration
component is wrapped in a `<FormSpy>` component.