### PR TITLE
ImagesTable: Add pagination to the bottom of the table

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -19,6 +19,7 @@ import {
   EmptyStateBody,
   EmptyStateSecondaryActions,
   Pagination,
+  PaginationVariant,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -193,8 +194,8 @@ const ImagesTable = () => {
                   page={page}
                   onSetPage={onSetPage}
                   onPerPageSelect={onPerPageSelect}
-                  widgetId="compose-pagination"
-                  data-testid="images-pagination"
+                  widgetId="compose-pagination-top"
+                  data-testid="images-pagination-top"
                   isCompact
                 />
               </ToolbarItem>
@@ -286,6 +287,26 @@ const ImagesTable = () => {
                 );
               })}
           </TableComposable>
+          <Toolbar>
+            <ToolbarContent>
+              <ToolbarItem
+                variant="pagination"
+                align={{ default: 'alignRight' }}
+              >
+                <Pagination
+                  variant={PaginationVariant.bottom}
+                  itemCount={composes.count}
+                  perPage={perPage}
+                  page={page}
+                  onSetPage={onSetPage}
+                  onPerPageSelect={onPerPageSelect}
+                  widgetId="compose-pagination-bottom"
+                  data-testid="images-pagination-bottom"
+                  isCompact
+                />
+              </ToolbarItem>
+            </ToolbarContent>
+          </Toolbar>
         </React.Fragment>
       )}
     </React.Fragment>

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -537,6 +537,7 @@ describe('Images Table Toolbar', () => {
     screen.getByTestId('create-image-action');
 
     // check pagination renders
-    screen.getByTestId('images-pagination');
+    screen.getByTestId('images-pagination-top');
+    screen.getByTestId('images-pagination-bottom');
   });
 });


### PR DESCRIPTION
Fixes #594. This adds pagination to the bottom of the images list so the user doesn't have to scroll up to use it.

Tests were also updated to reflect the change.