### PR TITLE
ImagesTable: Increase font size of text in Status column

### DIFF
--- a/src/Components/ImagesTable/ImageBuildStatus.js
+++ b/src/Components/ImagesTable/ImageBuildStatus.js
@@ -63,7 +63,7 @@ const ImageBuildStatus = (props) => {
         messages[props.status].map((message, key) => (
           <Flex key={key} className="pf-u-align-items-baseline pf-m-nowrap">
             <div className="pf-u-mr-sm">{message.icon}</div>
-            <small>{message.text}</small>
+            {message.text}
           </Flex>
         ))}
     </React.Fragment>


### PR DESCRIPTION
Fixes #808. This removes the `<small>` tag around status message to unify the font size within the table.