### PR TITLE
ImagesTable: Increase bottom margin of the pagination toolbar

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -291,7 +291,7 @@ const ImagesTable = () => {
                 );
               })}
           </TableComposable>
-          <Toolbar>
+          <Toolbar className="pf-u-mb-xl">
             <ToolbarContent>
               <ToolbarItem
                 variant="pagination"


### PR DESCRIPTION
Fixes #797. This increases the size of the margin at the bottom of the table of images. That way the pagination controls are not obscured by the notifications icon.