### PR TITLE
App: explicitly pass the store to the NotificationsPortal

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,16 @@
 import React, { useEffect } from 'react';
+import { useStore } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import '@patternfly/patternfly/patternfly-addons.css';
-
-import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
+
 import { Router } from './Router';
 
 const App = (props) => {
   const navigate = useNavigate();
+  const store = useStore();
 
   useEffect(() => {
-    const registry = getRegistry();
-    registry.register({ notifications: notificationsReducer });
     document.title = 'Image Builder | Red Hat Insights';
     insights.chrome.init();
     insights.chrome.identifyApp('image-builder');
@@ -26,7 +24,7 @@ const App = (props) => {
 
   return (
     <React.Fragment>
-      <NotificationsPortal />
+      <NotificationsPortal store={store} />
       <Router childProps={props} />
     </React.Fragment>
   );


### PR DESCRIPTION
Because of mismatched redux versions between NotificationPortal and our app, the former couldn't automatically discover the store.

Also drop reregister of notificationsReducer, we already register it in store.