### PR TITLE
ImagesTable: Indicate expiration of aws.s3 targets

### DIFF
--- a/src/Components/ImagesTable/ImageBuildStatus.js
+++ b/src/Components/ImagesTable/ImageBuildStatus.js
@@ -5,7 +5,9 @@ import { Flex } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
+  ExclamationTriangleIcon,
   InProgressIcon,
+  OffIcon,
   PendingIcon,
 } from '@patternfly/react-icons';
 
@@ -56,6 +58,20 @@ const ImageBuildStatus = (props) => {
         text: 'Cloud registration in progress',
       },
     ],
+    expiring: [
+      {
+        icon: <ExclamationTriangleIcon className="expiring" />,
+        text: `Expires in ${props.remainingHours} ${
+          props.remainingHours > 1 ? 'hours' : 'hour'
+        }`,
+      },
+    ],
+    expired: [
+      {
+        icon: <OffIcon />,
+        text: 'Expired',
+      },
+    ],
   };
   return (
     <React.Fragment>
@@ -72,6 +88,7 @@ const ImageBuildStatus = (props) => {
 
 ImageBuildStatus.propTypes = {
   status: PropTypes.string,
+  remainingHours: PropTypes.number,
 };
 
 export default ImageBuildStatus;

--- a/src/Components/ImagesTable/ImageBuildStatus.scss
+++ b/src/Components/ImagesTable/ImageBuildStatus.scss
@@ -7,3 +7,6 @@
 .pending {
   color: var(--pf-global--info-color--100);
 }
+.expiring {
+  color: var(--pf-global--warning-color--100);
+}

--- a/src/Components/ImagesTable/ImageLinkDirect.js
+++ b/src/Components/ImagesTable/ImageLinkDirect.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
 
 import {
   Button,
@@ -9,8 +10,10 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { DownloadIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { resolveRelPath } from '../../Utilities/path';
 
 const ImageLinkDirect = (props) => {
+  const navigate = useNavigate();
   const fileExtensions = {
     vsphere: '.vmdk',
     'guest-image': '.qcow2',
@@ -101,19 +104,40 @@ const ImageLinkDirect = (props) => {
         </Popover>
       );
     } else if (uploadStatus.type === 'aws.s3') {
-      return (
-        <Button
-          component="a"
-          target="_blank"
-          variant="link"
-          icon={<DownloadIcon />}
-          iconPosition="right"
-          isInline
-          href={uploadStatus.options.url}
-        >
-          Download {fileExtensions[props.imageType]}
-        </Button>
-      );
+      if (!props.isExpired) {
+        return (
+          <Button
+            component="a"
+            target="_blank"
+            variant="link"
+            icon={<DownloadIcon />}
+            iconPosition="right"
+            isInline
+            href={uploadStatus.options.url}
+          >
+            Download {fileExtensions[props.imageType]}
+          </Button>
+        );
+      } else {
+        return (
+          <Button
+            component="a"
+            target="_blank"
+            variant="link"
+            onClick={() =>
+              navigate(resolveRelPath('/imagewizard'), {
+                state: {
+                  composeRequest: props.recreateImage,
+                  initialStep: 'review',
+                },
+              })
+            }
+            isInline
+          >
+            Recreate image
+          </Button>
+        );
+      }
     }
   }
 
@@ -123,6 +147,8 @@ const ImageLinkDirect = (props) => {
 ImageLinkDirect.propTypes = {
   imageStatus: PropTypes.object,
   imageType: PropTypes.string,
+  isExpired: PropTypes.bool,
+  recreateImage: PropTypes.object,
   uploadOptions: PropTypes.object,
 };
 


### PR DESCRIPTION
This adds indication of expiring presigned urls for aws.s3 targets. Previously the targets remained marked as `Ready` until the builds disappeared after 14 days.

When an image is ready, the countdown in hours is shown in `Status` column. After that the image is marked as `Expired` and the download link changes to `Recreate image`.