### PR TITLE
src/Router: use release as a basename in BrowserRouter

### DIFF
--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
+
+import { getBaseName } from './Utilities/path';
 import App from './App';
 import { store } from './store';
 

--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -25,6 +25,7 @@ import './CreateImageWizard.scss';
 import api from '../../api';
 import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../constants';
 import isRhel from '../../Utilities/isRhel';
+import { resolveRelPath } from '../../Utilities/path';
 
 const handleKeyDown = (e, handleClose) => {
   if (e.key === 'Escape') {
@@ -415,7 +416,7 @@ const CreateImageWizard = () => {
   const initialState = requestToState(composeRequest);
   const stepHistory = formStepHistory(composeRequest);
 
-  const handleClose = () => navigate('/');
+  const handleClose = () => navigate(resolveRelPath(''));
 
   return (
     <ImageCreator
@@ -440,7 +441,7 @@ const CreateImageWizard = () => {
           )
         )
           .then(() => {
-            navigate('/');
+            navigate(resolveRelPath(''));
             dispatch(
               addNotification({
                 variant: 'success',

--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -34,6 +34,7 @@ import ImageLink from './ImageLink';
 import ErrorDetails from './ImageBuildErrorDetails';
 import DocumentationButton from '../sharedComponents/DocumentationButton';
 import { fetchComposes, fetchComposeStatus } from '../../store/actions/actions';
+import { resolveRelPath } from '../../Utilities/path';
 
 const ImagesTable = () => {
   const [page, setPage] = useState(1);
@@ -129,7 +130,7 @@ const ImagesTable = () => {
     {
       title: 'Recreate image',
       onClick: () =>
-        navigate('/imagewizard', {
+        navigate(resolveRelPath('imagewizard'), {
           state: { composeRequest: compose.request, initialStep: 'review' },
         }),
     },
@@ -165,7 +166,7 @@ const ImagesTable = () => {
             set and an activation key to automate the registration process.
           </EmptyStateBody>
           <Link
-            to="/imagewizard"
+            to={resolveRelPath('imagewizard')}
             className="pf-c-button pf-m-primary"
             data-testid="create-image-action"
           >
@@ -181,7 +182,7 @@ const ImagesTable = () => {
             <ToolbarContent>
               <ToolbarItem>
                 <Link
-                  to="/imagewizard"
+                  to={resolveRelPath('imagewizard')}
                   className="pf-c-button pf-m-primary"
                   data-testid="create-image-action"
                 >

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,6 +1,8 @@
 import React, { lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
+import { resolveRelPath } from './Utilities/path';
+
 const LandingPage = lazy(() => import('./Components/LandingPage/LandingPage'));
 const CreateImageWizard = lazy(() =>
   import('./Components/CreateImageWizard/CreateImageWizard')
@@ -9,8 +11,11 @@ const CreateImageWizard = lazy(() =>
 export const Router = () => {
   return (
     <Routes>
-      <Route path="/imagewizard/*" element={<CreateImageWizard />} />
-      <Route path="*" element={<LandingPage />} />
+      <Route
+        path={resolveRelPath('imagewizard/*')}
+        element={<CreateImageWizard />}
+      />
+      <Route path={resolveRelPath('*')} element={<LandingPage />} />
     </Routes>
   );
 };

--- a/src/Utilities/path.js
+++ b/src/Utilities/path.js
@@ -9,7 +9,11 @@ function getBaseName(pathname) {
     release = `/beta/`;
   }
 
-  return `${release}${pathName[0]}/${pathName[1] || ''}`;
+  return `${release}`;
 }
 
-export default getBaseName;
+function resolveRelPath(path) {
+  return `/insights/image-builder/${path}`;
+}
+
+export { getBaseName, resolveRelPath };

--- a/src/entry.test.js
+++ b/src/entry.test.js
@@ -1,15 +1,13 @@
-import getBaseName from './Utilities/getBaseName';
+import { getBaseName } from './Utilities/path';
 
 describe('Utilities/getBaseName', () => {
   it('should find the right base name on Stable ', () => {
-    expect(getBaseName('/insights/foo/bar/baz')).toEqual('/insights/foo');
-    expect(getBaseName('/rhcs/bar/bar/baz')).toEqual('/rhcs/bar');
+    expect(getBaseName('/')).toEqual('/');
+    expect(getBaseName('/rhcs/bar/bar/baz')).toEqual('/');
   });
 
   it('should find the right base name on Beta ', () => {
-    expect(getBaseName('/beta/insights/foo/bar/baz')).toEqual(
-      '/beta/insights/foo'
-    );
-    expect(getBaseName('/beta/test/fff/bar/baz')).toEqual('/beta/test/fff');
+    expect(getBaseName('/beta')).toEqual('/beta/');
+    expect(getBaseName('/beta/foo/bar/baz')).toEqual('/beta/');
   });
 });

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -35,7 +35,7 @@ function getCancelButton() {
 function verifyCancelButton(cancel, history) {
   cancel.click();
 
-  expect(history.location.pathname).toBe('/');
+  expect(history.location.pathname).toBe('/insights/image-builder/');
 }
 
 // packages
@@ -1814,7 +1814,9 @@ describe('Click through all steps', () => {
     await expect(composeImage).toHaveBeenCalledTimes(6);
 
     // returns back to the landing page
-    await waitFor(() => expect(history.location.pathname).toBe('/'));
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/insights/image-builder/')
+    );
     expect(store.getState().composes.allIds).toEqual(ids);
     // set test timeout of 10 seconds
   }, 10000);
@@ -1936,7 +1938,7 @@ describe('Keyboard accessibility', () => {
     const awsTile = screen.getByTestId('upload-aws');
     userEvent.click(awsTile);
     userEvent.keyboard('{esc}');
-    expect(history.location.pathname).toBe('/');
+    expect(history.location.pathname).toBe('/insights/image-builder/');
   });
 
   test('pressing Enter does not advance the wizard', async () => {

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -433,7 +433,9 @@ describe('Images Table', () => {
     });
     userEvent.click(recreateButton);
 
-    expect(history.location.pathname).toBe('/imagewizard');
+    expect(history.location.pathname).toBe(
+      '/insights/image-builder/imagewizard'
+    );
     expect(history.location.state.composeRequest).toStrictEqual(
       mockComposes.data.find((c) => c.id === imageId).request
     );


### PR DESCRIPTION
The insights platform is moving to react router v6, meaning router contexts can no longer be nested. As a result all applications will end up sharing the same `BrowserRouter`.

Switch to using the release (`/` or `/beta/`) as a basename for the BrowserRouter, and offload the full path (`/insights/$appname`) to the individual routes. This makes it easier to drop the BrowserRouter in image builder for the platform one in future.

---

`ci.ext.devshift.net PR build` can be ignored until #828 is merged and this is rebased