### PR TITLE
Aws multiple regions

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -117,7 +117,7 @@ const ReviewStep = () => {
         Review the information and click &quot;Create image&quot; to create the
         image using the following criteria.
       </Text>
-      <DescriptionList isCompact isHorizontal>
+      <DescriptionList isCompact>
         <DescriptionListGroup>
           {getState()?.values?.['image-name'] && (
             <>
@@ -166,6 +166,12 @@ const ReviewStep = () => {
                     </TextListItem>
                     <TextListItem component={TextListItemVariants.dd}>
                       {getState()?.values?.['aws-account-id']}
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dt}>
+                      Default Region
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>
+                      us-east-1
                     </TextListItem>
                   </TextList>
                 </TextContent>

--- a/src/Components/CreateImageWizard/steps/aws.js
+++ b/src/Components/CreateImageWizard/steps/aws.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
-import { Title } from '@patternfly/react-core';
+import { HelperText, HelperTextItem, Title } from '@patternfly/react-core';
 import nextStepMapper from './imageOutputStepMapper';
 import StepTemplate from './stepTemplate';
+import { DEFAULT_AWS_REGION } from '../../../constants';
 
 export default {
   StepTemplate,
@@ -24,9 +25,18 @@ export default {
       label: (
         <p>
           Your image will be uploaded to AWS and shared with the account you
-          provide below. <br />
-          The shared image will expire within 14 days. To keep the image longer,
-          copy it to your AWS account.
+          provide below.
+        </p>
+      ),
+    },
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'plain-text-component',
+      label: (
+        <p>
+          <b>The shared image will expire within 14 days.</b> To permanently
+          access the image, copy the image, which will be shared to your account
+          by Red Hat, to your own AWS account.
         </p>
       ),
     },
@@ -48,6 +58,29 @@ export default {
           threshold: 12,
         },
       ],
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'aws-default-region',
+      className: 'pf-u-w-25',
+      'data-testid': 'aws-default-region',
+      type: 'text',
+      label: 'Default Region',
+      value: DEFAULT_AWS_REGION,
+      isReadOnly: true,
+      isRequired: true,
+      helperText: (
+        <HelperText>
+          <HelperTextItem
+            component="div"
+            variant="indeterminate"
+            className="pf-u-w-25"
+          >
+            Images are built in the default region but can be copied to other
+            regions later.
+          </HelperTextItem>
+        </HelperText>
+      ),
     },
   ],
 };

--- a/src/Components/ImagesTable/ClonesTable.js
+++ b/src/Components/ImagesTable/ClonesTable.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  TableComposable,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
+import { useSelector } from 'react-redux';
+import { ImageBuildStatus } from './ImageBuildStatus';
+import ImageLink from './ImageLink';
+import {
+  selectClonesById,
+  selectComposeById,
+  selectImageById,
+} from '../../store/composesSlice';
+import { timestampToDisplayString } from '../../Utilities/time';
+
+const Row = ({ imageId }) => {
+  const image = useSelector((state) => selectImageById(state, imageId));
+  return (
+    <Tbody>
+      <Tr>
+        <Td dataLabel="UUID">{image.id}</Td>
+        <Td dataLabel="Created">
+          {timestampToDisplayString(image.created_at)}
+        </Td>
+        <Td dataLabel="Account">{image.share_with_accounts?.[0]}</Td>
+        <Td dataLabel="Region">{image.region}</Td>
+        <Td dataLabel="Status">
+          <ImageBuildStatus imageId={image.id} />
+        </Td>
+        <Td dataLabel="Instance">
+          <ImageLink imageId={image.id} isInClonesTable={true} />
+        </Td>
+      </Tr>
+    </Tbody>
+  );
+};
+
+const ClonesTable = ({ composeId }) => {
+  const parentCompose = useSelector((state) =>
+    selectComposeById(state, composeId)
+  );
+  const clones = useSelector((state) => selectClonesById(state, composeId));
+
+  return (
+    <TableComposable
+      variant="compact"
+      className="pf-u-mb-md"
+      data-testid="clones-table"
+    >
+      <Thead>
+        <Tr className="no-bottom-border">
+          <Th>UUID</Th>
+          <Th>Created</Th>
+          <Th>Account</Th>
+          <Th>Region</Th>
+          <Th>Status</Th>
+          <Th>Instance</Th>
+        </Tr>
+      </Thead>
+      <Row imageId={parentCompose.id} imageType={'compose'} />
+      {clones.map((clone) => (
+        <Row imageId={clone.id} key={clone.id} />
+      ))}
+    </TableComposable>
+  );
+};
+
+Row.propTypes = {
+  imageId: PropTypes.string,
+};
+
+ClonesTable.propTypes = {
+  composeId: PropTypes.string,
+};
+
+export default ClonesTable;

--- a/src/Components/ImagesTable/ImageBuildStatus.js
+++ b/src/Components/ImagesTable/ImageBuildStatus.js
@@ -12,25 +12,34 @@ import {
 } from '@patternfly/react-icons';
 
 import './ImageBuildStatus.scss';
+import { useSelector } from 'react-redux';
+import {
+  selectImageById,
+  selectImageStatusesById,
+} from '../../store/composesSlice';
+import { hoursToExpiration } from '../../Utilities/time';
+import { AWS_S3_EXPIRATION_TIME_IN_HOURS } from '../../constants';
 
-const ImageBuildStatus = (props) => {
+export const ImageBuildStatus = ({ imageId }) => {
+  const image = useSelector((state) => selectImageById(state, imageId));
+
+  const remainingHours =
+    AWS_S3_EXPIRATION_TIME_IN_HOURS - hoursToExpiration(image.created_at);
+
+  // Messages appear in order of priority
   const messages = {
-    success: [
-      {
-        icon: <CheckCircleIcon className="success" />,
-        text: 'Ready',
-      },
-    ],
     failure: [
       {
         icon: <ExclamationCircleIcon className="error" />,
         text: 'Image build failed',
+        priority: 6,
       },
     ],
     pending: [
       {
         icon: <PendingIcon />,
         text: 'Image build is pending',
+        priority: 2,
       },
     ],
     // Keep "running" for backward compatibility
@@ -38,31 +47,42 @@ const ImageBuildStatus = (props) => {
       {
         icon: <InProgressIcon className="pending" />,
         text: 'Image build in progress',
+        priority: 1,
       },
     ],
     building: [
       {
         icon: <InProgressIcon className="pending" />,
         text: 'Image build in progress',
+        priority: 3,
       },
     ],
     uploading: [
       {
         icon: <InProgressIcon className="pending" />,
         text: 'Image upload in progress',
+        priority: 4,
       },
     ],
     registering: [
       {
         icon: <InProgressIcon className="pending" />,
         text: 'Cloud registration in progress',
+        priority: 5,
+      },
+    ],
+    success: [
+      {
+        icon: <CheckCircleIcon className="success" />,
+        text: 'Ready',
+        priority: 0,
       },
     ],
     expiring: [
       {
         icon: <ExclamationTriangleIcon className="expiring" />,
-        text: `Expires in ${props.remainingHours} ${
-          props.remainingHours > 1 ? 'hours' : 'hour'
+        text: `Expires in ${remainingHours} ${
+          remainingHours > 1 ? 'hours' : 'hour'
         }`,
       },
     ],
@@ -73,10 +93,38 @@ const ImageBuildStatus = (props) => {
       },
     ],
   };
+
+  let status;
+  if (image.imageType === 'aws') {
+    const imageStatuses = useSelector((state) =>
+      selectImageStatusesById(state, image.id)
+    );
+    const filteredImageStatuses = imageStatuses.filter(
+      (imageStatus) => imageStatus !== undefined
+    );
+    if (filteredImageStatuses.length === 0) {
+      status = image.status;
+    } else {
+      status = filteredImageStatuses.reduce((prev, current) => {
+        return messages[prev][0].priority > messages[current][0].priority
+          ? prev
+          : current;
+      });
+    }
+  } else if (image.uploadType === 'aws.s3' && image.status === 'success') {
+    // Cloud API currently reports expired images status as 'success'
+    status =
+      hoursToExpiration(image.created_at) >= AWS_S3_EXPIRATION_TIME_IN_HOURS
+        ? 'expired'
+        : 'expiring';
+  } else {
+    status = image.status;
+  }
+
   return (
     <React.Fragment>
-      {messages[props.status] &&
-        messages[props.status].map((message, key) => (
+      {messages[status] &&
+        messages[status].map((message, key) => (
           <Flex key={key} className="pf-u-align-items-baseline pf-m-nowrap">
             <div className="pf-u-mr-sm">{message.icon}</div>
             {message.text}
@@ -87,8 +135,5 @@ const ImageBuildStatus = (props) => {
 };
 
 ImageBuildStatus.propTypes = {
-  status: PropTypes.string,
-  remainingHours: PropTypes.number,
+  imageId: PropTypes.string,
 };
-
-export default ImageBuildStatus;

--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -140,6 +140,17 @@ const ImagesTable = () => {
     },
   ];
 
+  const awsActions = (compose) => [
+    {
+      title: 'Share to new region',
+      onClick: () =>
+        navigate(resolveRelPath(`share`), {
+          state: { composeId: compose.id },
+        }),
+    },
+    ...actions(compose),
+  ];
+
   // the state.page is not an index so must be reduced by 1 get the starting index
   const itemsStartInclusive = (page - 1) * perPage;
   const itemsEndExclusive = itemsStartInclusive + perPage;
@@ -253,7 +264,12 @@ const ImagesTable = () => {
                         />
                       </Td>
                       <Td>
-                        <ActionsColumn items={actions(compose)} />
+                        {compose.request.image_requests[0].upload_request
+                          .type === 'aws' ? (
+                          <ActionsColumn items={awsActions(compose)} />
+                        ) : (
+                          <ActionsColumn items={actions(compose)} />
+                        )}
                       </Td>
                     </Tr>
                     <Tr isExpanded={isExpanded(compose)}>

--- a/src/Components/ImagesTable/ImagesTable.scss
+++ b/src/Components/ImagesTable/ImagesTable.scss
@@ -1,11 +1,4 @@
-@media only screen and (min-width: 768px) {
-    .pf-c-table__expandable-row td:first-child {
-        // Align with expand/collapse button by duplicating its padding
-        padding-left: calc(var(--pf-c-table--cell--first-last-child--PaddingLeft) + var(--pf-global--spacer--md));
-    }
-}
-.pf-m-expanded tr:first-child {
-    // Remove border between a compose and its expanded detail
+.pf-m-expanded .no-bottom-border {
     border-bottom-style: none;
 }
 

--- a/src/Components/ImagesTable/RegionsPopover.js
+++ b/src/Components/ImagesTable/RegionsPopover.js
@@ -1,0 +1,90 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Popover } from '@patternfly/react-core';
+import { useSelector } from 'react-redux';
+import { createSelector } from '@reduxjs/toolkit';
+import { selectComposeById, selectImagesById } from '../../store/composesSlice';
+
+export const selectRegions = createSelector(
+  [selectComposeById, selectImagesById],
+  (compose, images) => {
+    const filteredImages = images.filter(
+      (image) =>
+        compose.share_with_accounts &&
+        compose.share_with_accounts[0] === image.share_with_accounts[0]
+    );
+
+    let regions = {};
+    filteredImages.forEach((image) => {
+      if (image.region && image.status === 'success') {
+        if (regions[image.region]) {
+          new Date(image.created_at) <
+          new Date(regions[image.region].created_at)
+            ? null
+            : (regions[image.region] = {
+                ami: image.ami,
+                created_at: image.created_at,
+              });
+        } else {
+          regions[image.region] = {
+            ami: image.ami,
+            created_at: image.created_at,
+          };
+        }
+      }
+    });
+
+    return regions;
+  }
+);
+
+const ImageLinkRegion = ({ region, ami }) => {
+  const url =
+    'https://console.aws.amazon.com/ec2/v2/home?region=' +
+    region +
+    '#LaunchInstanceWizard:ami=' +
+    ami;
+
+  return (
+    <Button component="a" target="_blank" variant="link" isInline href={url}>
+      {region}
+    </Button>
+  );
+};
+
+export const RegionsPopover = ({ composeId }) => {
+  const regions = useSelector((state) => selectRegions(state, composeId));
+
+  const listItems = useMemo(() => {
+    let listItems = [];
+    for (const [key, value] of Object.entries(regions).sort()) {
+      listItems.push(
+        <li key={key}>
+          <ImageLinkRegion region={key} ami={value.ami} />
+        </li>
+      );
+    }
+    return listItems;
+  }, [regions]);
+
+  return (
+    <Popover
+      aria-label="Launch instance"
+      headerContent={<div>Launch instance</div>}
+      bodyContent={<ul>{listItems}</ul>}
+    >
+      <Button variant="link" isInline>
+        Launch
+      </Button>
+    </Popover>
+  );
+};
+
+ImageLinkRegion.propTypes = {
+  region: PropTypes.string,
+  ami: PropTypes.string,
+};
+
+RegionsPopover.propTypes = {
+  composeId: PropTypes.string,
+};

--- a/src/Components/ImagesTable/Target.js
+++ b/src/Components/ImagesTable/Target.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { selectComposeById } from '../../store/composesSlice';
 
-const Target = (props) => {
+const Target = ({ composeId }) => {
+  const compose = useSelector((state) => selectComposeById(state, composeId));
+
   const targetOptions = {
     aws: 'Amazon Web Services',
     azure: 'Microsoft Azure',
@@ -12,18 +16,21 @@ const Target = (props) => {
   };
 
   let target;
-  if (props.uploadType === 'aws.s3') {
-    target = targetOptions[props.imageType];
+  if (compose.uploadType === 'aws.s3') {
+    target = targetOptions[compose.imageType];
+  } else if (compose.uploadType === 'aws') {
+    target =
+      targetOptions[compose.uploadType] +
+      ` (${compose.clones.length !== 0 ? compose.clones.length + 1 : 1})`;
   } else {
-    target = targetOptions[props.uploadType];
+    target = targetOptions[compose.uploadType];
   }
 
   return <>{target}</>;
 };
 
 Target.propTypes = {
-  uploadType: PropTypes.string,
-  imageType: PropTypes.string,
+  composeId: PropTypes.string,
 };
 
 export default Target;

--- a/src/Components/ShareImageModal/RegionsSelect.js
+++ b/src/Components/ShareImageModal/RegionsSelect.js
@@ -1,0 +1,228 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import {
+  ActionGroup,
+  Button,
+  Form,
+  FormGroup,
+  Popover,
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon, HelpIcon } from '@patternfly/react-icons';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { createSelector } from '@reduxjs/toolkit';
+import { AWS_REGIONS } from '../../constants';
+import { selectClonesById, selectComposeById } from '../../store/composesSlice';
+import api from '../../api';
+import { cloneAdded } from '../../store/clonesSlice';
+import { resolveRelPath } from '../../Utilities/path';
+
+export const selectRegionsToDisable = createSelector(
+  [selectComposeById, selectClonesById],
+  (compose, clones) => {
+    let regions = new Set();
+    regions.add(compose.region);
+    clones.map((clone) => {
+      clone.region &&
+        clone.share_with_accounts[0] === compose.share_with_accounts[0] &&
+        clone.status !== 'failure' &&
+        regions.add(clone.region);
+    });
+
+    return regions;
+  }
+);
+
+const prepareRegions = (regionsToDisable) => {
+  const regions = AWS_REGIONS.map((region) => ({
+    ...region,
+    disabled: regionsToDisable.has(region.value),
+  }));
+
+  return regions;
+};
+
+const RegionsSelect = ({
+  composeId,
+  handleClose,
+  handleToggle,
+  isOpen,
+  setIsOpen,
+}) => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const [isSaving, setIsSaving] = useState(false);
+  const [selected, setSelected] = useState([]);
+  const titleId = 'Clone this image';
+  const [validated, setValidated] = useState('default');
+  const [helperTextInvalid] = useState(
+    'Select at least one region to share to.'
+  );
+
+  const compose = useSelector((state) => selectComposeById(state, composeId));
+
+  const regionsToDisable = useSelector((state) =>
+    selectRegionsToDisable(state, composeId)
+  );
+  const [options] = useState(prepareRegions(regionsToDisable));
+
+  const handleSelect = (event, selection) => {
+    let nextSelected;
+    if (selected.includes(selection)) {
+      nextSelected = selected.filter((region) => region !== selection);
+      setSelected(nextSelected);
+    } else {
+      nextSelected = [...selected, selection];
+      setSelected(nextSelected);
+    }
+    nextSelected.length === 0 ? setValidated('error') : setValidated('default');
+  };
+
+  const handleClear = () => {
+    setSelected([]);
+    setIsOpen(false);
+    setValidated('error');
+  };
+
+  const generateRequests = () => {
+    const requests = selected.map((region) => {
+      return {
+        region: region,
+        share_with_accounts: [compose.share_with_accounts[0]],
+      };
+    });
+    return requests;
+  };
+
+  const handleSubmit = () => {
+    setIsSaving(true);
+    const requests = generateRequests();
+    Promise.all(
+      requests.map((request) =>
+        api.cloneImage(composeId, request).then((response) => {
+          dispatch(
+            cloneAdded({
+              clone: {
+                ...response,
+                request,
+                image_status: { status: 'pending' },
+              },
+              parent: composeId,
+            })
+          );
+        })
+      )
+    )
+      .then(() => {
+        navigate(resolveRelPath(''));
+        dispatch(
+          addNotification({
+            variant: 'success',
+            title: 'Your image is being shared',
+          })
+        );
+
+        setIsSaving(false);
+      })
+      .catch((err) => {
+        navigate(resolveRelPath(''));
+        dispatch(
+          addNotification({
+            variant: 'danger',
+            title: 'Your image could not be created',
+            description: `Status code ${err.response.status}: ${err.response.statusText}`,
+          })
+        );
+      });
+  };
+
+  return (
+    <Form>
+      <span id={titleId} hidden>
+        Select a region
+      </span>
+      <FormGroup
+        label="Select region"
+        isRequired
+        validated={validated}
+        helperTextInvalid={helperTextInvalid}
+        helperTextInvalidIcon={<ExclamationCircleIcon />}
+        labelIcon={
+          <Popover
+            headerContent={<div>Sharing images to other regions</div>}
+            bodyContent={
+              <div>
+                Your image will be built, uploaded to AWS, and shared to the
+                regions you select. The shared image will expire within 14 days.
+                To permanently access the image, copy the image, which will be
+                shared to your account by Red Hat, to your own AWS account.
+              </div>
+            }
+          >
+            <button
+              type="button"
+              aria-label="More info for name field"
+              onClick={(e) => e.preventDefault()}
+              aria-describedby="simple-form-name-01"
+              className="pf-c-form__group-label-help"
+            >
+              <HelpIcon noVerticalAlign />
+            </button>
+          </Popover>
+        }
+      >
+        <Select
+          variant={SelectVariant.typeaheadMulti}
+          typeAheadAriaLabel="Select a region"
+          onToggle={handleToggle}
+          onSelect={handleSelect}
+          onClear={handleClear}
+          selections={selected}
+          isOpen={isOpen}
+          aria-labelledby={titleId}
+          placeholderText="Select a region"
+          menuAppendTo="parent"
+          validated={validated}
+          maxHeight="25rem"
+        >
+          {options.map((option, index) => (
+            <SelectOption
+              isDisabled={option.disabled}
+              key={index}
+              value={option.value}
+              {...(option.description && { description: option.description })}
+            />
+          ))}
+        </Select>
+      </FormGroup>
+      <ActionGroup>
+        <Button
+          onClick={handleSubmit}
+          variant="primary"
+          key="share"
+          isDisabled={selected.length === 0 || isSaving}
+          isLoading={isSaving}
+        >
+          Share
+        </Button>
+        <Button variant="link" onClick={handleClose} key="cancel">
+          Cancel
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};
+
+RegionsSelect.propTypes = {
+  composeId: PropTypes.string,
+  handleClose: PropTypes.func,
+  handleToggle: PropTypes.func,
+  isOpen: PropTypes.bool,
+  setIsOpen: PropTypes.bool,
+};
+
+export default RegionsSelect;

--- a/src/Components/ShareImageModal/ShareImageModal.js
+++ b/src/Components/ShareImageModal/ShareImageModal.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { Modal } from '@patternfly/react-core';
+import { useLocation, useNavigate } from 'react-router-dom';
+import RegionsSelect from './RegionsSelect';
+import { resolveRelPath } from '../../Utilities/path';
+
+const ShareToRegionsModal = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const handleClose = () => navigate(resolveRelPath(''));
+  const [isOpen, setIsOpen] = useState(false);
+
+  const composeId = location?.state?.composeId;
+
+  const handleToggle = (isOpen) => setIsOpen(isOpen);
+
+  const handleEscapePress = () => {
+    if (isOpen) {
+      handleToggle(isOpen);
+    } else {
+      handleClose();
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={true}
+      variant="small"
+      aria-label="Share to new region"
+      onClose={handleClose}
+      title="Share to new region"
+      description="Configure new regions for this image that will run on your AWS. All the
+        regions will launch with the same configuration."
+      onEscapePress={handleEscapePress}
+    >
+      <RegionsSelect
+        composeId={composeId}
+        handleClose={handleClose}
+        handleToggle={handleToggle}
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+      />
+    </Modal>
+  );
+};
+
+export default ShareToRegionsModal;

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,5 +1,6 @@
 import React, { lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
+import ShareImageModal from './Components/ShareImageModal/ShareImageModal';
 
 import { resolveRelPath } from './Utilities/path';
 
@@ -16,6 +17,7 @@ export const Router = () => {
         element={<CreateImageWizard />}
       />
       <Route path={resolveRelPath('*')} element={<LandingPage />} />
+      <Route path={resolveRelPath('share/*')} element={<ShareImageModal />} />
     </Routes>
   );
 };

--- a/src/Utilities/time.js
+++ b/src/Utilities/time.js
@@ -1,15 +1,3 @@
-export const timestampToISO8601 = (timestamp) => {
-  if (!timestamp) {
-    return '';
-  }
-
-  const date = timestamp.slice(0, 10);
-  const time = timestamp.slice(11, 26);
-
-  return `${date}T${time}+0000`;
-};
-
-
 export const timestampToDisplayString = (ts) => {
   // timestamp has format 2021-04-27 12:31:12.794809 +0000 UTC
   // must be converted to ms timestamp and then reformatted to Apr 27, 2021
@@ -23,4 +11,31 @@ export const timestampToDisplayString = (ts) => {
   const options = { month: 'short', day: 'numeric', year: 'numeric' };
   const tsDisplay = new Intl.DateTimeFormat('en-US', options).format(ms);
   return tsDisplay;
+};
+
+export const convertStringToDate = (createdAtAsString) => {
+  if (isNaN(Date.parse(createdAtAsString))) {
+    // converts property created_at of the image object from string to UTC
+    const [dateValues, timeValues] = createdAtAsString.split(' ');
+    const datetimeString = `${dateValues}T${timeValues}Z`;
+    return Date.parse(datetimeString);
+  } else {
+    return Date.parse(createdAtAsString);
+  }
+};
+
+export const hoursToExpiration = (imageCreatedAt) => {
+  if (imageCreatedAt) {
+    const currentTime = Date.now();
+    // miliseconds in hour - needed for calculating the difference
+    // between current date and the date of the image creation
+    const msInHour = 1000 * 60 * 60;
+    const timeUntilExpiration = Math.floor(
+      (currentTime - convertStringToDate(imageCreatedAt)) / msInHour
+    );
+    return timeUntilExpiration;
+  } else {
+    // when creating a new image, the compose.created_at can be undefined when first queued
+    return 0;
+  }
 };

--- a/src/Utilities/time.js
+++ b/src/Utilities/time.js
@@ -1,0 +1,26 @@
+export const timestampToISO8601 = (timestamp) => {
+  if (!timestamp) {
+    return '';
+  }
+
+  const date = timestamp.slice(0, 10);
+  const time = timestamp.slice(11, 26);
+
+  return `${date}T${time}+0000`;
+};
+
+
+export const timestampToDisplayString = (ts) => {
+  // timestamp has format 2021-04-27 12:31:12.794809 +0000 UTC
+  // must be converted to ms timestamp and then reformatted to Apr 27, 2021
+  if (!ts) {
+    return '';
+  }
+
+  // get YYYY-MM-DD format
+  const date = ts.slice(0, 10);
+  const ms = Date.parse(date);
+  const options = { month: 'short', day: 'numeric', year: 'numeric' };
+  const tsDisplay = new Intl.DateTimeFormat('en-US', options).format(ms);
+  return tsDisplay;
+};

--- a/src/api.js
+++ b/src/api.js
@@ -76,8 +76,38 @@ async function getActivationKeys() {
   return request.data.body;
 }
 
+// get clones of a compose
+async function getClones(id, limit, offset) {
+  const params = new URLSearchParams({
+    limit,
+    offset,
+  });
+  const path = `/composes/${id}/clones?${params}`;
+  const request = await axios.get(IMAGE_BUILDER_API.concat(path));
+  return request.data;
+}
+
+async function getCloneStatus(id) {
+  const path = `/clones/${id}`;
+  const request = await axios.get(IMAGE_BUILDER_API.concat(path));
+  return request.data;
+}
+
+async function cloneImage(composeId, body) {
+  const path = `/composes/${composeId}/clone`;
+  const request = await axios.post(
+    IMAGE_BUILDER_API.concat(path),
+    body,
+    postHeaders
+  );
+  return request.data;
+}
+
 export default {
+  cloneImage,
   composeImage,
+  getClones,
+  getCloneStatus,
   getComposes,
   getComposeStatus,
   getPackages,

--- a/src/constants.js
+++ b/src/constants.js
@@ -43,3 +43,5 @@ export const AWS_REGIONS = [
   { description: 'Middle East (UAE)', value: 'me-central-1' },
   { description: 'South America (S\u00e3o Paolo)', value: 'sa-east-1' },
 ];
+
+export const AWS_S3_EXPIRATION_TIME_IN_HOURS = 6;

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,3 +14,32 @@ export const RELEASES = {
   'centos-8': 'CentOS Stream 8',
   'centos-9': 'CentOS Stream 9',
 };
+
+export const DEFAULT_AWS_REGION = 'us-east-1';
+
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
+export const AWS_REGIONS = [
+  { description: 'US East (Ohio)', value: 'us-east-2' },
+  { description: 'US East (N. Virginia)', value: 'us-east-1' },
+  { description: 'US West (N. California)', value: 'us-west-1' },
+  { description: 'US West (Oregon)', value: 'us-west-2' },
+  { description: 'Africa (Cape Town)', value: 'af-south-1' },
+  { description: 'Asia Pacific (Hong Kong)', value: 'ap-east-1' },
+  { description: 'Asia Pacific (Jakarta)', value: 'ap-southeast-3' },
+  { description: 'Asia Pacific (Mumbai)', value: 'ap-south-1' },
+  { description: 'Asia Pacific (Osaka)', value: 'ap-northeast-3' },
+  { description: 'Asia Pacific (Seoul)', value: 'ap-northeast-2' },
+  { description: 'Asia Pacific (Singapore)', value: 'ap-southeast-1' },
+  { description: 'Asia Pacific (Sydney)', value: 'ap-southeast-2' },
+  { description: 'Asia Pacific (Tokyo)', value: 'ap-northeast-1' },
+  { description: 'Canada (Central)', value: 'ca-central-1' },
+  { description: 'Europe (Frankfurt)', value: 'eu-central-1' },
+  { description: 'Europe (Ireland)', value: 'eu-west-1' },
+  { description: 'Europe (London)', value: 'eu-west-2' },
+  { description: 'Europe (Milan)', value: 'eu-south-1' },
+  { description: 'Europe (Paris)', value: 'eu-west-3' },
+  { description: 'Europe (Stockholm)', value: 'eu-north-1' },
+  { description: 'Middle East (Bahrain)', value: 'me-south-1' },
+  { description: 'Middle East (UAE)', value: 'me-central-1' },
+  { description: 'South America (S\u00e3o Paolo)', value: 'sa-east-1' },
+];

--- a/src/store/actions/actions.js
+++ b/src/store/actions/actions.js
@@ -1,3 +1,4 @@
+import { cloneAdded, cloneUpdatedStatus } from '../clonesSlice';
 import {
   composeAdded,
   composesUpdatedCount,
@@ -16,12 +17,40 @@ export const fetchComposeStatus = (id) => async (dispatch) => {
 };
 
 export const fetchComposes = (limit, offset) => async (dispatch) => {
-  const request = await api.getComposes(limit, offset);
-  request.data.map((compose) => {
+  const composeRequest = await api.getComposes(limit, offset);
+
+  composeRequest.data.map((compose) => {
     dispatch(composeAdded({ compose, insert: false }));
     dispatch(fetchComposeStatus(compose.id));
   });
-  dispatch(composesUpdatedCount({ count: request.meta.count }));
+  dispatch(composesUpdatedCount({ count: composeRequest.meta.count }));
+
+  composeRequest.data.forEach((compose) => {
+    dispatch(fetchClones(compose.id, 100, 0));
+  });
 };
 
-export default { fetchComposes, fetchComposeStatus };
+export const fetchCloneStatus = (id) => async (dispatch) => {
+  const request = await api.getCloneStatus(id);
+  dispatch(
+    cloneUpdatedStatus({
+      id,
+      status: request,
+    })
+  );
+};
+
+export const fetchClones = (id, limit, offset) => async (dispatch) => {
+  const request = await api.getClones(id, limit, offset);
+  request.data?.forEach((clone) => {
+    dispatch(cloneAdded({ clone, parent: id }));
+    dispatch(fetchCloneStatus(clone.id));
+  });
+};
+
+export default {
+  fetchClones,
+  fetchCloneStatus,
+  fetchComposes,
+  fetchComposeStatus,
+};

--- a/src/store/clonesSlice.js
+++ b/src/store/clonesSlice.js
@@ -1,0 +1,53 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  allIds: [],
+  byId: {},
+  error: null,
+};
+
+export const clonesSlice = createSlice({
+  name: 'clones',
+  initialState,
+  reducers: {
+    cloneAdded: (state, action) => {
+      if (!state.allIds.includes(action.payload.clone.id)) {
+        state.allIds.push(action.payload.clone.id);
+      }
+      state.byId[action.payload.clone.id] = { ...action.payload.clone };
+      state.byId[action.payload.clone.id].parent = action.payload.parent;
+      state.error = null;
+    },
+    cloneUpdatedStatus: (state, action) => {
+      const image_status = {
+        status: action.payload.status.status,
+        upload_status: action.payload.status,
+      };
+      state.byId[action.payload.id].image_status = image_status;
+    },
+  },
+});
+
+export const selectCloneById = (state, cloneId) => {
+  const clone = state.clones.byId[cloneId];
+
+  if (clone !== undefined) {
+    return {
+      created_at: clone.created_at,
+      id: clone.id,
+      region: clone.request.region,
+      ami: clone.image_status?.upload_status?.options?.ami,
+      share_with_accounts: clone.request.share_with_accounts,
+      status: clone.image_status?.status,
+      uploadStatus: clone.image_status?.upload_status,
+      parent: clone.parent,
+      imageType: 'ami',
+      isClone: true,
+    };
+  } else {
+    return null;
+  }
+};
+
+export const { cloneAdded, cloneUpdatedStatus } = clonesSlice.actions;
+export default clonesSlice.reducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import promiseMiddleware from 'redux-promise-middleware';
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import clonesSlice from './clonesSlice';
 import composesSlice from './composesSlice';
 
 export const reducer = {
+  clones: clonesSlice,
   composes: composesSlice,
   notifications: notificationsReducer,
 };

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -46,10 +46,12 @@ const mockComposes = {
         image_requests: [
           {
             architecture: 'x86_64',
-            image_type: 'ami',
+            image_type: 'vhd',
             upload_request: {
-              type: 'aws',
-              options: {},
+              type: 'gcp',
+              options: {
+                share_with_accounts: ['serviceAccount:test@email.com'],
+              },
             },
           },
         ],
@@ -247,7 +249,13 @@ const mockStatus = {
   // kept "running" for backward compatibility
   'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa': {
     image_status: {
-      status: 'running',
+      status: 'failure',
+      error: {
+        reason: 'A dependency error occured',
+        details: {
+          reason: 'Error in depsolve job',
+        },
+      },
     },
   },
   'edbae1c2-62bc-42c1-ae0c-3110ab718f58': {
@@ -537,17 +545,17 @@ describe('Images Table', () => {
     const { getAllByRole } = within(table);
     const rows = getAllByRole('row');
 
-    const errorToggle = within(rows[7]).getByRole('button', {
+    const errorToggle = within(rows[2]).getByRole('button', {
       name: /details/i,
     });
 
     expect(
-      screen.getAllByText(/61b0effa-c901-4ee5-86b9-2010b47f1b22/i)[1]
+      screen.getAllByText(/c1cfa347-4c37-49b5-8e73-6aa1d1746cfa/i)[1]
     ).not.toBeVisible();
     userEvent.click(errorToggle);
 
     expect(
-      screen.getAllByText(/61b0effa-c901-4ee5-86b9-2010b47f1b22/i)[1]
+      screen.getAllByText(/c1cfa347-4c37-49b5-8e73-6aa1d1746cfa/i)[1]
     ).toBeVisible();
     expect(screen.getAllByText(/Error in depsolve job/i)[0]).toBeVisible();
   });

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -337,6 +337,8 @@ const mockStatus = {
   },
 };
 
+const mockClones = {};
+
 jest
   .spyOn(api, 'getComposes')
   .mockImplementation(() => Promise.resolve(mockComposes));
@@ -344,6 +346,10 @@ jest
 jest.spyOn(api, 'getComposeStatus').mockImplementation((id) => {
   return Promise.resolve(mockStatus[id]);
 });
+
+jest
+  .spyOn(api, 'getClones')
+  .mockImplementation(() => Promise.resolve(mockClones));
 
 describe('Images Table', () => {
   test('render ImagesTable', async () => {

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.js
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.js
@@ -1,0 +1,321 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithReduxRouter } from '../../testUtils';
+import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
+import api from '../../../api.js';
+import { RHEL_8 } from '../../../constants.js';
+
+const mockComposes = {
+  count: 1,
+  allIds: ['1579d95b-8f1d-4982-8c53-8c2afa4ab04c'],
+  byId: {
+    '1579d95b-8f1d-4982-8c53-8c2afa4ab04c': {
+      id: '1579d95b-8f1d-4982-8c53-8c2afa4abc',
+      image_name: 'testImageName',
+      created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'ami',
+            upload_request: {
+              type: 'aws',
+              options: {
+                share_with_accounts: ['123123123123'],
+              },
+            },
+          },
+        ],
+      },
+      clones: [
+        'f9133ec4-7a9e-4fd9-9a9f-9636b82b0a5d',
+        '48fce414-0cc0-4a16-8645-e3f0edec3212',
+        '0169538e-515c-477e-b934-f12783939313',
+        '4a851db1-919f-43ca-a7ef-dd209877a77e',
+      ],
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            ami: 'ami-0217b81d9be50e44b',
+            region: 'us-east-1',
+          },
+          status: 'success',
+          type: 'aws',
+        },
+      },
+    },
+  },
+  error: null,
+};
+
+const mockClones = {
+  allIds: [
+    'f9133ec4-7a9e-4fd9-9a9f-9636b82b0a5d',
+    '48fce414-0cc0-4a16-8645-e3f0edec3212',
+    '0169538e-515c-477e-b934-f12783939313',
+    '4a851db1-919f-43ca-a7ef-dd209877a77e',
+  ],
+  byId: {
+    'f9133ec4-7a9e-4fd9-9a9f-9636b82b0a5d': {
+      created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
+      id: 'f9133ec4-7a9e-4fd9-9a9f-9636b82b0a5d',
+      request: {
+        region: 'us-west-1',
+        share_with_accounts: ['123123123123'],
+      },
+      parent: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            ami: 'ami-0e778053cd490ad21',
+            region: 'us-west-1',
+          },
+          status: 'success',
+          type: 'aws',
+        },
+      },
+    },
+    // Duplicate us-west-1 clone with different ami created one day later
+    '48fce414-0cc0-4a16-8645-e3f0edec3212': {
+      created_at: '2021-04-28 12:31:12.794809 +0000 UTC',
+      id: '48fce414-0cc0-4a16-8645-e3f0edec3212',
+      request: {
+        region: 'us-west-1',
+        share_with_accounts: ['123123123123'],
+      },
+      parent: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            ami: 'ami-9f0asd1tlk2142124',
+            region: 'us-west-1',
+          },
+          status: 'success',
+          type: 'aws',
+        },
+      },
+    },
+    '0169538e-515c-477e-b934-f12783939313': {
+      created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
+      id: '0169538e-515c-477e-b934-f12783939313',
+      request: {
+        region: 'us-west-2',
+        share_with_accounts: ['123123123123'],
+      },
+      parent: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
+      image_status: {
+        status: 'failure',
+        upload_status: {
+          options: {
+            ami: 'ami-9fdskj12fdsak1211',
+            region: 'us-west-2',
+          },
+          status: 'failure',
+          type: 'aws',
+        },
+      },
+    },
+    '4a851db1-919f-43ca-a7ef-dd209877a77e': {
+      created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
+      id: '4a851db1-919f-43ca-a7ef-dd209877a77e',
+      request: {
+        region: 'eu-central-1',
+        share_with_accounts: ['000000000000'],
+      },
+      parent: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            ami: 'ami-9fdskj12fdsak1211',
+            region: 'eu-central-1',
+          },
+          status: 'success',
+          type: 'aws',
+        },
+      },
+    },
+  },
+  error: null,
+};
+
+const mockState = {
+  clones: { ...mockClones },
+  composes: { ...mockComposes },
+  notifications: [],
+};
+
+const mockLocation = {
+  state: {
+    composeId: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
+  },
+};
+
+let view;
+let history;
+let store;
+
+describe('Create Share To Regions Modal', () => {
+  test('validation', () => {
+    renderWithReduxRouter(<ShareImageModal />, mockState, mockLocation);
+
+    const shareButton = screen.getByRole('button', { name: /share/i });
+    expect(shareButton).toBeDisabled();
+
+    let invalidAlert = screen.queryByText(
+      /select at least one region to share to\./i
+    );
+    expect(invalidAlert).not.toBeInTheDocument();
+
+    const selectToggle = screen.getByRole('button', { name: /options menu/i });
+    userEvent.click(selectToggle);
+
+    const usEast2 = screen.getByRole('option', {
+      name: /us-east-2 us east \(ohio\)/i,
+    });
+    expect(usEast2).not.toHaveClass('pf-m-disabled');
+    userEvent.click(usEast2);
+    expect(shareButton).toBeEnabled();
+
+    const clearAllButton = screen.getByRole('button', { name: /clear all/i });
+    clearAllButton.click();
+    expect(shareButton).toBeDisabled();
+
+    invalidAlert = screen.getByText(
+      /select at least one region to share to\./i
+    );
+    expect(invalidAlert).toBeInTheDocument();
+  });
+
+  test('cancel button redirects to landing page', async () => {
+    view = renderWithReduxRouter(<ShareImageModal />, mockState, mockLocation);
+    history = view.history;
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    cancelButton.click();
+
+    // returns back to the landing page
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/insights/image-builder/')
+    );
+  });
+
+  test('close button redirects to landing page', async () => {
+    view = renderWithReduxRouter(<ShareImageModal />, mockState, mockLocation);
+    history = view.history;
+
+    const closeButton = screen.getByRole('button', { name: /close/i });
+    closeButton.click();
+
+    // returns back to the landing page
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/insights/image-builder/')
+    );
+  });
+
+  test('select options disabled correctly based on status and region', () => {
+    renderWithReduxRouter(<ShareImageModal />, mockState, mockLocation);
+
+    const selectToggle = screen.getByRole('button', { name: /options menu/i });
+    userEvent.click(selectToggle);
+
+    // parent region disabled
+    const usEast1 = screen.getByRole('option', {
+      name: /us-east-1 us east \(n. virginia\)/i,
+    });
+    expect(usEast1).toHaveClass('pf-m-disabled');
+
+    // successful clone disabled
+    const usWest1 = screen.getByRole('option', {
+      name: /us-west-1 us west \(n. california\)/i,
+    });
+    expect(usWest1).toHaveClass('pf-m-disabled');
+
+    // unsuccessful clone enabled
+    const usWest2 = screen.getByRole('option', {
+      name: /us-west-2 us west \(oregon\)/i,
+    });
+    expect(usWest2).not.toHaveClass('pf-m-disabled');
+
+    // successful clone with different share_with_accounts than its parent enabled
+    const euCentral1 = screen.getByRole('option', {
+      name: /eu-central-1 europe \(frankfurt\)/i,
+    });
+    expect(euCentral1).not.toHaveClass('pf-m-disabled');
+  });
+
+  test('cloning an image results in successful store updates', async () => {
+    view = renderWithReduxRouter(<ShareImageModal />, mockState, mockLocation);
+    history = view.history;
+    store = view.store;
+
+    const selectToggle = screen.getByRole('button', { name: /options menu/i });
+    userEvent.click(selectToggle);
+
+    const usEast2 = screen.getByRole('option', {
+      name: /us-east-2 us east \(ohio\)/i,
+    });
+    expect(usEast2).not.toHaveClass('pf-m-disabled');
+    userEvent.click(usEast2);
+
+    const mockResponse = {
+      id: '123e4567-e89b-12d3-a456-426655440000',
+    };
+    const cloneImage = jest.spyOn(api, 'cloneImage').mockImplementation(() => {
+      return Promise.resolve(mockResponse);
+    });
+
+    const shareButton = screen.getByRole('button', { name: /share/i });
+    expect(shareButton).toBeEnabled();
+    shareButton.click();
+
+    expect(cloneImage).toHaveBeenCalledTimes(1);
+
+    // returns back to the landing page
+    await waitFor(() =>
+      expect(history.location.pathname).toBe('/insights/image-builder/')
+    );
+
+    // Clone has been added to its parent's list of clones
+    expect(
+      store.getState().composes.byId['1579d95b-8f1d-4982-8c53-8c2afa4ab04c']
+        .clones
+    ).toEqual([
+      'f9133ec4-7a9e-4fd9-9a9f-9636b82b0a5d',
+      '48fce414-0cc0-4a16-8645-e3f0edec3212',
+      '0169538e-515c-477e-b934-f12783939313',
+      '4a851db1-919f-43ca-a7ef-dd209877a77e',
+      '123e4567-e89b-12d3-a456-426655440000',
+    ]);
+
+    // Clone has been added to state.clones.allIds
+    expect(store.getState().clones.allIds).toEqual([
+      'f9133ec4-7a9e-4fd9-9a9f-9636b82b0a5d',
+      '48fce414-0cc0-4a16-8645-e3f0edec3212',
+      '0169538e-515c-477e-b934-f12783939313',
+      '4a851db1-919f-43ca-a7ef-dd209877a77e',
+      '123e4567-e89b-12d3-a456-426655440000',
+    ]);
+
+    // Clone has been added to state.clones.byId
+    expect(
+      store.getState().clones.byId['123e4567-e89b-12d3-a456-426655440000']
+    ).toEqual({
+      id: '123e4567-e89b-12d3-a456-426655440000',
+      image_status: {
+        status: 'pending',
+      },
+      parent: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
+      request: {
+        region: 'us-east-2',
+        share_with_accounts: ['123123123123'],
+      },
+    });
+  });
+});

--- a/src/test/testUtils.js
+++ b/src/test/testUtils.js
@@ -25,3 +25,15 @@ export const renderWithReduxRouter = (
     store,
   };
 };
+
+export const renderWithProvider = (
+  component,
+  container,
+  preloadedState = {}
+) => {
+  const store = configureStore({ reducer, middleware, preloadedState });
+
+  return render(<Provider store={store}>{component}</Provider>, {
+    container: container,
+  });
+};


### PR DESCRIPTION
This PR exposes the API's clone endpoints in the frontend. 

At this time, only AWS images support cloning (or 'sharing', as it is referred to in the frontend). An AWS composes' clones are displayed in a sub-table located in an expandable row.

Composes can be cloned (shared) to other regions via a new modal.

This PR also continues the process of modernizing our Redux store through the use of selectors for data normalization.