### PR TITLE
imagestable: request.json link now non-styled

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -181,10 +181,11 @@ const ImagesTable = () => {
     {
       title: (
         <a
+          className="ib-subdued-link"
           href={`data:text/plain;charset=utf-8,${encodeURIComponent(
             JSON.stringify(compose.request)
           )}`}
-          download="request.json"
+          download={`request-${compose.id}.json`}
         >
           Download compose request (.json)
         </a>

--- a/src/Components/ImagesTable/ImagesTable.scss
+++ b/src/Components/ImagesTable/ImagesTable.scss
@@ -8,3 +8,13 @@
     // Remove border between a compose and its expanded detail
     border-bottom-style: none;
 }
+
+.ib-subdued-link {
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+        color: inherit;
+        text-decoration: none;
+    }
+}

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -487,7 +487,9 @@ describe('Images Table', () => {
     // No actual clicking because downloading is hard to test.
     // Instead, we just check href and download properties of the <a> element.
     const downloadLink = within(downloadButton).getByRole('link');
-    expect(downloadLink.download).toBe('request.json');
+    expect(downloadLink.download).toBe(
+      'request-1579d95b-8f1d-4982-8c53-8c2afa4ab04c.json'
+    );
 
     const hrefParts = downloadLink.href.split(',');
     expect(hrefParts.length).toBe(2);


### PR DESCRIPTION
By skipping the rendering of the <a /> we can still download a data-URI formatted link.

This resolves: #805.