### PR TITLE
ImagesTable: indent the downloaded compose request

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -130,7 +130,7 @@ const ImagesTable = () => {
         <a
           className="ib-subdued-link"
           href={`data:text/plain;charset=utf-8,${encodeURIComponent(
-            JSON.stringify(compose.request)
+            JSON.stringify(compose.request, null, '  ')
           )}`}
           download={`request-${compose.id}.json`}
         >

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -584,7 +584,7 @@ describe('Images Table', () => {
     const [header, encodedRequest] = hrefParts;
     expect(header).toBe('data:text/plain;charset=utf-8');
     expect(encodedRequest).toBe(
-      encodeURIComponent(JSON.stringify(expectedRequest))
+      encodeURIComponent(JSON.stringify(expectedRequest, null, '  '))
     );
   });
 


### PR DESCRIPTION
Prior to this commit, the downloaded request was just an ugly unformatted json. Surely, `jq . <request.json` could fix that, but it's much more convenient if the frontend does it itself.

Signed-off-by: Ondřej Budai <ondrej@budai.cz>

Example:

```
{
  "image_name": "I am formatted!",
  "distribution": "rhel-86",
  "customizations": {
    "packages": [
      "bind-utils",
      "jq",
      "logrotate",
      "nfs-utils",
      "podman",
      "podman-remote",
      "sos",
      "unzip",
      "zip"
    ]
  },
  "image_requests": [
    {
      "image_type": "gcp",
      "architecture": "x86_64",
      "upload_request": {
        "type": "gcp",
        "options": {
          "share_with_accounts": [
            "serviceAccount:abcdef@abcdef.iam.gserviceaccount.com"
          ]
        }
      }
    }
  ]
}
```