### PR TITLE
api: use content-sources api for package search

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -108,17 +108,24 @@ const Packages = ({ defaultArch, ...props }) => {
   };
 
   const getAllPackages = async () => {
-    const args = [
-      getState()?.values?.release,
-      getState()?.values?.architecture || defaultArch,
-      packagesSearchName,
-    ];
-    let { data, meta } = await api.getPackages(...args);
-    if (data?.length === meta.count) {
-      return data;
-    } else if (data) {
-      ({ data } = await api.getPackages(...args, meta.count));
-      return data;
+    // if the env is stage beta then use content-sources api
+    // else use image-builder api
+    if (!insights.chrome.isProd() && insights.chrome.isBeta()) {
+      const args = [getState()?.values?.release, packagesSearchName];
+      return await api.getPackagesContentSources(...args);
+    } else {
+      const args = [
+        getState()?.values?.release,
+        getState()?.values?.architecture || defaultArch,
+        packagesSearchName,
+      ];
+      let { data, meta } = await api.getPackages(...args);
+      if (data?.length === meta.count) {
+        return data;
+      } else if (data) {
+        ({ data } = await api.getPackages(...args, meta.count));
+        return data;
+      }
     }
   };
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 export const IMAGE_BUILDER_API = '/api/image-builder/v1';
 export const RHSM_API = '/api/rhsm/v2';
+export const CONTENT_SOURCES = '/api/content-sources/v1';
 export const RHEL_8 = 'rhel-86';
 export const RHEL_9 = 'rhel-90';
 

--- a/src/repos.js
+++ b/src/repos.js
@@ -1,0 +1,102 @@
+import { RHEL_8, RHEL_9 } from './constants';
+
+export const repos = {
+  [RHEL_8]: [
+    {
+      name: 'baseos',
+      distribution_arch: 'x86_64',
+      url: 'https://cdn.redhat.com/content/dist/rhel8/8.6/x86_64/baseos/os',
+    },
+    {
+      distribution_arch: 'x86_64',
+      name: 'appstream',
+      url: 'https://cdn.redhat.com/content/dist/rhel8/8.6/x86_64/appstream/os',
+    },
+    {
+      distribution_arch: 'x86_64',
+      name: 'google-compute-engine',
+      url: 'https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable',
+    },
+    {
+      distribution_arch: 'x86_64',
+      name: 'rhel-86-google-cloud-sdk',
+      url: 'https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64',
+    },
+  ],
+  [RHEL_9]: [
+    {
+      name: 'baseos',
+      distribution_arch: 'x86_64',
+      url: 'https://cdn.redhat.com/content/dist/rhel9/9.0/x86_64/baseos/os',
+    },
+    {
+      distribution_arch: 'x86_64',
+      name: 'appstream',
+      url: 'https://cdn.redhat.com/content/dist/rhel9/9.0/x86_64/appstream/os',
+    },
+    {
+      distribution_arch: 'x86_64',
+      name: 'google-compute-engine',
+      url: 'https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable',
+    },
+    {
+      distribution_arch: 'x86_64',
+      name: 'google-cloud-sdk',
+      url: 'https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64',
+    },
+  ],
+  'centos-8': [
+    {
+      name: 'baseos',
+      distribution_arch: 'x86_64',
+      url: 'http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/',
+    },
+    {
+      name: 'appstream',
+      distribution_arch: 'x86_64',
+      url: 'http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/',
+    },
+    {
+      name: 'extras',
+      distribution_arch: 'x86_64',
+      url: 'http://mirror.centos.org/centos/8-stream/extras/x86_64/os/',
+    },
+    {
+      name: 'google-compute-engine',
+      distribution_arch: 'x86_64',
+      url: 'https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable',
+    },
+    {
+      name: 'google-cloud-sdk',
+      distribution_arch: 'x86_64',
+      url: 'https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64',
+    },
+  ],
+  'centos-9': [
+    {
+      name: 'baseos',
+      distribution_arch: 'x86_64',
+      url: 'http://mirror.centos.org/centos/9-stream/BaseOS/x86_64/os/',
+    },
+    {
+      name: 'appstream',
+      distribution_arch: 'x86_64',
+      url: 'http://mirror.centos.org/centos/9-stream/AppStream/x86_64/os/',
+    },
+    {
+      name: 'extras',
+      distribution_arch: 'x86_64',
+      url: 'http://mirror.centos.org/centos/9-stream/extras/x86_64/os/',
+    },
+    {
+      name: 'google-compute-engine',
+      distribution_arch: 'x86_64',
+      url: 'https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable',
+    },
+    {
+      name: 'google-cloud-sdk',
+      distribution_arch: 'x86_64',
+      url: 'https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64',
+    },
+  ],
+};


### PR DESCRIPTION
The Content Sources service is now used for handling package info and search. The api call to this service requires a list of repo urls. The `repos.json` file tracks the supported repositories for each distro. This is then mapped into a url array for whichever distro we are searching for packages. The response body is similar to what existed in image-builder but the key `package_name` needs to be mapped to just `name`. Also, there is no pagination in Content Sources for `/rpms/names` so we can currently only fetch a limit of 20 packages.