### PR TITLE
ImagesTable: Fix Recreate image button

### DIFF
--- a/src/Components/ImagesTable/ImageLinkDirect.js
+++ b/src/Components/ImagesTable/ImageLinkDirect.js
@@ -119,7 +119,7 @@ const ImageLinkDirect = ({ uploadStatus, ...props }) => {
           target="_blank"
           variant="link"
           onClick={() =>
-            navigate(resolveRelPath('/imagewizard'), {
+            navigate(resolveRelPath('imagewizard'), {
               state: {
                 composeRequest: props.recreateImage,
                 initialStep: 'review',


### PR DESCRIPTION
This removes an extra `/` from the path for the `navigate` function to be able to resolve relative path correctly.