### PR TITLE
DocumentationButton: fix documentation url

### DIFF
--- a/src/Components/sharedComponents/DocumentationButton.js
+++ b/src/Components/sharedComponents/DocumentationButton.js
@@ -4,7 +4,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 const DocumentationButton = () => {
   const documentationURL =
-    'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_a_customized_rhel_system_image/index';
+    'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_rhel_images_using_the_image_builder_service/index';
 
   return (
     <Button


### PR DESCRIPTION
The old URL pointed to the on-prem documentation, not the service docs.