### PR TITLE
HMSPROV #355 - add architecture to provisioning wizard

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -39,6 +39,7 @@ const ProvisioningLink = ({ imageId, isExpired, isInClonesTable }) => {
             image={{
               name: image.imageName,
               id: image.id,
+              architecture: image.architecture,
             }}
           />
         )}

--- a/src/store/composesSlice.js
+++ b/src/store/composesSlice.js
@@ -65,6 +65,7 @@ export const selectComposeById = (state, composeId) => {
       uploadOptions: compose.request.image_requests[0].upload_request.options,
       uploadStatus: compose.image_status?.upload_status,
       request: compose.request,
+      architecture: compose.request.image_requests[0].architecture,
       isClone: false,
     };
   } else {


### PR DESCRIPTION
This is needed for filtering all unmatched instance types architecture in the provisioning wizard.
