### PR TITLE
Add provisioning-fronternd integration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,19 @@ The UI should be running on
 https://prod.foo.redhat.com:1337/beta/insights/image-builder/landing.
 Note that this requires you to have access to either production or stage (plus VPN and proxy config) of insights.
 
+### Develop with provisioning-frontend
+
+The provisioning-wizard is a separate frontend [app](https://github.com/RHEnVision/provisioning-frontend) which is consumed for launching images in image-builder. In some cases, developers would like to develop and integrate both apps at once.
+
+run `npm run dev:hms`
+this script will
+    -  git clone `provisioning-frontend` and `cloud-services-config` to parent directory (if needed)
+    -  copy files and install npm modules
+    -  add local routes to webpack-proxy 
+    -  run `provisioning-frontend` as federated module
+    -  run http server to serve the cloud-config locally
+    -  run image builder in stage-beta
+ 
 ## Backend Development
 
 To develop both the frontend and the backend you can again use the proxy to run both the

--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -12,6 +12,8 @@ const webpackProxy = {
   appUrl: process.env.BETA
     ? '/beta/insights/image-builder'
     : '/insights/image-builder',
+  routesPath:
+    process.env.DEV_ROUTES_PATH && resolve(process.env.DEV_ROUTES_PATH),
 };
 
 const { config: webpackConfig, plugins } = config({

--- a/config/routes.dev.config.js
+++ b/config/routes.dev.config.js
@@ -1,0 +1,11 @@
+const CHROME_CONFIG_PORT = 8889;
+const PROV_FRONT_PORT = 8003;
+const PROV_APP_PATH = `${process.env.BETA ? '/beta' : ''}/apps/provisioning`;
+const CONFIG_PATH = `${process.env.BETA ? '/beta' : ''}/config/chrome`;
+
+module.exports = {
+  routes: {
+    [PROV_APP_PATH]: { host: `http://127.0.0.1:${PROV_FRONT_PORT}` },
+    [CONFIG_PATH]: { host: `http://127.0.0.1:${CHROME_CONFIG_PORT}` },
+  },
+};

--- a/devel/provisioning.sh
+++ b/devel/provisioning.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+IB_DIR=$(pwd)
+PROVISIONING_DIR=$IB_DIR/../provisioning-frontend
+CLOUD_CONFIG_DIR=$IB_DIR/../cloud-services-config
+
+PROVISIONING_REPO='https://github.com/RHEnVision/provisioning-frontend.git'
+CLOUD_CONFIG_REPO='https://github.com/RedHatInsights/cloud-services-config.git'
+
+if [ ! -d $PROVISIONING_DIR ]
+then
+  cd $IB_DIR/.. && git clone $PROVISIONING_REPO &&
+  cd $PROVISIONING_DIR && npm install
+fi  
+if [ ! -d $CLOUD_CONFIG_DIR ]
+then
+  cd $IB_DIR/.. && git clone $CLOUD_CONFIG_REPO &&
+  cd $CLOUD_CONFIG_DIR && mkdir -p "beta/config" && cp -R chrome "beta/config"
+fi  
+
+cd $CLOUD_CONFIG_DIR && npx http-server -p 8889 &
+cd $PROVISIONING_DIR && BETA=true npm run start:federated &
+cd $IB_DIR && STAGE=true npm run prod-beta

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "test": "TZ=UTC jest --verbose --no-cache",
     "test:single": "jest --verbose -w 1",
     "build": "webpack --config config/prod.webpack.config.js",
-    "verify": "npm-run-all build lint test"
+    "verify": "npm-run-all build lint test",
+    "dev:hms": "DEV_ROUTES_PATH=config/routes.dev.config.js ./devel/provisioning.sh"
   },
   "insights": {
     "appname": "image-builder"


### PR DESCRIPTION
The provisioning-wizard is a separate frontend [app](https://github.com/RHEnVision/provisioning-frontend) which is consumed for launching images in image-builder. In some cases, developers would like to develop and integrate both apps at once.

run `npm run dev:hms`
this script will
    -  git clone `provisioning-frontend` and `cloud-services-config` to parent directory (if needed)
    -  copy files and install npm modules
    -  add local routes to webpack-proxy 
    -  run `provisioning-frontend` as federated module
    -  run http server to serve the cloud-config locally
    -  run image builder in stage-beta