### PR TITLE
Migrate to shared history

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -34,6 +34,8 @@ plugins.push(
       exposes: {
         './RootApp': resolve(__dirname, '../src/AppEntry.js'),
       },
+      shared: [{ 'react-router-dom': { singleton: true } }],
+      exclude: ['react-router-dom'],
     }
   )
 );

--- a/src/AppEntry.js
+++ b/src/AppEntry.js
@@ -1,17 +1,13 @@
 import React from 'react';
 
 import { Provider } from 'react-redux';
-import { BrowserRouter as Router } from 'react-router-dom';
 
 import App from './App';
 import { store } from './store';
-import { getBaseName } from './Utilities/path';
 
 const ImageBuilder = () => (
   <Provider store={store}>
-    <Router basename={getBaseName(window.location.pathname)}>
-      <App />
-    </Router>
+    <App />
   </Provider>
 );
 

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -9,6 +9,7 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
+import { Outlet } from 'react-router-dom';
 
 import ImagesTable from '../ImagesTable/ImagesTable';
 import './LandingPage.scss';
@@ -63,6 +64,7 @@ class LandingPage extends Component {
         <section className="pf-l-page__main-section pf-c-page__main-section">
           <ImagesTable />
         </section>
+        <Outlet />
       </React.Fragment>
     );
   }

--- a/src/Router.js
+++ b/src/Router.js
@@ -3,7 +3,6 @@ import React, { lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import ShareImageModal from './Components/ShareImageModal/ShareImageModal';
-import { resolveRelPath } from './Utilities/path';
 
 const LandingPage = lazy(() => import('./Components/LandingPage/LandingPage'));
 const CreateImageWizard = lazy(() =>
@@ -13,12 +12,10 @@ const CreateImageWizard = lazy(() =>
 export const Router = () => {
   return (
     <Routes>
-      <Route
-        path={resolveRelPath('imagewizard/*')}
-        element={<CreateImageWizard />}
-      />
-      <Route path={resolveRelPath('*')} element={<LandingPage />} />
-      <Route path={resolveRelPath('share/*')} element={<ShareImageModal />} />
+      <Route path="*" element={<LandingPage />}>
+        <Route path="imagewizard/*" element={<CreateImageWizard />} />
+        <Route path="share/*" element={<ShareImageModal />} />
+      </Route>
     </Routes>
   );
 };

--- a/src/Utilities/path.js
+++ b/src/Utilities/path.js
@@ -12,8 +12,8 @@ function getBaseName(pathname) {
   return `${release}`;
 }
 
-function resolveRelPath(path) {
-  return `/insights/image-builder/${path}`;
+function resolveRelPath(path = '') {
+  return `/insights/image-builder${path.length > 0 ? `/${path}` : ''}`;
 }
 
 export { getBaseName, resolveRelPath };

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.stage.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.stage.test.js
@@ -1384,7 +1384,7 @@ describe('Click through all steps', () => {
 
     // returns back to the landing page
     await waitFor(() =>
-      expect(history.location.pathname).toBe('/insights/image-builder/')
+      expect(history.location.pathname).toBe('/insights/image-builder')
     );
     expect(store.getState().composes.allIds).toEqual(ids);
     // set test timeout of 10 seconds

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -37,7 +37,7 @@ function getCancelButton() {
 function verifyCancelButton(cancel, history) {
   cancel.click();
 
-  expect(history.location.pathname).toBe('/insights/image-builder/');
+  expect(history.location.pathname).toBe('/insights/image-builder');
 }
 
 // packages
@@ -1785,7 +1785,7 @@ describe('Click through all steps', () => {
 
     // returns back to the landing page
     await waitFor(() =>
-      expect(history.location.pathname).toBe('/insights/image-builder/')
+      expect(history.location.pathname).toBe('/insights/image-builder')
     );
     expect(store.getState().composes.allIds).toEqual(ids);
     // set test timeout of 10 seconds
@@ -1908,7 +1908,7 @@ describe('Keyboard accessibility', () => {
     const awsTile = screen.getByTestId('upload-aws');
     userEvent.click(awsTile);
     userEvent.keyboard('{esc}');
-    expect(history.location.pathname).toBe('/insights/image-builder/');
+    expect(history.location.pathname).toBe('/insights/image-builder');
   });
 
   test('pressing Enter does not advance the wizard', async () => {

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.js
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.js
@@ -205,7 +205,7 @@ describe('Create Share To Regions Modal', () => {
 
     // returns back to the landing page
     await waitFor(() =>
-      expect(history.location.pathname).toBe('/insights/image-builder/')
+      expect(history.location.pathname).toBe('/insights/image-builder')
     );
   });
 
@@ -218,7 +218,7 @@ describe('Create Share To Regions Modal', () => {
 
     // returns back to the landing page
     await waitFor(() =>
-      expect(history.location.pathname).toBe('/insights/image-builder/')
+      expect(history.location.pathname).toBe('/insights/image-builder')
     );
   });
 
@@ -288,7 +288,7 @@ describe('Create Share To Regions Modal', () => {
 
     // returns back to the landing page
     await waitFor(() =>
-      expect(history.location.pathname).toBe('/insights/image-builder/')
+      expect(history.location.pathname).toBe('/insights/image-builder')
     );
 
     // Clone has been added to its parent's list of clones


### PR DESCRIPTION
### Changes
- migrate over to chrome router context
- fix LandingPage component not rendering when modals are opened


The image builder should work even without this change, but we do not guarantee stability.

**This PR will have follow the Chrome release schedule!**