### PR TITLE
Wizard: Improve validation of GCP targets

### DIFF
--- a/src/Components/CreateImageWizard/steps/googleCloud.js
+++ b/src/Components/CreateImageWizard/steps/googleCloud.js
@@ -151,7 +151,7 @@ export default {
         },
         {
           type: validatorTypes.PATTERN,
-          pattern: '[a-z0-9._%+-]+@[a-z0-9.-]+.[a-z]{2,}$',
+          pattern: '^[a-z0-9._%+-]+@[a-z0-9.-]+.[a-z]{2,}$',
           message: 'Please enter a valid email address',
         },
       ],


### PR DESCRIPTION
Fixes #879. This adds anchor at the beginning of the regular expression for validation of GCP targets.