### PR TITLE
Wizard: Remove clear handler from Release select on Image Output step

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ImageOutputReleaseSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/ImageOutputReleaseSelect.js
@@ -24,11 +24,6 @@ const ImageOutputReleaseSelect = ({ label, isRequired, ...props }) => {
     setIsOpen(false);
   };
 
-  const handleClear = () => {
-    change(input.name, null);
-    setShowDevelopmentOptions(false);
-  };
-
   const handleExpand = () => {
     setShowDevelopmentOptions(true);
   };
@@ -39,7 +34,6 @@ const ImageOutputReleaseSelect = ({ label, isRequired, ...props }) => {
         variant={SelectVariant.single}
         onToggle={() => setIsOpen(!isOpen)}
         onSelect={setRelease}
-        onClear={handleClear}
         selections={RELEASES[getState()?.values?.[input.name]]}
         isOpen={isOpen}
         {...(!showDevelopmentOptions && {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -307,37 +307,6 @@ describe('Step Image output', () => {
     userEvent.click(releaseMenu);
   });
 
-  test('clear button resets to initial state (unexpanded)', async () => {
-    setUp();
-
-    const releaseMenu = screen.getByRole('button', {
-      name: /options menu/i,
-    });
-    userEvent.click(releaseMenu);
-
-    const showOptionsButton = screen.getByRole('button', {
-      name: 'Show options for further development of RHEL',
-    });
-    userEvent.click(showOptionsButton);
-
-    const clearAllButton = screen.getByRole('button', {
-      name: /clear all/i,
-    });
-    userEvent.click(clearAllButton);
-
-    await screen.findByRole('option', {
-      name: 'Red Hat Enterprise Linux (RHEL) 8',
-    });
-    await screen.findByRole('option', {
-      name: 'Red Hat Enterprise Linux (RHEL) 9',
-    });
-    await screen.findByRole('button', {
-      name: 'Show options for further development of RHEL',
-    });
-
-    userEvent.click(releaseMenu);
-  });
-
   test('CentOS acknowledgement appears', async () => {
     setUp();
 


### PR DESCRIPTION
This commit fixes #893 by removing the ability to clear the release select on the image output step (this is the select where the user chooses from RHEL 8, RHEL 9, CentOS 8 or 9, etc...).

Originally the ability to clear the select was added so that the default state (where CentOS options are hidden behind a 'speedbump') could be returned to but this seems unnecessary in retrospect and introduces opportunities for bugs (as seen with the validation in #893) so it seems wise to simply remove the ability to clear altogether.