### PR TITLE
Wizard: Clarify variable names and comments in requestToState()

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -359,9 +359,15 @@ const requestToState = (composeRequest) => {
     formState['selected-packages'] = packs;
 
     // repositories
-    // 'payload-repositories' is treated as read-only and is used to populate
-    // the table in the repositories table
-    formState['payload-repositories'] =
+    // 'original-payload-repositories' is treated as read-only and is used to populate
+    // the table in the repositories step
+    // This is necessary because there may be repositories present in the request's
+    // json blob that are not managed using the content sources API. In that case,
+    // they are still displayed in the table of repositories but without any information
+    // from the content sources API (in other words, only the URL of the repository is
+    // displayed). This information needs to persist throughout the lifetime of the
+    // Wizard as it is needed every time the repositories step is visited.
+    formState['original-payload-repositories'] =
       composeRequest?.customizations?.payload_repositories;
     // 'custom-repositories' is mutable and is used to generate the request
     // sent to image-builder

--- a/src/Components/CreateImageWizard/formComponents/Repositories.js
+++ b/src/Components/CreateImageWizard/formComponents/Repositories.js
@@ -135,7 +135,8 @@ const Repositories = (props) => {
 
     // Repositories in the form state can be present when 'Recreate image' is used
     // to open the wizard that are not necessarily in content sources.
-    const formStateReposList = getState()?.values?.['payload-repositories'];
+    const formStateReposList =
+      getState()?.values?.['original-payload-repositories'];
 
     const mergeRepositories = (contentSourcesRepos, formStateReposList) => {
       const formStateRepos = {};


### PR DESCRIPTION
This commit clarifies variable names and comments that were found to be confusing during the review of 5adc0e.