### PR TITLE
ImagesTable: Fix status bug

### DIFF
--- a/src/Components/ImagesTable/ImageBuildStatus.js
+++ b/src/Components/ImagesTable/ImageBuildStatus.js
@@ -20,7 +20,7 @@ import {
 } from '../../store/composesSlice';
 import { hoursToExpiration } from '../../Utilities/time';
 
-export const ImageBuildStatus = ({ imageId }) => {
+export const ImageBuildStatus = ({ imageId, isImagesTableRow }) => {
   const image = useSelector((state) => selectImageById(state, imageId));
 
   const remainingHours =
@@ -96,9 +96,15 @@ export const ImageBuildStatus = ({ imageId }) => {
 
   let status;
   if (
-    !image.isClone &&
+    isImagesTableRow &&
     (image.imageType === 'aws' || image.imageType === 'ami')
   ) {
+    // The ImageBuildStatus component is used by both the images table and the clones table.
+    // For 'aws' and 'ami' image rows in the images table, the highest priority status for
+    // *all* images (the parent image and its clones) should be displayed as the status.
+    // For instance, the parent and several of its clones may have a success status. But if a single
+    // clone has a failure status, then the status displayed in the images table row should be
+    // failure.
     const imageStatuses = useSelector((state) =>
       selectImageStatusesById(state, image.id)
     );
@@ -139,4 +145,5 @@ export const ImageBuildStatus = ({ imageId }) => {
 
 ImageBuildStatus.propTypes = {
   imageId: PropTypes.string,
+  isImagesTableRow: PropTypes.bool,
 };

--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -253,7 +253,10 @@ const ImagesTable = () => {
                         <Target composeId={id} />
                       </Td>
                       <Td dataLabel="Status">
-                        <ImageBuildStatus imageId={id} />
+                        <ImageBuildStatus
+                          imageId={id}
+                          isImagesTableRow={true}
+                        />
                       </Td>
                       <Td dataLabel="Instance">
                         <ImageLink

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -497,7 +497,7 @@ describe('Images Table', () => {
         expect(row.cells[5]).toHaveTextContent('Expired');
       } else {
         renderWithProvider(
-          <ImageBuildStatus imageId={compose.id} />,
+          <ImageBuildStatus imageId={compose.id} isImagesTableRow={true} />,
           testElement,
           state
         );


### PR DESCRIPTION
Fixes #899. The status of images (parent images and clones) in the clones table was displayed incorrectly - the 'highest priority' (e.g. failure > success) was displayed for all images.

This was due to a bug in a conditional in the ImageBuildStatus component. In the main images table, rows for AWS images should display the highest priority status of *all* images. A single failed clone should cause the status of the row in the main images table to be failure, even if the parent compose status is successful.

This logic was incorrectly being applied to *all* statuses. This commit fixes this - from now on, this logic is only used for rows in the main images table.