### PR TITLE
Aws sources

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -7,7 +7,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import ImageCreator from './ImageCreator';
 import {
-  awsTarget,
+  awsTargetStable,
+  awsTargetBeta,
   fileSystemConfiguration,
   googleCloudTarger,
   imageName,
@@ -475,6 +476,8 @@ const formStepHistory = (composeRequest) => {
 };
 
 const CreateImageWizard = () => {
+  const awsTarget = insights.chrome.isBeta() ? awsTargetBeta : awsTargetStable;
+
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const location = useLocation();

--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -48,3 +48,7 @@
 .pf-u-min-width {
     --pf-u-min-width--MinWidth: 11ch;
 }
+
+.pf-u-max-width {
+    --pf-u-max-width--MaxWidth: 26rem;
+}

--- a/src/Components/CreateImageWizard/ImageCreator.js
+++ b/src/Components/CreateImageWizard/ImageCreator.js
@@ -8,9 +8,12 @@ import { Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
 import ActivationKeys from './formComponents/ActivationKeys';
+import { AWSSourcesSelect } from './formComponents/AWSSourcesSelect';
 import AzureAuthButton from './formComponents/AzureAuthButton';
 import CentOSAcknowledgement from './formComponents/CentOSAcknowledgement';
+import FieldListenerWrapper from './formComponents/FieldListener';
 import FileSystemConfiguration from './formComponents/FileSystemConfiguration';
+import GalleryLayout from './formComponents/GalleryLayout';
 import ImageOutputReleaseSelect from './formComponents/ImageOutputReleaseSelect';
 import {
   ContentSourcesPackages,
@@ -63,6 +66,9 @@ const ImageCreator = ({
         'image-output-release-select': ImageOutputReleaseSelect,
         'centos-acknowledgement': CentOSAcknowledgement,
         'repositories-table': Repositories,
+        'aws-sources-select': AWSSourcesSelect,
+        'gallery-layout': GalleryLayout,
+        'field-listener': FieldListenerWrapper,
         ...customComponentMapper,
       }}
       onCancel={onClose}

--- a/src/Components/CreateImageWizard/formComponents/AWSSourcesSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/AWSSourcesSelect.js
@@ -1,0 +1,120 @@
+import React, { useState } from 'react';
+
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import { Alert } from '@patternfly/react-core';
+import {
+  FormGroup,
+  Select,
+  SelectOption,
+  SelectVariant,
+  Spinner,
+} from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+import { useGetAWSSourcesQuery } from '../../../store/apiSlice';
+
+export const AWSSourcesSelect = ({
+  label,
+  isRequired,
+  className,
+  ...props
+}) => {
+  const { change, getState } = useFormApi();
+  const { input } = useFieldApi(props);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedSourceId, setSelectedSourceId] = useState(
+    getState()?.values?.['aws-sources-select']
+  );
+
+  const {
+    data: sources,
+    isFetching,
+    isSuccess,
+    isError,
+    refetch,
+  } = useGetAWSSourcesQuery();
+
+  const handleSelect = (_, sourceName) => {
+    const sourceId = sources.find((source) => source.name === sourceName).id;
+    setSelectedSourceId(sourceId);
+    setIsOpen(false);
+    change(input.name, sourceId);
+  };
+
+  const handleClear = () => {
+    setSelectedSourceId();
+    change(input.name, undefined);
+  };
+
+  const handleToggle = () => {
+    // Refetch upon opening (but not upon closing)
+    if (!isOpen) {
+      refetch();
+    }
+
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <>
+      <FormGroup
+        isRequired={isRequired}
+        label={label}
+        data-testid="sources"
+        className={className}
+      >
+        <Select
+          variant={SelectVariant.typeahead}
+          onToggle={handleToggle}
+          onSelect={handleSelect}
+          onClear={handleClear}
+          selections={
+            selectedSourceId
+              ? sources.find((source) => source.id === selectedSourceId)?.name
+              : undefined
+          }
+          isOpen={isOpen}
+          placeholderText="Select source"
+          typeAheadAriaLabel="Select source"
+          menuAppendTo="parent"
+          maxHeight="25rem"
+          isDisabled={!isSuccess}
+        >
+          {isSuccess &&
+            sources.map((source) => (
+              <SelectOption
+                key={source.id}
+                value={source.name}
+                description={source.account_id}
+              />
+            ))}
+          {isFetching && (
+            <SelectOption isNoResultsOption={true}>
+              <Spinner isSVG size="lg" />
+            </SelectOption>
+          )}
+        </Select>
+      </FormGroup>
+      <>
+        {isError && (
+          <Alert
+            variant={'danger'}
+            isPlain={true}
+            isInline={true}
+            title={'Sources unavailable'}
+          >
+            Sources cannot be reached, try again later or enter an AWS account
+            ID manually.
+          </Alert>
+        )}
+      </>
+    </>
+  );
+};
+
+AWSSourcesSelect.propTypes = {
+  className: PropTypes.string,
+  label: PropTypes.node,
+  isRequired: PropTypes.bool,
+};

--- a/src/Components/CreateImageWizard/formComponents/FieldListener.js
+++ b/src/Components/CreateImageWizard/formComponents/FieldListener.js
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+
+import { FormSpy, useFormApi } from '@data-driven-forms/react-form-renderer';
+
+import { useGetAWSSourcesQuery } from '../../../store/apiSlice';
+
+const FieldListener = () => {
+  // This listener synchronizes the value of the AWS account ID text field with the
+  // value of the AWS source select field on the AWS target step.
+  // Using a listener to set the value of one field according to the value of another
+  // is a recommended pattern for Data Driven Forms:
+  // https://www.data-driven-forms.org/examples/value-listener
+  const { getState, change } = useFormApi();
+  const awsSourcesSelect = getState().values['aws-sources-select'];
+  const { data: awsSources } = useGetAWSSourcesQuery();
+
+  useEffect(() => {
+    if (awsSourcesSelect) {
+      const awsAccountId = awsSources.find(
+        (source) => source.id === getState()?.values?.['aws-sources-select']
+      )?.account_id;
+
+      change('aws-associated-account-id', awsAccountId);
+    } else {
+      change('aws-associated-account-id', undefined);
+    }
+  }, [awsSourcesSelect]);
+
+  return null;
+};
+
+const FieldListenerWrapper = () => (
+  <FormSpy subcription={{ values: true }}>{() => <FieldListener />}</FormSpy>
+);
+
+export default FieldListenerWrapper;

--- a/src/Components/CreateImageWizard/formComponents/GalleryLayout.js
+++ b/src/Components/CreateImageWizard/formComponents/GalleryLayout.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import { Gallery, GalleryItem } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+const GalleryLayout = ({ fields, minWidths, maxWidths }) => {
+  const { renderForm } = useFormApi();
+
+  return (
+    <Gallery minWidths={minWidths} maxWidths={maxWidths} hasGutter>
+      {fields.map((field) => (
+        <GalleryItem key={field.name}>{renderForm([field])}</GalleryItem>
+      ))}
+    </Gallery>
+  );
+};
+
+GalleryLayout.propTypes = {
+  fields: PropTypes.array,
+  maxWidths: PropTypes.object,
+  minWidths: PropTypes.object,
+};
+
+export default GalleryLayout;

--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -36,6 +36,7 @@ import PropTypes from 'prop-types';
 import ActivationKeyInformation from './ActivationKeyInformation';
 
 import { RELEASES, UNIT_GIB, UNIT_MIB } from '../../../constants';
+import { useGetAWSSourcesQuery } from '../../../store/apiSlice';
 import isRhel from '../../../Utilities/isRhel';
 import { googleAccType } from '../steps/googleCloud';
 
@@ -80,6 +81,9 @@ const ReviewStep = () => {
   const [activeTabKey, setActiveTabKey] = useState(0);
   const [minSize, setMinSize] = useState();
   const { change, getState } = useFormApi();
+
+  const { data: awsSources, isSuccess: isSuccessAWSSources } =
+    useGetAWSSourcesQuery();
 
   useEffect(() => {
     const registerSystem = getState()?.values?.['register-system'];
@@ -167,10 +171,38 @@ const ReviewStep = () => {
                       component={TextListItemVariants.dt}
                       className="pf-u-min-width"
                     >
+                      {getState()?.values?.['aws-target-type'] ===
+                      'aws-target-type-source'
+                        ? 'Source'
+                        : null}
+                    </TextListItem>
+                    <TextListItem component={TextListItemVariants.dd}>
+                      {isSuccessAWSSources &&
+                      getState()?.values?.['aws-target-type'] ===
+                        'aws-target-type-source'
+                        ? awsSources.find(
+                            (source) =>
+                              source.id ===
+                              getState()?.values?.['aws-sources-select']
+                          )?.name
+                        : null}
+                    </TextListItem>
+                    <TextListItem
+                      component={TextListItemVariants.dt}
+                      className="pf-u-min-width"
+                    >
                       Account ID
                     </TextListItem>
                     <TextListItem component={TextListItemVariants.dd}>
-                      {getState()?.values?.['aws-account-id']}
+                      {isSuccessAWSSources &&
+                      getState()?.values?.['aws-target-type'] ===
+                        'aws-target-type-source'
+                        ? awsSources.find(
+                            (source) =>
+                              source.id ===
+                              getState()?.values?.['aws-sources-select']
+                          )?.account_id
+                        : getState()?.values?.['aws-account-id']}
                     </TextListItem>
                     <TextListItem component={TextListItemVariants.dt}>
                       Default Region

--- a/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
+++ b/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
@@ -11,6 +11,8 @@ import {
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
+import { usePrefetch } from '../../../store/apiSlice';
+
 const TargetEnvironment = ({ label, isRequired, ...props }) => {
   const { getState, change } = useFormApi();
   const { input } = useFieldApi({ label, isRequired, ...props });
@@ -22,12 +24,19 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
     'guest-image': false,
     'image-installer': false,
   });
+  const prefetchAWSSources = usePrefetch('getAWSSources');
 
   useEffect(() => {
     if (getState()?.values?.[input.name]) {
       setEnvironment(getState().values[input.name]);
     }
   }, []);
+
+  useEffect(() => {
+    if (environment['aws'] === true) {
+      prefetchAWSSources();
+    }
+  }, [environment]);
 
   const handleSetEnvironment = (env) =>
     setEnvironment((prevEnv) => {

--- a/src/Components/CreateImageWizard/steps/aws.beta.js
+++ b/src/Components/CreateImageWizard/steps/aws.beta.js
@@ -1,0 +1,192 @@
+import React from 'react';
+
+import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
+import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
+import {
+  Button,
+  HelperText,
+  HelperTextItem,
+  Title,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import nextStepMapper from './imageOutputStepMapper';
+import StepTemplate from './stepTemplate';
+
+import { DEFAULT_AWS_REGION } from '../../../constants';
+import CustomButtons from '../formComponents/CustomButtons';
+
+const SourcesButton = () => {
+  return (
+    <Button
+      component="a"
+      target="_blank"
+      variant="link"
+      icon={<ExternalLinkAltIcon />}
+      iconPosition="right"
+      isInline
+      href={'settings/sources'}
+    >
+      Create and manage sources here
+    </Button>
+  );
+};
+
+export default {
+  StepTemplate,
+  id: 'wizard-target-aws',
+  title: 'Amazon Web Services',
+  customTitle: (
+    <Title headingLevel="h1" size="xl">
+      Target environment - Amazon Web Services
+    </Title>
+  ),
+  name: 'aws-target-env',
+  substepOf: 'Target environment',
+  nextStep: ({ values }) => nextStepMapper(values, { skipAws: true }),
+  buttons: CustomButtons,
+  fields: [
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'plain-text-component',
+      label: (
+        <p>
+          Your image will be uploaded to AWS and shared with the account you
+          provide below.
+        </p>
+      ),
+    },
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'plain-text-component',
+      label: (
+        <p>
+          <b>The shared image will expire within 14 days.</b> To permanently
+          access the image, copy the image, which will be shared to your account
+          by Red Hat, to your own AWS account.
+        </p>
+      ),
+    },
+    {
+      component: componentTypes.RADIO,
+      label: 'Share method:',
+      name: 'aws-target-type',
+      initialValue: 'aws-target-type-source',
+      autoFocus: true,
+      options: [
+        {
+          label: 'Use an account configured from Sources.',
+          description:
+            'Use a configured source to launch environments directly from the console.',
+          value: 'aws-target-type-source',
+          'data-testid': 'aws-radio-source',
+          autoFocus: true,
+        },
+        {
+          label: 'Manually enter an account ID.',
+          value: 'aws-target-type-account-id',
+          'data-testid': 'aws-radio-account-id',
+          className: 'pf-u-mt-sm',
+        },
+      ],
+    },
+    {
+      component: 'aws-sources-select',
+      name: 'aws-sources-select',
+      className: 'pf-u-max-width',
+      label: 'Source Name',
+      isRequired: true,
+      validate: [
+        {
+          type: validatorTypes.REQUIRED,
+        },
+      ],
+      condition: {
+        when: 'aws-target-type',
+        is: 'aws-target-type-source',
+      },
+    },
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'aws-sources-select-description',
+      label: <SourcesButton />,
+      condition: {
+        when: 'aws-target-type',
+        is: 'aws-target-type-source',
+      },
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'aws-account-id',
+      className: 'pf-u-w-25',
+      'data-testid': 'aws-account-id',
+      type: 'text',
+      label: 'AWS account ID',
+      isRequired: true,
+      validate: [
+        {
+          type: validatorTypes.REQUIRED,
+        },
+        {
+          type: validatorTypes.EXACT_LENGTH,
+          threshold: 12,
+        },
+      ],
+      condition: {
+        when: 'aws-target-type',
+        is: 'aws-target-type-account-id',
+      },
+    },
+    {
+      name: 'gallery-layout',
+      component: 'gallery-layout',
+      minWidths: { default: '12.5rem' },
+      maxWidths: { default: '12.5rem' },
+      fields: [
+        {
+          component: componentTypes.TEXT_FIELD,
+          name: 'aws-default-region',
+          value: DEFAULT_AWS_REGION,
+          'data-testid': 'aws-default-region',
+          type: 'text',
+          label: 'Default Region',
+          isReadOnly: true,
+          isRequired: true,
+          helperText: (
+            <HelperText>
+              <HelperTextItem component="div" variant="indeterminate">
+                Images are built in the default region but can be copied to
+                other regions later.
+              </HelperTextItem>
+            </HelperText>
+          ),
+        },
+        {
+          component: componentTypes.TEXT_FIELD,
+          name: 'aws-associated-account-id',
+          'data-testid': 'aws-associated-account-id',
+          type: 'text',
+          label: 'Associated Account ID',
+          isReadOnly: true,
+          isRequired: true,
+          helperText: (
+            <HelperText>
+              <HelperTextItem component="div" variant="indeterminate">
+                This is the account associated with the source.
+              </HelperTextItem>
+            </HelperText>
+          ),
+          condition: {
+            when: 'aws-target-type',
+            is: 'aws-target-type-source',
+          },
+        },
+        {
+          component: 'field-listener',
+          name: 'aws-associated-account-id-listener',
+          hideField: true,
+        },
+      ],
+    },
+  ],
+};

--- a/src/Components/CreateImageWizard/steps/aws.js
+++ b/src/Components/CreateImageWizard/steps/aws.js
@@ -2,13 +2,35 @@ import React from 'react';
 
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
-import { HelperText, HelperTextItem, Title } from '@patternfly/react-core';
+import {
+  Button,
+  HelperText,
+  HelperTextItem,
+  Title,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import nextStepMapper from './imageOutputStepMapper';
 import StepTemplate from './stepTemplate';
 
 import { DEFAULT_AWS_REGION } from '../../../constants';
 import CustomButtons from '../formComponents/CustomButtons';
+
+const SourcesButton = () => {
+  return (
+    <Button
+      component="a"
+      target="_blank"
+      variant="link"
+      icon={<ExternalLinkAltIcon />}
+      iconPosition="right"
+      isInline
+      href={'settings/sources'}
+    >
+      Create and manage sources here
+    </Button>
+  );
+};
 
 export default {
   StepTemplate,
@@ -46,6 +68,54 @@ export default {
       ),
     },
     {
+      component: componentTypes.RADIO,
+      label: 'Share method:',
+      name: 'aws-target-type',
+      initialValue: 'aws-target-type-source',
+      autoFocus: true,
+      options: [
+        {
+          label: 'Use an account configured from Sources.',
+          description:
+            'Use a configured source to launch environments directly from the console.',
+          value: 'aws-target-type-source',
+          'data-testid': 'aws-radio-source',
+          autoFocus: true,
+        },
+        {
+          label: 'Manually enter an account ID.',
+          value: 'aws-target-type-account-id',
+          'data-testid': 'aws-radio-account-id',
+          className: 'pf-u-mt-sm',
+        },
+      ],
+    },
+    {
+      component: 'aws-sources-select',
+      name: 'aws-sources-select',
+      className: 'pf-u-max-width',
+      label: 'Source Name',
+      isRequired: true,
+      validate: [
+        {
+          type: validatorTypes.REQUIRED,
+        },
+      ],
+      condition: {
+        when: 'aws-target-type',
+        is: 'aws-target-type-source',
+      },
+    },
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'aws-sources-select-description',
+      label: <SourcesButton />,
+      condition: {
+        when: 'aws-target-type',
+        is: 'aws-target-type-source',
+      },
+    },
+    {
       component: componentTypes.TEXT_FIELD,
       name: 'aws-account-id',
       className: 'pf-u-w-25',
@@ -53,7 +123,6 @@ export default {
       type: 'text',
       label: 'AWS account ID',
       isRequired: true,
-      autoFocus: true,
       validate: [
         {
           type: validatorTypes.REQUIRED,
@@ -63,29 +132,61 @@ export default {
           threshold: 12,
         },
       ],
+      condition: {
+        when: 'aws-target-type',
+        is: 'aws-target-type-account-id',
+      },
     },
     {
-      component: componentTypes.TEXT_FIELD,
-      name: 'aws-default-region',
-      className: 'pf-u-w-25',
-      'data-testid': 'aws-default-region',
-      type: 'text',
-      label: 'Default Region',
-      value: DEFAULT_AWS_REGION,
-      isReadOnly: true,
-      isRequired: true,
-      helperText: (
-        <HelperText>
-          <HelperTextItem
-            component="div"
-            variant="indeterminate"
-            className="pf-u-w-25"
-          >
-            Images are built in the default region but can be copied to other
-            regions later.
-          </HelperTextItem>
-        </HelperText>
-      ),
+      name: 'gallery-layout',
+      component: 'gallery-layout',
+      minWidths: { default: '12.5rem' },
+      maxWidths: { default: '12.5rem' },
+      fields: [
+        {
+          component: componentTypes.TEXT_FIELD,
+          name: 'aws-default-region',
+          value: DEFAULT_AWS_REGION,
+          'data-testid': 'aws-default-region',
+          type: 'text',
+          label: 'Default Region',
+          isReadOnly: true,
+          isRequired: true,
+          helperText: (
+            <HelperText>
+              <HelperTextItem component="div" variant="indeterminate">
+                Images are built in the default region but can be copied to
+                other regions later.
+              </HelperTextItem>
+            </HelperText>
+          ),
+        },
+        {
+          component: componentTypes.TEXT_FIELD,
+          name: 'aws-associated-account-id',
+          'data-testid': 'aws-associated-account-id',
+          type: 'text',
+          label: 'Associated Account ID',
+          isReadOnly: true,
+          isRequired: true,
+          helperText: (
+            <HelperText>
+              <HelperTextItem component="div" variant="indeterminate">
+                This is the account associated with the source.
+              </HelperTextItem>
+            </HelperText>
+          ),
+          condition: {
+            when: 'aws-target-type',
+            is: 'aws-target-type-source',
+          },
+        },
+        {
+          component: 'field-listener',
+          name: 'aws-associated-account-id-listener',
+          hideField: true,
+        },
+      ],
     },
   ],
 };

--- a/src/Components/CreateImageWizard/steps/aws.js
+++ b/src/Components/CreateImageWizard/steps/aws.js
@@ -2,35 +2,13 @@ import React from 'react';
 
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
-import {
-  Button,
-  HelperText,
-  HelperTextItem,
-  Title,
-} from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { HelperText, HelperTextItem, Title } from '@patternfly/react-core';
 
 import nextStepMapper from './imageOutputStepMapper';
 import StepTemplate from './stepTemplate';
 
 import { DEFAULT_AWS_REGION } from '../../../constants';
 import CustomButtons from '../formComponents/CustomButtons';
-
-const SourcesButton = () => {
-  return (
-    <Button
-      component="a"
-      target="_blank"
-      variant="link"
-      icon={<ExternalLinkAltIcon />}
-      iconPosition="right"
-      isInline
-      href={'settings/sources'}
-    >
-      Create and manage sources here
-    </Button>
-  );
-};
 
 export default {
   StepTemplate,
@@ -68,54 +46,6 @@ export default {
       ),
     },
     {
-      component: componentTypes.RADIO,
-      label: 'Share method:',
-      name: 'aws-target-type',
-      initialValue: 'aws-target-type-source',
-      autoFocus: true,
-      options: [
-        {
-          label: 'Use an account configured from Sources.',
-          description:
-            'Use a configured source to launch environments directly from the console.',
-          value: 'aws-target-type-source',
-          'data-testid': 'aws-radio-source',
-          autoFocus: true,
-        },
-        {
-          label: 'Manually enter an account ID.',
-          value: 'aws-target-type-account-id',
-          'data-testid': 'aws-radio-account-id',
-          className: 'pf-u-mt-sm',
-        },
-      ],
-    },
-    {
-      component: 'aws-sources-select',
-      name: 'aws-sources-select',
-      className: 'pf-u-max-width',
-      label: 'Source Name',
-      isRequired: true,
-      validate: [
-        {
-          type: validatorTypes.REQUIRED,
-        },
-      ],
-      condition: {
-        when: 'aws-target-type',
-        is: 'aws-target-type-source',
-      },
-    },
-    {
-      component: componentTypes.PLAIN_TEXT,
-      name: 'aws-sources-select-description',
-      label: <SourcesButton />,
-      condition: {
-        when: 'aws-target-type',
-        is: 'aws-target-type-source',
-      },
-    },
-    {
       component: componentTypes.TEXT_FIELD,
       name: 'aws-account-id',
       className: 'pf-u-w-25',
@@ -123,6 +53,7 @@ export default {
       type: 'text',
       label: 'AWS account ID',
       isRequired: true,
+      autoFocus: true,
       validate: [
         {
           type: validatorTypes.REQUIRED,
@@ -132,61 +63,29 @@ export default {
           threshold: 12,
         },
       ],
-      condition: {
-        when: 'aws-target-type',
-        is: 'aws-target-type-account-id',
-      },
     },
     {
-      name: 'gallery-layout',
-      component: 'gallery-layout',
-      minWidths: { default: '12.5rem' },
-      maxWidths: { default: '12.5rem' },
-      fields: [
-        {
-          component: componentTypes.TEXT_FIELD,
-          name: 'aws-default-region',
-          value: DEFAULT_AWS_REGION,
-          'data-testid': 'aws-default-region',
-          type: 'text',
-          label: 'Default Region',
-          isReadOnly: true,
-          isRequired: true,
-          helperText: (
-            <HelperText>
-              <HelperTextItem component="div" variant="indeterminate">
-                Images are built in the default region but can be copied to
-                other regions later.
-              </HelperTextItem>
-            </HelperText>
-          ),
-        },
-        {
-          component: componentTypes.TEXT_FIELD,
-          name: 'aws-associated-account-id',
-          'data-testid': 'aws-associated-account-id',
-          type: 'text',
-          label: 'Associated Account ID',
-          isReadOnly: true,
-          isRequired: true,
-          helperText: (
-            <HelperText>
-              <HelperTextItem component="div" variant="indeterminate">
-                This is the account associated with the source.
-              </HelperTextItem>
-            </HelperText>
-          ),
-          condition: {
-            when: 'aws-target-type',
-            is: 'aws-target-type-source',
-          },
-        },
-        {
-          component: 'field-listener',
-          name: 'aws-associated-account-id-listener',
-          hideField: true,
-        },
-      ],
+      component: componentTypes.TEXT_FIELD,
+      name: 'aws-default-region',
+      className: 'pf-u-w-25',
+      'data-testid': 'aws-default-region',
+      type: 'text',
+      label: 'Default Region',
+      value: DEFAULT_AWS_REGION,
+      isReadOnly: true,
+      isRequired: true,
+      helperText: (
+        <HelperText>
+          <HelperTextItem
+            component="div"
+            variant="indeterminate"
+            className="pf-u-w-25"
+          >
+            Images are built in the default region but can be copied to other
+            regions later.
+          </HelperTextItem>
+        </HelperText>
+      ),
     },
   ],
 };

--- a/src/Components/CreateImageWizard/steps/index.js
+++ b/src/Components/CreateImageWizard/steps/index.js
@@ -1,4 +1,5 @@
-export { default as awsTarget } from './aws';
+export { default as awsTargetStable } from './aws';
+export { default as awsTargetBeta } from './aws.beta';
 export { default as googleCloudTarger } from './googleCloud';
 export { default as msAzureTarget } from './msAzure';
 export { default as packages } from './packages';

--- a/src/store/apiSlice.js
+++ b/src/store/apiSlice.js
@@ -6,10 +6,42 @@ export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: fetchBaseQuery({ baseUrl: '' }),
   endpoints: (builder) => ({
-    getSources: builder.query({
-      query: () => PROVISIONING_SOURCES_ENDPOINT,
+    getAWSSources: builder.query({
+      async queryFn(_arg, _queryApi, _extraOptions, fetchWithBQ) {
+        // The provisioning sources endpoint response does not include the account ids
+        // associated with the sources. For each source, another API request must be
+        // made to get the account id. This custom queryFn combines all of these API
+        // requests so that the React components can call simply call a single hook,
+        // useGetAWSSourcesQuery().
+
+        const awsSources = await fetchWithBQ(
+          `${PROVISIONING_SOURCES_ENDPOINT}?provider=aws`
+        );
+
+        if (awsSources.error) return { error: awsSources.error };
+
+        const awsAccountIds = await Promise.allSettled(
+          awsSources.data.map((source) =>
+            fetchWithBQ(
+              `${PROVISIONING_SOURCES_ENDPOINT}/${source.id}/account_identity`
+            )
+          )
+        );
+
+        // Merge the account ids into awsSources
+        for (let i = 0; i < awsSources.data.length; i++) {
+          if (awsAccountIds[i].value.error) {
+            awsSources.data[i].account_id = '';
+          } else {
+            awsSources.data[i].account_id =
+              awsAccountIds[i].value.data.aws.account_id;
+          }
+        }
+
+        return awsSources;
+      },
     }),
   }),
 });
 
-export const { useGetSourcesQuery } = apiSlice;
+export const { useGetAWSSourcesQuery, usePrefetch } = apiSlice;

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -600,6 +600,9 @@ describe('Step Packages', () => {
     getNextButton().click();
 
     // aws step
+    screen
+      .getByRole('radio', { name: /enter aws account id manually/i })
+      .click();
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
     getNextButton().click();
     // skip registration
@@ -878,6 +881,9 @@ describe('Step Custom repositories', () => {
     getNextButton().click();
 
     // aws step
+    screen
+      .getByRole('radio', { name: /enter aws account id manually/i })
+      .click();
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
     getNextButton().click();
     // skip registration
@@ -1027,6 +1033,9 @@ describe('Click through all steps', () => {
     userEvent.click(screen.getByTestId('checkbox-image-installer'));
 
     screen.getByRole('button', { name: /Next/ }).click();
+    screen
+      .getByRole('radio', { name: /enter aws account id manually/i })
+      .click();
     userEvent.type(screen.getByTestId('aws-account-id'), '012345678901');
     screen.getByRole('button', { name: /Next/ }).click();
 

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -5,17 +5,43 @@ import { PROVISIONING_SOURCES_ENDPOINT } from '../../constants';
 const baseURL = 'http://localhost';
 
 export const handlers = [
-  rest.get(baseURL.concat(PROVISIONING_SOURCES_ENDPOINT), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          id: '123',
-          name: 'my_source',
-          source_type_id: '1',
-          uid: 'de5e35d4-4c1f-49d7-9ef3-7d08e6b9c76a',
-        },
-      ])
-    );
-  }),
+  rest.get(
+    baseURL.concat(`${PROVISIONING_SOURCES_ENDPOINT}`),
+    (req, res, ctx) => {
+      const provider = req.url.searchParams.get('provider');
+      if (provider === 'aws') {
+        return res(
+          ctx.status(200),
+          ctx.json([
+            {
+              id: '123',
+              name: 'my_source',
+              source_type_id: '1',
+              uid: 'de5e35d4-4c1f-49d7-9ef3-7d08e6b9c76a',
+            },
+          ])
+        );
+      }
+    }
+  ),
+  rest.get(
+    baseURL.concat(
+      `${PROVISIONING_SOURCES_ENDPOINT}/:accountId/account_identity`
+    ),
+    (req, res, ctx) => {
+      const { accountId } = req.params;
+      if (accountId === '123') {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            aws: {
+              account_id: '123456789012',
+            },
+          })
+        );
+      } else {
+        return res(ctx.status(404));
+      }
+    }
+  ),
 ];


### PR DESCRIPTION
This PR adds the ability to configure an AWS target using the Sources service available on Insights instead of manually entering an AWS account ID. 

Note that the Sources API is not queried directly, rather the Provisioning API provides endpoints to obtain sources and their associated information (such as the account id). The Provisioning endpoints are available via RTK Query hooks, and mocked in the tests using Mock Service Worker.

