### PR TITLE
Show 'Open Service' badge and popover

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -1,8 +1,6 @@
 const { resolve } = require('path');
 
 const config = require('@redhat-cloud-services/frontend-components-config');
-const { GitRevisionPlugin } = require('git-revision-webpack-plugin');
-const { DefinePlugin } = require('webpack');
 
 const webpackProxy = {
   useProxy: true,
@@ -36,12 +34,6 @@ plugins.push(
       exclude: ['react-router-dom'],
     }
   )
-);
-
-plugins.push(
-  new DefinePlugin({
-    COMMITHASH: JSON.stringify(new GitRevisionPlugin().commithash()),
-  })
 );
 
 module.exports = {

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -1,8 +1,6 @@
 const { resolve } = require('path');
 
 const config = require('@redhat-cloud-services/frontend-components-config');
-const { GitRevisionPlugin } = require('git-revision-webpack-plugin');
-const { DefinePlugin } = require('webpack');
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   sassPrefix: '.imageBuilder',
@@ -19,12 +17,6 @@ plugins.push(
       exclude: ['react-router-dom'],
     }
   )
-);
-
-plugins.push(
-  new DefinePlugin({
-    COMMITHASH: JSON.stringify(new GitRevisionPlugin().commithash()),
-  })
 );
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
       "!src/entry-dev.js"
     ],
     "testEnvironment": "jsdom",
-    "globals": {
-      "COMMITHASH": "dummy"
-    },
     "roots": [
       "<rootDir>/src/"
     ],

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -1,5 +1,3 @@
-/* global COMMITHASH */
-
 import React, { Component } from 'react';
 
 import { Button, Popover, Text, TextContent } from '@patternfly/react-core';

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -3,7 +3,11 @@
 import React, { Component } from 'react';
 
 import { Button, Popover, Text, TextContent } from '@patternfly/react-core';
-import { GithubIcon, HelpIcon } from '@patternfly/react-icons';
+import {
+  HelpIcon,
+  CodeIcon,
+  ExternalLinkAltIcon,
+} from '@patternfly/react-icons';
 // eslint-disable-next-line rulesdir/disallow-fec-relative-imports
 import {
   PageHeader,
@@ -34,30 +38,48 @@ class LandingPage extends Component {
                   images and push them to cloud environments.
                 </Text>
                 <DocumentationButton />
-                <br />
-                <Button
-                  component="a"
-                  target="_blank"
-                  variant="link"
-                  icon={<GithubIcon />}
-                  iconPosition="right"
-                  isInline
-                  href={
-                    'https://github.com/RedHatInsights/image-builder-frontend/tree/' +
-                    COMMITHASH
-                  }
-                >
-                  Contribute on GitHub
-                </Button>
               </TextContent>
             }
           >
             <Button
               variant="plain"
               aria-label="About image builder"
-              className="pf-u-pl-sm"
+              className="pf-u-pl-sm header-button"
             >
               <HelpIcon />
+            </Button>
+          </Popover>
+          <Popover
+            headerContent={'About open source'}
+            bodyContent={
+              <TextContent>
+                <Text>
+                  This service is open source, so all of its code is
+                  inspectable. Explore repositories to view and contribute to
+                  the source code.
+                </Text>
+                <Button
+                  component="a"
+                  target="_blank"
+                  variant="link"
+                  icon={<ExternalLinkAltIcon />}
+                  iconPosition="right"
+                  isInline
+                  href={
+                    'https://www.osbuild.org/guides/image-builder-service/architecture.html'
+                  }
+                >
+                  Repositories
+                </Button>
+              </TextContent>
+            }
+          >
+            <Button
+              variant="plain"
+              aria-label="About Open Services"
+              className="pf-u-pl-sm header-button"
+            >
+              <CodeIcon />
             </Button>
           </Popover>
         </PageHeader>

--- a/src/Components/LandingPage/LandingPage.scss
+++ b/src/Components/LandingPage/LandingPage.scss
@@ -9,3 +9,7 @@
 .pf-c-form__group-label-help:active {
     color: var(--pf-global--icon--Color--dark);
 }
+
+.header-button {
+    padding-right: 0;
+}


### PR DESCRIPTION
As part of our 'Open Source Services' initiative, we'll add a badge that indicates that our service is open. The popover will give additional context as well as a link to our architectural docs.

![image](https://user-images.githubusercontent.com/261436/216776976-b35f7532-fba8-4613-9d70-f3b5b3dc6b51.png)

