### PR TITLE
config: remove module name in webpack config (#959)

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -18,9 +18,8 @@ const webpackProxy = {
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
   debug: true,
-  modules: ['image_builder'],
   useFileHash: false,
-  sassPrefix: '.imageBuilder, .image_builder',
+  sassPrefix: '.imageBuilder',
   deployment: process.env.BETA ? 'beta/apps' : 'apps',
   ...(process.env.PROXY ? webpackProxy : {}),
 });
@@ -30,7 +29,6 @@ plugins.push(
     {
       root: resolve(__dirname, '../'),
       useFileHash: false,
-      moduleName: 'image_builder',
       exposes: {
         './RootApp': resolve(__dirname, '../src/AppEntry.js'),
       },

--- a/config/prod.webpack.config.js
+++ b/config/prod.webpack.config.js
@@ -5,15 +5,13 @@ const { GitRevisionPlugin } = require('git-revision-webpack-plugin');
 const { DefinePlugin } = require('webpack');
 const { config: webpackConfig, plugins } = config({
   rootFolder: resolve(__dirname, '../'),
-  modules: ['image_builder'],
-  sassPrefix: '.imageBuilder, .image_builder',
+  sassPrefix: '.imageBuilder',
 });
 
 plugins.push(
   require('@redhat-cloud-services/frontend-components-config/federated-modules')(
     {
       root: resolve(__dirname, '../'),
-      moduleName: 'image_builder',
       exposes: {
         './RootApp': resolve(__dirname, '../src/AppEntry.js'),
       },

--- a/deploy/frontend-clowder.yml
+++ b/deploy/frontend-clowder.yml
@@ -19,13 +19,13 @@ objects:
           - /apps/image-builder
       image: ${IMAGE}:${IMAGE_TAG}
       navItems:
-        - appId: "image_builder"
+        - appId: "imageBuilder"
           title: "Image builder"
           href: "/insights/image-builder"
           product: "Red Hat Insights"
       module:
         manifestLocation: "/apps/image-builder/fed-mods.json"
-        moduleID: image_builder
+        moduleID: imageBuilder
         modules:
           - id: "image-builder"
             module: "./RootApp"

--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -536,7 +536,7 @@ const CreateImageWizard = () => {
           {
             component: componentTypes.WIZARD,
             name: 'image-builder-wizard',
-            className: 'image_builder',
+            className: 'imageBuilder',
             isDynamic: true,
             inModal: true,
             onKeyDown: (e) => {


### PR DESCRIPTION
Due to merging the openshift and chrome plugin systems there's additional requirements on the format of the module name.

Camelcase is the default, so the values can just be removed from the config.