### PR TITLE
WIP: Add open source alert

### DIFF
--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react';
 
-import { Button, Popover, Text, TextContent } from '@patternfly/react-core';
+import { Alert, AlertActionCloseButton, Button, Popover, Text, TextContent } from '@patternfly/react-core';
 import { HelpIcon, CodeIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line rulesdir/disallow-fec-relative-imports
 import {
@@ -80,6 +80,7 @@ class LandingPage extends Component {
             </Button>
           </Popover>
         </PageHeader>
+        <Alert id="open-source-alert" variant="default" customIcon={<CodeIcon />} isInline title="Click on the open source badge to explore and contribute to the source of this service." actionClose={<AlertActionCloseButton onClose={() => document.getElementById("open-source-alert").style.display="none"} />} />
         <section className="pf-l-page__main-section pf-c-page__main-section">
           <ImagesTable />
         </section>

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -3,7 +3,7 @@
 import React, { Component } from 'react';
 
 import { Button, Popover, Text, TextContent } from '@patternfly/react-core';
-import { GithubIcon, HelpIcon } from '@patternfly/react-icons';
+import { HelpIcon, CodeIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line rulesdir/disallow-fec-relative-imports
 import {
   PageHeader,
@@ -34,21 +34,6 @@ class LandingPage extends Component {
                   images and push them to cloud environments.
                 </Text>
                 <DocumentationButton />
-                <br />
-                <Button
-                  component="a"
-                  target="_blank"
-                  variant="link"
-                  icon={<GithubIcon />}
-                  iconPosition="right"
-                  isInline
-                  href={
-                    'https://github.com/RedHatInsights/image-builder-frontend/tree/' +
-                    COMMITHASH
-                  }
-                >
-                  Contribute on GitHub
-                </Button>
               </TextContent>
             }
           >
@@ -58,6 +43,40 @@ class LandingPage extends Component {
               className="pf-u-pl-sm"
             >
               <HelpIcon />
+            </Button>
+          </Popover>
+          <Popover
+            headerContent={'About open source'}
+            bodyContent={
+              <TextContent>
+                <Text>
+                  This service is open source, so all of its
+                  code is inspectable. Explore
+                  repositories to view and contribute to
+                  the source code.
+                </Text>
+                <Button
+                  component="a"
+                  target="_blank"
+                  variant="link"
+                  icon={<ExternalLinkAltIcon />}
+                  iconPosition="right"
+                  isInline
+                  href={
+                    'https://www.osbuild.org/guides/image-builder-service/architecture.html'
+                  }
+                >
+                  Repositories
+                </Button>
+              </TextContent>
+            }
+          >
+            <Button
+              variant="plain"
+              aria-label="About Open Services"
+              className="pf-u-pl-sm"
+            >
+              <CodeIcon />
             </Button>
           </Popover>
         </PageHeader>


### PR DESCRIPTION
This is based on top of #949. It adds a dismissable alert to the landing page of the service that highlights the new badge.

1. Not sure if this is the way to properly close the alert.
2. I'm waiting for feedback from UX if dismissing the alert should dismiss it 'forever' for a particular user.

Related to: COMPOSER-1899