### PR TITLE
Wizard: Get distribution repositories from an api endpoint

### DIFF
--- a/src/store/apiSlice.js
+++ b/src/store/apiSlice.js
@@ -1,6 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
-import { PROVISIONING_SOURCES_ENDPOINT } from '../constants';
+import { IMAGE_BUILDER_API, PROVISIONING_SOURCES_ENDPOINT } from '../constants';
 
 export const apiSlice = createApi({
   reducerPath: 'api',
@@ -41,7 +41,15 @@ export const apiSlice = createApi({
         return awsSources;
       },
     }),
+    getArchitecturesByDistribution: builder.query({
+      query: (distribution) =>
+        `${IMAGE_BUILDER_API}/architectures/${distribution}`,
+    }),
   }),
 });
 
-export const { useGetAWSSourcesQuery, usePrefetch } = apiSlice;
+export const {
+  useGetAWSSourcesQuery,
+  useGetArchitecturesByDistributionQuery,
+  usePrefetch,
+} = apiSlice;

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -34,25 +34,6 @@ function getNextButton() {
   return next;
 }
 
-// packages
-const mockPkgResultContentSources = [
-  {
-    name: 'testPkg',
-    summary: 'test package summary',
-    version: '1.0',
-  },
-  {
-    name: 'lib-test',
-    summary: 'lib-test package summary',
-    version: '1.0',
-  },
-  {
-    name: 'test',
-    summary: 'summary for test package',
-    version: '1.0',
-  },
-];
-
 const mockPkgResultAlphaContentSources = [
   {
     name: 'lib-test',
@@ -70,8 +51,6 @@ const mockPkgResultAlphaContentSources = [
     version: '1.0',
   },
 ];
-
-const mockPkgResultEmptyContentSources = [];
 
 const mockRepositoryResults = {
   data: [
@@ -771,19 +750,18 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() => Promise.resolve(mockPkgResultContentSources));
-
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
-    const availablePackagesList = screen.getByTestId('available-pkgs-list');
-    const availablePackagesItems = within(availablePackagesList).getAllByRole(
-      'option'
+    const availablePackagesList = await screen.findByTestId(
+      'available-pkgs-list'
     );
+    const availablePackagesItems = await within(
+      availablePackagesList
+    ).findAllByRole('option');
     expect(availablePackagesItems).toHaveLength(3);
     const [firstItem, secondItem, thirdItem] = availablePackagesItems;
     expect(firstItem).toHaveTextContent('testsummary for test package');
@@ -796,14 +774,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() => Promise.resolve(mockPkgResultContentSources));
-
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     screen.getByTestId('available-pkgs-testPkg').click();
     screen.getByRole('button', { name: /Add selected/ }).click();
@@ -827,14 +802,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() => Promise.resolve(mockPkgResultContentSources));
-
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     screen.getByRole('button', { name: /Add all/ }).click();
     screen.getByRole('button', { name: /Remove all/ }).click();
@@ -854,13 +826,12 @@ describe('Step Packages', () => {
     await setUp();
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
+
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() => Promise.resolve(mockPkgResultContentSources));
 
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
     screen.getByRole('button', { name: /Add all/ }).click();
 
     // remove a single package
@@ -885,16 +856,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() =>
-        Promise.resolve(mockPkgResultEmptyContentSources)
-      );
-
     await searchForAvailablePackages(searchbox, 'asdf');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     await screen.findByText('No packages found');
   });
@@ -905,13 +871,10 @@ describe('Step Packages', () => {
     const searchboxAvailable = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
     const searchboxChosen = screen.getAllByRole('textbox')[1];
 
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() => Promise.resolve(mockPkgResultContentSources));
-
+    expect(searchboxAvailable).toBeDisabled();
+    await waitFor(() => expect(searchboxAvailable).toBeEnabled());
     searchboxAvailable.click();
     await searchForAvailablePackages(searchboxAvailable, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     screen.getByRole('button', { name: /Add all/ }).click();
 
@@ -928,6 +891,8 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
     const getPackages = jest
@@ -956,14 +921,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0];
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() => Promise.resolve(mockPkgResultContentSources));
-
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     const availablePackagesList = screen.getByTestId('available-pkgs-list');
     const availablePackagesItems = within(availablePackagesList).getAllByRole(
@@ -983,14 +945,11 @@ describe('Step Packages', () => {
 
     const availableSearchbox = screen.getAllByRole('textbox')[0];
 
+    expect(availableSearchbox).toBeDisabled();
+    await waitFor(() => expect(availableSearchbox).toBeEnabled());
     availableSearchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() => Promise.resolve(mockPkgResultContentSources));
-
     await searchForAvailablePackages(availableSearchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     const availablePackagesList = screen.getByTestId('available-pkgs-list');
     const availablePackagesItems = within(availablePackagesList).getAllByRole(
@@ -1006,7 +965,7 @@ describe('Step Packages', () => {
 
     const chosenSearchbox = screen.getAllByRole('textbox')[1];
     chosenSearchbox.click();
-    await searchForChosenPackages(chosenSearchbox, 'Pkg');
+    await searchForChosenPackages(chosenSearchbox, 'lib');
     chosenPackagesItems = within(chosenPackagesList).getAllByRole('option');
     // eslint-disable-next-line jest-dom/prefer-in-document
     expect(chosenPackagesItems).toHaveLength(1);
@@ -1307,20 +1266,18 @@ describe('Click through all steps', () => {
     within(rows[2]).getByRole('option', { name: 'MiB' }).click();
     getNextButton().click();
 
-    // packages
-    const getPackages = jest
-      .spyOn(api, 'getPackagesContentSources')
-      .mockImplementation(() => Promise.resolve(mockPkgResultContentSources));
-
     screen.getByText(
       /Images built with Image Builder include all required packages/i
     );
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
+
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
+
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
     screen
-      .getByRole('option', { name: /testPkg test package summary/ })
+      .getByRole('option', { name: /test summary for test package/ })
       .click();
     screen.getByRole('button', { name: /Add selected/ }).click();
     getNextButton().click();
@@ -1400,7 +1357,7 @@ describe('Click through all steps', () => {
           min_size: 104857600,
         },
       ],
-      packages: ['testPkg'],
+      packages: ['test'],
       subscription: {
         'activation-key': 'name0',
         insights: true,

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -40,29 +40,6 @@ function verifyCancelButton(cancel, history) {
   expect(history.location.pathname).toBe('/insights/image-builder');
 }
 
-// packages
-const mockPkgResult = {
-  meta: { count: 3 },
-  links: { first: '', last: '' },
-  data: [
-    {
-      name: 'testPkg',
-      summary: 'test package summary',
-      version: '1.0',
-    },
-    {
-      name: 'lib-test',
-      summary: 'lib-test package summary',
-      version: '1.0',
-    },
-    {
-      name: 'test',
-      summary: 'summary for test package',
-      version: '1.0',
-    },
-  ],
-};
-
 const mockPkgResultAlpha = {
   meta: { count: 3 },
   links: { first: '', last: '' },
@@ -107,12 +84,6 @@ const mockPkgResultAll = {
       version: '1.0',
     };
   }),
-};
-
-const mockPkgResultEmpty = {
-  meta: { count: 0 },
-  links: { first: '', last: '' },
-  data: null,
 };
 
 const searchForAvailablePackages = async (searchbox, searchTerm) => {
@@ -788,14 +759,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
-
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     const availablePackagesList = screen.getByTestId('available-pkgs-list');
     const availablePackagesItems = within(availablePackagesList).getAllByRole(
@@ -813,14 +781,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
-
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     screen.getByTestId('available-pkgs-testPkg').click();
     screen.getByRole('button', { name: /Add selected/ }).click();
@@ -844,14 +809,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
-
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     screen.getByRole('button', { name: /Add all/ }).click();
     screen.getByRole('button', { name: /Remove all/ }).click();
@@ -871,13 +833,12 @@ describe('Step Packages', () => {
     await setUp();
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
+
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
 
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
     screen.getByRole('button', { name: /Add all/ }).click();
 
     // remove a single package
@@ -915,14 +876,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResultEmpty));
-
     await searchForAvailablePackages(searchbox, 'asdf');
-    expect(getPackages).toHaveBeenCalledTimes(1);
     screen.getByText('No packages found');
   });
 
@@ -931,21 +889,18 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
-
-    let getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
 
     await searchForAvailablePackages(searchbox, 'test');
 
-    getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResultEmpty));
+    screen
+      .getByRole('button', { name: /clear available packages search/i })
+      .click();
 
     await searchForAvailablePackages(searchbox, 'asdf');
 
-    expect(getPackages).toHaveBeenCalledTimes(2);
     screen.getByText('No packages found');
   });
 
@@ -955,13 +910,10 @@ describe('Step Packages', () => {
     const searchboxAvailable = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
     const searchboxChosen = screen.getAllByRole('textbox')[1];
 
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
-
+    expect(searchboxAvailable).toBeDisabled();
+    await waitFor(() => expect(searchboxAvailable).toBeEnabled());
     searchboxAvailable.click();
     await searchForAvailablePackages(searchboxAvailable, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     screen.getByRole('button', { name: /Add all/ }).click();
 
@@ -978,6 +930,8 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
     const getPackages = jest
@@ -1003,6 +957,8 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
     const getPackages = jest
@@ -1029,14 +985,11 @@ describe('Step Packages', () => {
 
     const searchbox = screen.getAllByRole('textbox')[0];
 
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
     searchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
-
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     const availablePackagesList = screen.getByTestId('available-pkgs-list');
     const availablePackagesItems = within(availablePackagesList).getAllByRole(
@@ -1056,14 +1009,11 @@ describe('Step Packages', () => {
 
     const availableSearchbox = screen.getAllByRole('textbox')[0];
 
+    expect(availableSearchbox).toBeDisabled();
+    await waitFor(() => expect(availableSearchbox).toBeEnabled());
     availableSearchbox.click();
 
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
-
     await searchForAvailablePackages(availableSearchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
 
     const availablePackagesList = screen.getByTestId('available-pkgs-list');
     const availablePackagesItems = within(availablePackagesList).getAllByRole(
@@ -1079,8 +1029,10 @@ describe('Step Packages', () => {
 
     const chosenSearchbox = screen.getAllByRole('textbox')[1];
     chosenSearchbox.click();
-    await searchForChosenPackages(chosenSearchbox, 'Pkg');
-    chosenPackagesItems = within(chosenPackagesList).getAllByRole('option');
+    await searchForChosenPackages(chosenSearchbox, 'lib');
+    chosenPackagesItems = await within(chosenPackagesList).findAllByRole(
+      'option'
+    );
     // eslint-disable-next-line jest-dom/prefer-in-document
     expect(chosenPackagesItems).toHaveLength(1);
 
@@ -1463,20 +1415,18 @@ describe('Click through all steps', () => {
     within(rows[2]).getByRole('option', { name: 'MiB' }).click();
     getNextButton().click();
 
-    // packages
-    const getPackages = jest
-      .spyOn(api, 'getPackages')
-      .mockImplementation(() => Promise.resolve(mockPkgResult));
-
     screen.getByText(
       /Images built with Image Builder include all required packages/i
     );
 
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
+
+    expect(searchbox).toBeDisabled();
+    await waitFor(() => expect(searchbox).toBeEnabled());
+
     await searchForAvailablePackages(searchbox, 'test');
-    expect(getPackages).toHaveBeenCalledTimes(1);
     screen
-      .getByRole('option', { name: /testPkg test package summary/ })
+      .getByRole('option', { name: /test summary for test package/ })
       .click();
     screen.getByRole('button', { name: /Add selected/ }).click();
     getNextButton().click();
@@ -1554,7 +1504,7 @@ describe('Click through all steps', () => {
                   min_size: 104857600,
                 },
               ],
-              packages: ['testPkg'],
+              packages: ['test'],
               subscription: {
                 'activation-key': 'name0',
                 insights: true,
@@ -1596,7 +1546,7 @@ describe('Click through all steps', () => {
                   min_size: 104857600,
                 },
               ],
-              packages: ['testPkg'],
+              packages: ['test'],
               subscription: {
                 'activation-key': 'name0',
                 insights: true,
@@ -1640,7 +1590,7 @@ describe('Click through all steps', () => {
                   min_size: 104857600,
                 },
               ],
-              packages: ['testPkg'],
+              packages: ['test'],
               subscription: {
                 'activation-key': 'name0',
                 insights: true,
@@ -1680,7 +1630,7 @@ describe('Click through all steps', () => {
                   min_size: 104857600,
                 },
               ],
-              packages: ['testPkg'],
+              packages: ['test'],
               subscription: {
                 'activation-key': 'name0',
                 insights: true,
@@ -1720,7 +1670,7 @@ describe('Click through all steps', () => {
                   min_size: 104857600,
                 },
               ],
-              packages: ['testPkg'],
+              packages: ['test'],
               subscription: {
                 'activation-key': 'name0',
                 insights: true,
@@ -1760,7 +1710,7 @@ describe('Click through all steps', () => {
                   min_size: 104857600,
                 },
               ],
-              packages: ['testPkg'],
+              packages: ['test'],
               subscription: {
                 'activation-key': 'name0',
                 insights: true,
@@ -1889,6 +1839,8 @@ describe('Keyboard accessibility', () => {
         name: /search input/i,
       });
     });
+    expect(availablePackagesInput).toBeDisabled();
+    await waitFor(() => expect(availablePackagesInput).toBeEnabled());
     expect(availablePackagesInput).toHaveFocus();
     clickNext();
 

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -44,4 +44,154 @@ export const handlers = [
       }
     }
   ),
+  rest.post(
+    baseURL.concat('/api/content-sources/v1/rpms/names'),
+    async (req, res, ctx) => {
+      const { search } = await req.json();
+      if (search === 'test') {
+        return res(
+          ctx.status(200),
+          ctx.json([
+            {
+              name: 'testPkg',
+              summary: 'test package summary',
+              version: '1.0',
+            },
+            {
+              name: 'lib-test',
+              summary: 'lib-test package summary',
+              version: '1.0',
+            },
+            {
+              name: 'test',
+              summary: 'summary for test package',
+              version: '1.0',
+            },
+          ])
+        );
+      } else if (search === 'asdf') {
+        return res(ctx.status(200), ctx.json([]));
+      }
+    }
+  ),
+  rest.get(
+    baseURL.concat('/api/image-builder/v1/packages'),
+    (req, res, ctx) => {
+      const search = req.url.searchParams.get('search');
+      if (search === 'test') {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            data: [
+              {
+                name: 'testPkg',
+                summary: 'test package summary',
+                version: '1.0',
+              },
+              {
+                name: 'lib-test',
+                summary: 'lib-test package summary',
+                version: '1.0',
+              },
+              {
+                name: 'test',
+                summary: 'summary for test package',
+                version: '1.0',
+              },
+            ],
+            meta: {
+              count: 3,
+            },
+          })
+        );
+      } else if (search === 'asdf') {
+        return res(ctx.status(200), ctx.json({ data: [], meta: 0 }));
+      }
+    }
+  ),
+  rest.get(
+    baseURL.concat('/api/image-builder/v1/architectures/:distro'),
+    (req, res, ctx) => {
+      const { distro } = req.params;
+      if (distro === 'rhel-91') {
+        return res(
+          ctx.status(200),
+          ctx.json([
+            {
+              arch: 'x86_64',
+              repositories: [
+                {
+                  baseurl:
+                    'https://cdn.redhat.com/content/dist/rhel9/9.1/x86_64/baseos/os',
+                  rhsm: true,
+                },
+              ],
+            },
+            {
+              arch: 'aarch64',
+              repositories: [
+                {
+                  baseurl:
+                    'https://cdn.redhat.com/content/dist/rhel9/9.1/aarch64/baseos/os',
+                  rhsm: true,
+                },
+              ],
+            },
+          ])
+        );
+      } else if (distro === 'rhel-87') {
+        return res(
+          ctx.status(200),
+          ctx.json([
+            {
+              arch: 'x86_64',
+              repositories: [
+                {
+                  baseurl:
+                    'https://cdn.redhat.com/content/dist/rhel8/8.7/x86_64/baseos/os',
+                  rhsm: true,
+                },
+              ],
+            },
+            {
+              arch: 'aarch64',
+              repositories: [
+                {
+                  baseurl:
+                    'https://cdn.redhat.com/content/dist/rhel8/8.7/aarch64/baseos/os',
+                  rhsm: true,
+                },
+              ],
+            },
+          ])
+        );
+      } else if (distro === 'centos-8') {
+        return res(
+          ctx.status(200),
+          ctx.json([
+            {
+              arch: 'x86_64',
+              repositories: [
+                {
+                  baseurl:
+                    'http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/',
+                  rhsm: false,
+                },
+              ],
+            },
+            {
+              arch: 'aarch64',
+              repositories: [
+                {
+                  baseurl:
+                    'http://mirror.centos.org/centos/8-stream/BaseOS/aarch64/os/',
+                  rhsm: false,
+                },
+              ],
+            },
+          ])
+        );
+      }
+    }
+  ),
 ];


### PR DESCRIPTION
Previously the base repository links for each distribution were read from `repos.js` file. This gets the needed information from a call to api endpoint `architectures/{distribution}`. The data is fetched via RTK Query and is then filtered by an architecture. For now the x86_64 architecture is hardcoded, this will change when multiple architectures get available.