### PR TITLE
src/repos: Fix urls

### DIFF
--- a/src/repos.js
+++ b/src/repos.js
@@ -15,16 +15,6 @@ export const repos = {
       name: 'appstream',
       url: 'https://cdn.redhat.com/content/dist/rhel8/8.7/x86_64/appstream/os',
     },
-    {
-      distribution_arch: 'x86_64',
-      name: 'google-compute-engine',
-      url: 'https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable',
-    },
-    {
-      distribution_arch: 'x86_64',
-      name: 'rhel-86-google-cloud-sdk',
-      url: 'https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64',
-    },
   ],
   [RHEL_9]: [
     {
@@ -36,16 +26,6 @@ export const repos = {
       distribution_arch: 'x86_64',
       name: 'appstream',
       url: 'https://cdn.redhat.com/content/dist/rhel9/9.1/x86_64/appstream/os',
-    },
-    {
-      distribution_arch: 'x86_64',
-      name: 'google-compute-engine',
-      url: 'https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable',
-    },
-    {
-      distribution_arch: 'x86_64',
-      name: 'google-cloud-sdk',
-      url: 'https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64',
     },
   ],
   'centos-8': [
@@ -64,42 +44,17 @@ export const repos = {
       distribution_arch: 'x86_64',
       url: 'http://mirror.centos.org/centos/8-stream/extras/x86_64/os/',
     },
-    {
-      name: 'google-compute-engine',
-      distribution_arch: 'x86_64',
-      url: 'https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable',
-    },
-    {
-      name: 'google-cloud-sdk',
-      distribution_arch: 'x86_64',
-      url: 'https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64',
-    },
   ],
   'centos-9': [
     {
       name: 'baseos',
       distribution_arch: 'x86_64',
-      url: 'http://mirror.centos.org/centos/9-stream/BaseOS/x86_64/os/',
+      url: 'http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/',
     },
     {
       name: 'appstream',
       distribution_arch: 'x86_64',
-      url: 'http://mirror.centos.org/centos/9-stream/AppStream/x86_64/os/',
-    },
-    {
-      name: 'extras',
-      distribution_arch: 'x86_64',
-      url: 'http://mirror.centos.org/centos/9-stream/extras/x86_64/os/',
-    },
-    {
-      name: 'google-compute-engine',
-      distribution_arch: 'x86_64',
-      url: 'https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable',
-    },
-    {
-      name: 'google-cloud-sdk',
-      distribution_arch: 'x86_64',
-      url: 'https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64',
+      url: 'http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/',
     },
   ],
 };


### PR DESCRIPTION
These URLs are used for package searching with the content-service.

- Remove the google cloud repos, these are added only for gcp
- Fix centos 9 URLs