### PR TITLE
Jest: Add mock service worker server commands to jest.setup.js

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,6 @@
 import 'whatwg-fetch';
+import { server } from './src/test/mocks/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());


### PR DESCRIPTION
This commit makes the `msw` server globally available to all test files. Given that the majority of our test files will ultimately make calls to APIs using RTK Query (calls are made in both the table and the wizard), making these globally available in jest.setup.js is reasonable.