### PR TITLE
App: Disable the global filter

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ const App = (props) => {
     document.title = 'Image Builder | Red Hat Insights';
     insights.chrome.init();
     insights.chrome.identifyApp('image-builder');
+    insights.chrome.hideGlobalFilter();
     const unregister = insights.chrome.on('APP_NAVIGATION', () =>
       navigate(resolveRelPath(''))
     );


### PR DESCRIPTION
This disables the global filter on the top of the page. So later when an option to filter images by name is added, there won't be multiple filters which could lead to confusion.