### PR TITLE
Wizard: Ensure only one scrollbar on the Packages step

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -8,8 +8,9 @@
     pointer-events: initial;
 }
 
-.pf-c-dual-list-selector__menu {
-    --pf-c-dual-list-selector__menu--MinHeight: 20.5rem
+.pf-c-dual-list-selector {
+    --pf-c-dual-list-selector__menu--MinHeight: 18.5rem;
+    --pf-c-dual-list-selector__menu--MaxHeight: 18.5rem;
 }
 
 .pf-c-form {


### PR DESCRIPTION
Fixes #914.

This adds a maximum height limit to the dual list selector on the Packages step. That way the Wizard doesn't become scrollable when the Packages search returns more results.