### PR TITLE
Wizard: Update activation keys link text and URI

### DIFF
--- a/src/Components/CreateImageWizard/steps/registration.js
+++ b/src/Components/CreateImageWizard/steps/registration.js
@@ -108,20 +108,17 @@ export default {
       component: componentTypes.PLAIN_TEXT,
       name: 'subscription-activation-description',
       label: (
-        <>
-          Create and manage activation keys in the&nbsp;
-          <Button
-            component="a"
-            target="_blank"
-            variant="link"
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="right"
-            isInline
-            href="https://access.redhat.com/"
-          >
-            Customer Portal
-          </Button>
-        </>
+        <Button
+          component="a"
+          target="_blank"
+          variant="link"
+          icon={<ExternalLinkAltIcon />}
+          iconPosition="right"
+          isInline
+          href="https://access.redhat.com/management/activation_keys"
+        >
+          Create and manage activation keys here
+        </Button>
       ),
       condition: {
         or: [


### PR DESCRIPTION
This commit updates the link on the registration step so users are directed to the exact place where they can manage keys.

Because managing keys through the customer portal will soon become deprecated (keys will be managed through the keys service on insights) the text was also changed to be more general.