### PR TITLE
Landingpage: Switch to CodeBranchIcon

### DIFF
--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { Button, Popover, Text, TextContent } from '@patternfly/react-core';
 import {
   HelpIcon,
-  CodeIcon,
+  CodeBranchIcon,
   ExternalLinkAltIcon,
 } from '@patternfly/react-icons';
 // eslint-disable-next-line rulesdir/disallow-fec-relative-imports
@@ -77,7 +77,7 @@ class LandingPage extends Component {
               aria-label="About Open Services"
               className="pf-u-pl-sm header-button"
             >
-              <CodeIcon />
+              <CodeBranchIcon />
             </Button>
           </Popover>
         </PageHeader>


### PR DESCRIPTION
Use the CodeBranchIcon instead of just CodeIcon for the Open Source Services popover button.

This is a follow-up of https://github.com/RedHatInsights/image-builder-frontend/pull/949

Here's how the new icon looks:
![image](https://user-images.githubusercontent.com/261436/222188264-18bcd494-8e0a-43d0-af18-97f58237da85.png)
