### PR TITLE
Update docker-compose setup to use local `osbuild`

### DIFF
--- a/devel/README.md
+++ b/devel/README.md
@@ -7,8 +7,9 @@ Development Tools for Image Builder
 To start local development, first clone the image builder stack:
 
 ```bash
-git clone git@github.com:osbuild/osbuild.git
 git clone git@github.com:osbuild/osbuild-composer.git
+mkdir osbuild-composer/osbuild
+git clone git@github.com:osbuild/osbuild.git osbuild-composer/osbuild
 git clone git@github.com:osbuild/image-builder.git
 git clone git@github.com:osbuild/image-builder-frontend.git
 ```
@@ -19,8 +20,8 @@ The folder structure should look like:
 .
 ├── image-builder
 ├── image-builder-frontend
-├── osbuild
 └── osbuild-composer
+    └── osbuild
 ```
 Secondly redirect a few domains to localhost. One for each environment
 of cloud.redhat.com that exists. You only need the ones you will be

--- a/devel/docker-compose.yml
+++ b/devel/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     image: local/osbuild-worker
     build:
       context: ../../osbuild-composer
-      dockerfile: ./distribution/Dockerfile-worker
+      dockerfile: ./distribution/Dockerfile-worker-devel
     # override the entrypoint to specify composer hostname and port
     entrypoint: [ "/usr/libexec/osbuild-composer/osbuild-worker", "composer:8700" ]
     volumes:


### PR DESCRIPTION
Making `osbuild` a subdirectory of `osbuild-composer` so that when the build context is sent to docker it also contains `osbuild`

In conjuction with the updated dockerfile for worker, this enables changes in `osbuild` to be tested alongside with everything else

Depends-on: osbuild/osbuild-composer#3316