### PR TITLE
Launch link aws sources only

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -35,7 +35,7 @@ const ProvisioningLink = ({ imageId, isExpired, isInClonesTable }) => {
   );
 
   const provider = getImageProvider(image);
-  if (!error) {
+  if (!error && image.share_with_sources) {
     return (
       <Suspense fallback="loading">
         <Button variant="link" isInline onClick={() => openWizard(true)}>
@@ -50,6 +50,7 @@ const ProvisioningLink = ({ imageId, isExpired, isInClonesTable }) => {
               id: image.id,
               architecture: image.architecture,
               provider: provider,
+              sourceId: image.share_with_sources[0],
             }}
           />
         )}


### PR DESCRIPTION
The Launch service wizard should only be used to launch AWS images that
were created using share_with_sources (and not share_with_accounts) in
their request.

The Launch service only supports a single source at the moment, as does
the Image Builder Frontend. Therefore, we do not pass the entire
share_with_sources array - only the 0th element, which should be the
`only` source for images created using the front-end. We do not expect
full compatibility between images created using the API (which could
theoretically have multiple sources in share_with_sources) and Image
Builder Frontend.