### PR TITLE
Wizard: Fix disabled search input on the Additional custom packages step

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -7,6 +8,7 @@ import React, {
 } from 'react';
 
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import WizardContext from '@data-driven-forms/react-form-renderer/wizard-context';
 import {
   DualListSelector,
   DualListSelectorControl,
@@ -81,6 +83,7 @@ export const ContentSourcesPackages = () => {
 };
 
 const Packages = ({ getAllPackages, isSuccess }) => {
+  const { currentStep } = useContext(WizardContext);
   const { change, getState } = useFormApi();
   const [packagesSearchName, setPackagesSearchName] = useState(undefined);
   const [filterChosen, setFilterChosen] = useState('');
@@ -277,7 +280,7 @@ const Packages = ({ getAllPackages, isSuccess }) => {
             onSearch={handleAvailablePackagesSearch}
             resetButtonLabel="Clear available packages search"
             onClear={handleClearAvailableSearch}
-            isDisabled={!isSuccess}
+            isDisabled={currentStep.name === 'packages' ? !isSuccess : false}
           />
         }
       >


### PR DESCRIPTION
The search input on the Packages step is disabled until needed data is fetched. This was causing a problem on the Additional custom packages step which uses the same component.

A check of the current step was added so the search input gets disabled only for the Packages step.