### PR TITLE
ClonesTable: Ensure source exists before reading its account_id property

### DIFF
--- a/src/Components/ImagesTable/ClonesTable.js
+++ b/src/Components/ImagesTable/ClonesTable.js
@@ -31,7 +31,7 @@ const Row = ({ imageId }) => {
       if (isSuccess) {
         const accountId = awsSources.find(
           (source) => source.id === image.share_with_sources[0]
-        ).account_id;
+        )?.account_id;
         return accountId;
       }
       return null;


### PR DESCRIPTION
If a clone is created using a source, and the source is then deleted, the source will be undefined. Attempting to read the account_id from undefined causes the app to crash. Optional chaining fixes this.