### PR TITLE
Dev Deps: Bump `@scalprum/react-core` and `@redhat-cloud-services/frontend-components`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "@patternfly/patternfly": "4.224.2",
         "@patternfly/react-core": "4.276.6",
         "@patternfly/react-table": "4.112.6",
-        "@redhat-cloud-services/frontend-components": "3.9.25",
+        "@redhat-cloud-services/frontend-components": "3.9.32",
         "@redhat-cloud-services/frontend-components-notifications": "3.2.12",
         "@redhat-cloud-services/frontend-components-utilities": "3.3.11",
         "@reduxjs/toolkit": "^1.9.3",
-        "@scalprum/react-core": "^0.2.8",
+        "@scalprum/react-core": "^0.4.1",
         "classnames": "2.3.2",
         "lodash": "4.17.21",
         "react": "17.0.2",
@@ -3051,6 +3051,42 @@
       "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
       "dev": true
     },
+    "node_modules/@openshift/dynamic-plugin-sdk": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz",
+      "integrity": "sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==",
+      "dependencies": {
+        "lodash-es": "^4.17.21",
+        "semver": "^7.3.7",
+        "uuid": "^8.3.2",
+        "yup": "^0.32.11"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2"
+      }
+    },
+    "node_modules/@openshift/dynamic-plugin-sdk/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@openshift/dynamic-plugin-sdk/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@patternfly/patternfly": {
       "version": "4.224.2",
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.224.2.tgz",
@@ -3246,14 +3282,14 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "3.9.25",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.25.tgz",
-      "integrity": "sha512-ynppJJrMtkgzt5/uUF9rR51HeE5WkC5kCkNzIBqAFHHMsGueGazc9y5g1nzPkl7jgBajsTg7tePCLCvKP/HEnw==",
+      "version": "3.9.32",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.32.tgz",
+      "integrity": "sha512-4xxEy+pgWhTNOTzVnZiMl4lqYIJWTEBCX8bp7WjKzk+xuIxjyIy/dAeBZi+GIrRgV+pEnyv3hCdE8+IsR1+bNg==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
-        "@redhat-cloud-services/types": "^0.0.15",
-        "@scalprum/core": "^0.2.3",
-        "@scalprum/react-core": "^0.2.4",
+        "@redhat-cloud-services/types": "^0.0.17",
+        "@scalprum/core": "^0.4.0",
+        "@scalprum/react-core": "^0.4.0",
         "sanitize-html": "^2.7.2"
       },
       "peerDependencies": {
@@ -3529,11 +3565,6 @@
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@redhat-cloud-services/types": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.15.tgz",
-      "integrity": "sha512-1aqJcgQZq4uih+LxRpVJQblt2x4o/hlrqSZMYFhWyTLgnVNhJ8Y7B5pwoVjpA5PCE1fBNahrydVwugEKMsDDtg=="
-    },
     "node_modules/@redhat-cloud-services/rbac-client": {
       "version": "1.0.106",
       "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.106.tgz",
@@ -3589,16 +3620,20 @@
       }
     },
     "node_modules/@scalprum/core": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.2.4.tgz",
-      "integrity": "sha512-kQaLJxjNeAwRj8PE6p0dMxgfZaveQK/o8JoOJk56fnRqSgfJFI/eDmu4TZcSUkdqbfTptFHywOplIpndVQVm4g=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.4.1.tgz",
+      "integrity": "sha512-Ff8G2Mhc6ORPx+5C/B6vYYyGL2mBmQ8jR1I0yhgmYClzZU4gzQalZrSIwBDozGCoYmdKggF+hPCxojFwgE227g==",
+      "dependencies": {
+        "@openshift/dynamic-plugin-sdk": "^2.0.1"
+      }
     },
     "node_modules/@scalprum/react-core": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.2.8.tgz",
-      "integrity": "sha512-+qGfiA6FkXAx4x53fHmv7Q3oZcEQK0NChgaVeKGaZfG+LSNa1ozgkd4oSWueAMG3XV3St0QbAxzAtRQNFRyqNQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
+      "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
       "dependencies": {
-        "@scalprum/core": "^0.2.3",
+        "@openshift/dynamic-plugin-sdk": "^2.0.1",
+        "@scalprum/core": "^0.4.1",
         "lodash": "^4.17.0"
       },
       "peerDependencies": {
@@ -4299,6 +4334,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -13867,6 +13907,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -14622,6 +14667,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -15855,6 +15905,11 @@
       "peerDependencies": {
         "react": ">=0.14.0"
       }
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -17956,6 +18011,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+    },
     "node_modules/totalist": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
@@ -19425,6 +19485,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     }
   },
@@ -21592,6 +21669,32 @@
       "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
       "dev": true
     },
+    "@openshift/dynamic-plugin-sdk": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-2.0.1.tgz",
+      "integrity": "sha512-fiSPxk8ghs/aEp7UasDBhjdXrQ5/IQl+QuCB8FHz6IhAkN5mB/aQ7GcBHfW+ITK4g0eb6ydb4x2IaKP8iZeBJw==",
+      "requires": {
+        "lodash-es": "^4.17.21",
+        "semver": "^7.3.7",
+        "uuid": "^8.3.2",
+        "yup": "^0.32.11"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
     "@patternfly/patternfly": {
       "version": "4.224.2",
       "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.224.2.tgz",
@@ -21717,22 +21820,15 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "3.9.25",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.25.tgz",
-      "integrity": "sha512-ynppJJrMtkgzt5/uUF9rR51HeE5WkC5kCkNzIBqAFHHMsGueGazc9y5g1nzPkl7jgBajsTg7tePCLCvKP/HEnw==",
+      "version": "3.9.32",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.32.tgz",
+      "integrity": "sha512-4xxEy+pgWhTNOTzVnZiMl4lqYIJWTEBCX8bp7WjKzk+xuIxjyIy/dAeBZi+GIrRgV+pEnyv3hCdE8+IsR1+bNg==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
-        "@redhat-cloud-services/types": "^0.0.15",
-        "@scalprum/core": "^0.2.3",
-        "@scalprum/react-core": "^0.2.4",
+        "@redhat-cloud-services/types": "^0.0.17",
+        "@scalprum/core": "^0.4.0",
+        "@scalprum/react-core": "^0.4.0",
         "sanitize-html": "^2.7.2"
-      },
-      "dependencies": {
-        "@redhat-cloud-services/types": {
-          "version": "0.0.15",
-          "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.15.tgz",
-          "integrity": "sha512-1aqJcgQZq4uih+LxRpVJQblt2x4o/hlrqSZMYFhWyTLgnVNhJ8Y7B5pwoVjpA5PCE1fBNahrydVwugEKMsDDtg=="
-        }
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
@@ -21949,16 +22045,20 @@
       "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA=="
     },
     "@scalprum/core": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.2.4.tgz",
-      "integrity": "sha512-kQaLJxjNeAwRj8PE6p0dMxgfZaveQK/o8JoOJk56fnRqSgfJFI/eDmu4TZcSUkdqbfTptFHywOplIpndVQVm4g=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.4.1.tgz",
+      "integrity": "sha512-Ff8G2Mhc6ORPx+5C/B6vYYyGL2mBmQ8jR1I0yhgmYClzZU4gzQalZrSIwBDozGCoYmdKggF+hPCxojFwgE227g==",
+      "requires": {
+        "@openshift/dynamic-plugin-sdk": "^2.0.1"
+      }
     },
     "@scalprum/react-core": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.2.8.tgz",
-      "integrity": "sha512-+qGfiA6FkXAx4x53fHmv7Q3oZcEQK0NChgaVeKGaZfG+LSNa1ozgkd4oSWueAMG3XV3St0QbAxzAtRQNFRyqNQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
+      "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
       "requires": {
-        "@scalprum/core": "^0.2.3",
+        "@openshift/dynamic-plugin-sdk": "^2.0.1",
+        "@scalprum/core": "^0.4.1",
         "lodash": "^4.17.0"
       }
     },
@@ -22565,6 +22665,11 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.191",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+      "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ=="
     },
     "@types/mime": {
       "version": "3.0.1",
@@ -29750,6 +29855,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -30307,6 +30417,11 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "nanoclone": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nanoclone/-/nanoclone-0.2.1.tgz",
+      "integrity": "sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA=="
     },
     "nanoid": {
       "version": "3.3.4",
@@ -31209,6 +31324,11 @@
         "react-is": "^16.3.2",
         "warning": "^4.0.0"
       }
+    },
+    "property-expr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.5.tgz",
+      "integrity": "sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -32798,6 +32918,11 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
+    "toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg=="
+    },
     "totalist": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-1.1.0.tgz",
@@ -33878,6 +34003,20 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "yup": {
+      "version": "0.32.11",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.32.11.tgz",
+      "integrity": "sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "@types/lodash": "^4.14.175",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "nanoclone": "^0.2.1",
+        "property-expr": "^2.0.4",
+        "toposort": "^2.0.2"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "@patternfly/patternfly": "4.224.2",
     "@patternfly/react-core": "4.276.6",
     "@patternfly/react-table": "4.112.6",
-    "@redhat-cloud-services/frontend-components": "3.9.25",
+    "@redhat-cloud-services/frontend-components": "3.9.32",
     "@redhat-cloud-services/frontend-components-notifications": "3.2.12",
     "@redhat-cloud-services/frontend-components-utilities": "3.3.11",
     "@reduxjs/toolkit": "^1.9.3",
-    "@scalprum/react-core": "^0.2.8",
+    "@scalprum/react-core": "^0.4.1",
     "classnames": "2.3.2",
     "lodash": "4.17.21",
     "react": "17.0.2",
@@ -41,6 +41,9 @@
     "moduleNameMapper": {
       "\\.(css|scss)$": "identity-obj-proxy"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@openshift|lodash-es|uuid)/)"
+    ],
     "setupFiles": [
       "jest-canvas-mock"
     ],


### PR DESCRIPTION


This bumps:
- `@scalprum/react-core` from 0.2.8 to 0.4.1
- `@redhat-cloud-services/frontend-components` from 3.9.25 to 3.9.32

The bump was ending with failing tests and an error `SyntaxError: Cannot use import statement outside a module`.

The problem lies in Jest not transforming files inside the `node_modules` by default. To transpile the modules that were triggering the error the `transformIgnorePatterns` was added.