### PR TITLE
Wizard: Fix sources select bug

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -59,3 +59,22 @@ ul.pf-m-plain {
     padding-left: 0;
     margin-left: 0;
 }
+
+/*
+These z-index values prevent a bug where dropdowns that are appended to their
+parent (in order to allow them to "pop out" of the modal and prevent scrolling
+inside the modal's inner window) appear 'underneath' the wizard footer. This is
+a known bug in Patternfly 4. When it is fixed (likely in PF5), these z-index
+values can be removed.
+*/
+
+.pf-c-wizard__header,
+.pf-c-wizard__main {
+    z-index: auto !important;
+}
+
+.pf-c-wizard__toggle,
+.pf-c-wizard__nav,
+.pf-c-wizard__footer {
+    z-index: 1 !important;
+}


### PR DESCRIPTION
Fixes https://github.com/RedHatInsights/image-builder-frontend/issues/1007. A bug in Patternfly causes dropdown and select menus to
appear underneath the Wizard footer when they are appended to their
parent (which is done to allow them to 'pop out' of the wizard and avoid
scrolling inside of the wizard's inner window).

The bug is discussed here:
https://github.com/patternfly/patternfly/issues/4794#issuecomment-1451187628

For now, the best solution seems to be adjusting the wizard's z-index
values as the other solutions discussed have a negative impact on
accessibility and keyboard navigation.