### PR TITLE
Wizard: Expose beta features in qa environment

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -31,6 +31,7 @@ import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../constants';
 import { useGetArchitecturesByDistributionQuery } from '../../store/apiSlice';
 import { composeAdded } from '../../store/composesSlice';
 import { fetchRepositories } from '../../store/repositoriesSlice';
+import isBeta from '../../Utilities/isBeta';
 import isRhel from '../../Utilities/isRhel';
 import { resolveRelPath } from '../../Utilities/path';
 import DocumentationButton from '../sharedComponents/DocumentationButton';
@@ -262,7 +263,7 @@ const getPackageDescription = async (release, arch, repoUrls, packageName) => {
   let pack;
   // if the env is stage beta then use content-sources api
   // else use image-builder api
-  if (insights.chrome.isBeta()) {
+  if (isBeta()) {
     const data = await api.getPackagesContentSources(repoUrls, packageName);
     pack = data.find((pack) => packageName === pack.name);
   } else {
@@ -480,7 +481,7 @@ const formStepHistory = (composeRequest) => {
       steps.push('registration');
     }
 
-    if (insights.chrome.isBeta()) {
+    if (isBeta()) {
       steps.push('File system configuration', 'packages', 'repositories');
 
       const customRepositories =
@@ -501,7 +502,7 @@ const formStepHistory = (composeRequest) => {
 };
 
 const CreateImageWizard = () => {
-  const awsTarget = insights.chrome.isBeta() ? awsTargetBeta : awsTargetStable;
+  const awsTarget = isBeta() ? awsTargetBeta : awsTargetStable;
 
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -514,7 +515,7 @@ const CreateImageWizard = () => {
   const handleClose = () => navigate(resolveRelPath(''));
 
   useEffect(() => {
-    if (insights.chrome.isBeta()) {
+    if (isBeta()) {
       dispatch(fetchRepositories());
     }
   }, []);

--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -29,6 +29,7 @@ import PropTypes from 'prop-types';
 
 import api from '../../../api';
 import { useGetArchitecturesByDistributionQuery } from '../../../store/apiSlice';
+import isBeta from '../../../Utilities/isBeta';
 
 export const RedHatPackages = ({ defaultArch }) => {
   const { getState } = useFormApi();
@@ -39,7 +40,7 @@ export const RedHatPackages = ({ defaultArch }) => {
   const getAllPackages = async (packagesSearchName) => {
     // if the env is stage beta then use content-sources api
     // else use image-builder api
-    if (insights.chrome.isBeta()) {
+    if (isBeta()) {
       const filteredArchx86_64 = distributionInformation.find(
         (info) => info.arch === 'x86_64'
       );

--- a/src/Components/CreateImageWizard/formComponents/Repositories.js
+++ b/src/Components/CreateImageWizard/formComponents/Repositories.js
@@ -35,6 +35,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 import { selectValidRepositories } from '../../../store/repositoriesSlice';
+import isBeta from '../../../Utilities/isBeta';
 
 const BulkSelect = ({
   selected,
@@ -273,11 +274,7 @@ const Repositories = (props) => {
           <Button
             variant="primary"
             component="a"
-            href={
-              insights.chrome.isBeta()
-                ? '/beta/settings/content'
-                : '/settings/content'
-            }
+            href={isBeta() ? '/beta/settings/content' : '/settings/content'}
           >
             Repositories
           </Button>

--- a/src/Components/CreateImageWizard/steps/packages.js
+++ b/src/Components/CreateImageWizard/steps/packages.js
@@ -5,6 +5,7 @@ import { Text } from '@patternfly/react-core';
 
 import StepTemplate from './stepTemplate';
 
+import isBeta from '../../../Utilities/isBeta';
 import CustomButtons from '../formComponents/CustomButtons';
 
 export default {
@@ -14,7 +15,7 @@ export default {
   name: 'packages',
   substepOf: 'Content',
   nextStep: () => {
-    if (insights.chrome.isBeta()) {
+    if (isBeta()) {
       return 'repositories';
     } else {
       return 'image-name';

--- a/src/Utilities/isBeta.js
+++ b/src/Utilities/isBeta.js
@@ -1,0 +1,7 @@
+function isBeta() {
+  return insights.chrome.isBeta() || insights.chrome.getEnvironment() === 'qa'
+    ? true
+    : false;
+}
+
+export default isBeta;

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -545,6 +545,9 @@ beforeAll(() => {
       isProd: () => {
         return true;
       },
+      getEnvironment: () => {
+        return 'prod';
+      },
     },
   };
 });

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -140,6 +140,9 @@ beforeAll(() => {
       isProd: () => {
         return true;
       },
+      getEnvironment: () => {
+        return 'prod';
+      },
     },
   };
 });


### PR DESCRIPTION
The QE team has requested that all beta features be exposed in the ephemeral environment (insights.chrome.getEnvironment() === 'qa').