### PR TITLE
Deps: Bump @scalprum/react-core from 0.4.1 to 0.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@redhat-cloud-services/frontend-components-notifications": "3.2.13",
         "@redhat-cloud-services/frontend-components-utilities": "3.3.13",
         "@reduxjs/toolkit": "^1.9.3",
-        "@scalprum/react-core": "^0.4.1",
+        "@scalprum/react-core": "^0.5.1",
         "@unleash/proxy-client-react": "^3.5.2",
         "classnames": "2.3.2",
         "lodash": "4.17.21",
@@ -3600,6 +3600,20 @@
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@scalprum/react-core": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
+      "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
+      "dependencies": {
+        "@openshift/dynamic-plugin-sdk": "^2.0.1",
+        "@scalprum/core": "^0.4.1",
+        "lodash": "^4.17.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || >=17.0.0",
+        "react-dom": ">=16.8.0 || >=17.0.0"
+      }
+    },
     "node_modules/@redhat-cloud-services/rbac-client": {
       "version": "1.0.106",
       "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.106.tgz",
@@ -3663,17 +3677,61 @@
       }
     },
     "node_modules/@scalprum/react-core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
-      "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.5.1.tgz",
+      "integrity": "sha512-S3R/cSA9Dlrf4REwDIH80d5M+lEzzYhYHCPOFzmt1Zm3v4sFkFAUx9ZARfyrWK0UOYfXUE/L6D6R1lGgTWm54Q==",
       "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^2.0.1",
-        "@scalprum/core": "^0.4.1",
+        "@openshift/dynamic-plugin-sdk": "^3.0.0",
+        "@scalprum/core": "^0.5.1",
         "lodash": "^4.17.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0 || >=17.0.0",
         "react-dom": ">=16.8.0 || >=17.0.0"
+      }
+    },
+    "node_modules/@scalprum/react-core/node_modules/@openshift/dynamic-plugin-sdk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-3.0.0.tgz",
+      "integrity": "sha512-HHVjKxlssDS92DwfPGmeDbnZN+zR96juDTBEJEUluWwvyIqwgopx9GD5YrDGPDv8XvrG5TajJ/yJ9j2Wt4ap4g==",
+      "dependencies": {
+        "lodash-es": "^4.17.21",
+        "semver": "^7.3.7",
+        "uuid": "^8.3.2",
+        "yup": "^0.32.11"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18"
+      }
+    },
+    "node_modules/@scalprum/react-core/node_modules/@scalprum/core": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.5.1.tgz",
+      "integrity": "sha512-xYj9GRXleYMo2bsbdHN9fJmmwPkUHI9sjEoJU7jWoKzfTZTQWnhHVGjW53XOhtz4NO4lAZGPID7dbuJksNyvuA==",
+      "dependencies": {
+        "@openshift/dynamic-plugin-sdk": "^3.0.0"
+      }
+    },
+    "node_modules/@scalprum/react-core/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@scalprum/react-core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@sentry/browser": {
@@ -21885,6 +21943,18 @@
         "@scalprum/core": "^0.4.0",
         "@scalprum/react-core": "^0.4.0",
         "sanitize-html": "^2.7.2"
+      },
+      "dependencies": {
+        "@scalprum/react-core": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
+          "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
+          "requires": {
+            "@openshift/dynamic-plugin-sdk": "^2.0.1",
+            "@scalprum/core": "^0.4.1",
+            "lodash": "^4.17.0"
+          }
+        }
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
@@ -22110,13 +22180,47 @@
       }
     },
     "@scalprum/react-core": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.4.1.tgz",
-      "integrity": "sha512-R5gtrnqbeR6qRDUddZAtJUDUYOU+HjMbTROAYP6ryFzFnwbDBPY1DtNx4n8458yaZBRRiPYfkJEWvWzui1D0hw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.5.1.tgz",
+      "integrity": "sha512-S3R/cSA9Dlrf4REwDIH80d5M+lEzzYhYHCPOFzmt1Zm3v4sFkFAUx9ZARfyrWK0UOYfXUE/L6D6R1lGgTWm54Q==",
       "requires": {
-        "@openshift/dynamic-plugin-sdk": "^2.0.1",
-        "@scalprum/core": "^0.4.1",
+        "@openshift/dynamic-plugin-sdk": "^3.0.0",
+        "@scalprum/core": "^0.5.1",
         "lodash": "^4.17.0"
+      },
+      "dependencies": {
+        "@openshift/dynamic-plugin-sdk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-3.0.0.tgz",
+          "integrity": "sha512-HHVjKxlssDS92DwfPGmeDbnZN+zR96juDTBEJEUluWwvyIqwgopx9GD5YrDGPDv8XvrG5TajJ/yJ9j2Wt4ap4g==",
+          "requires": {
+            "lodash-es": "^4.17.21",
+            "semver": "^7.3.7",
+            "uuid": "^8.3.2",
+            "yup": "^0.32.11"
+          }
+        },
+        "@scalprum/core": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.5.1.tgz",
+          "integrity": "sha512-xYj9GRXleYMo2bsbdHN9fJmmwPkUHI9sjEoJU7jWoKzfTZTQWnhHVGjW53XOhtz4NO4lAZGPID7dbuJksNyvuA==",
+          "requires": {
+            "@openshift/dynamic-plugin-sdk": "^3.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
       }
     },
     "@sentry/browser": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@redhat-cloud-services/frontend-components-notifications": "3.2.13",
     "@redhat-cloud-services/frontend-components-utilities": "3.3.13",
     "@reduxjs/toolkit": "^1.9.3",
-    "@scalprum/react-core": "^0.4.1",
+    "@scalprum/react-core": "^0.5.1",
     "@unleash/proxy-client-react": "^3.5.2",
     "classnames": "2.3.2",
     "lodash": "4.17.21",
@@ -43,7 +43,7 @@
       "\\.(css|scss)$": "identity-obj-proxy"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(@openshift|lodash-es|uuid)/)"
+      "node_modules/(?!(@scalprum|@openshift|lodash-es|uuid)/)"
     ],
     "setupFiles": [
       "jest-canvas-mock"


### PR DESCRIPTION
This bumps @scalprum/react-core and adds `@scalprum` module to `transformIgnorePatterns`.

This solves the problem with failing tests, same as in #996