### PR TITLE
config/dev: run proxy without VPN for production envs

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -4,6 +4,8 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 
 const webpackProxy = {
   useProxy: true,
+  useAgent: process.env.STAGE ? true : false,
+  bounceProd: process.env.STAGE ? false : true,
   proxyVerbose: true,
   env: `${process.env.STAGE ? 'stage' : 'prod'}-${
     process.env.BETA ? 'beta' : 'stable'


### PR DESCRIPTION
This allows users to develop against production without having access to the internal network.

https://github.com/RedHatInsights/frontend-components/tree/62f37029ca0f5f7e9b0fd61815fe62c96503bcbf/packages/config#running-prod-proxy-without-vpn