### PR TITLE
ESLint: Add `no-console` rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -29,3 +29,4 @@ rules:
   prefer-const:
   - error
   - destructuring: any
+  no-console: 2


### PR DESCRIPTION
This adds `no-console` rule to throw an error when using any of the `console` methods as those are used only for debugging purposes.