### PR TITLE
Wizard: Migrate activation keys calls to RTK Query

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { useFormApi } from '@data-driven-forms/react-form-renderer';
 import {
+  Alert,
   Button,
   Popover,
   Spinner,
@@ -27,6 +28,7 @@ import {
   useGetAWSSourcesQuery,
   useGetAzureSourcesQuery,
 } from '../../../store/apiSlice';
+import { useGetActivationKeyInformationQuery } from '../../../store/apiSlice';
 import { googleAccType } from '../steps/googleCloud';
 
 const ExpirationWarning = () => {
@@ -429,85 +431,103 @@ export const RegisterLaterList = () => {
 
 export const RegisterNowList = () => {
   const { getState } = useFormApi();
+  const activationKey = getState()?.values?.['subscription-activation-key'];
+  const { isError } = useGetActivationKeyInformationQuery(activationKey, {
+    skip: !activationKey,
+  });
   return (
-    <TextContent>
-      <TextList component={TextListVariants.dl}>
-        <TextListItem
-          component={TextListItemVariants.dt}
-          className="pf-u-min-width"
-        >
-          Registration type
-        </TextListItem>
-        <TextListItem
-          component={TextListItemVariants.dd}
-          data-testid="review-registration"
-        >
-          <TextList isPlain>
-            {getState()?.values?.['register-system']?.startsWith(
-              'register-now'
-            ) && (
-              <TextListItem>
-                Register with Red Hat Subscription Manager (RHSM)
-                <br />
-              </TextListItem>
-            )}
-            {(getState()?.values?.['register-system'] ===
-              'register-now-insights' ||
-              getState()?.values?.['register-system'] ===
-                'register-now-rhc') && (
-              <TextListItem>
-                Connect to Red Hat Insights
-                <br />
-              </TextListItem>
-            )}
-            {getState()?.values?.['register-system'] === 'register-now-rhc' && (
-              <TextListItem>
-                Use remote host configuration (RHC) utility
-                <br />
-              </TextListItem>
-            )}
-          </TextList>
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dt}>
-          Activation key
-          <Popover
-            bodyContent={
-              <TextContent>
-                <Text>
-                  Activation keys enable you to register a system with
-                  appropriate subscriptions, system purpose, and repositories
-                  attached.
-                  <br />
-                  <br />
-                  If using an activation key with command line registration, you
-                  must provide your organization&apos;s ID. Your
-                  organization&apos;s ID is{' '}
-                  {getState()?.values?.['subscription-organization-id'] !==
-                  undefined ? (
-                    getState()?.values?.['subscription-organization-id']
-                  ) : (
-                    <Spinner size="md" />
-                  )}
-                </Text>
-              </TextContent>
-            }
+    <>
+      <TextContent>
+        <TextList component={TextListVariants.dl}>
+          <TextListItem
+            component={TextListItemVariants.dt}
+            className="pf-u-min-width"
           >
-            <Button
-              variant="plain"
-              aria-label="About activation key"
-              className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
-              isSmall
+            Registration type
+          </TextListItem>
+          <TextListItem
+            component={TextListItemVariants.dd}
+            data-testid="review-registration"
+          >
+            <TextList isPlain>
+              {getState()?.values?.['register-system']?.startsWith(
+                'register-now'
+              ) && (
+                <TextListItem>
+                  Register with Red Hat Subscription Manager (RHSM)
+                  <br />
+                </TextListItem>
+              )}
+              {(getState()?.values?.['register-system'] ===
+                'register-now-insights' ||
+                getState()?.values?.['register-system'] ===
+                  'register-now-rhc') && (
+                <TextListItem>
+                  Connect to Red Hat Insights
+                  <br />
+                </TextListItem>
+              )}
+              {getState()?.values?.['register-system'] ===
+                'register-now-rhc' && (
+                <TextListItem>
+                  Use remote host configuration (RHC) utility
+                  <br />
+                </TextListItem>
+              )}
+            </TextList>
+          </TextListItem>
+          <TextListItem component={TextListItemVariants.dt}>
+            Activation key
+            <Popover
+              bodyContent={
+                <TextContent>
+                  <Text>
+                    Activation keys enable you to register a system with
+                    appropriate subscriptions, system purpose, and repositories
+                    attached.
+                    <br />
+                    <br />
+                    If using an activation key with command line registration,
+                    you must provide your organization&apos;s ID. Your
+                    organization&apos;s ID is{' '}
+                    {getState()?.values?.['subscription-organization-id'] !==
+                    undefined ? (
+                      getState()?.values?.['subscription-organization-id']
+                    ) : (
+                      <Spinner size="md" />
+                    )}
+                  </Text>
+                </TextContent>
+              }
             >
-              <HelpIcon />
-            </Button>
-          </Popover>
-        </TextListItem>
-        <TextListItem component={TextListItemVariants.dd}>
-          <ActivationKeyInformation />
-        </TextListItem>
-      </TextList>
-      <br />
-    </TextContent>
+              <Button
+                variant="plain"
+                aria-label="About activation key"
+                className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
+                isSmall
+              >
+                <HelpIcon />
+              </Button>
+            </Popover>
+          </TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>
+            <ActivationKeyInformation />
+          </TextListItem>
+        </TextList>
+        <br />
+      </TextContent>
+      {isError && (
+        <Alert
+          title="Information about the activation key unavailable"
+          variant="danger"
+          isPlain
+          isInline
+        >
+          Information about the activation key cannot be loaded. Please check
+          the key was not removed and try again later.
+        </Alert>
+      )}
+    </>
   );
 };
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { CONTENT_SOURCES, IMAGE_BUILDER_API, RHSM_API } from './constants';
+import { CONTENT_SOURCES, IMAGE_BUILDER_API } from './constants';
 
 const postHeaders = { headers: { 'Content-Type': 'application/json' } };
 
@@ -77,18 +77,6 @@ async function getVersion() {
   return request.data;
 }
 
-async function getActivationKeys() {
-  const path = '/activation_keys';
-  const request = await axios.get(RHSM_API.concat(path));
-  return request.data.body;
-}
-
-async function getActivationKey(name) {
-  const path = `/activation_keys/${name}`;
-  const request = await axios.get(RHSM_API.concat(path));
-  return request.data.body;
-}
-
 // get clones of a compose
 async function getClones(id, limit, offset) {
   const params = new URLSearchParams({
@@ -127,6 +115,4 @@ export default {
   getPackagesContentSources,
   getRepositories,
   getVersion,
-  getActivationKeys,
-  getActivationKey,
 };

--- a/src/store/apiSlice.js
+++ b/src/store/apiSlice.js
@@ -1,6 +1,10 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
-import { IMAGE_BUILDER_API, PROVISIONING_SOURCES_ENDPOINT } from '../constants';
+import {
+  IMAGE_BUILDER_API,
+  PROVISIONING_SOURCES_ENDPOINT,
+  RHSM_API,
+} from '../constants';
 
 export const apiSlice = createApi({
   reducerPath: 'api',
@@ -53,6 +57,12 @@ export const apiSlice = createApi({
       query: (distribution) =>
         `${IMAGE_BUILDER_API}/architectures/${distribution}`,
     }),
+    getActivationKeys: builder.query({
+      query: () => `${RHSM_API}/activation_keys`,
+    }),
+    getActivationKeyInformation: builder.query({
+      query: (activationKey) => `${RHSM_API}/activation_keys/${activationKey}`,
+    }),
   }),
 });
 
@@ -61,5 +71,7 @@ export const {
   useGetArchitecturesByDistributionQuery,
   useGetAzureSourcesQuery,
   useGetAzureSourceDetailQuery,
+  useGetActivationKeysQuery,
+  useGetActivationKeyInformationQuery,
   usePrefetch,
 } = apiSlice;

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
@@ -32,17 +32,6 @@ describe('Step Upload to Azure', () => {
     // scrollTo is not defined in jsdom
     window.HTMLElement.prototype.scrollTo = function () {};
 
-    // mock the activation key api call
-    const mockActivationKeys = [{ name: 'name0' }, { name: 'name1' }];
-    jest
-      .spyOn(api, 'getActivationKeys')
-      .mockImplementation(() => Promise.resolve(mockActivationKeys));
-
-    const mockActivationKey = { body: [{ name: 'name0' }, { name: 'name1' }] };
-    jest.spyOn(api, 'getActivationKey').mockImplementation((name) => {
-      return Promise.resolve(mockActivationKey[name]);
-    });
-
     jest
       .spyOn(api, 'getRepositories')
       .mockImplementation(() => Promise.resolve(mockRepositoryResults));

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -143,17 +143,6 @@ beforeAll(() => {
   // scrollTo is not defined in jsdom
   window.HTMLElement.prototype.scrollTo = function () {};
 
-  // mock the activation key api call
-  const mockActivationKeys = [{ name: 'name0' }, { name: 'name1' }];
-  jest
-    .spyOn(api, 'getActivationKeys')
-    .mockImplementation(() => Promise.resolve(mockActivationKeys));
-
-  const mockActivationKey = { body: [{ name: 'name0' }, { name: 'name1' }] };
-  jest.spyOn(api, 'getActivationKey').mockImplementation((name) => {
-    return Promise.resolve(mockActivationKey[name]);
-  });
-
   global.insights = {
     chrome: {
       auth: {
@@ -804,57 +793,6 @@ describe('Click through all steps', () => {
     screen.getByRole('button', { name: /Next/ }).click();
 
     // registration
-    const mockActivationKeys = [
-      { id: '0', name: 'name0' },
-      { id: 1, name: 'name1' },
-    ];
-    jest
-      .spyOn(api, 'getActivationKeys')
-      .mockImplementation(() => Promise.resolve(mockActivationKeys));
-    const mockActivationKey = {
-      name0: {
-        additionalRepositories: [
-          {
-            repositoryLabel: 'repository0',
-          },
-          {
-            repositoryLabel: 'repository1',
-          },
-          {
-            repositoryLabel: 'repository2',
-          },
-        ],
-        id: '0',
-        name: 'name0',
-        releaseVersion: '',
-        role: '',
-        serviceLevel: 'Self-Support',
-        usage: 'Production',
-      },
-      name1: {
-        additionalRepositories: [
-          {
-            repositoryLabel: 'repository3',
-          },
-          {
-            repositoryLabel: 'repository4',
-          },
-          {
-            repositoryLabel: 'repository5',
-          },
-        ],
-        id: '1',
-        name: 'name1',
-        releaseVersion: '',
-        role: '',
-        serviceLevel: 'Premium',
-        usage: 'Production',
-      },
-    };
-    jest.spyOn(api, 'getActivationKey').mockImplementation((name) => {
-      return Promise.resolve(mockActivationKey[name]);
-    });
-
     const activationKeyDropdown = await screen.findByRole('textbox', {
       name: 'Select activation key',
     });

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -110,17 +110,6 @@ beforeAll(() => {
   // scrollTo is not defined in jsdom
   window.HTMLElement.prototype.scrollTo = function () {};
 
-  // mock the activation key api call
-  const mockActivationKeys = [{ name: 'name0' }, { name: 'name1' }];
-  jest
-    .spyOn(api, 'getActivationKeys')
-    .mockImplementation(() => Promise.resolve(mockActivationKeys));
-
-  const mockActivationKey = { body: [{ name: 'name0' }, { name: 'name1' }] };
-  jest.spyOn(api, 'getActivationKey').mockImplementation((name) => {
-    return Promise.resolve(mockActivationKey[name]);
-  });
-
   global.insights = {
     chrome: {
       auth: {
@@ -1380,57 +1369,6 @@ describe('Click through all steps', () => {
     screen.getByRole('button', { name: /Next/ }).click();
 
     // registration
-    const mockActivationKeys = [
-      { id: '0', name: 'name0' },
-      { id: 1, name: 'name1' },
-    ];
-    jest
-      .spyOn(api, 'getActivationKeys')
-      .mockImplementation(() => Promise.resolve(mockActivationKeys));
-    const mockActivationKey = {
-      name0: {
-        additionalRepositories: [
-          {
-            repositoryLabel: 'repository0',
-          },
-          {
-            repositoryLabel: 'repository1',
-          },
-          {
-            repositoryLabel: 'repository2',
-          },
-        ],
-        id: '0',
-        name: 'name0',
-        releaseVersion: '',
-        role: '',
-        serviceLevel: 'Self-Support',
-        usage: 'Production',
-      },
-      name1: {
-        additionalRepositories: [
-          {
-            repositoryLabel: 'repository3',
-          },
-          {
-            repositoryLabel: 'repository4',
-          },
-          {
-            repositoryLabel: 'repository5',
-          },
-        ],
-        id: '1',
-        name: 'name1',
-        releaseVersion: '',
-        role: '',
-        serviceLevel: 'Premium',
-        usage: 'Production',
-      },
-    };
-    jest.spyOn(api, 'getActivationKey').mockImplementation((name) => {
-      return Promise.resolve(mockActivationKey[name]);
-    });
-
     const registrationRadio = screen.getByTestId('registration-radio-now');
     await user.click(registrationRadio);
 

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -1,6 +1,6 @@
 import { rest } from 'msw';
 
-import { PROVISIONING_SOURCES_ENDPOINT } from '../../constants';
+import { PROVISIONING_SOURCES_ENDPOINT, RHSM_API } from '../../constants';
 
 const baseURL = 'http://localhost';
 
@@ -241,6 +241,80 @@ export const handlers = [
               ],
             },
           ])
+        );
+      }
+    }
+  ),
+  rest.get(baseURL.concat(`${RHSM_API}/activation_keys`), (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        body: [
+          {
+            id: 0,
+            name: 'name0',
+          },
+          {
+            id: 1,
+            name: 'name1',
+          },
+        ],
+      })
+    );
+  }),
+  rest.get(
+    baseURL.concat(`${RHSM_API}/activation_keys/:key`),
+    (req, res, ctx) => {
+      const { key } = req.params;
+      if (key === 'name0') {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            body: {
+              additionalRepositories: [
+                {
+                  repositoryLabel: 'repository0',
+                },
+                {
+                  repositoryLabel: 'repository1',
+                },
+                {
+                  repositoryLabel: 'repository2',
+                },
+              ],
+              id: '0',
+              name: 'name0',
+              releaseVersion: '',
+              role: '',
+              serviceLevel: 'Self-Support',
+              usage: 'Production',
+            },
+          })
+        );
+      } else if (key === 'name1') {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            body: {
+              additionalRepositories: [
+                {
+                  repositoryLabel: 'repository3',
+                },
+                {
+                  repositoryLabel: 'repository4',
+                },
+                {
+                  repositoryLabel: 'repository5',
+                },
+              ],
+              id: '1',
+              name: 'name1',
+              releaseVersion: '',
+              role: '',
+              serviceLevel: 'Premium',
+              usage: 'Production',
+            },
+          })
         );
       }
     }


### PR DESCRIPTION
This migrates calls to RHSM endpoints `activation_keys` and `/activation_keys/{name}` to RTK Query.

Tests were also updated to use Mock Service Worker instead of previous Jest mock function.