### PR TITLE
Wizard: Remove prop validation for `ReviewStepTables` and `ReviewStepTextLists`

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTables.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTables.js
@@ -10,7 +10,6 @@ import {
   Thead,
   Tr,
 } from '@patternfly/react-table';
-import PropTypes from 'prop-types';
 
 import { UNIT_GIB, UNIT_MIB } from '../../../constants';
 
@@ -104,16 +103,4 @@ export const RepositoriesTable = () => {
       </PanelMain>
     </Panel>
   );
-};
-
-FSReviewTable.propTypes = {
-  fsc: PropTypes.arrayOf(PropTypes.object).isRequired,
-};
-
-PackagesTable.propTypes = {
-  packages: PropTypes.arrayOf(PropTypes.object).isRequired,
-};
-
-RepositoriesTable.propTypes = {
-  repositories: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -14,7 +14,6 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon, HelpIcon } from '@patternfly/react-icons';
-import PropTypes from 'prop-types';
 
 import ActivationKeyInformation from './ActivationKeyInformation';
 import {
@@ -534,17 +533,4 @@ export const ImageDetailsList = () => {
       <br />
     </TextContent>
   );
-};
-
-TargetEnvAWSList.propTypes = {
-  awsSources: PropTypes.arrayOf(PropTypes.object),
-  isSuccessAWSSources: PropTypes.bool,
-};
-
-TargetEnvGCPList.propTypes = {
-  googleAccType: PropTypes.object,
-};
-
-FSCList.propTypes = {
-  minSize: PropTypes.string,
 };


### PR DESCRIPTION
This removes prop validation that was left behind after the props were removed during a Review step updates PR review.