### PR TITLE
CreateImageWizard: show error details on save

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -554,15 +554,16 @@ const CreateImageWizard = () => {
             setIsSaving(false);
           })
           .catch((err) => {
+            let msg = err.response.statusText;
+            if (err.response.data?.errors[0]?.detail) {
+              msg = err.response.data?.errors[0]?.detail;
+            }
+
             dispatch(
               addNotification({
                 variant: 'danger',
                 title: 'Your image could not be created',
-                description:
-                  'Status code ' +
-                  err.response.status +
-                  ': ' +
-                  err.response.statusText,
+                description: 'Status code ' + err.response.status + ': ' + msg,
               })
             );
 


### PR DESCRIPTION
Show details when the wizard sends a request that results in an error. Now that AWS and Azure have a maximum size, this needs to be shown.

---

