### PR TITLE
Wizard: Disable remove button for the root partition

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -389,6 +389,7 @@ const FileSystemConfiguration = ({ ...props }) => {
                       icon={<MinusCircleIcon />}
                       onClick={() => removeRow(row.id)}
                       data-testid="remove-mount-point"
+                      isDisabled={row.mountpoint === '/' ? true : false}
                     />
                   </Td>
                 </Tr>

--- a/src/Components/CreateImageWizard/formComponents/MountPoint.js
+++ b/src/Components/CreateImageWizard/formComponents/MountPoint.js
@@ -11,7 +11,6 @@ import {
 import PropTypes from 'prop-types';
 
 const MountPoint = ({ ...props }) => {
-  // check '/' last!
   const validPrefixes = [
     '/app',
     '/boot',
@@ -23,7 +22,6 @@ const MountPoint = ({ ...props }) => {
     '/usr',
     '/usr/local',
     '/var',
-    '/',
   ];
   const [isOpen, setIsOpen] = useState(false);
   const [prefix, setPrefix] = useState('/');
@@ -72,6 +70,7 @@ const MountPoint = ({ ...props }) => {
         onSelect={onSelect}
         selections={prefix}
         variant={SelectVariant.single}
+        isDisabled={prefix === '/' ? true : false}
       >
         {validPrefixes.map((pfx, index) => {
           return <SelectOption key={index} value={pfx} />;


### PR DESCRIPTION
Fixes #910. This disables the remove button and select for the root partition as that one is required to continue with creating an image.

The third point mentioned in the issue is removing mount points that have already been chosen from the dropdown to prevent adding duplicate mountpoints.

This point was not implemented as we need to allow the user to create multiple sub directories under the same mount point if needed.