### PR TITLE
Wizard: Add "refine search" warning to Packages step

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -9,8 +9,8 @@
 }
 
 .pf-c-dual-list-selector {
-    --pf-c-dual-list-selector__menu--MinHeight: 18.5rem;
-    --pf-c-dual-list-selector__menu--MaxHeight: 18.5rem;
+    --pf-c-dual-list-selector__menu--MinHeight: 15.5rem;
+    --pf-c-dual-list-selector__menu--MaxHeight: 15.5rem;
 }
 
 .pf-c-form {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -486,7 +486,7 @@ describe('Step Packages', () => {
 
     await searchForAvailablePackages(searchbox, 'asdf');
 
-    await screen.findByText('No packages found');
+    await screen.findByText('No results found');
   });
 
   test('should display empty chosen state on failed search', async () => {


### PR DESCRIPTION
Fixes #913.

This adds status bars to the `DualListSelectorPane` on the Packages step. The status bar indicates how many packages were found and how many of those have been selected.

Warning for too many returned results was also added. When an exact match is found during a search with over 100 results, it is shown together with the warning.