### PR TITLE
Wizard: Fix bug causing crash upon visiting Azure step

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -472,7 +472,7 @@ const formStepHistory = (composeRequest) => {
     if (uploadRequest.type === 'aws') {
       steps.push('aws-target-env');
     } else if (uploadRequest.type === 'azure') {
-      steps.push('azure-target-env');
+      steps.push('ms-azure-target-env');
     } else if (uploadRequest.type === 'gcp') {
       steps.push('google-cloud-target-env');
     }


### PR DESCRIPTION
This commit fixes a bug in the wizard. The Azure step name was incorrectly set when using the 'Recreate image' option which caused the wizard to crash when trying to access the Azure step.