### PR TITLE
Wizard: Use useChrome hook to set beta feature flag

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { useStore } from 'react-redux';
 import { useNavigate } from 'react-router-dom';

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
 import { useStore } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
@@ -12,14 +13,12 @@ const App = (props) => {
   const navigate = useNavigate();
   const store = useStore();
 
+  const { hideGlobalFilter, on, updateDocumentTitle } = useChrome();
+
   useEffect(() => {
-    document.title = 'Image Builder | Red Hat Insights';
-    insights.chrome.init();
-    insights.chrome.identifyApp('image-builder');
-    insights.chrome.hideGlobalFilter();
-    const unregister = insights.chrome.on('APP_NAVIGATION', () =>
-      navigate(resolveRelPath(''))
-    );
+    updateDocumentTitle('Image Builder | Red Hat Insights');
+    hideGlobalFilter();
+    const unregister = on('APP_NAVIGATION', () => navigate(resolveRelPath('')));
     return () => {
       unregister();
     };

--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -302,7 +302,7 @@ const getPackageDescription = async (
 };
 
 // map the compose request object to the expected form state
-const requestToState = (composeRequest, distroInfo, isBeta) => {
+const requestToState = (composeRequest, distroInfo, isBeta, isProd) => {
   if (composeRequest) {
     const imageRequest = composeRequest.image_requests[0];
     const uploadRequest = imageRequest.upload_request;
@@ -461,7 +461,7 @@ const requestToState = (composeRequest, distroInfo, isBeta) => {
       formState['subscription-activation-key'] = subscription['activation-key'];
       formState['subscription-organization-id'] = subscription.organization;
 
-      if (insights.chrome.isProd()) {
+      if (isProd) {
         formState['subscription-server-url'] = 'subscription.rhsm.redhat.com';
         formState['subscription-base-url'] = 'https://cdn.redhat.com/';
       } else {
@@ -544,11 +544,16 @@ const CreateImageWizard = () => {
   // This will occur if 'Recreate image' is clicked
   const initialStep = compose?.request ? 'review' : undefined;
 
-  const { isBeta } = useGetEnvironment();
+  const { isBeta, isProd } = useGetEnvironment();
 
   const awsTarget = isBeta() ? awsTargetBeta : awsTargetStable;
   const msAzureTarget = isBeta() ? msAzureTargetBeta : msAzureTargetStable;
-  let initialState = requestToState(composeRequest, distroInfo, isBeta());
+  let initialState = requestToState(
+    composeRequest,
+    distroInfo,
+    isBeta(),
+    isProd()
+  );
   const stepHistory = formStepHistory(composeRequest, isBeta());
 
   initialState

--- a/src/Components/CreateImageWizard/formComponents/ActivationKeys.js
+++ b/src/Components/CreateImageWizard/formComponents/ActivationKeys.js
@@ -13,8 +13,10 @@ import {
 import PropTypes from 'prop-types';
 
 import { useGetActivationKeysQuery } from '../../../store/apiSlice';
+import { useGetEnvironment } from '../../../Utilities/useGetEnvironment';
 
 const ActivationKeys = ({ label, isRequired, ...props }) => {
+  const { isProd } = useGetEnvironment();
   const { change, getState } = useFormApi();
   const { input } = useFieldApi(props);
   const [isOpen, setIsOpen] = useState(false);
@@ -31,7 +33,7 @@ const ActivationKeys = ({ label, isRequired, ...props }) => {
   } = useGetActivationKeysQuery();
 
   useEffect(() => {
-    if (insights.chrome.isProd()) {
+    if (isProd()) {
       change('subscription-server-url', 'subscription.rhsm.redhat.com');
       change('subscription-base-url', 'https://cdn.redhat.com/');
     } else {

--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -31,7 +31,6 @@ import PropTypes from 'prop-types';
 
 import api from '../../../api';
 import { useGetArchitecturesByDistributionQuery } from '../../../store/apiSlice';
-import isBeta from '../../../Utilities/isBeta';
 
 const ExactMatch = ({
   pkgList,
@@ -67,7 +66,7 @@ export const RedHatPackages = ({ defaultArch }) => {
   const getAllPackages = async (packagesSearchName) => {
     // if the env is stage beta then use content-sources api
     // else use image-builder api
-    if (isBeta()) {
+    if (getState()?.values?.isBeta) {
       const filteredArchx86_64 = distributionInformation.find(
         (info) => info.arch === 'x86_64'
       );

--- a/src/Components/CreateImageWizard/formComponents/Repositories.js
+++ b/src/Components/CreateImageWizard/formComponents/Repositories.js
@@ -35,7 +35,6 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 import { selectValidRepositories } from '../../../store/repositoriesSlice';
-import isBeta from '../../../Utilities/isBeta';
 
 const BulkSelect = ({
   selected,
@@ -276,7 +275,11 @@ const Repositories = (props) => {
           <Button
             variant="primary"
             component="a"
-            href={isBeta() ? '/beta/settings/content' : '/settings/content'}
+            href={
+              getState()?.values?.isBeta
+                ? '/beta/settings/content'
+                : '/settings/content'
+            }
           >
             Repositories
           </Button>

--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -7,6 +7,7 @@ import {
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 import {
   ContentList,
@@ -24,6 +25,7 @@ import {
 import isRhel from '../../../Utilities/isRhel';
 
 const ReviewStep = () => {
+  const { auth } = useChrome();
   const [isExpandedImageOutput, setIsExpandedImageOutput] = useState(false);
   const [isExpandedTargetEnvs, setIsExpandedTargetEnvs] = useState(false);
   const [isExpandedFSC, setIsExpandedFSC] = useState(false);
@@ -36,7 +38,7 @@ const ReviewStep = () => {
     const registerSystem = getState()?.values?.['register-system'];
     if (registerSystem?.startsWith('register-now')) {
       (async () => {
-        const userData = await insights?.chrome?.auth?.getUser();
+        const userData = await auth?.getUser();
         const id = userData?.identity?.internal?.org_id;
         change('subscription-organization-id', id);
       })();

--- a/src/Components/CreateImageWizard/steps/packages.js
+++ b/src/Components/CreateImageWizard/steps/packages.js
@@ -5,7 +5,6 @@ import { Text } from '@patternfly/react-core';
 
 import StepTemplate from './stepTemplate';
 
-import isBeta from '../../../Utilities/isBeta';
 import CustomButtons from '../formComponents/CustomButtons';
 
 export default {
@@ -14,8 +13,8 @@ export default {
   title: 'Additional Red Hat packages',
   name: 'packages',
   substepOf: 'Content',
-  nextStep: () => {
-    if (isBeta()) {
+  nextStep: ({ values }) => {
+    if (values.isBeta) {
       return 'repositories';
     } else {
       return 'image-name';

--- a/src/Components/CreateImageWizard/steps/registration.js
+++ b/src/Components/CreateImageWizard/steps/registration.js
@@ -11,6 +11,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 import StepTemplate from './stepTemplate';
 
@@ -18,10 +19,11 @@ import CustomButtons from '../formComponents/CustomButtons';
 
 const PopoverActivation = () => {
   const [orgId, setOrgId] = useState(null);
+  const { auth } = useChrome();
 
   useEffect(() => {
     (async () => {
-      const userData = await insights?.chrome?.auth?.getUser();
+      const userData = await auth?.getUser();
       const id = userData?.identity?.internal?.org_id;
       setOrgId(id);
     })();

--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -1,7 +1,7 @@
 import React, { Suspense, useState, useMemo } from 'react';
 
 import { Button, Modal, ModalVariant } from '@patternfly/react-core';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 import { useLoadModule, useScalprum } from '@scalprum/react-core';
 import { useFlag } from '@unleash/proxy-client-react';
 import PropTypes from 'prop-types';
@@ -11,6 +11,7 @@ import ImageLinkDirect from './ImageLinkDirect';
 
 import { MODAL_ANCHOR } from '../../constants';
 import { selectImageById } from '../../store/composesSlice';
+import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
 
 const getImageProvider = ({ imageType }) => {
   switch (imageType) {
@@ -91,18 +92,13 @@ const ProvisioningLink = ({ imageId, isExpired, isInClonesTable }) => {
 const ImageLink = ({ imageId, isExpired, isInClonesTable }) => {
   const image = useSelector((state) => selectImageById(state, imageId));
   const uploadStatus = image.uploadStatus;
-  const {
-    initialized: chromeInitialized,
-    isBeta,
-    getEnvironment,
-  } = useChrome();
+  const { initialized: chromeInitialized } = useChrome();
+  const { isBeta } = useGetEnvironment();
   const azureFeatureFlag = useFlag('provisioning.azure');
 
   const scalprum = useScalprum();
   const hasProvisioning =
-    chromeInitialized &&
-    scalprum.config?.provisioning &&
-    (isBeta() || getEnvironment() === 'qa');
+    chromeInitialized && scalprum.config?.provisioning && isBeta();
 
   if (!uploadStatus || image.status !== 'success') return null;
 

--- a/src/Components/ImagesTable/RegionsPopover.js
+++ b/src/Components/ImagesTable/RegionsPopover.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 import { selectComposeById, selectImagesById } from '../../store/composesSlice';
-import isBeta from '../../Utilities/isBeta';
+import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
 import BetaLabel from '../sharedComponents/BetaLabel';
 
 export const selectRegions = createSelector(
@@ -57,6 +57,7 @@ const ImageLinkRegion = ({ region, ami }) => {
 };
 
 export const RegionsPopover = ({ composeId }) => {
+  const { isBeta } = useGetEnvironment();
   const regions = useSelector((state) => selectRegions(state, composeId));
 
   const listItems = useMemo(() => {

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -28,7 +28,7 @@ import azureQuickStart from './azurequickstart.json';
 import contentQuickStart from './contentquickstart.json';
 import './LandingPage.scss';
 
-import isBeta from '../../Utilities/isBeta';
+import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
 import ImagesTable from '../ImagesTable/ImagesTable';
 import DocumentationButton from '../sharedComponents/DocumentationButton';
 
@@ -37,6 +37,7 @@ export const LandingPage = () => {
   const [showHint, setShowHint] = useState(true);
 
   const { quickStarts } = useChrome();
+  const { isBeta } = useGetEnvironment();
   const activateQuickstart = (qs) => quickStarts.toggle(qs.metadata.name);
 
   useEffect(() => {

--- a/src/Utilities/isBeta.js
+++ b/src/Utilities/isBeta.js
@@ -1,7 +1,0 @@
-function isBeta() {
-  return insights.chrome.isBeta() || insights.chrome.getEnvironment() === 'qa'
-    ? true
-    : false;
-}
-
-export default isBeta;

--- a/src/Utilities/useGetEnvironment.js
+++ b/src/Utilities/useGetEnvironment.js
@@ -1,10 +1,10 @@
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 export const useGetEnvironment = () => {
-  const { isBeta, getEnvironment } = useChrome();
+  const { isBeta, isProd, getEnvironment } = useChrome();
   // Expose beta features in the ephemeral environment
   if (isBeta() || getEnvironment() === 'qa') {
-    return { isBeta: () => true };
+    return { isBeta: () => true, isProd: isProd };
   }
-  return { isBeta: () => false };
+  return { isBeta: () => false, isProd: isProd };
 };

--- a/src/Utilities/useGetEnvironment.js
+++ b/src/Utilities/useGetEnvironment.js
@@ -1,0 +1,10 @@
+import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+
+export const useGetEnvironment = () => {
+  const { isBeta, getEnvironment } = useChrome();
+  // Expose beta features in the ephemeral environment
+  if (isBeta() || getEnvironment() === 'qa') {
+    return { isBeta: () => true };
+  }
+  return { isBeta: () => false };
+};

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
@@ -10,6 +10,14 @@ import { mockRepositoryResults } from '../../fixtures/repositories';
 import { server } from '../../mocks/server.js';
 import { renderWithReduxRouter } from '../../testUtils';
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
 describe('Step Upload to Azure', () => {
   const getNextButton = () => {
     const next = screen.getByRole('button', { name: /Next/ });
@@ -46,15 +54,6 @@ describe('Step Upload to Azure', () => {
               },
             };
           },
-        },
-        isBeta: () => {
-          return true;
-        },
-        isProd: () => {
-          return true;
-        },
-        getEnvironment: () => {
-          return 'prod';
         },
       },
     };

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
@@ -12,6 +12,17 @@ import { renderWithReduxRouter } from '../../testUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
     isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
@@ -41,31 +52,10 @@ describe('Step Upload to Azure', () => {
     jest
       .spyOn(api, 'getRepositories')
       .mockImplementation(() => Promise.resolve(mockRepositoryResults));
-
-    global.insights = {
-      chrome: {
-        auth: {
-          getUser: () => {
-            return {
-              identity: {
-                internal: {
-                  org_id: 5,
-                },
-              },
-            };
-          },
-        },
-      },
-    };
   });
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  // restore global mock
-  afterAll(() => {
-    global.insights = undefined;
   });
 
   const user = userEvent.setup();

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -30,6 +30,14 @@ const mockComposes = {
   data: [],
 };
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
 // Mocking getComposes is necessary because in many tests we call navigate()
 // to navigate to the images table (via useNavigate hook), which will in turn
 // result in a call to getComposes. If it is not mocked, tests fail due to MSW
@@ -169,14 +177,8 @@ beforeAll(() => {
           };
         },
       },
-      isBeta: () => {
-        return true;
-      },
       isProd: () => {
         return true;
-      },
-      getEnvironment: () => {
-        return 'prod';
       },
     },
   };

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -32,6 +32,17 @@ const mockComposes = {
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
     isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
@@ -159,39 +170,14 @@ const searchForChosenPackages = async (searchbox, searchTerm) => {
   }
 };
 
-// mock the insights dependency
 beforeAll(() => {
   // scrollTo is not defined in jsdom
   window.HTMLElement.prototype.scrollTo = function () {};
-
-  global.insights = {
-    chrome: {
-      auth: {
-        getUser: () => {
-          return {
-            identity: {
-              internal: {
-                org_id: 5,
-              },
-            },
-          };
-        },
-      },
-      isProd: () => {
-        return true;
-      },
-    },
-  };
 });
 
 afterEach(() => {
   jest.clearAllMocks();
   router = undefined;
-});
-
-// restore global mock
-afterAll(() => {
-  global.insights = undefined;
 });
 
 describe('Create Image Wizard', () => {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -31,6 +31,14 @@ jest
   .spyOn(api, 'getComposes')
   .mockImplementation(() => Promise.resolve(mockComposes));
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    isBeta: () => false,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
 function getBackButton() {
   const back = screen.getByRole('button', { name: /Back/ });
   return back;

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -33,6 +33,17 @@ jest
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
     isBeta: () => false,
     isProd: () => true,
     getEnvironment: () => 'prod',
@@ -124,45 +135,14 @@ const searchForChosenPackages = async (searchbox, searchTerm) => {
   }
 };
 
-// mock the insights dependency
 beforeAll(() => {
   // scrollTo is not defined in jsdom
   window.HTMLElement.prototype.scrollTo = function () {};
-
-  global.insights = {
-    chrome: {
-      auth: {
-        getUser: () => {
-          return {
-            identity: {
-              internal: {
-                org_id: 5,
-              },
-            },
-          };
-        },
-      },
-      isBeta: () => {
-        return false;
-      },
-      isProd: () => {
-        return true;
-      },
-      getEnvironment: () => {
-        return 'prod';
-      },
-    },
-  };
 });
 
 afterEach(() => {
   jest.clearAllMocks();
   router = undefined;
-});
-
-// restore global mock
-afterAll(() => {
-  global.insights = undefined;
 });
 
 describe('Create Image Wizard', () => {

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -425,21 +425,13 @@ const mockCloneStatus = {
   },
 };
 
-beforeAll(() => {
-  global.insights = {
-    chrome: {
-      isBeta: () => {
-        return false;
-      },
-      isProd: () => {
-        return true;
-      },
-      getEnvironment: () => {
-        return 'prod';
-      },
-    },
-  };
-});
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    isBeta: () => false,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
 
 jest
   .spyOn(api, 'getComposes')

--- a/src/test/Components/LandingPage/LandingPage.test.js
+++ b/src/test/Components/LandingPage/LandingPage.test.js
@@ -10,17 +10,19 @@ jest.mock('../../../store/actions/actions', () => {
   };
 });
 
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    isBeta: () => false,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
 beforeAll(() => {
   global.insights = {
     chrome: {
-      isBeta: () => {
-        return false;
-      },
       isProd: () => {
         return true;
-      },
-      getEnvironment: () => {
-        return 'prod';
       },
     },
   };

--- a/src/test/Components/LandingPage/LandingPage.test.js
+++ b/src/test/Components/LandingPage/LandingPage.test.js
@@ -18,16 +18,6 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   }),
 }));
 
-beforeAll(() => {
-  global.insights = {
-    chrome: {
-      isProd: () => {
-        return true;
-      },
-    },
-  };
-});
-
 describe('Landing Page', () => {
   test('renders page heading', async () => {
     renderWithReduxRouter('', {});

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.js
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.js
@@ -6,21 +6,13 @@ import api from '../../../api.js';
 import { RHEL_8 } from '../../../constants.js';
 import { renderWithReduxRouter } from '../../testUtils';
 
-beforeAll(() => {
-  global.insights = {
-    chrome: {
-      isBeta: () => {
-        return false;
-      },
-      isProd: () => {
-        return true;
-      },
-      getEnvironment: () => {
-        return 'prod';
-      },
-    },
-  };
-});
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    isBeta: () => false,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
 
 const mockComposes = {
   count: 1,


### PR DESCRIPTION
Calling insights.chrome is deprecated. The commits in this PR:

(1) replace isBeta() function with custom useGetEnvironment() hook
(2) adapt App.js to useChrome() hook (stop calling insights.chrome directly)
(3) replace all calls in code to insights.chrome with calls to either useChrome() or useGetEnvironment() hooks

This PR is important, because calling the deprecated insights.chrome functions results in a massive amount of warnings flooding the console, which makes it very difficult to find real/important error messages.

Chrome API docs can be found here:
http://front-end-docs-insights.apps.ocp4.prod.psi.redhat.com/chrome/chrome-api