### PR TITLE
Wizard: Ensure unique IDs for buttons

### DIFF
--- a/src/Components/CreateImageWizard/steps/packagesContentSources.js
+++ b/src/Components/CreateImageWizard/steps/packagesContentSources.js
@@ -5,6 +5,8 @@ import { Text } from '@patternfly/react-core';
 
 import StepTemplate from './stepTemplate';
 
+import CustomButtons from '../formComponents/CustomButtons';
+
 export default {
   StepTemplate,
   id: 'wizard-systemconfiguration-content-sources-packages',
@@ -12,6 +14,7 @@ export default {
   name: 'packages-content-sources',
   substepOf: 'Content',
   nextStep: 'image-name',
+  buttons: CustomButtons,
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,

--- a/src/Components/CreateImageWizard/steps/repositories.js
+++ b/src/Components/CreateImageWizard/steps/repositories.js
@@ -6,6 +6,8 @@ import { Text } from '@patternfly/react-core';
 import nextStepMapper from './repositoriesStepMapper';
 import StepTemplate from './stepTemplate';
 
+import CustomButtons from '../formComponents/CustomButtons';
+
 export default {
   StepTemplate,
   id: 'wizard-repositories',
@@ -13,6 +15,7 @@ export default {
   name: 'repositories',
   substepOf: 'Content',
   nextStep: ({ values }) => nextStepMapper(values),
+  buttons: CustomButtons,
   fields: [
     {
       component: componentTypes.PLAIN_TEXT,


### PR DESCRIPTION
Fixes #1065.

This sets buttons on the Repositories and Additional custom packages steps to `CustomButtons` to ensure buttons in each of the steps have a unique ID.