### PR TITLE
Jest: Add --runInBand to `npm run verify` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "test": "TZ=UTC jest --verbose --no-cache",
     "test:single": "jest --verbose -w 1",
     "build": "webpack --config config/prod.webpack.config.js",
-    "verify": "npm-run-all build lint test"
+    "verify": "npm-run-all build lint test -- --runInBand"
   },
   "insights": {
     "appname": "image-builder"


### PR DESCRIPTION
This option can help with slow tests in resource constrained environments (CI) by running tests sequentially.