### PR TITLE
build(deps): bump data driven forms to 3.20.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "image-builder",
       "version": "1.1.0",
       "dependencies": {
-        "@data-driven-forms/pf4-component-mapper": "3.20.5",
-        "@data-driven-forms/react-form-renderer": "3.20.5",
+        "@data-driven-forms/pf4-component-mapper": "3.20.6",
+        "@data-driven-forms/react-form-renderer": "3.20.6",
         "@patternfly/patternfly": "4.224.2",
         "@patternfly/react-core": "4.276.8",
         "@patternfly/react-table": "4.113.0",
@@ -1998,9 +1998,9 @@
       }
     },
     "node_modules/@data-driven-forms/common": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.20.5.tgz",
-      "integrity": "sha512-Z/kOXQrRQab5DrRAlcVvWp3zs7Ftq6Dw0blJqASRKzFi3wQDlnPawEe7uFE5OWVEGL8afAZlSESYZKepuyLf7A==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.20.6.tgz",
+      "integrity": "sha512-Mj/QuSc7IAfUNEadzkQvPwIxALL8f+CAUWsc/7g/VVTtkNpi+z3JAoZpaFnCL0ChaixfmkHNYgv+4CH+vWW2gQ==",
       "dependencies": {
         "clsx": "^1.0.4",
         "lodash": "^4.17.15",
@@ -2012,17 +2012,17 @@
       }
     },
     "node_modules/@data-driven-forms/pf4-component-mapper": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-3.20.5.tgz",
-      "integrity": "sha512-EIF0da50PYRZfKEz1iOO3aepPrb78tjk+A6ZURIYTo8q71JITA7Wnab/omK4OR6W3OdUiIw42S7ECu15w/kxWg==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-3.20.6.tgz",
+      "integrity": "sha512-VseWvXwujEa/315z7BNv3qtKM8t1rwPk2JXBNVAvIQUQaL5od3eHLUjE36qaMTBGQhhOwoiU97A4tZ1+r91+Mw==",
       "dependencies": {
-        "@data-driven-forms/common": "^3.20.5",
+        "@data-driven-forms/common": "^3.20.6",
         "downshift": "^5.4.3",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@data-driven-forms/react-form-renderer": "^3.20.5",
+        "@data-driven-forms/react-form-renderer": "^3.20.6",
         "@patternfly/react-core": "^4.157.3",
         "@patternfly/react-icons": "^4.11.7",
         "react": "^16.13.1 || ^17.0.2 || ^18.0.0",
@@ -2030,9 +2030,9 @@
       }
     },
     "node_modules/@data-driven-forms/react-form-renderer": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.20.5.tgz",
-      "integrity": "sha512-QejAra4T1vWGJSKP+4E3tgjn7e54mDjqNymV12HqzubWqvk99qoRIoIp1LkGf1jlXkun00bWVGlnamlABRXrEQ==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.20.6.tgz",
+      "integrity": "sha512-yf2jneAbSDD/mxE8dG12QYtof0a4ta6XOwcAwR8USS0OUUV0Rjzs5f/bqbBR716bwH7J4VbUo9E44tMwyL9VfQ==",
       "dependencies": {
         "final-form": "^4.20.4",
         "final-form-arrays": "^3.0.2",
@@ -9335,9 +9335,9 @@
       }
     },
     "node_modules/final-form": {
-      "version": "4.20.7",
-      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.7.tgz",
-      "integrity": "sha512-ii3X9wNfyBYFnDPunYN5jh1/HAvtOZ9aJI/TVk0MB86hZuOeYkb+W5L3icgwW9WWNztZR6MDU3En6eoZTUoFPg==",
+      "version": "4.20.9",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.9.tgz",
+      "integrity": "sha512-shA1X/7v8RmukWMNRHx0l7+Bm41hOivY78IvOiBrPVHjyWFIyqqIEMCz7yTVRc9Ea+EU4WkZ5r4MH6whSo5taw==",
       "dependencies": {
         "@babel/runtime": "^7.10.0"
       },
@@ -9347,11 +9347,11 @@
       }
     },
     "node_modules/final-form-arrays": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.0.2.tgz",
-      "integrity": "sha512-TfO8aZNz3RrsZCDx8GHMQcyztDNpGxSSi9w4wpSNKlmv2PfFWVVM8P7Yj5tj4n0OWax+x5YwTLhT5BnqSlCi+w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.1.0.tgz",
+      "integrity": "sha512-TWBvun+AopgBLw9zfTFHBllnKMVNEwCEyDawphPuBGGqNsuhGzhT7yewHys64KFFwzIs6KEteGLpKOwvTQEscQ==",
       "peerDependencies": {
-        "final-form": "^4.18.2"
+        "final-form": "^4.20.8"
       }
     },
     "node_modules/final-form-focus": {
@@ -20957,9 +20957,9 @@
       }
     },
     "@data-driven-forms/common": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.20.5.tgz",
-      "integrity": "sha512-Z/kOXQrRQab5DrRAlcVvWp3zs7Ftq6Dw0blJqASRKzFi3wQDlnPawEe7uFE5OWVEGL8afAZlSESYZKepuyLf7A==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.20.6.tgz",
+      "integrity": "sha512-Mj/QuSc7IAfUNEadzkQvPwIxALL8f+CAUWsc/7g/VVTtkNpi+z3JAoZpaFnCL0ChaixfmkHNYgv+4CH+vWW2gQ==",
       "requires": {
         "clsx": "^1.0.4",
         "lodash": "^4.17.15",
@@ -20967,20 +20967,20 @@
       }
     },
     "@data-driven-forms/pf4-component-mapper": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-3.20.5.tgz",
-      "integrity": "sha512-EIF0da50PYRZfKEz1iOO3aepPrb78tjk+A6ZURIYTo8q71JITA7Wnab/omK4OR6W3OdUiIw42S7ECu15w/kxWg==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-3.20.6.tgz",
+      "integrity": "sha512-VseWvXwujEa/315z7BNv3qtKM8t1rwPk2JXBNVAvIQUQaL5od3eHLUjE36qaMTBGQhhOwoiU97A4tZ1+r91+Mw==",
       "requires": {
-        "@data-driven-forms/common": "^3.20.5",
+        "@data-driven-forms/common": "^3.20.6",
         "downshift": "^5.4.3",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       }
     },
     "@data-driven-forms/react-form-renderer": {
-      "version": "3.20.5",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.20.5.tgz",
-      "integrity": "sha512-QejAra4T1vWGJSKP+4E3tgjn7e54mDjqNymV12HqzubWqvk99qoRIoIp1LkGf1jlXkun00bWVGlnamlABRXrEQ==",
+      "version": "3.20.6",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.20.6.tgz",
+      "integrity": "sha512-yf2jneAbSDD/mxE8dG12QYtof0a4ta6XOwcAwR8USS0OUUV0Rjzs5f/bqbBR716bwH7J4VbUo9E44tMwyL9VfQ==",
       "requires": {
         "final-form": "^4.20.4",
         "final-form-arrays": "^3.0.2",
@@ -26579,17 +26579,17 @@
       }
     },
     "final-form": {
-      "version": "4.20.7",
-      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.7.tgz",
-      "integrity": "sha512-ii3X9wNfyBYFnDPunYN5jh1/HAvtOZ9aJI/TVk0MB86hZuOeYkb+W5L3icgwW9WWNztZR6MDU3En6eoZTUoFPg==",
+      "version": "4.20.9",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.9.tgz",
+      "integrity": "sha512-shA1X/7v8RmukWMNRHx0l7+Bm41hOivY78IvOiBrPVHjyWFIyqqIEMCz7yTVRc9Ea+EU4WkZ5r4MH6whSo5taw==",
       "requires": {
         "@babel/runtime": "^7.10.0"
       }
     },
     "final-form-arrays": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.0.2.tgz",
-      "integrity": "sha512-TfO8aZNz3RrsZCDx8GHMQcyztDNpGxSSi9w4wpSNKlmv2PfFWVVM8P7Yj5tj4n0OWax+x5YwTLhT5BnqSlCi+w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.1.0.tgz",
+      "integrity": "sha512-TWBvun+AopgBLw9zfTFHBllnKMVNEwCEyDawphPuBGGqNsuhGzhT7yewHys64KFFwzIs6KEteGLpKOwvTQEscQ==",
       "requires": {}
     },
     "final-form-focus": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "npm": ">=7.0.0"
   },
   "dependencies": {
-    "@data-driven-forms/pf4-component-mapper": "3.20.5",
-    "@data-driven-forms/react-form-renderer": "3.20.5",
+    "@data-driven-forms/pf4-component-mapper": "3.20.6",
+    "@data-driven-forms/react-form-renderer": "3.20.6",
     "@patternfly/patternfly": "4.224.2",
     "@patternfly/react-core": "4.276.8",
     "@patternfly/react-table": "4.113.0",


### PR DESCRIPTION
3.20.6 includes a hotfix that allows modals to take an appendTo prop, which is necessary for modals to display correctly with the new quickstart tutorials.