### PR TITLE
Wizard: Fix unavailable key information error

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ActivationKeyInformation.js
+++ b/src/Components/CreateImageWizard/formComponents/ActivationKeyInformation.js
@@ -156,7 +156,7 @@ const ActivationKeyInformation = () => {
           </TextList>
         </TextContent>
       )}
-      {currentStep.name === 'registration' && (
+      {isErrorActivationKeyInfo && currentStep.name === 'registration' && (
         <>
           <br />
           <Alert


### PR DESCRIPTION
When creating a new image and selecting an activation key on the Registration step the warning about unavailable key information is displayed even though the key information is loaded without any problems.

This shows the error on the Registration step only when fetching the activation key information ends in error.