### PR TITLE
ImagesTable: Fix bug where Launch link incorrectly displayed

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -18,6 +18,7 @@ const getImageProvider = ({ imageType }) => {
     case 'azure':
       return 'azure';
     default:
+      //TODO check with Provisioning: what if imageType is not 'aws', 'ami', or 'azure'?
       return 'aws';
   }
 };
@@ -95,8 +96,8 @@ const ImageLink = ({ imageId, isExpired, isInClonesTable }) => {
   if (!uploadStatus || image.status !== 'success') return null;
 
   const provisioningLinkEnabled = (image) => {
-    switch (getImageProvider(image)) {
-      case 'aws':
+    switch (image.imageType) {
+      case 'aws' || 'ami':
         return true;
       case 'azure':
         return !!azureFeatureFlag;


### PR DESCRIPTION
This commit fixes a bug where the Launch link (which opens the Provisioning wizard) was incorrectly displayed for all image types.

The bug is currently in production beta, so this commit is needed for the hotfix. Changes made are minimal, only what is necessary to fix the bug - we still need to discuss the getImageProvider() function (the original source of the bug) with the Provisioning team.