### PR TITLE
LaunchWizard: Add large variant prop to set width of wizard correctly

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -55,6 +55,7 @@ const ProvisioningLink = ({ imageId, isExpired, isInClonesTable }) => {
             hasNoBodyWrapper
             appendTo={appendTo}
             showClose={false}
+            variant={'large'}
           >
             <ProvisioningWizard
               onClose={() => openWizard(false)}


### PR DESCRIPTION
Without this prop, the wizard's width expands to fill the entire window.