### PR TITLE
ImagesTable/ShareImageModal: Update sharing options for AWS

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -145,6 +145,7 @@ const ImagesTable = () => {
     {
       title: 'Share to new region',
       onClick: () => navigate(resolveRelPath(`share/${compose.id}`)),
+      isDisabled: compose?.image_status?.status === 'success' ? false : true,
     },
     ...actions(compose),
   ];

--- a/src/Components/ShareImageModal/RegionsSelect.js
+++ b/src/Components/ShareImageModal/RegionsSelect.js
@@ -43,7 +43,8 @@ export const selectRegionsToDisable = createSelector(
 const prepareRegions = (regionsToDisable) => {
   const regions = AWS_REGIONS.map((region) => ({
     ...region,
-    disabled: regionsToDisable.has(region.value),
+    disabled:
+      regionsToDisable.has(region.value) || region?.disableRegion === true,
   }));
 
   return regions;

--- a/src/constants.js
+++ b/src/constants.js
@@ -22,29 +22,97 @@ export const DEFAULT_AWS_REGION = 'us-east-1';
 
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
 export const AWS_REGIONS = [
-  { description: 'US East (Ohio)', value: 'us-east-2' },
-  { description: 'US East (N. Virginia)', value: 'us-east-1' },
-  { description: 'US West (N. California)', value: 'us-west-1' },
-  { description: 'US West (Oregon)', value: 'us-west-2' },
-  { description: 'Africa (Cape Town)', value: 'af-south-1' },
-  { description: 'Asia Pacific (Hong Kong)', value: 'ap-east-1' },
-  { description: 'Asia Pacific (Jakarta)', value: 'ap-southeast-3' },
-  { description: 'Asia Pacific (Mumbai)', value: 'ap-south-1' },
-  { description: 'Asia Pacific (Osaka)', value: 'ap-northeast-3' },
-  { description: 'Asia Pacific (Seoul)', value: 'ap-northeast-2' },
-  { description: 'Asia Pacific (Singapore)', value: 'ap-southeast-1' },
-  { description: 'Asia Pacific (Sydney)', value: 'ap-southeast-2' },
-  { description: 'Asia Pacific (Tokyo)', value: 'ap-northeast-1' },
-  { description: 'Canada (Central)', value: 'ca-central-1' },
-  { description: 'Europe (Frankfurt)', value: 'eu-central-1' },
-  { description: 'Europe (Ireland)', value: 'eu-west-1' },
-  { description: 'Europe (London)', value: 'eu-west-2' },
-  { description: 'Europe (Milan)', value: 'eu-south-1' },
-  { description: 'Europe (Paris)', value: 'eu-west-3' },
-  { description: 'Europe (Stockholm)', value: 'eu-north-1' },
-  { description: 'Middle East (Bahrain)', value: 'me-south-1' },
-  { description: 'Middle East (UAE)', value: 'me-central-1' },
-  { description: 'South America (S\u00e3o Paolo)', value: 'sa-east-1' },
+  { description: 'US East (Ohio)', value: 'us-east-2', disableRegion: false },
+  {
+    description: 'US East (N. Virginia)',
+    value: 'us-east-1',
+    disableRegion: false,
+  },
+  {
+    description: 'US West (N. California)',
+    value: 'us-west-1',
+    disableRegion: false,
+  },
+  { description: 'US West (Oregon)', value: 'us-west-2', disableRegion: false },
+  {
+    description: 'Africa (Cape Town)',
+    value: 'af-south-1',
+    disableRegion: true,
+  },
+  {
+    description: 'Asia Pacific (Hong Kong)',
+    value: 'ap-east-1',
+    disableRegion: true,
+  },
+  {
+    description: 'Asia Pacific (Jakarta)',
+    value: 'ap-southeast-3',
+    disableRegion: true,
+  },
+  {
+    description: 'Asia Pacific (Mumbai)',
+    value: 'ap-south-1',
+    disableRegion: false,
+  },
+  {
+    description: 'Asia Pacific (Osaka)',
+    value: 'ap-northeast-3',
+    disableRegion: false,
+  },
+  {
+    description: 'Asia Pacific (Seoul)',
+    value: 'ap-northeast-2',
+    disableRegion: false,
+  },
+  {
+    description: 'Asia Pacific (Singapore)',
+    value: 'ap-southeast-1',
+    disableRegion: false,
+  },
+  {
+    description: 'Asia Pacific (Sydney)',
+    value: 'ap-southeast-2',
+    disableRegion: false,
+  },
+  {
+    description: 'Asia Pacific (Tokyo)',
+    value: 'ap-northeast-1',
+    disableRegion: false,
+  },
+  {
+    description: 'Canada (Central)',
+    value: 'ca-central-1',
+    disableRegion: false,
+  },
+  {
+    description: 'Europe (Frankfurt)',
+    value: 'eu-central-1',
+    disableRegion: false,
+  },
+  { description: 'Europe (Ireland)', value: 'eu-west-1', disableRegion: false },
+  { description: 'Europe (London)', value: 'eu-west-2', disableRegion: false },
+  { description: 'Europe (Milan)', value: 'eu-south-1', disableRegion: true },
+  { description: 'Europe (Paris)', value: 'eu-west-3', disableRegion: false },
+  {
+    description: 'Europe (Stockholm)',
+    value: 'eu-north-1',
+    disableRegion: false,
+  },
+  {
+    description: 'Middle East (Bahrain)',
+    value: 'me-south-1',
+    disableRegion: true,
+  },
+  {
+    description: 'Middle East (UAE)',
+    value: 'me-central-1',
+    disableRegion: true,
+  },
+  {
+    description: 'South America (S\u00e3o Paolo)',
+    value: 'sa-east-1',
+    disableRegion: false,
+  },
 ];
 
 export const AWS_S3_EXPIRATION_TIME_IN_HOURS = 6;


### PR DESCRIPTION
This disables sharing to new regions in case of failed build of the parent image.

The regions that always end in failure were also disabled in the `ShareImageModal`.

![Screenshot from 2023-05-05 09-27-53](https://user-images.githubusercontent.com/49452678/236402654-0f732f31-f7cb-4c90-ab5c-c91602e7de7b.png)
