### PR TITLE
ClonesTable: Remove Instance column

### DIFF
--- a/src/Components/ImagesTable/ClonesTable.js
+++ b/src/Components/ImagesTable/ClonesTable.js
@@ -12,7 +12,6 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 
 import { ImageBuildStatus } from './ImageBuildStatus';
-import ImageLink from './ImageLink';
 
 import { useGetAWSSourcesQuery } from '../../store/apiSlice';
 import {
@@ -51,9 +50,6 @@ const Row = ({ imageId }) => {
         <Td dataLabel="Status">
           <ImageBuildStatus imageId={image.id} imageRegion={image.region} />
         </Td>
-        <Td dataLabel="Instance">
-          <ImageLink imageId={image.id} isInClonesTable={true} />
-        </Td>
       </Tr>
     </Tbody>
   );
@@ -78,7 +74,6 @@ const ClonesTable = ({ composeId }) => {
           <Th>Account</Th>
           <Th>Region</Th>
           <Th>Status</Th>
-          <Th>Instance</Th>
         </Tr>
       </Thead>
       <Row imageId={parentCompose.id} imageType={'compose'} />

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -684,7 +684,6 @@ describe('Clones table', () => {
     expect(header.cells[2]).toHaveTextContent('Account');
     expect(header.cells[3]).toHaveTextContent('Region');
     expect(header.cells[4]).toHaveTextContent('Status');
-    expect(header.cells[5]).toHaveTextContent('Instance');
 
     expect(cloneRows).toHaveLength(5);
 
@@ -736,16 +735,6 @@ describe('Clones table', () => {
         state
       );
       expect(row.cells[4]).toHaveTextContent(testElement.textContent);
-
-      // instance cell
-      renderWithProvider(
-        <BrowserRouter>
-          <ImageLink imageId={imageId} isInClonesTable={true} />
-        </BrowserRouter>,
-        testElement,
-        state
-      );
-      expect(row.cells[5]).toHaveTextContent(testElement.textContent);
     }
   });
 });


### PR DESCRIPTION
The instance column is no longer in the clones table per the latest designs.