### PR TITLE
ClonesTable: Remove `created_at` column from the clones table

### DIFF
--- a/src/Components/ImagesTable/ClonesTable.js
+++ b/src/Components/ImagesTable/ClonesTable.js
@@ -19,7 +19,6 @@ import {
   selectComposeById,
   selectImageById,
 } from '../../store/composesSlice';
-import { timestampToDisplayString } from '../../Utilities/time';
 
 const Row = ({ imageId }) => {
   const image = useSelector((state) => selectImageById(state, imageId));
@@ -42,9 +41,6 @@ const Row = ({ imageId }) => {
     <Tbody>
       <Tr>
         <Td dataLabel="UUID">{image.id}</Td>
-        <Td dataLabel="Created">
-          {timestampToDisplayString(image.created_at)}
-        </Td>
         <Td dataLabel="Account">{getAccount(image)}</Td>
         <Td dataLabel="Region">{image.region}</Td>
         <Td dataLabel="Status">
@@ -69,11 +65,10 @@ const ClonesTable = ({ composeId }) => {
     >
       <Thead>
         <Tr className="no-bottom-border">
-          <Th>UUID</Th>
-          <Th>Created</Th>
-          <Th>Account</Th>
-          <Th>Region</Th>
-          <Th>Status</Th>
+          <Th className="pf-m-width-40">UUID</Th>
+          <Th className="pf-m-width-20">Account</Th>
+          <Th className="pf-m-width-20">Region</Th>
+          <Th className="pf-m-width-20">Status</Th>
         </Tr>
       </Thead>
       <Row imageId={parentCompose.id} imageType={'compose'} />

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -10,7 +10,6 @@ import ImageLink from '../../../Components/ImagesTable/ImageLink';
 import Target from '../../../Components/ImagesTable/Target';
 import '@testing-library/jest-dom';
 import { RHEL_8 } from '../../../constants.js';
-import { timestampToDisplayString } from '../../../Utilities/time.js';
 import { renderWithProvider, renderWithReduxRouter } from '../../testUtils';
 
 const currentDate = new Date();
@@ -680,10 +679,9 @@ describe('Clones table', () => {
     const header = cloneRows.shift();
     // test the header has correct labels
     expect(header.cells[0]).toHaveTextContent('UUID');
-    expect(header.cells[1]).toHaveTextContent('Created');
-    expect(header.cells[2]).toHaveTextContent('Account');
-    expect(header.cells[3]).toHaveTextContent('Region');
-    expect(header.cells[4]).toHaveTextContent('Status');
+    expect(header.cells[1]).toHaveTextContent('Account');
+    expect(header.cells[2]).toHaveTextContent('Region');
+    expect(header.cells[3]).toHaveTextContent('Status');
 
     expect(cloneRows).toHaveLength(5);
 
@@ -713,17 +711,11 @@ describe('Clones table', () => {
       // render UUIDs in correct order
       expect(row.cells[0]).toHaveTextContent(clonesTableData.uuid[index]);
 
-      // date should match the month day and year of the timestamp.
-      const formattedDate = timestampToDisplayString(
-        clonesTableData.created[index]
-      );
-      expect(row.cells[1]).toHaveTextContent(formattedDate);
-
       // account cell
-      expect(row.cells[2]).toHaveTextContent(clonesTableData.account[index]);
+      expect(row.cells[1]).toHaveTextContent(clonesTableData.account[index]);
 
       // region cell
-      expect(row.cells[3]).toHaveTextContent(clonesTableData.region[index]);
+      expect(row.cells[2]).toHaveTextContent(clonesTableData.region[index]);
 
       const testElement = document.createElement('testElement');
       const imageId = clonesTableData.uuid[index];
@@ -734,7 +726,7 @@ describe('Clones table', () => {
         testElement,
         state
       );
-      expect(row.cells[4]).toHaveTextContent(testElement.textContent);
+      expect(row.cells[3]).toHaveTextContent(testElement.textContent);
     }
   });
 });


### PR DESCRIPTION
This removes the `created_at` column from the clones table as per the latest designs.