### PR TITLE
Wizard: Fix erroneous switch statement in ImageLink

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -15,7 +15,9 @@ import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
 
 const getImageProvider = ({ imageType }) => {
   switch (imageType) {
-    case 'aws' || 'ami':
+    case 'aws':
+      return 'aws';
+    case 'ami':
       return 'aws';
     case 'azure':
       return 'azure';


### PR DESCRIPTION
The switch statement used to determine the image type for the Launch wizard was written incorrectly, this commit fixes it.

![image](https://user-images.githubusercontent.com/95542540/236447355-80e4964c-dd18-41df-89c2-181683d83a4a.png)
