### PR TITLE
Wizard: Image name validation

### DIFF
--- a/src/Components/CreateImageWizard/steps/imageName.js
+++ b/src/Components/CreateImageWizard/steps/imageName.js
@@ -32,8 +32,10 @@ export default {
       autoFocus: true,
       validate: [
         {
-          type: validatorTypes.MAX_LENGTH,
-          threshold: 100,
+          type: validatorTypes.PATTERN,
+          pattern: /^[a-z][-a-z0-9]{1,61}[a-z0-9]$/,
+          message:
+            'The image name can be 3-63 characters long. It can contain lowercase letters, digits and hyphens, has to start with a letter and cannot end with a hyphen.',
         },
       ],
     },

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -740,7 +740,7 @@ describe('Click through all steps', () => {
     const nameInput = screen.getByRole('textbox', {
       name: 'Image name',
     });
-    await user.type(nameInput, 'MyImageName');
+    await user.type(nameInput, 'my-image-name');
     getNextButton().click();
 
     // review
@@ -767,7 +767,7 @@ describe('Click through all steps', () => {
       'image-details-expandable'
     );
     imageDetailsExpandable.click();
-    await screen.findByText('MyImageName');
+    await screen.findByText('my-image-name');
 
     await screen.findByText('name0');
     await screen.findByText('Self-Support');
@@ -793,7 +793,7 @@ describe('Click through all steps', () => {
         if (body.image_requests[0].upload_request.type === 'aws') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -812,7 +812,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].upload_request.type === 'gcp') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -831,7 +831,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].upload_request.type === 'azure') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -852,7 +852,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].image_type === 'vsphere-ova') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -869,7 +869,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].image_type === 'guest-image') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -886,7 +886,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].image_type === 'image-installer') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1105,7 +1105,7 @@ describe('Step Details', () => {
     getNextButton().click();
   };
 
-  test('image name invalid for more than 100 chars', async () => {
+  test('image name invalid for more than 63 chars', async () => {
     await setUp();
 
     // Enter image name
@@ -1113,12 +1113,12 @@ describe('Step Details', () => {
       name: 'Image name',
     });
     // 101 character name
-    const invalidName = 'a'.repeat(101);
+    const invalidName = 'a'.repeat(64);
     await user.type(nameInput, invalidName);
     expect(getNextButton()).toHaveClass('pf-m-disabled');
     expect(getNextButton()).toBeDisabled();
     await user.clear(nameInput);
-    await user.type(nameInput, 'validName');
+    await user.type(nameInput, 'valid-name');
     expect(getNextButton()).not.toHaveClass('pf-m-disabled');
     expect(getNextButton()).toBeEnabled();
   });
@@ -1386,7 +1386,7 @@ describe('Click through all steps', () => {
     const nameInput = screen.getByRole('textbox', {
       name: 'Image name',
     });
-    await user.type(nameInput, 'MyImageName');
+    await user.type(nameInput, 'my-image-name');
     getNextButton().click();
 
     // review
@@ -1404,7 +1404,7 @@ describe('Click through all steps', () => {
       'image-details-expandable'
     );
     imageDetailsExpandable.click();
-    await screen.findByText('MyImageName');
+    await screen.findByText('my-image-name');
 
     const registrationExpandable = await screen.findByTestId(
       'registration-expandable'
@@ -1438,7 +1438,7 @@ describe('Click through all steps', () => {
         if (body.image_requests[0].upload_request.type === 'aws') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -1481,7 +1481,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].upload_request.type === 'gcp') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -1524,7 +1524,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].upload_request.type === 'azure') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -1569,7 +1569,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].image_type === 'vsphere-ova') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -1610,7 +1610,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].image_type === 'guest-image') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',
@@ -1651,7 +1651,7 @@ describe('Click through all steps', () => {
         } else if (body.image_requests[0].image_type === 'image-installer') {
           expect(body).toEqual({
             distribution: RHEL_8,
-            image_name: 'MyImageName',
+            image_name: 'my-image-name',
             image_requests: [
               {
                 architecture: 'x86_64',


### PR DESCRIPTION
This adds validation of an image name based on a pattern, which was chosen as an intersection of the naming constrains of hyperscalers.

The pattern is based on the one for naming GCP images as those naming guidelines are the most restrictive. With added minimal length restriction of AWS.

Sources:
- [Azure](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules)
- [GCP](https://cloud.google.com/compute/docs/naming-resources)
- [AWS](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-image.html) and
![Screenshot from 2023-05-15 15-00-04](https://github.com/RedHatInsights/image-builder-frontend/assets/49452678/e5972f21-a67e-4922-a861-997b0a70a0a9)

As the length of the name for AMI differs between the CLI reference and the screenshot of the error the stricter rule was chosen.
