### PR TITLE
Fix timestampToDisplayString to not strip time from UTC timestamp

### DIFF
--- a/src/Utilities/time.js
+++ b/src/Utilities/time.js
@@ -6,8 +6,7 @@ export const timestampToDisplayString = (ts) => {
   }
 
   // get YYYY-MM-DD format
-  const date = ts.slice(0, 10);
-  const ms = Date.parse(date);
+  const ms = Date.parse(ts);
   const options = { month: 'short', day: 'numeric', year: 'numeric' };
   const tsDisplay = new Intl.DateTimeFormat('en-US', options).format(ms);
   return tsDisplay;


### PR DESCRIPTION
For browsers in a time zone with a negative offset relative to UTC, the `Created/Updated` date displayed in the image builder table is almost always one day off. For example, images created on May 16, 2023 show "May 15, 2023" as the created/updated date. The timestamp formatting in `timestampToDisplayString` strips the time from the UTC timestamp returned by the API, then converts this date + 00:00:00 UTC to the local timezone, which in my case is always the previous day in Eastern Time.

This PR fixes the issue by using the full timestamp string when converting to the local time zone.