### PR TITLE
devel: update local containerised development

### DIFF
--- a/config/devel.webpack.config.js
+++ b/config/devel.webpack.config.js
@@ -1,0 +1,42 @@
+const { resolve } = require('path');
+
+const config = require('@redhat-cloud-services/frontend-components-config');
+
+const { config: webpackConfig, plugins } = config({
+  rootFolder: resolve(__dirname, '../'),
+  debug: true,
+  useFileHash: false,
+  sassPrefix: '.imageBuilder',
+  deployment: 'beta/apps',
+  appUrl: '/preview/insights/image-builder',
+  env: 'stage-beta',
+  useProxy: true,
+  useAgent: true,
+  bounceProd: false,
+  proxyVerbose: true,
+  routes: {
+    // This is from the docker-compose file network.
+    // The backend server has an ip address of 172.30.0.40 or
+    // a dns of `backend`
+    '/api/image-builder/v1': { host: 'http://backend:8086' },
+  },
+});
+
+plugins.push(
+  require('@redhat-cloud-services/frontend-components-config/federated-modules')(
+    {
+      root: resolve(__dirname, '../'),
+      useFileHash: false,
+      exposes: {
+        './RootApp': resolve(__dirname, '../src/AppEntry.js'),
+      },
+      shared: [{ 'react-router-dom': { singleton: true } }],
+      exclude: ['react-router-dom'],
+    }
+  )
+);
+
+module.exports = {
+  ...webpackConfig,
+  plugins,
+};

--- a/devel/README.md
+++ b/devel/README.md
@@ -22,6 +22,7 @@ The folder structure should look like:
 ├── osbuild
 └── osbuild-composer
 ```
+
 Secondly redirect a few domains to localhost. One for each environment
 of cloud.redhat.com that exists. You only need the ones you will be
 developing against. If you are outside the Red Hat VPN, only `prod` is
@@ -60,19 +61,30 @@ The config variables for the Image Builder backend can be found [here](https://g
 
 ## Run
 
+To build the containers run the following command:
+
 ```bash
-docker-compose up --build
+docker compose build # (or docker-compose build)
 ```
 
+To run the containers:
+
+```bash
+docker compose up # (or docker-compose up)
+```
+
+Note: As per the [docker compose cli](https://docs.docker.com/compose/reference/) docs, the new syntax for running docker compose changed from
+`docker-compose` to `docker compose`
+
 Access the service through the GUI:
-[https://prod.foo.redhat.com:1337/beta/insights/image-builder](https://prod.foo.redhat.com:1337/beta/insights/image-builder), or
+[https://stage.foo.redhat.com:1337/beta/insights/image-builder](https://stage.foo.redhat.com:1337/beta/insights/image-builder), or
 directly through the API:
-[https://prod.foo.redhat.com:1337/docs/api/image-builder](https://prod.foo.redhat.com:1337/docs/api/image-builder).
+[https://stage.foo.redhat.com:1337/docs/api/image-builder](https://stage.foo.redhat.com:1337/docs/api/image-builder).
 
 The metrics containers are only launched when explicitly required. The command for this is below:
 
 ```bash
-docker-compose --profile metrics up
+docker compose --profile metrics up
 ```
 
 Access the Grafana dashboard on [https://localhost:3000](https://localhost:3000). The default username is `admin` and the password is set to `foobar`.

--- a/devel/docker-compose.yml
+++ b/devel/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.4'
+version: '3.9'
 services:
   composer:
     image: local/osbuild-composer
@@ -42,12 +42,12 @@ services:
       - MKNOD
       - SYS_ADMIN
       - NET_ADMIN
-    networks:
-      net:
-        ipv4_address: 172.31.0.20
     depends_on:
       - "composer"
     restart: on-failure
+    networks:
+      net:
+        ipv4_address: 172.31.0.20
   postgres:
     image: docker.io/postgres:10.5
     healthcheck:
@@ -68,6 +68,8 @@ services:
     build:
       context: ../../image-builder
       dockerfile: ./distribution/Dockerfile-ubi
+    ports:
+      - "8086:8086"
     healthcheck:
       test: [ "CMD", "curl", "localhost:8086/status" ]
       interval: 2s
@@ -94,15 +96,17 @@ services:
       - COMPOSER_CA_PATH=/etc/image-builder/ca-crt.pem
       - DISTRIBUTIONS_DIR=/app/distributions
       - QUOTA_FILE=/config/quotas.json
-    networks:
-      net:
-        ipv4_address: 172.31.0.40
     depends_on:
       - "composer"
       - "postgres"
     restart: on-failure
+    networks:
+      net:
+        ipv4_address: 172.31.0.40
   frontend:
     image: local/image-builder-frontend
+    ports:
+      - "1337:1337"
     build:
       context: ../../image-builder-frontend
       dockerfile: ./distribution/Dockerfile
@@ -111,27 +115,6 @@ services:
     networks:
       net:
         ipv4_address: 172.31.0.50
-  insightsproxy:
-    image: redhatinsights/insights-proxy:latest
-    security_opt:
-      - label=disable
-    environment:
-      - CUSTOM_CONF=true
-    volumes:
-      - ${SPANDX_CONFIG}:/config/spandx.config.js:Z
-    extra_hosts:
-      - "prod.foo.redhat.com:127.0.0.1"
-      - "qa.foo.redhat.com:127.0.0.1"
-      - "ci.foo.redhat.com:127.0.0.1"
-      - "stage.foo.redhat.com:127.0.0.1"
-    networks:
-      net:
-        ipv4_address: 172.31.0.60
-    ports:
-      - 1337:1337
-    depends_on:
-     - "backend"
-     - "frontend"
   prometheus:
     profiles: ["metrics"]
     image: prom/prometheus:latest
@@ -143,11 +126,11 @@ services:
       - ${CERT_DIR}/client-crt.pem:/etc/image-builder/client-crt.pem:z
       - ${CERT_DIR}/client-key.pem:/etc/image-builder/client-key.pem:z
     restart: unless-stopped
-    networks:
-      net:
-        ipv4_address: 172.31.0.70
     command:
       - "--config.file=/config/prometheus.yml"
+    networks:
+      net:
+        ipv4_address: 172.31.0.60
   grafana:
     profiles: ["metrics"]
     image: grafana/grafana:latest
@@ -156,11 +139,11 @@ services:
     volumes:
       - ./config/grafana:/etc/grafana/provisioning/
     restart: unless-stopped
-    networks:
-      net:
-        ipv4_address: 172.31.0.80
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=foobar
+    networks:
+      net:
+        ipv4_address: 172.31.0.70
   fauxauth:
     image: local/osbuild-fauxauth
     build:
@@ -173,7 +156,7 @@ services:
       - "8888:8888"
     networks:
       net:
-        ipv4_address: 172.31.0.90
+        ipv4_address: 172.31.0.80
 networks:
   net:
     ipam:

--- a/distribution/Dockerfile
+++ b/distribution/Dockerfile
@@ -1,12 +1,12 @@
-FROM docker.io/node:16
+FROM node:18
 
-WORKDIR /usr/src/app
-
-COPY package*.json ./
-
-RUN npm install
+WORKDIR /app
 
 COPY . .
 
+RUN npm ci
+
 EXPOSE 8002
-CMD [ "npm", "run", "prod-beta" ]
+EXPOSE 1337
+
+CMD [ "npm", "run", "devel" ]

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "lint:js": "eslint config src",
     "lint:js:fix": "eslint config src --fix",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
+    "devel": "webpack serve --config config/devel.webpack.config.js",
     "prod-beta": "BETA=true PROXY=true webpack serve --config config/dev.webpack.config.js",
     "prod-stable": "PROXY=true webpack serve --config config/dev.webpack.config.js",
     "stage-stable": "STAGE=true npm run prod-stable",


### PR DESCRIPTION
Update multiple aspects of our docker development stack. The frontend now has a devel specific webpack that allows development against a local server/api. The docker-composer.yaml also includes both versioning and networking updates. Overall, the major change is to migrate our proxy access into the crc webpack proxy.