### PR TITLE
test: Move button clicking functions to `testUtils`

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
@@ -6,7 +6,11 @@ import { rest } from 'msw';
 
 import { PROVISIONING_API } from '../../../constants.js';
 import { server } from '../../mocks/server.js';
-import { renderWithReduxRouter } from '../../testUtils';
+import {
+  clickNext,
+  getNextButton,
+  renderWithReduxRouter,
+} from '../../testUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: () => ({
@@ -28,13 +32,8 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 }));
 
 describe('Step Upload to Azure', () => {
-  const getNextButton = () => {
-    const next = screen.getByRole('button', { name: /Next/ });
-    return next;
-  };
-
   const getSourceDropdown = async () => {
-    const sourceDropdown = screen.getByRole('textbox', {
+    const sourceDropdown = await screen.findByRole('textbox', {
       name: /select source/i,
     });
     // Wait for isSuccess === true, dropdown is disabled while isSuccess === false
@@ -59,7 +58,7 @@ describe('Step Upload to Azure', () => {
     const azureTile = screen.getByTestId('upload-azure');
     azureTile.click();
 
-    getNextButton().click();
+    await clickNext();
 
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Target environment - Microsoft Azure'
@@ -67,15 +66,15 @@ describe('Step Upload to Azure', () => {
   };
 
   test('azure step basics works', async () => {
-    setUp();
+    await setUp();
 
-    expect(getNextButton()).toHaveClass('pf-m-disabled');
+    expect(await getNextButton()).toHaveClass('pf-m-disabled');
     expect(screen.getByTestId('azure-radio-source')).toBeChecked();
 
     await user.click(screen.getByTestId('azure-radio-manual'));
     expect(screen.getByTestId('azure-radio-manual')).toBeChecked();
 
-    expect(getNextButton()).toHaveClass('pf-m-disabled');
+    expect(await getNextButton()).toHaveClass('pf-m-disabled');
 
     await user.type(
       screen.getByTestId('azure-tenant-id-manual'),
@@ -90,11 +89,11 @@ describe('Step Upload to Azure', () => {
       'testGroup'
     );
 
-    expect(getNextButton()).not.toHaveClass('pf-m-disabled');
+    expect(await getNextButton()).not.toHaveClass('pf-m-disabled');
 
     screen.getByTestId('azure-radio-source').click();
 
-    expect(getNextButton()).toHaveClass('pf-m-disabled');
+    expect(await getNextButton()).toHaveClass('pf-m-disabled');
 
     const sourceDropdown = await getSourceDropdown();
 
@@ -121,7 +120,7 @@ describe('Step Upload to Azure', () => {
     expect(groups).toHaveLength(2);
     await user.click(screen.getByLabelText('Resource group myResourceGroup1'));
 
-    expect(getNextButton()).not.toHaveClass('pf-m-disabled');
+    expect(await getNextButton()).not.toHaveClass('pf-m-disabled');
   }, 10000);
 
   test('handles change of selected Source', async () => {

--- a/src/test/testUtils.js
+++ b/src/test/testUtils.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
-import { render } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
@@ -52,4 +53,29 @@ export const renderWithProvider = (
   return render(<Provider store={store}>{component}</Provider>, {
     container: container,
   });
+};
+
+export const clickBack = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /Back/ }));
+};
+
+export const clickNext = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /Next/ }));
+};
+
+export const clickCancel = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole('button', { name: /Cancel/ }));
+};
+
+export const getNextButton = async () => {
+  const next = await screen.findByRole('button', { name: /Next/ });
+  return next;
+};
+
+export const verifyCancelButton = async (router) => {
+  await clickCancel();
+  expect(router.state.location.pathname).toBe('/insights/image-builder');
 };


### PR DESCRIPTION
This moves the `clickBack`, `clickCancel`, `clickNext`, `getNextButton` and `verifyCancelButton` functions from the tests to `testUtils`.