### PR TITLE
Mock Service Worker: Relative handler URLs

### DIFF
--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -22,20 +22,13 @@ import {
   mockUploadInfo,
 } from '../fixtures/sources';
 
-const baseURL = 'http://localhost';
-
 export const handlers = [
+  rest.get(`${PROVISIONING_SOURCES_ENDPOINT}`, (req, res, ctx) => {
+    const provider = req.url.searchParams.get('provider');
+    return res(ctx.status(200), ctx.json(mockSourcesByProvider(provider)));
+  }),
   rest.get(
-    baseURL.concat(`${PROVISIONING_SOURCES_ENDPOINT}`),
-    (req, res, ctx) => {
-      const provider = req.url.searchParams.get('provider');
-      return res(ctx.status(200), ctx.json(mockSourcesByProvider(provider)));
-    }
-  ),
-  rest.get(
-    baseURL.concat(
-      `${PROVISIONING_SOURCES_ENDPOINT}/:accountId/account_identity`
-    ),
+    `${PROVISIONING_SOURCES_ENDPOINT}/:accountId/account_identity`,
     (req, res, ctx) => {
       const { accountId } = req.params;
       if (accountId === '123') {
@@ -46,7 +39,7 @@ export const handlers = [
     }
   ),
   rest.get(
-    baseURL.concat(`${PROVISIONING_SOURCES_ENDPOINT}/:sourceId/upload_info`),
+    `${PROVISIONING_SOURCES_ENDPOINT}/:sourceId/upload_info`,
     (req, res, ctx) => {
       const { sourceId } = req.params;
       if (sourceId === '666' || sourceId === '667') {
@@ -56,44 +49,32 @@ export const handlers = [
       }
     }
   ),
-  rest.post(
-    baseURL.concat(`${CONTENT_SOURCES}/rpms/names`),
-    async (req, res, ctx) => {
-      const { search } = await req.json();
-      return res(ctx.status(200), ctx.json(mockSourcesPackagesResults(search)));
-    }
-  ),
-  rest.get(baseURL.concat(`${IMAGE_BUILDER_API}/packages`), (req, res, ctx) => {
+  rest.post(`${CONTENT_SOURCES}/rpms/names`, async (req, res, ctx) => {
+    const { search } = await req.json();
+    return res(ctx.status(200), ctx.json(mockSourcesPackagesResults(search)));
+  }),
+  rest.get(`${IMAGE_BUILDER_API}/packages`, (req, res, ctx) => {
     const search = req.url.searchParams.get('search');
     return res(ctx.status(200), ctx.json(mockPackagesResults(search)));
   }),
-  rest.get(
-    baseURL.concat(`${IMAGE_BUILDER_API}/architectures/:distro`),
-    (req, res, ctx) => {
-      const { distro } = req.params;
-      return res(ctx.status(200), ctx.json(mockArchitecturesByDistro(distro)));
-    }
-  ),
-  rest.get(baseURL.concat(`${RHSM_API}/activation_keys`), (req, res, ctx) => {
+  rest.get(`${IMAGE_BUILDER_API}/architectures/:distro`, (req, res, ctx) => {
+    const { distro } = req.params;
+    return res(ctx.status(200), ctx.json(mockArchitecturesByDistro(distro)));
+  }),
+  rest.get(`${RHSM_API}/activation_keys`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(mockActivationKeysResults()));
   }),
-  rest.get(
-    baseURL.concat(`${RHSM_API}/activation_keys/:key`),
-    (req, res, ctx) => {
-      const { key } = req.params;
-      return res(ctx.status(200), ctx.json(mockActivationKeyInformation(key)));
-    }
-  ),
-  rest.get(
-    baseURL.concat(`${CONTENT_SOURCES}/repositories/`),
-    (req, res, ctx) => {
-      const available_for_arch = req.url.searchParams.get('available_for_arch');
-      const available_for_version = req.url.searchParams.get(
-        'available_for_version'
-      );
-      const limit = req.url.searchParams.get('limit');
-      const args = { available_for_arch, available_for_version, limit };
-      return res(ctx.status(200), ctx.json(mockRepositoryResults(args)));
-    }
-  ),
+  rest.get(`${RHSM_API}/activation_keys/:key`, (req, res, ctx) => {
+    const { key } = req.params;
+    return res(ctx.status(200), ctx.json(mockActivationKeyInformation(key)));
+  }),
+  rest.get(`${CONTENT_SOURCES}/repositories/`, (req, res, ctx) => {
+    const available_for_arch = req.url.searchParams.get('available_for_arch');
+    const available_for_version = req.url.searchParams.get(
+      'available_for_version'
+    );
+    const limit = req.url.searchParams.get('limit');
+    const args = { available_for_arch, available_for_version, limit };
+    return res(ctx.status(200), ctx.json(mockRepositoryResults(args)));
+  }),
 ];


### PR DESCRIPTION
This commit removes the base URL from the MSW handlers. This is
necessary in order for MSW to integrate into the browser (future commit)
and does not adversely affect the current test integration with MSW.