### PR TITLE
Webpack: Run proxy without VPN for production environments

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -4,6 +4,9 @@ const config = require('@redhat-cloud-services/frontend-components-config');
 
 const webpackProxy = {
   useProxy: true,
+  // Configure useAgent and bounceProd to allow access to prod from outside the VPN
+  useAgent: process.env.STAGE ? true : false,
+  bounceProd: process.env.STAGE ? false : true,
   proxyVerbose: true,
   env: `${process.env.STAGE ? 'stage' : 'prod'}-${
     process.env.BETA ? 'beta' : 'stable'


### PR DESCRIPTION
This allows users to develop against production without having access to the internal network.

https://github.com/RedHatInsights/frontend-components/tree/62f37029ca0f5f7e9b0fd61815fe62c96503bcbf/packages/config#running-prod-proxy-without-vpn

This was previously introduced with #49b3f04 and then reverted because it seemed to cause problems with developing against stage. However, I am unable to replicate that - stage is working fine at the moment with these changes in place. Perhaps it was a coincidence - in any case, we should try again and if problems with stage arise, we will investigate them and fix them. It is important to be able to develop against the front-end outside of the VPN in order to support our open source service objectives.