### PR TITLE
LandingPage: Update Open Source Badge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@patternfly/patternfly": "4.224.2",
         "@patternfly/react-core": "4.276.8",
         "@patternfly/react-table": "4.113.0",
-        "@redhat-cloud-services/frontend-components": "3.9.35",
+        "@redhat-cloud-services/frontend-components": "3.9.36",
         "@redhat-cloud-services/frontend-components-notifications": "3.2.14",
         "@redhat-cloud-services/frontend-components-utilities": "3.5.0",
         "@reduxjs/toolkit": "^1.9.5",
@@ -3321,9 +3321,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "3.9.35",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.35.tgz",
-      "integrity": "sha512-SMdeq/y+pTnnstlDPilc58ItIK/fL5Pqaodp/ucBqOraKYpcs9MDczQpolCry84Iv9FgN9bwALl2HGJZvkrdAQ==",
+      "version": "3.9.36",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.36.tgz",
+      "integrity": "sha512-GbvxGHDwdPPcubCz6h9SSJxI+fceyBoIOAikaIq2OSXQxQ0QPnkDXQD1tyVJz0Af+TQ6jHDQ+wPQf7MT90S/QQ==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
         "@redhat-cloud-services/types": "^0.0.17",
@@ -22047,9 +22047,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "3.9.35",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.35.tgz",
-      "integrity": "sha512-SMdeq/y+pTnnstlDPilc58ItIK/fL5Pqaodp/ucBqOraKYpcs9MDczQpolCry84Iv9FgN9bwALl2HGJZvkrdAQ==",
+      "version": "3.9.36",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.36.tgz",
+      "integrity": "sha512-GbvxGHDwdPPcubCz6h9SSJxI+fceyBoIOAikaIq2OSXQxQ0QPnkDXQD1tyVJz0Af+TQ6jHDQ+wPQf7MT90S/QQ==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
         "@redhat-cloud-services/types": "^0.0.17",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@patternfly/patternfly": "4.224.2",
     "@patternfly/react-core": "4.276.8",
     "@patternfly/react-table": "4.113.0",
-    "@redhat-cloud-services/frontend-components": "3.9.35",
+    "@redhat-cloud-services/frontend-components": "3.9.36",
     "@redhat-cloud-services/frontend-components-notifications": "3.2.14",
     "@redhat-cloud-services/frontend-components-utilities": "3.5.0",
     "@reduxjs/toolkit": "^1.9.5",

--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -9,14 +9,10 @@ import {
   Text,
   TextContent,
 } from '@patternfly/react-core';
-import {
-  ArrowRightIcon,
-  HelpIcon,
-  CodeBranchIcon,
-  ExternalLinkAltIcon,
-} from '@patternfly/react-icons';
+import { ArrowRightIcon, HelpIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line rulesdir/disallow-fec-relative-imports
 import {
+  OpenSourceBadge,
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
@@ -61,38 +57,7 @@ export const LandingPage = () => {
             <HelpIcon />
           </Button>
         </Popover>
-        <Popover
-          headerContent={'About open source'}
-          bodyContent={
-            <TextContent>
-              <Text>
-                This service is open source, so all of its code is inspectable.
-                Explore repositories to view and contribute to the source code.
-              </Text>
-              <Button
-                component="a"
-                target="_blank"
-                variant="link"
-                icon={<ExternalLinkAltIcon />}
-                iconPosition="right"
-                isInline
-                href={
-                  'https://www.osbuild.org/guides/image-builder-service/architecture.html'
-                }
-              >
-                Repositories
-              </Button>
-            </TextContent>
-          }
-        >
-          <Button
-            variant="plain"
-            aria-label="About Open Services"
-            className="pf-u-pl-sm header-button"
-          >
-            <CodeBranchIcon />
-          </Button>
-        </Popover>
+        <OpenSourceBadge repositoriesURL="https://www.osbuild.org/guides/image-builder-service/architecture.html" />
       </PageHeader>
       <section className="pf-l-page__main-section pf-c-page__main-section">
         {!isBeta() && showBetaAlert && (


### PR DESCRIPTION
The open source badge now lives in @redhat-insights/frontend-components.