### PR TITLE
EdgeImageDetails: Implement manage edge image details page.

### DIFF
--- a/src/Components/edge/ImageDetails.js
+++ b/src/Components/edge/ImageDetails.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import AsyncComponent from '@redhat-cloud-services/frontend-components/AsyncComponent';
+import ErrorState from '@redhat-cloud-services/frontend-components/ErrorState';
+import Unavailable from '@redhat-cloud-services/frontend-components/Unavailable';
+import { useFlag } from '@unleash/proxy-client-react';
+import { useDispatch } from 'react-redux';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
+
+import {
+  getNotificationProp,
+  manageEdgeImagesUrlName,
+} from '../../Utilities/edge';
+import { resolveRelPath } from '../../Utilities/path';
+
+const ImageDetail = () => {
+  const dispatch = useDispatch();
+  const notificationProp = getNotificationProp(dispatch);
+  const edgeParityFlag = useFlag('edgeParity.image-list');
+
+  return edgeParityFlag ? (
+    <AsyncComponent
+      appName="edge"
+      module="./ImagesDetail"
+      ErrorComponent={<ErrorState />}
+      navigateProp={useNavigate}
+      locationProp={useLocation}
+      notificationProp={notificationProp}
+      pathPrefix={resolveRelPath('')}
+      urlName={manageEdgeImagesUrlName}
+      paramsProp={useParams}
+    />
+  ) : (
+    <Unavailable />
+  );
+};
+
+export default ImageDetail;

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,8 +1,11 @@
 import React, { lazy } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import { Route, Routes } from 'react-router-dom';
 
+import EdgeImageDetail from './Components/edge/ImageDetails';
 import ShareImageModal from './Components/ShareImageModal/ShareImageModal';
+import { manageEdgeImagesUrlName } from './Utilities/edge';
 
 const LandingPage = lazy(() => import('./Components/LandingPage/LandingPage'));
 const CreateImageWizard = lazy(() =>
@@ -10,12 +13,26 @@ const CreateImageWizard = lazy(() =>
 );
 
 export const Router = () => {
+  const edgeParityFlag = useFlag('edgeParity.image-list');
   return (
     <Routes>
       <Route path="*" element={<LandingPage />}>
         <Route path="imagewizard/:composeId?" element={<CreateImageWizard />} />
         <Route path="share/:composeId" element={<ShareImageModal />} />
       </Route>
+
+      {edgeParityFlag && (
+        <Route
+          path={`/${manageEdgeImagesUrlName}/:imageId`}
+          element={<EdgeImageDetail />}
+        >
+          <Route path="*" element={<EdgeImageDetail />} />
+          <Route
+            path={`versions/:imageVersionId/*`}
+            element={<EdgeImageDetail />}
+          />
+        </Route>
+      )}
     </Routes>
   );
 };

--- a/src/Utilities/edge.js
+++ b/src/Utilities/edge.js
@@ -1,0 +1,38 @@
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+
+const manageEdgeImagesUrlName = 'manage-edge-images';
+
+const getNotificationProp = (dispatch) => {
+  return {
+    hasInfo: (hasInfoMessage) => {
+      dispatch({
+        ...addNotification({
+          variant: 'info',
+          ...hasInfoMessage,
+        }),
+      });
+    },
+    hasSuccess: (hasSuccessMessage) => {
+      dispatch({
+        ...addNotification({
+          variant: 'success',
+          ...hasSuccessMessage,
+        }),
+      });
+    },
+    err: (errMessage, err) => {
+      dispatch({
+        ...addNotification({
+          variant: 'danger',
+          ...errMessage,
+          // Add error message from API, if present
+          description: err?.Title
+            ? `${errMessage.description}: ${err.Title}`
+            : errMessage.description,
+        }),
+      });
+    },
+  };
+};
+
+export { getNotificationProp, manageEdgeImagesUrlName };


### PR DESCRIPTION
In the context of HMS parity stage 1, implement federated manage edge image page at route manage-edge-image.

The url of the following screen looks like: /insights/image-builder/manage-edge-images/9130/versions/56308/packages/additional 

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/131553/03ab89df-28f2-4667-b099-2c8958859045)

dependency PR: https://github.com/RedHatInsights/edge-frontend/pull/686
