### PR TITLE
Wizard: Enable Azure and GCP provisioning links in ephemeral

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -96,7 +96,7 @@ const ProvisioningLink = ({ imageId, isExpired, isInClonesTable }) => {
 const ImageLink = ({ imageId, isExpired, isInClonesTable }) => {
   const image = useSelector((state) => selectImageById(state, imageId));
   const uploadStatus = image.uploadStatus;
-  const { initialized: chromeInitialized } = useChrome();
+  const { initialized: chromeInitialized, getEnvironment } = useChrome();
   const { isBeta } = useGetEnvironment();
   const azureFeatureFlag = useFlag('provisioning.azure');
   const gcpFeatureFlag = useFlag('provisioning.gcp');
@@ -112,8 +112,14 @@ const ImageLink = ({ imageId, isExpired, isInClonesTable }) => {
       case 'ami':
         return true;
       case 'azure':
+        if (getEnvironment() === 'qa') {
+          return true;
+        }
         return !!azureFeatureFlag;
       case 'gcp':
+        if (getEnvironment() === 'qa') {
+          return true;
+        }
         return !!gcpFeatureFlag;
       default:
         return false;


### PR DESCRIPTION
Unleash is being used to determine whether or not to use the Launch wizard for Azure and GCP images. Unleash is not yet supported in our ephemeral environments, but we want our ephemeral environments to have parity with beta. This commit ensures that the Launch wizard opens for Azure and GCP images in ephemeral.