### PR TITLE
ImagesTable: Remove `Image name` Spinner for failed Azure images

### DIFF
--- a/src/Components/ImagesTable/ImageDetails.js
+++ b/src/Components/ImagesTable/ImageDetails.js
@@ -222,6 +222,8 @@ const AzureIdentifiers = ({ id }) => {
               >
                 {compose.image_status.upload_status.options.image_name}
               </ClipboardCopy>
+            ) : compose?.image_status?.status === 'failure' ? (
+              <p></p>
             ) : (
               <Spinner isSVG size="md" />
             )}


### PR DESCRIPTION
This removes Spinner next to the Image name when a build of an Azure image fails.