### PR TITLE
GCP: rename Email label to Principal

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -153,7 +153,7 @@ export const TargetEnvGCPList = () => {
           {googleAccType?.[getState()?.values?.['google-account-type']] ===
           'Domain'
             ? 'Domain'
-            : 'Email address'}
+            : 'Principal'}
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
           {getState()?.values?.['google-email'] ||

--- a/src/Components/CreateImageWizard/steps/googleCloud.js
+++ b/src/Components/CreateImageWizard/steps/googleCloud.js
@@ -135,7 +135,7 @@ export default {
       name: 'google-email',
       'data-testid': 'input-google-email',
       type: 'text',
-      label: 'Email address',
+      label: 'Principal (e.g. e-mail address)',
       condition: {
         or: [
           { when: 'google-account-type', is: 'googleAccount' },


### PR DESCRIPTION
The GCP account identifier is not email, it can be, but not always. For example service accounts do have identifiers which look like emails, but they are not. This is also confirmed by the GCP docs. This patch renames that label to "Principal" which is also used in the GCP docs.

Now, to avoid confusion, I am keeping (e.g. e-mail address) just to not put too much stress on the customer trying to figure this out.

Warning: I don’t know React or any JS library pretty much so this might break all tests - review with care.