### PR TITLE
build(deps): Regress `data-driven-forms` libraries to version 3.20.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "image-builder",
       "version": "1.1.0",
       "dependencies": {
-        "@data-driven-forms/pf4-component-mapper": "3.20.8",
-        "@data-driven-forms/react-form-renderer": "3.20.8",
+        "@data-driven-forms/pf4-component-mapper": "3.20.5",
+        "@data-driven-forms/react-form-renderer": "3.20.5",
         "@patternfly/patternfly": "4.224.2",
         "@patternfly/react-core": "4.276.8",
         "@patternfly/react-table": "4.113.0",
@@ -2107,16 +2107,17 @@
       }
     },
     "node_modules/@data-driven-forms/pf4-component-mapper": {
-      "version": "3.20.8",
-      "license": "Apache-2.0",
+      "version": "3.20.5",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-3.20.5.tgz",
+      "integrity": "sha512-EIF0da50PYRZfKEz1iOO3aepPrb78tjk+A6ZURIYTo8q71JITA7Wnab/omK4OR6W3OdUiIw42S7ECu15w/kxWg==",
       "dependencies": {
-        "@data-driven-forms/common": "^3.20.8",
+        "@data-driven-forms/common": "^3.20.5",
         "downshift": "^5.4.3",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
       },
       "peerDependencies": {
-        "@data-driven-forms/react-form-renderer": "^3.20.8",
+        "@data-driven-forms/react-form-renderer": "^3.20.5",
         "@patternfly/react-core": "^4.157.3",
         "@patternfly/react-icons": "^4.11.7",
         "react": "^16.13.1 || ^17.0.2 || ^18.0.0",
@@ -2124,8 +2125,9 @@
       }
     },
     "node_modules/@data-driven-forms/react-form-renderer": {
-      "version": "3.20.8",
-      "license": "Apache-2.0",
+      "version": "3.20.5",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.20.5.tgz",
+      "integrity": "sha512-QejAra4T1vWGJSKP+4E3tgjn7e54mDjqNymV12HqzubWqvk99qoRIoIp1LkGf1jlXkun00bWVGlnamlABRXrEQ==",
       "dependencies": {
         "final-form": "^4.20.4",
         "final-form-arrays": "^3.0.2",
@@ -8860,7 +8862,8 @@
     },
     "node_modules/final-form": {
       "version": "4.20.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.9.tgz",
+      "integrity": "sha512-shA1X/7v8RmukWMNRHx0l7+Bm41hOivY78IvOiBrPVHjyWFIyqqIEMCz7yTVRc9Ea+EU4WkZ5r4MH6whSo5taw==",
       "dependencies": {
         "@babel/runtime": "^7.10.0"
       },
@@ -8871,14 +8874,16 @@
     },
     "node_modules/final-form-arrays": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.1.0.tgz",
+      "integrity": "sha512-TWBvun+AopgBLw9zfTFHBllnKMVNEwCEyDawphPuBGGqNsuhGzhT7yewHys64KFFwzIs6KEteGLpKOwvTQEscQ==",
       "peerDependencies": {
         "final-form": "^4.20.8"
       }
     },
     "node_modules/final-form-focus": {
       "version": "1.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/final-form-focus/-/final-form-focus-1.1.2.tgz",
+      "integrity": "sha512-Gd+Bd2Ll7ijo3/sd6kJ/bwLkhc2bUJPxTON6fIqee/008EJpACWhT+zoWCm9q6NcfMcWRS+Sp5ikRX8iqdXeGQ==",
       "peerDependencies": {
         "final-form": ">=1.3.0"
       }
@@ -15237,7 +15242,8 @@
     },
     "node_modules/react-final-form": {
       "version": "6.5.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.5.9.tgz",
+      "integrity": "sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==",
       "dependencies": {
         "@babel/runtime": "^7.15.4"
       },
@@ -15252,7 +15258,8 @@
     },
     "node_modules/react-final-form-arrays": {
       "version": "3.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-final-form-arrays/-/react-final-form-arrays-3.1.4.tgz",
+      "integrity": "sha512-siVFAolUAe29rMR6u8VwepoysUcUdh6MLV2OWnCtKpsPRUdT9VUgECjAPaVMAH2GROZNiVB9On1H9MMrm9gdpg==",
       "dependencies": {
         "@babel/runtime": "^7.19.4"
       },

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "npm": ">=7.0.0"
   },
   "dependencies": {
-    "@data-driven-forms/pf4-component-mapper": "3.20.8",
-    "@data-driven-forms/react-form-renderer": "3.20.8",
+    "@data-driven-forms/pf4-component-mapper": "3.20.5",
+    "@data-driven-forms/react-form-renderer": "3.20.5",
     "@patternfly/patternfly": "4.224.2",
     "@patternfly/react-core": "4.276.8",
     "@patternfly/react-table": "4.113.0",


### PR DESCRIPTION
This reverts an update of:
- `@data-driven-forms/pf4-component-mapper`
- `@data-driven-forms/react-form-renderer`

from version 3.20.8 to version 3.20.5.

The reason being a bug ending up in an "Node.removeChild: The node to be removed is not a child of this node"

Steps to reproduce the bug:
1. Open Image Wizard with a Create image button
2. Close the Wizard with Cancel button
3. Repeat two or three times

Also can be reproduced with:
1. Click on Kebab in the image row of the Images Table
2. Choose Recreate image
3. Close the Wizard with Cancel button