### PR TITLE
eslintrc: Add React hooks plugin

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,7 @@ globals:
   mount: 'readonly'
 plugins: 
   - import
+  - react-hooks
 rules:
   import/order:
   - error
@@ -31,3 +32,5 @@ rules:
   - destructuring: any
   no-console: 2
   eqeqeq: error
+  react-hooks/rules-of-hooks: error
+  react-hooks/exhaustive-deps: warn

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint-plugin-import": "2.27.5",
         "eslint-plugin-jest-dom": "4.0.3",
         "eslint-plugin-react": "7.32.2",
+        "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-testing-library": "5.11.0",
         "git-revision-webpack-plugin": "5.0.0",
         "history": "5.3.0",
@@ -8237,6 +8238,18 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz",
+      "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-jest-dom": "4.0.3",
     "eslint-plugin-react": "7.32.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "5.11.0",
     "git-revision-webpack-plugin": "5.0.0",
     "history": "5.3.0",


### PR DESCRIPTION
This plugin enforces the React 'rules of hooks'. See here: https://legacy.reactjs.org/docs/hooks-rules.html

(These are the legacy docs but I believe the information is still accurate.)