### PR TITLE
googleCloud: Format the text on GCP target

### DIFF
--- a/src/Components/CreateImageWizard/steps/googleCloud.js
+++ b/src/Components/CreateImageWizard/steps/googleCloud.js
@@ -101,17 +101,25 @@ export default {
       component: componentTypes.PLAIN_TEXT,
       name: 'google-cloud-text-component',
       label: (
-        <Text>
-          Your image will be uploaded to Google Cloud Platform and shared with
-          the account you provide below. <br />
-          The shared image will expire within 14 days. To keep the image longer,
-          copy it to your Google Cloud Platform account.
-        </Text>
+        <p>
+          Your image will be uploaded to GCP and shared with the account you
+          provide below.
+        </p>
+      ),
+    },
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'google-cloud-text-component',
+      label: (
+        <p>
+          <b>The shared image will expire within 14 days.</b> To permanently
+          access the image, copy it to your Google Cloud Platform account.
+        </p>
       ),
     },
     {
       component: 'radio-popover',
-      label: 'Type',
+      label: 'Account type',
       isRequired: true,
       Popover: PopoverInfo,
       name: 'google-account-type',


### PR DESCRIPTION
This commit fixes the format text when create image with Google Cloud Platform target
related to issue: https://github.com/RedHatInsights/image-builder-frontend/issues/1195
<img width="1093" alt="Screenshot 2023-06-27 at 14 35 46" src="https://github.com/RedHatInsights/image-builder-frontend/assets/73419853/01dc37d2-bdbe-48cf-aac9-2256f3a51c19">
