### PR TITLE
ImagesTable: Fix the GCP launch link

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -47,7 +47,7 @@ const ProvisioningLink = ({ imageId, isExpired, isInClonesTable }) => {
   const appendTo = useMemo(() => document.querySelector(MODAL_ANCHOR), []);
 
   const provider = getImageProvider(image);
-  if (!error && provider !== 'gcp') {
+  if (!error) {
     return (
       <Suspense fallback="loading...">
         <Button variant="link" isInline onClick={() => openWizard(true)}>


### PR DESCRIPTION
This fixes the bug when Launch button got replaced with Image command button even in the Preview.