### PR TITLE
src: Update doc links

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -287,7 +287,7 @@ const FileSystemConfiguration = ({ ...props }) => {
                 variant="link"
                 icon={<ExternalLinkAltIcon />}
                 iconPosition="right"
-                href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_rhel_images_using_the_image_builder_service/customizing-file-systems-during-the-image-creation"
+                href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_images_by_using_insights_image_builder/customizing-file-systems-during-the-image-creation"
                 className="pf-u-pl-0"
               >
                 Read more about manual configuration here

--- a/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
@@ -102,7 +102,7 @@ export default {
               variant="link"
               icon={<ExternalLinkAltIcon />}
               iconPosition="right"
-              href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_rhel_images_using_the_image_builder_service/customizing-file-systems-during-the-image-creation"
+              href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_images_by_using_insights_image_builder/customizing-file-systems-during-the-image-creation"
               className="pf-u-pl-0"
             >
               Customizing file systems during the image creation

--- a/src/Components/sharedComponents/DocumentationButton.js
+++ b/src/Components/sharedComponents/DocumentationButton.js
@@ -5,7 +5,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 const DocumentationButton = () => {
   const documentationURL =
-    'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_rhel_images_using_the_image_builder_service/index';
+    'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_images_by_using_insights_image_builder/index';
 
   return (
     <Button


### PR DESCRIPTION
The access.redhat.com documentation moved from
`https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_rhel_images_using_the_image_builder_service/index` to
`https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_images_by_using_insights_image_builder/index`.