### PR TITLE
test/ImagesTable: Remove `scrollTo is not a function` console error

### DIFF
--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -49,6 +49,11 @@ jest.spyOn(api, 'getCloneStatus').mockImplementation((id) => {
   return Promise.resolve(mockCloneStatus[id]);
 });
 
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
+
 describe('Images Table', () => {
   const user = userEvent.setup();
   test('render ImagesTable', async () => {


### PR DESCRIPTION
This eliminates the `Error: Uncaught [TypeError: stepBody.scrollTo is not a function]` console error by mocking `scrollTo` as a prototype.

The error was caused by `scrollTo` not being implemented in JSDOM.