### PR TITLE
test/ImagesTable: Remove `should be wrapped into act()` error

### DIFF
--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen, within } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BrowserRouter } from 'react-router-dom';
 
@@ -222,7 +222,10 @@ describe('Images Table', () => {
     expect(
       screen.getAllByText(/c1cfa347-4c37-49b5-8e73-6aa1d1746cfa/i)[1]
     ).not.toBeVisible();
-    await user.click(errorPopover);
+
+    await act(async () => {
+      await user.click(errorPopover);
+    });
 
     expect(screen.getAllByText(/Error in depsolve job/i)[0]).toBeVisible();
   });


### PR DESCRIPTION
This wraps clicking on an error popover into `act()` and thus removes the `When testing, code that causes React state updates should be wrapped into act(...)` error.