### PR TITLE
Wizard: Remove `ModalProps` from schema

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
@@ -28,7 +28,7 @@ import {
 
 import './CreateImageWizard.scss';
 import api from '../../api';
-import { UNIT_GIB, UNIT_KIB, UNIT_MIB, MODAL_ANCHOR } from '../../constants';
+import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../constants';
 import { useGetArchitecturesByDistributionQuery } from '../../store/apiSlice';
 import { composeAdded } from '../../store/composesSlice';
 import isRhel from '../../Utilities/isRhel';
@@ -525,8 +525,6 @@ const CreateImageWizard = () => {
 
   const handleClose = () => navigate(resolveRelPath(''));
 
-  const appendTo = useMemo(() => document.querySelector(MODAL_ANCHOR), []);
-
   // In case the `created_at` date is undefined when creating an image
   // a temporary value with current date is added
   const currentDate = new Date();
@@ -592,9 +590,6 @@ const CreateImageWizard = () => {
           {
             component: componentTypes.WIZARD,
             name: 'image-builder-wizard',
-            ModalProps: {
-              appendTo,
-            },
             className: 'imageBuilder',
             isDynamic: true,
             inModal: true,


### PR DESCRIPTION
These changes were introduced in #1079 to ensure that quickstarts stay visible even after opening a Wizard modal as they are both top-most components.

`ModalProps` which were used for this purpose were introduced in version 3.20.6 of `@data-driven-forms/pf4-component-mapper`. Since then we had to regress the version to 3.20.5 as it was crashing the application on closing of a modal. The issue linked to this can be found here: https://github.com/data-driven-forms/react-forms/issues/1389

As we are now using mapper version that does not allow to use `ModalProps` the functionality of the workaround was lost and it was causing following console.error: `Warning: React does not recognize the ModalProps prop on a DOM element.`