### PR TITLE
LandingPage: Fixes tabs selection on browser back/forward.

### DIFF
--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   Alert,
@@ -50,6 +50,9 @@ export const LandingPage = () => {
   const initialActiveTabKey =
     tabsPath.indexOf(pathname) >= 0 ? tabsPath.indexOf(pathname) : 0;
   const [activeTabKey, setActiveTabKey] = useState(initialActiveTabKey);
+  useEffect(() => {
+    setActiveTabKey(initialActiveTabKey);
+  }, [pathname]);
   const handleTabClick = (_event, tabIndex) => {
     const tabPath = tabsPath[tabIndex];
     if (tabPath !== undefined) {


### PR DESCRIPTION
In the context of HMS-parity with edge management, fixes the current behavior when using browser history back and forward.
- When selecting a tab and then push the browser history back/forward, the tab of the current url is selected.

FIXES: https://issues.redhat.com/browse/THEEDGE-3460

![image-builder-tabs-browser-back-forward](https://github.com/RedHatInsights/image-builder-frontend/assets/131553/ced85fb3-3c68-441d-ab19-4db99a04da63)
