### PR TITLE
test/fixtures: Update compose fixture and migrate it to TypeScript

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -12,8 +12,8 @@ import { rest } from 'msw';
 
 import api from '../../../api.js';
 import { RHEL_8, RHEL_9, PROVISIONING_API } from '../../../constants.js';
-import { mockComposesEmpty } from '../../fixtures/composes.js';
-import { customizations, ids } from '../../fixtures/customizations.js';
+import { mockComposesEmpty } from '../../fixtures/composes';
+import { customizations, ids } from '../../fixtures/customizations';
 import { mockPkgResultAlphaContentSources } from '../../fixtures/packages';
 import { server } from '../../mocks/server.js';
 import {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -11,7 +11,7 @@ import userEvent from '@testing-library/user-event';
 
 import api from '../../../api.js';
 import { RHEL_8 } from '../../../constants.js';
-import { mockComposesEmpty } from '../../fixtures/composes.js';
+import { mockComposesEmpty } from '../../fixtures/composes';
 import {
   mockPkgResultAlpha,
   mockPkgResultAll,

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -15,7 +15,7 @@ import {
   mockClones,
   mockCloneStatus,
   mockNoClones,
-} from '../../fixtures/composes.js';
+} from '../../fixtures/composes';
 import { renderWithProvider, renderWithReduxRouter } from '../../testUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -36,7 +36,7 @@ jest
   .mockImplementation(() => Promise.resolve(mockComposes));
 
 jest.spyOn(api, 'getComposeStatus').mockImplementation((id) => {
-  return Promise.resolve(mockStatus[id]);
+  return Promise.resolve(mockStatus(id));
 });
 
 jest.spyOn(api, 'getClones').mockImplementation((id) => {
@@ -46,7 +46,7 @@ jest.spyOn(api, 'getClones').mockImplementation((id) => {
 });
 
 jest.spyOn(api, 'getCloneStatus').mockImplementation((id) => {
-  return Promise.resolve(mockCloneStatus[id]);
+  return Promise.resolve(mockCloneStatus(id));
 });
 
 beforeAll(() => {
@@ -291,13 +291,13 @@ describe('Clones table', () => {
     const clonesTableData = {
       ami: [
         ...mockClones(composeId).data.map(
-          (clone) => mockCloneStatus[clone.id].options.ami
+          (clone) => mockCloneStatus(clone.id).options.ami
         ),
       ],
       created: [...mockClones(composeId).data.map((clone) => clone.created_at)],
       region: [
         ...mockClones(composeId).data.map(
-          (clone) => mockCloneStatus[clone.id].options.region
+          (clone) => mockCloneStatus(clone.id).options.region
         ),
       ],
     };

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.js
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.js
@@ -3,7 +3,7 @@ import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import api from '../../../api.js';
-import { mockState } from '../../fixtures/composes.js';
+import { mockState } from '../../fixtures/composes';
 import { renderWithReduxRouter } from '../../testUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({

--- a/src/test/fixtures/composes.tsx
+++ b/src/test/fixtures/composes.tsx
@@ -1,9 +1,19 @@
 import { RHEL_8 } from '../../constants';
+import {
+  ClonesResponse,
+  ComposeStatus,
+  ComposesResponse,
+  UploadStatus,
+} from '../../store/imageBuilderApi';
 
 // CreateImageWizard mocks
-export const mockComposesEmpty = {
+export const mockComposesEmpty: ComposesResponse = {
   meta: {
     count: 0,
+  },
+  links: {
+    first: '',
+    last: '',
   },
   data: [],
 };
@@ -12,9 +22,13 @@ export const mockComposesEmpty = {
 const currentDate = new Date();
 const currentDateInString = currentDate.toISOString();
 
-export const mockComposes = {
+export const mockComposes: ComposesResponse = {
   meta: {
     count: 12,
+  },
+  links: {
+    first: '',
+    last: '',
   },
   data: [
     {
@@ -232,124 +246,298 @@ export const mockComposes = {
   ],
 };
 
-export const mockStatus = {
-  '1579d95b-8f1d-4982-8c53-8c2afa4ab04c': {
-    image_status: {
-      status: 'success',
-      upload_status: {
-        options: {
-          ami: 'ami-0217b81d9be50e44b',
-          region: 'us-east-1',
-        },
+export const mockStatus = (composeId: string): ComposeStatus => {
+  const mockComposes: { [key: string]: ComposeStatus } = {
+    '1579d95b-8f1d-4982-8c53-8c2afa4ab04c': {
+      image_status: {
         status: 'success',
-        type: 'aws',
-      },
-    },
-  },
-  // kept "running" for backward compatibility
-  'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa': {
-    image_status: {
-      status: 'failure',
-      error: {
-        reason: 'A dependency error occured',
-        details: {
-          reason: 'Error in depsolve job',
+        upload_status: {
+          options: {
+            ami: 'ami-0217b81d9be50e44b',
+            region: 'us-east-1',
+          },
+          status: 'success',
+          type: 'aws',
         },
       },
-    },
-  },
-  'edbae1c2-62bc-42c1-ae0c-3110ab718f58': {
-    image_status: {
-      status: 'pending',
-    },
-  },
-  '42ad0826-30b5-4f64-a24e-957df26fd564': {
-    image_status: {
-      status: 'building',
-    },
-  },
-  '955944a2-e149-4058-8ac1-35b514cb5a16': {
-    image_status: {
-      status: 'uploading',
-    },
-  },
-  'f7a60094-b376-4b58-a102-5c8c82dfd18b': {
-    image_status: {
-      status: 'registering',
-    },
-  },
-  '61b0effa-c901-4ee5-86b9-2010b47f1b22': {
-    image_status: {
-      status: 'failure',
-      error: {
-        reason: 'A dependency error occured',
-        details: {
-          reason: 'Error in depsolve job',
-        },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'aws',
+            upload_request: {
+              type: 'aws',
+              options: {
+                share_with_accounts: ['123123123123'],
+              },
+            },
+          },
+        ],
       },
     },
-  },
-  'ca03f120-9840-4959-871e-94a5cb49d1f2': {
-    image_status: {
-      status: 'success',
-      upload_status: {
-        options: {
-          image_name: 'composer-api-d446d8cb-7c16-4756-bf7d-706293785b05',
-          project_id: 'red-hat-image-builder',
+    'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa': {
+      // kept "running" for backward compatibility
+      image_status: {
+        status: 'failure',
+        error: {
+          id: 0,
+          reason: 'A dependency error occured',
+          details: {
+            reason: 'Error in depsolve job',
+          },
         },
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'gcp',
+            upload_request: {
+              type: 'gcp',
+              options: {
+                share_with_accounts: ['serviceAccount:test@email.com'],
+              },
+            },
+          },
+        ],
+      },
+    },
+    'edbae1c2-62bc-42c1-ae0c-3110ab718f58': {
+      image_status: {
+        status: 'pending',
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'aws',
+            upload_request: {
+              type: 'aws',
+              options: {},
+            },
+          },
+        ],
+      },
+    },
+    '42ad0826-30b5-4f64-a24e-957df26fd564': {
+      image_status: {
+        status: 'building',
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'aws',
+            upload_request: {
+              type: 'aws',
+              options: {},
+            },
+          },
+        ],
+      },
+    },
+    '955944a2-e149-4058-8ac1-35b514cb5a16': {
+      image_status: {
+        status: 'uploading',
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'aws',
+            upload_request: {
+              type: 'aws',
+              options: {},
+            },
+          },
+        ],
+      },
+    },
+    'f7a60094-b376-4b58-a102-5c8c82dfd18b': {
+      image_status: {
+        status: 'registering',
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'aws',
+            upload_request: {
+              type: 'aws',
+              options: {},
+            },
+          },
+        ],
+      },
+    },
+    '61b0effa-c901-4ee5-86b9-2010b47f1b22': {
+      image_status: {
+        status: 'failure',
+        error: {
+          id: 0,
+          reason: 'A dependency error occured',
+          details: {
+            reason: 'Error in depsolve job',
+          },
+        },
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'aws',
+            upload_request: {
+              type: 'aws',
+              options: {},
+            },
+          },
+        ],
+      },
+    },
+    'ca03f120-9840-4959-871e-94a5cb49d1f2': {
+      image_status: {
         status: 'success',
-        type: 'gcp',
-      },
-    },
-  },
-  '551de6f6-1533-4b46-a69f-7924051f9bc6': {
-    image_status: {
-      status: 'building',
-    },
-  },
-  'b7193673-8dcc-4a5f-ac30-e9f4940d8346': {
-    image_status: {
-      status: 'success',
-      upload_status: {
-        options: {
-          url: 'https://s3.amazonaws.com/b7193673-8dcc-4a5f-ac30-e9f4940d8346-disk.vmdk',
+        upload_status: {
+          options: {
+            image_name: 'composer-api-d446d8cb-7c16-4756-bf7d-706293785b05',
+            project_id: 'red-hat-image-builder',
+          },
+          status: 'success',
+          type: 'gcp',
         },
-        status: 'success',
-        type: 'aws.s3',
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'gcp',
+            upload_request: {
+              type: 'gcp',
+              options: {
+                share_with_accounts: ['serviceAccount:test@email.com'],
+              },
+            },
+          },
+        ],
       },
     },
-  },
-  '4873fd0f-1851-4b9f-b4fe-4639fce90794': {
-    image_status: {
-      status: 'success',
-      upload_status: {
-        options: {
-          url: 'https://s3.amazonaws.com/4873fd0f-1851-4b9f-b4fe-4639fce90794-installer.iso',
+    '551de6f6-1533-4b46-a69f-7924051f9bc6': {
+      image_status: {
+        status: 'building',
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'azure',
+            upload_request: {
+              type: 'azure',
+              options: {},
+            },
+          },
+        ],
+      },
+    },
+    'b7193673-8dcc-4a5f-ac30-e9f4940d8346': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://s3.amazonaws.com/b7193673-8dcc-4a5f-ac30-e9f4940d8346-disk.vmdk',
+          },
+          status: 'success',
+          type: 'aws.s3',
         },
-        status: 'success',
-        type: 'aws.s3',
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'vsphere',
+            upload_request: {
+              options: {},
+              type: 'aws.s3',
+            },
+          },
+        ],
       },
     },
-  },
-  '7b7d0d51-7106-42ab-98f2-f89872a9d599': {
-    image_status: {
-      status: 'success',
-      upload_status: {
-        options: {
-          url: 'https://s3.amazonaws.com/7b7d0d51-7106-42ab-98f2-f89872a9d599-disk.qcow2',
+    '4873fd0f-1851-4b9f-b4fe-4639fce90794': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://s3.amazonaws.com/4873fd0f-1851-4b9f-b4fe-4639fce90794-installer.iso',
+          },
+          status: 'success',
+          type: 'aws.s3',
         },
-        status: 'success',
-        type: 'aws.s3',
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'image-installer',
+            upload_request: {
+              options: {},
+              type: 'aws.s3',
+            },
+          },
+        ],
       },
     },
+    '7b7d0d51-7106-42ab-98f2-f89872a9d599': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://s3.amazonaws.com/7b7d0d51-7106-42ab-98f2-f89872a9d599-disk.qcow2',
+          },
+          status: 'success',
+          type: 'aws.s3',
+        },
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'guest-image',
+            upload_request: {
+              options: {},
+              type: 'aws.s3',
+            },
+          },
+        ],
+      },
+    },
+  };
+  return mockComposes[composeId];
+};
+
+export const mockNoClones: ClonesResponse = {
+  data: [],
+  links: {
+    first: '',
+    last: '',
+  },
+  meta: {
+    count: 2,
   },
 };
 
-export const mockNoClones = {
-  data: null,
-};
-
-export const mockClones = (composeId) => {
+export const mockClones = (composeId: string): ClonesResponse => {
   if (composeId === '1579d95b-8f1d-4982-8c53-8c2afa4ab04c') {
     return {
       data: [
@@ -386,45 +574,64 @@ export const mockClones = (composeId) => {
           },
         },
       ],
+      meta: {
+        count: 4,
+      },
+      links: {
+        first: '',
+        last: '',
+      },
+    };
+  } else {
+    return {
+      data: [],
+      meta: {
+        count: 0,
+      },
+      links: {
+        first: '',
+        last: '',
+      },
     };
   }
-
-  return null;
 };
 
-export const mockCloneStatus = {
-  'f9133ec4-7a9e-4fd9-9a9f-9636b82b0a5d': {
-    options: {
-      ami: 'ami-0e778053cd490ad21',
-      region: 'us-west-1',
+export const mockCloneStatus = (cloneId: string): UploadStatus => {
+  const mockClones: { [key: string]: UploadStatus } = {
+    'f9133ec4-7a9e-4fd9-9a9f-9636b82b0a5d': {
+      options: {
+        ami: 'ami-0e778053cd490ad21',
+        region: 'us-west-1',
+      },
+      status: 'success',
+      type: 'aws',
     },
-    status: 'success',
-    type: 'aws',
-  },
-  '48fce414-0cc0-4a16-8645-e3f0edec3212': {
-    options: {
-      ami: 'ami-9f0asd1tlk2142124',
-      region: 'us-west-1',
+    '48fce414-0cc0-4a16-8645-e3f0edec3212': {
+      options: {
+        ami: 'ami-9f0asd1tlk2142124',
+        region: 'us-west-1',
+      },
+      status: 'success',
+      type: 'aws',
     },
-    status: 'success',
-    type: 'aws',
-  },
-  '0169538e-515c-477e-b934-f12783939313': {
-    options: {
-      ami: 'ami-9fdskj12fdsak1211',
-      region: 'us-west-2',
+    '0169538e-515c-477e-b934-f12783939313': {
+      options: {
+        ami: 'ami-9fdskj12fdsak1211',
+        region: 'us-west-2',
+      },
+      status: 'failure',
+      type: 'aws',
     },
-    status: 'failure',
-    type: 'aws',
-  },
-  '4a851db1-919f-43ca-a7ef-dd209877a77e': {
-    options: {
-      ami: 'ami-9fdskj12fdsak1211',
-      region: 'eu-central-1',
+    '4a851db1-919f-43ca-a7ef-dd209877a77e': {
+      options: {
+        ami: 'ami-9fdskj12fdsak1211',
+        region: 'eu-central-1',
+      },
+      status: 'success',
+      type: 'aws',
     },
-    status: 'success',
-    type: 'aws',
-  },
+  };
+  return mockClones[cloneId];
 };
 
 // ShareImageModal mocks

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -74,7 +74,7 @@ export const handlers = [
   }),
   rest.get(`${IMAGE_BUILDER_API}/composes/:composeId`, (req, res, ctx) => {
     const { composeId } = req.params;
-    return res(ctx.status(200), ctx.json(mockStatus[composeId]));
+    return res(ctx.status(200), ctx.json(mockStatus(composeId)));
   }),
   rest.get(
     `${IMAGE_BUILDER_API}/composes/:composeId/clones`,
@@ -85,6 +85,6 @@ export const handlers = [
   ),
   rest.get(`${IMAGE_BUILDER_API}/clones/:cloneId`, (req, res, ctx) => {
     const { cloneId } = req.params;
-    return res(ctx.status(200), ctx.json(mockCloneStatus[cloneId]));
+    return res(ctx.status(200), ctx.json(mockCloneStatus(cloneId)));
   }),
 ];


### PR DESCRIPTION
This adds `request` to a reponse from the `composes/{composeId}` endpoint and `meta` to a response from the `/composes/{composeId}/clones` endpoint as per API documentation.

The incomplete responses were causing problems when fetching data from the endpoints mentioned above.

The fixture was also migrated to TypeScript.