### PR TITLE
rename ib tab from traditional to conventional

### DIFF
--- a/src/Components/LandingPage/LandingPage.js
+++ b/src/Components/LandingPage/LandingPage.js
@@ -184,7 +184,7 @@ export const LandingPage = () => {
         >
           <Tab
             eventKey={0}
-            title={<TabTitleText>Traditional (RPM - DNF)</TabTitleText>}
+            title={<TabTitleText>Conventional (RPM - DNF)</TabTitleText>}
           >
             {traditionalImageList}
           </Tab>


### PR DESCRIPTION
Changing the traditional tab name To Conventional.
![image](https://github.com/RedHatInsights/image-builder-frontend/assets/5039367/eb880e68-a31a-4963-8a34-7dcde045e6bb)
