### PR TITLE
msw: Version bump in `mockServiceWorker.js`

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.1).
+ * Mock Service Worker (1.2.2).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.


### PR DESCRIPTION
Recently msw was bumped from 1.2.1 to 1.2.2 (https://github.com/RedHatInsights/image-builder-frontend/pull/1245). The version gets updated in `mockServiceWorker.js` upon running `npm ci`.

This PR changes the version as it wasn't a part of the original bump PR, but appears after every clean install.