### PR TITLE
msw: Version bump in mockServiceWorker.js 1.2.2 -> 1.2.3

### DIFF
--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.2).
+ * Mock Service Worker (1.2.3).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.


### PR DESCRIPTION
msw was bumped from 1.2.2 to 1.2.3 in https://github.com/RedHatInsights/image-builder-frontend/pull/1264

This changes the version in `mockServiceWorker.js` as done by `npm ci`.