### PR TITLE
imageTable:  Update links on empty state

### DIFF
--- a/src/Components/edge/ImagesTable.js
+++ b/src/Components/edge/ImagesTable.js
@@ -26,6 +26,9 @@ const ImagesTable = () => {
       navigateProp={useNavigate}
       locationProp={useLocation}
       showHeaderProp={false}
+      docLinkProp={
+        'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/creating_customized_images_by_using_insights_image_builder/index'
+      }
       notificationProp={notificationProp}
       pathPrefix={resolveRelPath('')}
       urlName={manageEdgeImagesUrlName}


### PR DESCRIPTION
This commit add specific link when open Immutable tab without any images at image builder table

Fixes # related to https://issues.redhat.com/browse/THEEDGE-3478
<img width="1321" alt="Screenshot 2023-07-25 at 18 32 38" src="https://github.com/RedHatInsights/image-builder-frontend/assets/73419853/e656ac4e-da10-4c6c-99bf-28c81b267db6">

