### PR TITLE
Wizard: change the name of wizard details

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -473,7 +473,7 @@ const formStepHistory = (composeRequest, isBeta) => {
       steps.push('File system configuration', 'packages');
     }
 
-    steps.push('image-name');
+    steps.push('details');
 
     return steps;
   } else {

--- a/src/Components/CreateImageWizard/steps/imageName.js
+++ b/src/Components/CreateImageWizard/steps/imageName.js
@@ -10,7 +10,7 @@ import CustomButtons from '../formComponents/CustomButtons';
 export default {
   StepTemplate,
   id: 'wizard-details',
-  name: 'image-name',
+  name: 'details',
   title: 'Details',
   nextStep: 'review',
   buttons: CustomButtons,

--- a/src/Components/CreateImageWizard/steps/packages.js
+++ b/src/Components/CreateImageWizard/steps/packages.js
@@ -17,7 +17,7 @@ export default {
     if (values.isBeta) {
       return 'repositories';
     } else {
-      return 'image-name';
+      return 'details';
     }
   },
   buttons: CustomButtons,

--- a/src/Components/CreateImageWizard/steps/packagesContentSources.js
+++ b/src/Components/CreateImageWizard/steps/packagesContentSources.js
@@ -13,7 +13,7 @@ export default {
   title: 'Additional custom packages',
   name: 'packages-content-sources',
   substepOf: 'Content',
-  nextStep: 'image-name',
+  nextStep: 'details',
   buttons: CustomButtons,
   fields: [
     {

--- a/src/Components/CreateImageWizard/steps/repositoriesStepMapper.js
+++ b/src/Components/CreateImageWizard/steps/repositoriesStepMapper.js
@@ -3,5 +3,5 @@ export default ({ 'payload-repositories': customRepositories } = {}) => {
     return 'packages-content-sources';
   }
 
-  return 'image-name';
+  return 'details';
 };


### PR DESCRIPTION
This commit change the name of wizard-details to details, to prevent misconfusion with the image-name component