### PR TITLE
Revert "build(deps): bump @patternfly/patternfly from 4.224.2 to 5.0.2"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "3.20.13",
         "@data-driven-forms/react-form-renderer": "3.20.13",
-        "@patternfly/patternfly": "5.0.2",
+        "@patternfly/patternfly": "4.224.2",
         "@patternfly/react-core": "4.276.8",
         "@patternfly/react-table": "4.113.3",
         "@redhat-cloud-services/frontend-components": "3.11.2",
@@ -3408,9 +3408,8 @@
       "license": "ISC"
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.0.2.tgz",
-      "integrity": "sha512-PB8+MLdYVgF1hIOxGmnVsZG+YHUX3RePe5W1oMS4gS00EmSgw1cobr1Qbpy/BqqS8/R9DRN4hZ2FKDT0d5tkFQ=="
+      "version": "4.224.2",
+      "license": "MIT"
     },
     "node_modules/@patternfly/react-core": {
       "version": "4.276.8",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@data-driven-forms/pf4-component-mapper": "3.20.13",
     "@data-driven-forms/react-form-renderer": "3.20.13",
-    "@patternfly/patternfly": "5.0.2",
+    "@patternfly/patternfly": "4.224.2",
     "@patternfly/react-core": "4.276.8",
     "@patternfly/react-table": "4.113.3",
     "@redhat-cloud-services/frontend-components": "3.11.2",


### PR DESCRIPTION
This reverts commit d8c6ca93d1cbc65d7895b3fdcb3c0fc1acc0a6fd.

Reverting the bump to PF5 as it will need to wait for ConsoleDot's adoption.