### PR TITLE
Fix missing aria label in launch wizard  modal console error

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -56,11 +56,11 @@ const ProvisioningLink = ({ imageId, isExpired, isInClonesTable }) => {
         {wizardOpen && (
           <Modal
             isOpen
-            modalVariant={ModalVariant.large}
             hasNoBodyWrapper
             appendTo={appendTo}
             showClose={false}
-            variant={'large'}
+            variant={ModalVariant.large}
+            aria-label="Open launch wizard"
           >
             <ProvisioningWizard
               onClose={() => openWizard(false)}


### PR DESCRIPTION
When no aria label is given to a modal component, an error is thrown in console:
```
Modal: Specify at least one of: title, aria-label, aria-labelledby. 
[Error] Modal: When using hasNoBodyWrapper or setting a custom header, ensure you assign an accessible name to the the modal container with aria-label or aria-labelledby.
```