### PR TITLE
wizard/activation key: remove a useEffect

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ActivationKeys.js
+++ b/src/Components/CreateImageWizard/formComponents/ActivationKeys.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
@@ -32,7 +32,10 @@ const ActivationKeys = ({ label, isRequired, ...props }) => {
     refetch,
   } = useListActivationKeysQuery();
 
-  useEffect(() => {
+  if (
+    getState()?.values?.['subscription-server-url'] === undefined ||
+    getState()?.values?.['subscription-base-url'] === undefined
+  ) {
     if (isProd()) {
       change('subscription-server-url', 'subscription.rhsm.redhat.com');
       change('subscription-base-url', 'https://cdn.redhat.com/');
@@ -40,7 +43,7 @@ const ActivationKeys = ({ label, isRequired, ...props }) => {
       change('subscription-server-url', 'subscription.rhsm.stage.redhat.com');
       change('subscription-base-url', 'https://cdn.stage.redhat.com/');
     }
-  }, []);
+  }
 
   const setActivationKey = (_, selection) => {
     selectActivationKey(selection);


### PR DESCRIPTION
Since the propagation of the subscription serer url and base url was
performed with a useEffect on every redraw, it's equivalent as calling
directly change to initialize the form directly.