### PR TITLE
Wizard: Fix the `Failed prop type` error

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -488,7 +488,7 @@ ExactMatch.propTypes = {
   pkgList: PropTypes.arrayOf(PropTypes.object),
   search: PropTypes.string,
   chosenPackages: PropTypes.object,
-  selectedAvailablePackages: PropTypes.arrayOf(PropTypes.string),
+  selectedAvailablePackages: PropTypes.object,
   handleSelectAvailableFunc: PropTypes.func,
 };
 


### PR DESCRIPTION
Incorrect proptype for `selectedAvailablePackages` was causing following error: ```Warning: Failed prop type: Invalid prop `selectedAvailablePackages` of type `object` supplied to `ExactMatch`, expected an array.```

This fixes the problem.