### PR TITLE
fixing the tests from their errors and warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "jest": "^29.6.2",
         "jest-canvas-mock": "2.5.2",
         "jest-environment-jsdom": "29.6.2",
+        "jest-fail-on-console": "^3.1.1",
         "msw": "^1.2.3",
         "npm-run-all": "4.1.5",
         "postcss-scss": "4.0.6",
@@ -12750,6 +12751,85 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-fail-on-console": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.1.1.tgz",
+      "integrity": "sha512-g9HGhKcWOz8lHeZhLCXGg+RD/7upngiKkkBrHimsO/tGB0qi++QZffOgybjeI2bDW1qgdFiJJEG6t/WeTlfmOw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/jest-fail-on-console/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-fail-on-console/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     ],
     "setupFilesAfterEnv": [
       "./src/test/jest.setup.js"
-    ]
+    ],
+    "testTimeout": 10000
   },
   "devDependencies": {
     "@babel/core": "7.22.9",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "jest": "^29.6.2",
     "jest-canvas-mock": "2.5.2",
     "jest-environment-jsdom": "29.6.2",
+    "jest-fail-on-console": "^3.1.1",
     "msw": "^1.2.3",
     "npm-run-all": "4.1.5",
     "postcss-scss": "4.0.6",

--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -567,8 +567,6 @@ const CreateImageWizard = () => {
                 title: 'Your image is being created',
               })
             );
-
-            setIsSaving(false);
           })
           .catch((err) => {
             let msg = err.response.statusText;

--- a/src/Components/ImagesTable/ClonesTable.js
+++ b/src/Components/ImagesTable/ClonesTable.js
@@ -23,6 +23,10 @@ import {
 const Row = ({ imageId }) => {
   const image = useSelector((state) => selectImageById(state, imageId));
 
+  if (!image) {
+    return null;
+  }
+
   return (
     <Tbody>
       <Tr className="no-bottom-border">

--- a/src/Components/ImagesTable/ImageLinkDirect.js
+++ b/src/Components/ImagesTable/ImageLinkDirect.js
@@ -32,6 +32,9 @@ const ImageLinkDirect = ({ imageId, isExpired, isInClonesTable }) => {
   const navigate = useNavigate();
 
   const image = useSelector((state) => selectImageById(state, imageId));
+  if (!image) {
+    return null;
+  }
   const uploadStatus = image.uploadStatus;
 
   const fileExtensions = {

--- a/src/store/actions/actions.js
+++ b/src/store/actions/actions.js
@@ -8,6 +8,7 @@ import {
 
 export const fetchComposeStatus = (id) => async (dispatch) => {
   const request = await api.getComposeStatus(id);
+  if (!request) return;
   dispatch(
     composeUpdatedStatus({
       id,
@@ -18,6 +19,7 @@ export const fetchComposeStatus = (id) => async (dispatch) => {
 
 export const fetchComposes = (limit, offset) => async (dispatch) => {
   const composeRequest = await api.getComposes(limit, offset);
+  if (!composeRequest) return;
 
   composeRequest.data.map((compose) => {
     dispatch(composeAdded({ compose, insert: false }));
@@ -32,6 +34,7 @@ export const fetchComposes = (limit, offset) => async (dispatch) => {
 
 export const fetchCloneStatus = (id) => async (dispatch) => {
   const request = await api.getCloneStatus(id);
+  if (!request) return;
   dispatch(
     cloneUpdatedStatus({
       id,
@@ -42,6 +45,7 @@ export const fetchCloneStatus = (id) => async (dispatch) => {
 
 export const fetchClones = (id, limit, offset) => async (dispatch) => {
   const request = await api.getClones(id, limit, offset);
+  if (!request) return;
   request.data?.forEach((clone) => {
     dispatch(cloneAdded({ clone, parent: id }));
     dispatch(fetchCloneStatus(clone.id));

--- a/src/store/composesSlice.js
+++ b/src/store/composesSlice.js
@@ -80,7 +80,7 @@ export const selectComposeById = (state, composeId) => {
 export const selectClonesById = (state, composeId) => {
   const compose = state.composes.byId[composeId];
 
-  if (compose.clones.length !== 0) {
+  if (compose && compose.clones.length !== 0) {
     const clones = compose.clones.map((cloneId) => {
       const clone = state.clones.byId[cloneId];
       return {
@@ -115,7 +115,7 @@ export const selectImagesById = createSelector(
 export const selectImageStatusesById = createSelector(
   [selectImagesById],
   (images) => {
-    return images.map((image) => image.status);
+    return images.map((image) => (image !== null ? image.status : null));
   }
 );
 

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.2.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.2.test.js
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom';
+
+import { screen } from '@testing-library/react';
+import { rest } from 'msw';
+
+import { PROVISIONING_API } from '../../../constants.js';
+import { server } from '../../mocks/server.js';
+import {
+  clickNext,
+  renderWithReduxRouter,
+} from '../../testUtils';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
+describe('Step Upload to Azure', () => {
+  beforeAll(() => {
+    // scrollTo is not defined in jsdom
+    window.HTMLElement.prototype.scrollTo = function () {};
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const setUp = async () => {
+    renderWithReduxRouter('imagewizard', {});
+    // select aws as upload destination
+    const azureTile = screen.getByTestId('upload-azure');
+    azureTile.click();
+
+    await clickNext();
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      'Target environment - Microsoft Azure'
+    );
+  };
+
+  test('component renders error state correctly', async () => {
+    setUp();
+    server.use(
+      rest.get(`${PROVISIONING_API}/sources`, (req, res, ctx) =>
+        res(ctx.status(500))
+      )
+    );
+
+    await screen.findByText(
+      /Sources cannot be reached, try again later or enter an account info for upload manually\./i
+    );
+    //
+  });
+  // set test timeout on 10 seconds
+}, 15000);

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.2.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.2.test.js
@@ -1,14 +1,29 @@
+import React from 'react';
 import '@testing-library/jest-dom';
 
 import { screen } from '@testing-library/react';
 import { rest } from 'msw';
 
+import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
+import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
 import { PROVISIONING_API } from '../../../constants.js';
 import { server } from '../../mocks/server.js';
-import {
-  clickNext,
-  renderWithReduxRouter,
-} from '../../testUtils';
+import { clickNext, renderCustomRoutesWithReduxRouter } from '../../testUtils';
+
+const routes = [
+  {
+    path: 'insights/image-builder/*',
+    element: <div />,
+  },
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+  {
+    path: 'insights/image-builder/share/:composeId',
+    element: <ShareImageModal />,
+  },
+];
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: () => ({
@@ -40,7 +55,7 @@ describe('Step Upload to Azure', () => {
   });
 
   const setUp = async () => {
-    renderWithReduxRouter('imagewizard', {});
+    renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
     // select aws as upload destination
     const azureTile = screen.getByTestId('upload-azure');
     azureTile.click();

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
@@ -156,19 +156,5 @@ describe('Step Upload to Azure', () => {
     expect(groups).toBeInTheDocument();
     expect(screen.getByLabelText('Resource group theirGroup2')).toBeVisible();
   });
-
-  test('component renders error state correctly', async () => {
-    setUp();
-    server.use(
-      rest.get(`${PROVISIONING_API}/sources`, (req, res, ctx) =>
-        res(ctx.status(500))
-      )
-    );
-
-    await screen.findByText(
-      /Sources cannot be reached, try again later or enter an account info for upload manually\./i
-    );
-    //
-  });
   // set test timeout on 10 seconds
 }, 15000);

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.beta.test.js
@@ -1,17 +1,31 @@
+import React from 'react';
 import '@testing-library/jest-dom';
 
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { rest } from 'msw';
 
-import { PROVISIONING_API } from '../../../constants.js';
-import { server } from '../../mocks/server.js';
+import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
+import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
 import {
   clickNext,
   getNextButton,
-  renderWithReduxRouter,
+  renderCustomRoutesWithReduxRouter,
 } from '../../testUtils';
 
+const routes = [
+  {
+    path: 'insights/image-builder/*',
+    element: <div />,
+  },
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+  {
+    path: 'insights/image-builder/share/:composeId',
+    element: <ShareImageModal />,
+  },
+];
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: () => ({
     auth: {
@@ -53,7 +67,7 @@ describe('Step Upload to Azure', () => {
 
   const user = userEvent.setup();
   const setUp = async () => {
-    renderWithReduxRouter('imagewizard', {});
+    renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
     // select aws as upload destination
     const azureTile = screen.getByTestId('upload-azure');
     azureTile.click();

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.beta.test.js
@@ -106,7 +106,9 @@ describe('Step Upload to AWS', () => {
 
     // select aws as upload destination
     const awsTile = await screen.findByTestId('upload-aws');
-    awsTile.click();
+    await act(async () => {
+      awsTile.click();
+    });
 
     await clickNext();
 
@@ -176,14 +178,20 @@ describe('Step Upload to AWS', () => {
     });
     // Wait for isSuccess === true, dropdown is disabled while isSuccess === false
     await waitFor(() => expect(sourceDropdown).toBeEnabled());
-    sourceDropdown.click();
+    await act(async () => {
+      sourceDropdown.click();
+    });
 
     const source = await screen.findByRole('option', {
       name: /my_source/i,
     });
-    source.click();
+    await act(async () => {
+      source.click();
+    });
 
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     // registration
     await screen.findByRole('textbox', {
@@ -191,14 +199,18 @@ describe('Step Upload to AWS', () => {
     });
 
     const registerLaterRadio = screen.getByLabelText('Register later');
-    await user.click(registerLaterRadio);
+    await act(async () => {
+      await user.click(registerLaterRadio);
+    });
 
     // click through to review step
-    await clickNext();
-    await clickNext();
-    await clickNext();
-    await clickNext();
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+      await clickNext();
+      await clickNext();
+      await clickNext();
+      await clickNext();
+    });
 
     const composeImage = jest
       .spyOn(api, 'composeImage')
@@ -227,7 +239,9 @@ describe('Step Upload to AWS', () => {
       });
 
     const create = screen.getByRole('button', { name: /Create/ });
-    create.click();
+    await act(async () => {
+      create.click();
+    });
 
     // API request sent to backend
     expect(composeImage).toHaveBeenCalledTimes(1);
@@ -250,15 +264,19 @@ describe('Step Packages', () => {
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
-    awsTile.click();
-    await clickNext();
+    await act(async () => {
+      awsTile.click();
+      await clickNext();
+    });
 
     // aws step
     await user.click(
       screen.getByRole('radio', { name: /manually enter an account id\./i })
     );
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
     // skip registration
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -266,10 +284,12 @@ describe('Step Packages', () => {
 
     const registerLaterRadio = screen.getByTestId('registration-radio-later');
     await user.click(registerLaterRadio);
-    await clickNext();
+    await act(async () => {
+      await clickNext();
 
-    // skip fsc
-    await clickNext();
+      // skip fsc
+      await clickNext();
+    });
   };
 
   test('search results should be sorted with most relevant results first', async () => {
@@ -284,7 +304,9 @@ describe('Step Packages', () => {
     //const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
     await waitFor(() => expect(searchbox).toBeEnabled());
-    searchbox.click();
+    await act(async () => {
+      searchbox.click();
+    });
 
     await searchForAvailablePackages(searchbox, 'test');
 
@@ -307,7 +329,9 @@ describe('Step Packages', () => {
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
     await waitFor(() => expect(searchbox).toBeEnabled());
-    searchbox.click();
+    await act(async () => {
+      searchbox.click();
+    });
 
     await searchForAvailablePackages(searchbox, 'test');
 
@@ -509,15 +533,19 @@ describe('Step Custom repositories', () => {
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
-    awsTile.click();
-    await clickNext();
+    await act(async () => {
+      awsTile.click();
+      await clickNext();
+    });
 
     // aws step
     await user.click(
       screen.getByRole('radio', { name: /manually enter an account id\./i })
     );
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
     // skip registration
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -525,13 +553,15 @@ describe('Step Custom repositories', () => {
 
     const registerLaterRadio = screen.getByLabelText('Register later');
     await user.click(registerLaterRadio);
-    await clickNext();
+    await act(async () => {
+      await clickNext();
 
-    // skip fsc
-    await clickNext();
+      // skip fsc
+      await clickNext();
 
-    // skip packages
-    await clickNext();
+      // skip packages
+      await clickNext();
+    });
   };
 
   test('selected repositories stored in and retrieved from form state', async () => {
@@ -547,8 +577,10 @@ describe('Step Custom repositories', () => {
     await user.click(firstRepoCheckbox);
     expect(firstRepoCheckbox.checked).toEqual(true);
 
-    await clickNext();
-    clickBack();
+    await act(async () => {
+      await clickNext();
+      clickBack();
+    });
 
     firstRepoCheckbox = await getFirstRepoCheckbox();
     expect(firstRepoCheckbox.checked).toEqual(true);
@@ -626,12 +658,21 @@ describe('Click through all steps', () => {
       screen.getByRole('radio', { name: /manually enter an account id\./i })
     );
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn1.click();
+    });
 
     await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn2 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn2.click();
+    });
 
-    screen.getByTestId('azure-radio-manual').click();
+    const azm = screen.getByTestId('azure-radio-manual');
+    await act(async () => {
+      azm.click();
+    });
     // Randomly generated GUID
     await user.type(
       screen.getByTestId('azure-tenant-id-manual'),
@@ -645,7 +686,10 @@ describe('Click through all steps', () => {
       screen.getByTestId('azure-resource-group-manual'),
       'testResourceGroup'
     );
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn4 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn4.click();
+    });
 
     // registration
     const activationKeyDropdown = await screen.findByRole('textbox', {
@@ -658,7 +702,9 @@ describe('Click through all steps', () => {
     await user.click(activationKey);
     screen.getByDisplayValue('name0');
 
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     // fsc
     (await screen.findByTestId('file-system-config-radio-manual')).click();
@@ -668,7 +714,9 @@ describe('Click through all steps', () => {
     const tbody = screen.getByTestId('file-system-configuration-tbody');
     const rows = within(tbody).getAllByRole('row');
     expect(rows).toHaveLength(3);
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
     // set mountpoint of final row to /var/tmp
     within(rows[2]).getAllByRole('button', { name: 'Options menu' })[0].click();
     within(rows[2]).getByRole('option', { name: '/var' }).click();
@@ -691,7 +739,9 @@ describe('Click through all steps', () => {
     );
     within(rows[2]).getAllByRole('button', { name: 'Options menu' })[1].click();
     within(rows[2]).getByRole('option', { name: 'MiB' }).click();
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     screen.getByText(
       /Images built with Image Builder include all required packages/i
@@ -702,11 +752,17 @@ describe('Click through all steps', () => {
     await waitFor(() => expect(searchbox).toBeEnabled());
 
     await searchForAvailablePackages(searchbox, 'test');
-    screen
-      .getByRole('option', { name: /test summary for test package/ })
-      .click();
-    screen.getByRole('button', { name: /Add selected/ }).click();
-    await clickNext();
+    const bot = screen .getByRole('option', { name: /test summary for test package/ })
+    await act(async () => {
+      bot.click();
+    });
+    const bas = screen.getByRole('button', { name: /Add selected/ });
+    await act(async () => {
+      bas.click();
+    });
+    await act(async () => {
+      await clickNext();
+    });
 
     // Custom repositories
     await user.click(
@@ -715,27 +771,33 @@ describe('Click through all steps', () => {
     await user.click(
       await screen.findByRole('checkbox', { name: /select row 1/i })
     );
-    await clickNext();
 
-    // Custom packages
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+      // Custom packages
+      await clickNext();
+    });
 
     // Enter image name
     const nameInput = screen.getByRole('textbox', {
       name: 'Image Name',
     });
 
-    await user.type(nameInput, 'my-image-name');
+    await act(async () => {
+      await user.type(nameInput, 'my-image-name');
+    });
 
     // Enter description for image
     const descriptionInput = screen.getByRole('textbox', {
       name: /Description/,
     });
-    await user.type(
-      descriptionInput,
-      'this is a perfect description for image'
-    );
-    await clickNext();
+    await act(async () => {
+      await user.type(
+        descriptionInput,
+        'this is a perfect description for image'
+      );
+      await clickNext();
+    });
 
     // review
     const targetEnvironmentsExpandable = await screen.findByTestId(
@@ -751,7 +813,9 @@ describe('Click through all steps', () => {
     const registrationExpandable = await screen.findByTestId(
       'registration-expandable'
     );
-    registrationExpandable.click();
+    await act(async () => {
+      registrationExpandable.click();
+    });
     const review = screen.getByTestId('review-registration');
     expect(review).toHaveTextContent(
       'Use remote host configuration (RHC) utility'
@@ -760,7 +824,9 @@ describe('Click through all steps', () => {
     const imageDetailsExpandable = await screen.findByTestId(
       'image-details-expandable'
     );
-    imageDetailsExpandable.click();
+    await act(async () => {
+      imageDetailsExpandable.click();
+    });
     await screen.findByText('my-image-name');
     await screen.findByText('this is a perfect description for image');
 
@@ -768,13 +834,19 @@ describe('Click through all steps', () => {
     await screen.findByText('Self-Support');
     await screen.findByText('Production');
 
-    screen.getByTestId('repositories-popover-button').click();
+    const brp = screen.getByTestId('repositories-popover-button');
+    await act(async () => {
+      brp.click();
+    });
     const repotbody = await screen.findByTestId(
       'additional-repositories-table'
     );
     expect(within(repotbody).getAllByRole('row')).toHaveLength(3);
 
-    screen.getByTestId('file-system-configuration-popover').click();
+    const fsc = screen.getByTestId('file-system-configuration-popover');
+    await act(async () => {
+      fsc.click();
+    });
     const revtbody = await screen.findByTestId(
       'file-system-configuration-tbody-review'
     );
@@ -908,7 +980,9 @@ describe('Click through all steps', () => {
       });
 
     const create = screen.getByRole('button', { name: /Create/ });
-    await user.click(create);
+    await act(async () => {
+      await user.click(create);
+    });
 
     // API request sent to backend
     expect(composeImage).toHaveBeenCalledTimes(6);
@@ -918,6 +992,6 @@ describe('Click through all steps', () => {
       expect(router.state.location.pathname).toBe('/insights/image-builder')
     );
     expect(store.getState().composes.allIds).toEqual(ids);
-    // set test timeout of 10 seconds
-  }, 10000);
+    // set test timeout of 20 seconds
+  }, 20000);
 });

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -258,7 +258,9 @@ describe('Step Upload to AWS', () => {
       await screen.findByTestId('aws-account-id'),
       '012345678901'
     );
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -270,7 +272,9 @@ describe('Step Upload to AWS', () => {
   test('clicking Back loads Release', async () => {
     await setUp();
 
-    await clickBack();
+    await act(async () => {
+      await clickBack();
+    });
 
     screen.getByTestId('upload-aws');
   });
@@ -310,8 +314,13 @@ describe('Step Upload to Google', () => {
   test('clicking Next loads Registration', async () => {
     await setUp();
 
-    await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
-    await clickNext();
+    await user.type(
+        screen.getByTestId('input-google-email'),
+        'test@test.com'
+      );
+    await act(async () => {
+      await clickNext();
+    });
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -362,7 +371,7 @@ describe('Step Upload to Azure', () => {
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-azure');
-    awsTile.click();
+    await awsTile.click();
     await clickNext();
 
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
@@ -385,8 +394,9 @@ describe('Step Upload to Azure', () => {
       screen.getByTestId('azure-resource-group'),
       'testResourceGroup'
     );
-
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -440,10 +450,13 @@ describe('Step Registration', () => {
     const awsTile = screen.getByTestId('upload-aws');
     awsTile.click();
 
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -456,7 +469,9 @@ describe('Step Registration', () => {
     const registerLaterRadio = screen.getByTestId('registration-radio-later');
     await user.click(registerLaterRadio);
 
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     screen.getByRole('heading', { name: /file system configuration/i });
   });
@@ -481,17 +496,33 @@ describe('Step Registration', () => {
     const activationKeyDropdown = await screen.findByRole('textbox', {
       name: 'Select activation key',
     });
-    await user.click(activationKeyDropdown);
+    await act(async () => {
+      await user.click(activationKeyDropdown);
+    });
     const activationKey = await screen.findByRole('option', {
       name: 'name0',
     });
-    await user.click(activationKey);
+    await act(async () => {
+      await user.click(activationKey);
+    });
     screen.getByDisplayValue('name0');
 
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
+    const n1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n1.click();
+    });
+    const n2 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n2.click();
+    });
+    const n3 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n3.click();
+    });
+    const n4 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n4.click();
+    });
     const review = screen.getByTestId('review-registration');
     expect(review).toHaveTextContent(
       'Register with Red Hat Subscription Manager (RHSM)'
@@ -506,30 +537,54 @@ describe('Step Registration', () => {
   test('should allow registering without rhc', async () => {
     await setUp();
 
-    await user.click(screen.getByTestId('registration-additional-options'));
-    await user.click(screen.getByTestId('registration-checkbox-rhc'));
+    await act(async () => {
+      await user.click(screen.getByTestId('registration-additional-options'));
+      await user.click(screen.getByTestId('registration-checkbox-rhc'));
+    });
 
     // going back and forward when rhc isn't selected should keep additional options shown
-    screen.getByRole('button', { name: /Back/ }).click();
+    const back1 = screen.getByRole('button', { name: /Back/ });
+    await act(async () => {
+      back1.click();
+    });
     await screen.findByTestId('aws-account-id');
-    screen.getByRole('button', { name: /Next/ }).click();
+    const next1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      next1.click();
+    });
     screen.getByTestId('registration-checkbox-insights');
     screen.getByTestId('registration-checkbox-rhc');
 
     const activationKeyDropdown = await screen.findByRole('textbox', {
       name: 'Select activation key',
     });
-    await user.click(activationKeyDropdown);
+    await act(async () => {
+      await user.click(activationKeyDropdown);
+    });
     const activationKey = await screen.findByRole('option', {
       name: 'name0',
     });
-    await user.click(activationKey);
+    await act(async () => {
+      await user.click(activationKey);
+    });
     screen.getByDisplayValue('name0');
 
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
+    const n1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n1.click();
+    });
+    const n2 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n2.click();
+    });
+    const n3 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n3.click();
+    });
+    const n4 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n4.click();
+    });
     const review = screen.getByTestId('review-registration');
     expect(review).toHaveTextContent(
       'Register with Red Hat Subscription Manager (RHSM)'
@@ -548,27 +603,52 @@ describe('Step Registration', () => {
     await user.click(screen.getByTestId('registration-checkbox-insights'));
 
     // going back and forward when neither rhc or insights is selected should keep additional options shown
-    screen.getByRole('button', { name: /Back/ }).click();
+    const b1 = screen.getByRole('button', { name: /Back/ });
+    await act(async () => {
+      b1.click();
+    });
     await screen.findByTestId('aws-account-id');
-    screen.getByRole('button', { name: /Next/ }).click();
+    const next1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      next1.click();
+    });
     screen.getByTestId('registration-checkbox-insights');
     screen.getByTestId('registration-checkbox-rhc');
 
     const activationKeyDropdown = await screen.findByRole('textbox', {
       name: 'Select activation key',
     });
-    await user.click(activationKeyDropdown);
+    await act(async () => {
+      await user.click(activationKeyDropdown);
+    });
     const activationKey = await screen.findByRole('option', {
       name: 'name0',
     });
-    await user.click(activationKey);
+    await act(async () => {
+      await user.click(activationKey);
+    });
     screen.getByDisplayValue('name0');
 
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByTestId('registration-expandable').click();
+    const n1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n1.click();
+    });
+    const n2 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n2.click();
+    });
+    const n3 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n3.click();
+    });
+    const n4 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n4.click();
+    });
+    const exp1 = screen.getByTestId('registration-expandable');
+    await act(async () => {
+      exp1.click();
+    });
     const review = screen.getByTestId('review-registration');
     expect(review).toHaveTextContent(
       'Register with Red Hat Subscription Manager (RHSM)'
@@ -587,25 +667,49 @@ describe('Step Registration', () => {
     ]);
 
     // click the later radio button which should remove any input fields
-    screen.getByTestId('registration-radio-later').click();
+    const rrl = screen.getByTestId('registration-radio-later');
+    await act(async () => {
+      rrl.click();
+    });
 
     await p1;
 
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
+    const n1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n1.click();
+    });
+    const n2 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n2.click();
+    });
+    const n3 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n3.click();
+    });
+    const n4 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n4.click();
+    });
     screen.getByText('Register the system later');
   });
 
   test('registering with rhc implies registering with insights', async () => {
     await setUp();
-    await user.click(screen.getByTestId('registration-additional-options'));
+    const rro = screen.getByTestId('registration-additional-options');
+    await act(async () => {
+      await user.click(rro);
+    });
 
-    await user.click(screen.getByTestId('registration-checkbox-insights'));
+    const rci = screen.getByTestId('registration-checkbox-insights');
+    await act(async () => {
+      await user.click(rci);
+    });
     expect(screen.getByTestId('registration-checkbox-rhc')).not.toBeChecked();
 
-    await user.click(screen.getByTestId('registration-checkbox-rhc'));
+    const rch = screen.getByTestId('registration-checkbox-rhc');
+    await act(async () => {
+      await user.click(rch);
+    });
     expect(screen.getByTestId('registration-checkbox-insights')).toBeChecked();
   });
 });
@@ -617,12 +721,18 @@ describe('Step File system configuration', () => {
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
-    awsTile.click();
-    await clickNext();
+    await act(async () => {
+      awsTile.click();
+    });
+    await act(async () => {
+      await clickNext();
+    });
 
     // aws step
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
     // skip registration
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -630,7 +740,9 @@ describe('Step File system configuration', () => {
 
     const registerLaterRadio = screen.getByTestId('registration-radio-later');
     await user.click(registerLaterRadio);
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
   };
 
   test('Error validation occurs upon clicking next button', async () => {
@@ -683,29 +795,37 @@ describe('Step Packages', () => {
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
-    awsTile.click();
-    await clickNext();
+    await act(async () => {
+      awsTile.click();
+      await clickNext();
+    });
 
     // aws step
-    await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    await clickNext();
+    const aai = screen.getByTestId('aws-account-id');
+    await act(async () => {
+      await user.type(aai, '012345678901');
+      await clickNext();
+    });
     // skip registration
     await screen.findByRole('textbox', {
       name: 'Select activation key',
     });
 
     const registerLaterRadio = screen.getByTestId('registration-radio-later');
-    await user.click(registerLaterRadio);
-    await clickNext();
-
-    // skip fsc
-    await clickNext();
+    await act(async () => {
+      await user.click(registerLaterRadio);
+      await clickNext();
+      // skip fsc
+      await clickNext();
+    });
   };
 
   test('clicking Next loads Image name', async () => {
     await setUp();
 
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     screen.getByRole('heading', {
       name: 'Details',
@@ -715,7 +835,9 @@ describe('Step Packages', () => {
   test('clicking Back loads file system configuration', async () => {
     await setUp();
 
-    await clickBack();
+    await act(async () => {
+      await clickBack();
+    });
 
     screen.getByRole('heading', { name: /file system configuration/i });
   });
@@ -729,7 +851,10 @@ describe('Step Packages', () => {
   test('should display search bar and button', async () => {
     await setUp();
 
-    await user.type(screen.getByTestId('search-available-pkgs-input'), 'test');
+    const sapi = screen.getByTestId('search-available-pkgs-input');
+    await act(async () => {
+      await user.type(sapi, 'test');
+    });
 
     screen.getByRole('button', {
       name: 'Search button for available packages',
@@ -749,7 +874,9 @@ describe('Step Packages', () => {
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
     await waitFor(() => expect(searchbox).toBeEnabled());
-    searchbox.click();
+    await act(async () => {
+      searchbox.click();
+    });
 
     await searchForAvailablePackages(searchbox, 'test');
 
@@ -770,15 +897,29 @@ describe('Step Packages', () => {
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
     await waitFor(() => expect(searchbox).toBeEnabled());
-    searchbox.click();
+    await act(async () => {
+      searchbox.click();
+    });
 
     await searchForAvailablePackages(searchbox, 'test');
 
-    screen.getByTestId('available-pkgs-testPkg').click();
-    screen.getByRole('button', { name: /Add selected/ }).click();
+    const apt = screen.getByTestId('available-pkgs-testPkg');
+    await act(async () => {
+      apt.click();
+    });
+    const bas = screen.getByRole('button', { name: /Add selected/ });
+    await act(async () => {
+      bas.click();
+    });
 
-    screen.getByTestId('selected-pkgs-testPkg').click();
-    screen.getByRole('button', { name: /Remove selected/ }).click();
+    const spt = screen.getByTestId('selected-pkgs-testPkg');
+    await act(async () => {
+      spt.click();
+    });
+    const brs = screen.getByRole('button', { name: /Remove selected/ });
+    await act(async () => {
+      brs.click();
+    });
 
     const availablePackagesList = screen.getByTestId('available-pkgs-list');
     const availablePackagesItems = within(availablePackagesList).getAllByRole(
@@ -797,12 +938,20 @@ describe('Step Packages', () => {
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
     await waitFor(() => expect(searchbox).toBeEnabled());
-    searchbox.click();
+    await act(async () => {
+      searchbox.click();
+    });
 
     await searchForAvailablePackages(searchbox, 'test');
 
-    screen.getByRole('button', { name: /Add all/ }).click();
-    screen.getByRole('button', { name: /Remove all/ }).click();
+    const baa = screen.getByRole('button', { name: /Add all/ });
+    await act(async () => {
+      baa.click();
+    });
+    const bra = screen.getByRole('button', { name: /Remove all/ });
+    await act(async () => {
+      bra.click();
+    });
 
     const availablePackagesList = screen.getByTestId('available-pkgs-list');
     const availablePackagesItems = within(availablePackagesList).getAllByRole(
@@ -821,35 +970,70 @@ describe('Step Packages', () => {
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
     await waitFor(() => expect(searchbox).toBeEnabled());
-    searchbox.click();
+    await act(async () => {
+      searchbox.click();
+    });
 
     await searchForAvailablePackages(searchbox, 'test');
-    screen.getByRole('button', { name: /Add all/ }).click();
+    const baa = screen.getByRole('button', { name: /Add all/ });
+    await act(async () => {
+      baa.click();
+    });
 
     // remove a single package
-    screen.getByTestId('selected-pkgs-lib-test').click();
-    screen.getByRole('button', { name: /Remove selected/ }).click();
+    const splt = screen.getByTestId('selected-pkgs-lib-test');
+    await act(async () => {
+      splt.click();
+    });
+    const brs = screen.getByRole('button', { name: /Remove selected/ });
+    await act(async () => {
+      brs.click();
+    });
 
     // skip name page
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn1.click();
+    });
 
     // review page
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn2 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn2.click();
+    });
 
     // await screen.findByTestId('chosen-packages-count');
     let chosen = await screen.findByTestId('chosen-packages-count');
     expect(chosen).toHaveTextContent('2');
 
     // remove another package
-    screen.getByRole('button', { name: /Back/ }).click();
-    screen.getByRole('button', { name: /Back/ }).click();
+    const bb1 = screen.getByRole('button', { name: /Back/ });
+    await act(async () => {
+      bb1.click();
+    });
+    const bb2 = screen.getByRole('button', { name: /Back/ });
+    await act(async () => {
+      bb2.click();
+    });
     await screen.findByTestId('search-available-pkgs-input');
-    screen.getByRole('option', { name: /summary for test package/ }).click();
-    screen.getByRole('button', { name: /Remove selected/ }).click();
+    const op = screen.getByRole('option', { name: /summary for test package/ });
+    await act(async () => {
+      op.click();
+    });
+    const brs2 = screen.getByRole('button', { name: /Remove selected/ });
+    await act(async () => {
+      brs2.click();
+    });
 
     // review page
-    screen.getByRole('button', { name: /Next/ }).click();
-    screen.getByRole('button', { name: /Next/ }).click();
+    const n1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n1.click();
+    });
+    const n2 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      n2.click();
+    });
 
     // await screen.findByTestId('chosen-packages-count');
     chosen = await screen.findByTestId('chosen-packages-count');
@@ -862,7 +1046,9 @@ describe('Step Packages', () => {
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
     await waitFor(() => expect(searchbox).toBeEnabled());
-    searchbox.click();
+    await act(async () => {
+      searchbox.click();
+    });
 
     await searchForAvailablePackages(searchbox, 'asdf');
     screen.getByText('No results found');
@@ -874,7 +1060,9 @@ describe('Step Packages', () => {
     const searchbox = screen.getAllByRole('textbox')[0]; // searching by id doesn't update the input ref
 
     await waitFor(() => expect(searchbox).toBeEnabled());
-    searchbox.click();
+    await act(async () => {
+      searchbox.click();
+    });
 
     await searchForAvailablePackages(searchbox, 'test');
 
@@ -1055,12 +1243,16 @@ describe('Step Details', () => {
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
-    awsTile.click();
-    await clickNext();
+    await act(async () => {
+      awsTile.click();
+      await clickNext();
+    });
 
     // aws step
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
     // skip registration
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -1068,12 +1260,14 @@ describe('Step Details', () => {
 
     const registerLaterRadio = screen.getByTestId('registration-radio-later');
     await user.click(registerLaterRadio);
-    await clickNext();
+    await act(async () => {
+      await clickNext();
 
-    // skip fsc
-    await clickNext();
-    // skip packages
-    await clickNext();
+      // skip fsc
+      await clickNext();
+      // skip packages
+      await clickNext();
+    });
   };
 
   test('image name invalid for more than 63 chars', async () => {
@@ -1085,7 +1279,9 @@ describe('Step Details', () => {
     });
     // 101 character name
     const invalidName = 'a'.repeat(64);
-    await user.type(nameInput, invalidName);
+    await act(async () => {
+      await user.type(nameInput, invalidName);
+    });
     expect(await getNextButton()).toHaveClass('pf-m-disabled');
     expect(await getNextButton()).toBeDisabled();
     await user.clear(nameInput);
@@ -1119,12 +1315,16 @@ describe('Step Review', () => {
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
-    awsTile.click();
-    await clickNext();
+    await act(async () => {
+      awsTile.click();
+      await clickNext();
+    });
 
     // aws step
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -1133,15 +1333,16 @@ describe('Step Review', () => {
     // skip registration
     const registerLaterRadio = screen.getByTestId('registration-radio-later');
     await user.click(registerLaterRadio);
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+      // skip fsc
+      await clickNext();
 
-    // skip fsc
-    await clickNext();
-
-    // skip packages
-    await clickNext();
-    // skip name
-    await clickNext();
+      // skip packages
+      await clickNext();
+      // skip name
+      await clickNext();
+    });
   };
 
   // eslint-disable-next-line no-unused-vars
@@ -1165,20 +1366,24 @@ describe('Step Review', () => {
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
-    awsTile.click();
-    await clickNext();
+    await act(async () => {
+      awsTile.click();
+      await clickNext();
+    });
 
     // aws step
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    await clickNext();
+    await act(async () => {
+      await clickNext();
 
-    // skip fsc
-    await clickNext();
+      // skip fsc
+      await clickNext();
 
-    // skip packages
-    await clickNext();
-    // skip name
-    await clickNext();
+      // skip packages
+      await clickNext();
+      // skip name
+      await clickNext();
+    });
   };
 
   test('has 3 buttons', async () => {
@@ -1278,12 +1483,21 @@ describe('Click through all steps', () => {
     await user.click(screen.getByTestId('checkbox-guest-image'));
     await user.click(screen.getByTestId('checkbox-image-installer'));
 
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn.click();
+    });
     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn1 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn1.click();
+    });
 
     await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn2 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn2.click();
+    });
 
     // Randomly generated GUID
     await user.type(
@@ -1298,7 +1512,10 @@ describe('Click through all steps', () => {
       screen.getByTestId('azure-resource-group'),
       'testResourceGroup'
     );
-    screen.getByRole('button', { name: /Next/ }).click();
+    const bn3 = screen.getByRole('button', { name: /Next/ });
+    await act(async () => {
+      bn3.click();
+    });
 
     // registration
     const registrationRadio = screen.getByTestId('registration-radio-now');
@@ -1314,7 +1531,9 @@ describe('Click through all steps', () => {
     await user.click(activationKey);
     screen.getByDisplayValue('name0');
 
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     // fsc
     screen.getByRole('heading', {
@@ -1327,7 +1546,9 @@ describe('Click through all steps', () => {
     const tbody = screen.getByTestId('file-system-configuration-tbody');
     const rows = within(tbody).getAllByRole('row');
     expect(rows).toHaveLength(3);
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
     // set mountpoint of final row to /var/tmp
     within(rows[2]).getAllByRole('button', { name: 'Options menu' })[0].click();
     within(rows[2]).getByRole('option', { name: '/var' }).click();
@@ -1350,7 +1571,9 @@ describe('Click through all steps', () => {
     );
     within(rows[2]).getAllByRole('button', { name: 'Options menu' })[1].click();
     within(rows[2]).getByRole('option', { name: 'MiB' }).click();
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     screen.getByText(
       /Images built with Image Builder include all required packages/i
@@ -1365,7 +1588,9 @@ describe('Click through all steps', () => {
       .getByRole('option', { name: /test summary for test package/ })
       .click();
     screen.getByRole('button', { name: /Add selected/ }).click();
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     // Enter image name
     const nameInput = screen.getByRole('textbox', {
@@ -1383,7 +1608,9 @@ describe('Click through all steps', () => {
       descriptionInput,
       'this is a perfect description for image'
     );
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     // review
     const targetEnvironmentsExpandable = await screen.findByTestId(
@@ -1699,10 +1926,12 @@ describe('Click through all steps', () => {
       });
 
     const create = screen.getByRole('button', { name: /Create/ });
-    create.click();
+    await act(async () => {
+      create.click();
+    });
 
     // API request sent to backend
-    await expect(composeImage).toHaveBeenCalledTimes(6);
+    expect(composeImage).toHaveBeenCalledTimes(6);
 
     // returns back to the landing page
     await waitFor(() =>
@@ -1733,7 +1962,36 @@ describe('Keyboard accessibility', () => {
     virtualizationCheckbox.click();
   };
 
-  const fillAzureInputs = async () => {
+  test('autofocus on each step first input element', async () => {
+    await setUp();
+
+    // Image output
+    selectAllEnvironments();
+    await act(async () => {
+      await clickNext();
+    });
+
+    // Target environment aws
+    const awsInput = screen.getByRole('textbox', { name: /aws account id/i });
+    expect(awsInput).toHaveFocus();
+    await user.type(awsInput, '012345678901');
+    await act(async () => {
+      await clickNext();
+    });
+
+    // Target environment google
+    const googleAccountRadio = screen.getByRole('radio', {
+      name: /google account/i,
+    });
+    expect(googleAccountRadio).toHaveFocus();
+    await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
+    await act(async () => {
+      await clickNext();
+    });
+
+    // Target environment azure
+    const tenantIDInput = screen.getByTestId('azure-tenant-id');
+    expect(tenantIDInput).toHaveFocus();
     await user.type(
       screen.getByTestId('azure-tenant-id'),
       'b8f86d22-4371-46ce-95e7-65c415f3b1e2'
@@ -1746,34 +2004,9 @@ describe('Keyboard accessibility', () => {
       screen.getByTestId('azure-resource-group'),
       'testResourceGroup'
     );
-  };
-
-  test('autofocus on each step first input element', async () => {
-    await setUp();
-
-    // Image output
-    selectAllEnvironments();
-    await clickNext();
-
-    // Target environment aws
-    const awsInput = screen.getByRole('textbox', { name: /aws account id/i });
-    expect(awsInput).toHaveFocus();
-    await user.type(awsInput, '012345678901');
-    await clickNext();
-
-    // Target environment google
-    const googleAccountRadio = screen.getByRole('radio', {
-      name: /google account/i,
+    await act(async () => {
+      await clickNext();
     });
-    expect(googleAccountRadio).toHaveFocus();
-    await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
-    await clickNext();
-
-    // Target environment azure
-    const tenantIDInput = screen.getByTestId('azure-tenant-id');
-    expect(tenantIDInput).toHaveFocus();
-    await fillAzureInputs();
-    await clickNext();
 
     // Registration
     await screen.findByText(
@@ -1788,10 +2021,14 @@ describe('Keyboard accessibility', () => {
     const registerLaterRadio = screen.getByTestId('registration-radio-later');
     await user.click(registerLaterRadio);
 
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     // File system configuration
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
 
     // Packages
     let availablePackagesInput;
@@ -1810,7 +2047,9 @@ describe('Keyboard accessibility', () => {
     // Name
     const nameInput = screen.getByRole('textbox', { name: /image name/i });
     expect(nameInput).toHaveFocus();
-    await clickNext();
+    await act(async () => {
+      await clickNext();
+    });
   });
 
   test('pressing Esc closes the wizard', async () => {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import '@testing-library/jest-dom';
 
 import {
@@ -10,6 +12,8 @@ import {
 import userEvent from '@testing-library/user-event';
 
 import api from '../../../api.js';
+import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
+import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
 import { RHEL_8 } from '../../../constants.js';
 import { mockComposesEmpty } from '../../fixtures/composes';
 import {
@@ -21,9 +25,24 @@ import {
   clickBack,
   clickNext,
   getNextButton,
-  renderWithReduxRouter,
+  renderCustomRoutesWithReduxRouter,
   verifyCancelButton,
 } from '../../testUtils';
+
+const routes = [
+  {
+    path: 'insights/image-builder/*',
+    element: <div />,
+  },
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+  {
+    path: 'insights/image-builder/share/:composeId',
+    element: <ShareImageModal />,
+  },
+];
 
 let store = undefined;
 let router = undefined;
@@ -86,7 +105,7 @@ afterEach(() => {
 
 describe('Create Image Wizard', () => {
   test('renders component', () => {
-    renderWithReduxRouter('imagewizard', {});
+    renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
     // check heading
     screen.getByRole('heading', { name: /Create image/ });
 
@@ -103,7 +122,7 @@ describe('Create Image Wizard', () => {
 describe('Step Image output', () => {
   const user = userEvent.setup();
   const setUp = () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     const imageOutputLink = screen.getByRole('button', {
       name: 'Image output',
@@ -238,7 +257,7 @@ describe('Step Image output', () => {
 describe('Step Upload to AWS', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
@@ -298,7 +317,7 @@ describe('Step Upload to AWS', () => {
 describe('Step Upload to Google', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-google');
@@ -314,10 +333,7 @@ describe('Step Upload to Google', () => {
   test('clicking Next loads Registration', async () => {
     await setUp();
 
-    await user.type(
-        screen.getByTestId('input-google-email'),
-        'test@test.com'
-      );
+    await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
     await act(async () => {
       await clickNext();
     });
@@ -367,7 +383,7 @@ describe('Step Upload to Google', () => {
 describe('Step Upload to Azure', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-azure');
@@ -444,7 +460,7 @@ describe('Step Upload to Azure', () => {
 describe('Step Registration', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
@@ -717,7 +733,7 @@ describe('Step Registration', () => {
 describe('Step File system configuration', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
@@ -791,7 +807,7 @@ describe('Step File system configuration', () => {
 describe('Step Packages', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
@@ -1239,7 +1255,7 @@ describe('Step Packages', () => {
 describe('Step Details', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
@@ -1311,7 +1327,7 @@ describe('Step Details', () => {
 describe('Step Review', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     // select aws as upload destination
     const awsTile = screen.getByTestId('upload-aws');
@@ -1347,7 +1363,7 @@ describe('Step Review', () => {
 
   // eslint-disable-next-line no-unused-vars
   const setUpCentOS = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
     const releaseMenu = screen.getByRole('button', {
       name: /options menu/i,
@@ -1460,7 +1476,11 @@ describe('Step Review', () => {
 describe('Click through all steps', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router, store } = renderWithReduxRouter('imagewizard', {}));
+    ({ router, store } = renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
   };
 
   test('with valid values', async () => {
@@ -1945,7 +1965,7 @@ describe('Click through all steps', () => {
 describe('Keyboard accessibility', () => {
   const user = userEvent.setup();
   const setUp = async () => {
-    ({ router } = renderWithReduxRouter('imagewizard', {}));
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
     await clickNext();
   };
 

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.js
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.js
@@ -1,10 +1,13 @@
+import React from 'react';
+
 import '@testing-library/jest-dom';
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import api from '../../../api.js';
+import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
 import { mockState } from '../../fixtures/composes';
-import { renderWithReduxRouter } from '../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: () => ({
@@ -16,10 +19,25 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 const composeId = '1579d95b-8f1d-4982-8c53-8c2afa4ab04c';
 
+const routes = [
+  {
+    path: 'insights/image-builder/*',
+    element: <div />,
+  },
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <div />,
+  },
+  {
+    path: 'insights/image-builder/share/:composeId',
+    element: <ShareImageModal />,
+  },
+];
+
 describe('Create Share To Regions Modal', () => {
   const user = userEvent.setup();
   test('validation', async () => {
-    renderWithReduxRouter(`share/${composeId}`, mockState);
+    renderCustomRoutesWithReduxRouter(`share/${composeId}`, mockState, routes);
 
     const shareButton = screen.getByRole('button', { name: /share/i });
     expect(shareButton).toBeDisabled();
@@ -51,7 +69,11 @@ describe('Create Share To Regions Modal', () => {
   });
 
   test('cancel button redirects to landing page', async () => {
-    const { router } = renderWithReduxRouter(`share/${composeId}`, mockState);
+    const { router } = renderCustomRoutesWithReduxRouter(
+      `share/${composeId}`,
+      mockState,
+      routes
+    );
 
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
     cancelButton.click();
@@ -63,7 +85,11 @@ describe('Create Share To Regions Modal', () => {
   });
 
   test('close button redirects to landing page', async () => {
-    const { router } = renderWithReduxRouter(`share/${composeId}`, mockState);
+    const { router } = renderCustomRoutesWithReduxRouter(
+      `share/${composeId}`,
+      mockState,
+      routes
+    );
 
     const closeButton = screen.getByRole('button', { name: /close/i });
     closeButton.click();
@@ -75,7 +101,7 @@ describe('Create Share To Regions Modal', () => {
   });
 
   test('select options disabled correctly based on status and region', async () => {
-    renderWithReduxRouter(`share/${composeId}`, mockState);
+    renderCustomRoutesWithReduxRouter(`share/${composeId}`, mockState, routes);
 
     const selectToggle = screen.getByRole('button', { name: /options menu/i });
     // eslint-disable-next-line testing-library/no-unnecessary-act
@@ -111,9 +137,10 @@ describe('Create Share To Regions Modal', () => {
   });
 
   test('cloning an image results in successful store updates', async () => {
-    const { router, store } = renderWithReduxRouter(
+    const { router, store } = renderCustomRoutesWithReduxRouter(
       `share/${composeId}`,
-      mockState
+      mockState,
+      routes
     );
 
     const selectToggle = screen.getByRole('button', { name: /options menu/i });

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.js
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.js
@@ -144,13 +144,13 @@ describe('Create Share To Regions Modal', () => {
     );
 
     const selectToggle = screen.getByRole('button', { name: /options menu/i });
-    await user.click(selectToggle);
+    await act(async () => user.click(selectToggle));
 
     const usEast2 = screen.getByRole('option', {
       name: /us-east-2 us east \(ohio\)/i,
     });
     expect(usEast2).not.toHaveClass('pf-m-disabled');
-    await user.click(usEast2);
+    await act(async () => user.click(usEast2));
 
     const mockResponse = {
       id: '123e4567-e89b-12d3-a456-426655440000',

--- a/src/test/testUtils.js
+++ b/src/test/testUtils.js
@@ -12,6 +12,26 @@ import ShareImageModal from '../Components/ShareImageModal/ShareImageModal';
 import { middleware, reducer } from '../store';
 import { resolveRelPath } from '../Utilities/path';
 
+export const renderCustomRoutesWithReduxRouter = (
+  route = '/',
+  preloadedState = {},
+  routes
+) => {
+  const store = configureStore({ reducer, middleware, preloadedState });
+
+  const router = createMemoryRouter(routes, {
+    initialEntries: [resolveRelPath(route)],
+  });
+
+  render(
+    <Provider store={store}>
+      <RouterProvider router={router} />
+    </Provider>
+  );
+
+  return { router, store };
+};
+
 export const renderWithReduxRouter = (route = '/', preloadedState = {}) => {
   const store = configureStore({ reducer, middleware, preloadedState });
 


### PR DESCRIPTION
This pull request aims at addressing the current issue regarding the errors thrown while executing the tests.
For now it fixes issues related with:
* scalprum
* act
* null access
* (and also one no-op)

For the errors that were not fixed in this PR, they are converted into warnings, and we will have to take care of them in the future. The conversion is made with a new lib https://github.com/ValentinH/jest-fail-on-console that @regexowl found out.
The lib also makes the tests actually fail if other errors are presents, so hopefully we can't add new ones.
