### PR TITLE
Migrate activation keys to TypeScript

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ActivationKeyInformation.tsx
+++ b/src/Components/CreateImageWizard/formComponents/ActivationKeyInformation.tsx
@@ -26,7 +26,7 @@ import {
 
 import { useShowActivationKeyQuery } from '../../../store/rhsmApi';
 
-const ActivationKeyInformation = () => {
+const ActivationKeyInformation = (): JSX.Element => {
   const { getState } = useFormApi();
   const { currentStep } = useContext(WizardContext);
 
@@ -101,7 +101,8 @@ const ActivationKeyInformation = () => {
               component={TextListItemVariants.dd}
               className="pf-u-display-flex pf-u-align-items-flex-end"
             >
-              {activationKeyInfo.body?.additionalRepositories?.length > 0 ? (
+              {activationKeyInfo.body?.additionalRepositories &&
+              activationKeyInfo.body?.additionalRepositories?.length > 0 ? (
                 <Popover
                   bodyContent={
                     <TextContent>

--- a/src/test/fixtures/activationKeys.ts
+++ b/src/test/fixtures/activationKeys.ts
@@ -1,21 +1,28 @@
-export const mockActivationKeysResults = () => {
+import {
+  ListActivationKeysApiResponse,
+  ShowActivationKeyApiResponse,
+} from '../../store/rhsmApi';
+
+export const mockActivationKeysResults = (): ListActivationKeysApiResponse => {
   return {
     body: [
       {
-        id: 0,
+        id: '0',
         name: 'name0',
       },
       {
-        id: 1,
+        id: '1',
         name: 'name1',
       },
     ],
   };
 };
 
-export const mockActivationKeyInformation = (key) => {
-  if (key === 'name0') {
-    return {
+export const mockActivationKeyInformation = (
+  key: string
+): ShowActivationKeyApiResponse => {
+  const mockKeys: { [key: string]: ShowActivationKeyApiResponse } = {
+    name0: {
       body: {
         additionalRepositories: [
           {
@@ -35,9 +42,8 @@ export const mockActivationKeyInformation = (key) => {
         serviceLevel: 'Self-Support',
         usage: 'Production',
       },
-    };
-  } else if (key === 'name1') {
-    return {
+    },
+    name1: {
       body: {
         additionalRepositories: [
           {
@@ -57,6 +63,7 @@ export const mockActivationKeyInformation = (key) => {
         serviceLevel: 'Premium',
         usage: 'Production',
       },
-    };
-  }
+    },
+  };
+  return mockKeys[key];
 };


### PR DESCRIPTION
This migrates the `ActivationKeyInformation` component to TypeScript together with the `activationKeys` fixture.