### PR TITLE
Prepare for Provisioning list endpoint nesting

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/AWSSourcesSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/AWSSourcesSelect.js
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
+import { extractProvisioningList } from '../../../store/helpers';
 import {
   useGetSourceListQuery,
   useGetSourceUploadInfoQuery,
@@ -32,12 +33,13 @@ export const AWSSourcesSelect = ({
   );
 
   const {
-    data: sources,
+    data: rawSources,
     isFetching,
     isSuccess,
     isError,
     refetch,
   } = useGetSourceListQuery({ provider: 'aws' });
+  const sources = extractProvisioningList(rawSources);
 
   const {
     data: sourceDetails,

--- a/src/Components/CreateImageWizard/formComponents/AzureSourcesSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/AzureSourcesSelect.js
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
+import { extractProvisioningList } from '../../../store/helpers';
 import {
   useGetSourceListQuery,
   useGetSourceUploadInfoQuery,
@@ -25,12 +26,13 @@ const AzureSourcesSelect = ({ label, isRequired, className, ...props }) => {
   const selectedSourceId = input.value;
 
   const {
-    data: sources,
+    data: rawSources,
     isFetching,
     isSuccess,
     isError,
     refetch,
   } = useGetSourceListQuery({ provider: 'azure' });
+  const sources = extractProvisioningList(rawSources);
 
   const {
     data: sourceDetails,

--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -26,6 +26,7 @@ import {
 } from './ReviewStepTables';
 
 import { RELEASES, UNIT_GIB } from '../../../constants';
+import { extractProvisioningList } from '../../../store/helpers';
 import { useGetSourceListQuery } from '../../../store/provisioningApi';
 import { useShowActivationKeyQuery } from '../../../store/rhsmApi';
 import { useGetEnvironment } from '../../../Utilities/useGetEnvironment';
@@ -64,9 +65,10 @@ export const ImageOutputList = () => {
 };
 
 export const TargetEnvAWSList = () => {
-  const { data: awsSources, isSuccess } = useGetSourceListQuery({
+  const { data: rawAWSSources, isSuccess } = useGetSourceListQuery({
     provider: 'aws',
   });
+  const awsSources = extractProvisioningList(rawAWSSources);
   const { isBeta } = useGetEnvironment();
 
   const { getState } = useFormApi();
@@ -170,8 +172,9 @@ export const TargetEnvGCPList = () => {
 
 export const TargetEnvAzureList = () => {
   const { getState } = useFormApi();
-  const { data: azureSources, isSuccess: isSuccessAzureSources } =
+  const { data: rawAzureSources, isSuccess: isSuccessAzureSources } =
     useGetSourceListQuery({ provider: 'azure' });
+  const azureSources = extractProvisioningList(rawAzureSources);
   return (
     <TextContent>
       <Text component={TextVariants.h3}>Microsoft Azure</Text>

--- a/src/Components/ImagesTable/ImageDetails.js
+++ b/src/Components/ImagesTable/ImageDetails.js
@@ -17,6 +17,7 @@ import { useSelector } from 'react-redux';
 
 import ClonesTable from './ClonesTable';
 
+import { extractProvisioningList } from '../../store/helpers';
 import { useGetSourceListQuery } from '../../store/provisioningApi';
 
 const sourceNotFoundPopover = () => {
@@ -59,9 +60,10 @@ const sourceNotFoundPopover = () => {
 };
 
 const getAzureSourceName = (id) => {
-  const { data: sources, isSuccess } = useGetSourceListQuery({
+  const { data: rawSources, isSuccess } = useGetSourceListQuery({
     provider: 'azure',
   });
+  const sources = extractProvisioningList(rawSources);
 
   if (isSuccess) {
     const sourcename = sources.find((source) => source.id === id);
@@ -76,9 +78,10 @@ const getAzureSourceName = (id) => {
 };
 
 const getAWSSourceName = (id) => {
-  const { data: sources, isSuccess } = useGetSourceListQuery({
+  const { data: rawSources, isSuccess } = useGetSourceListQuery({
     provider: 'aws',
   });
+  const sources = extractProvisioningList(rawSources);
 
   if (isSuccess) {
     const sourcename = sources.find((source) => source.id === id);

--- a/src/store/helpers.ts
+++ b/src/store/helpers.ts
@@ -1,0 +1,5 @@
+import type { V1SourceResponse } from './provisioningApi';
+
+export const extractProvisioningList = (
+  list: V1SourceResponse[] | { data: V1SourceResponse[] }
+) => (Array.isArray(list) ? list : list?.data);


### PR DESCRIPTION
This is first of all heads up what we are planning, second of all atempt to get ready for sources list response to be in format
```
{
  data: [ <source1>, <source2> ]
}
```
instead of
```
[<source1>, <source2>]
```

Follow-up with updated API spec after Prov change (https://github.com/RHEnVision/provisioning-backend/pull/638) is merged: https://github.com/RedHatInsights/image-builder-frontend/pull/1306
