### PR TITLE
feat(HMS-1909): enable a custom host in LOCAL_API env var

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -24,12 +24,13 @@ const webpackProxy = {
     ...(process.env.LOCAL_API && {
       ...(process.env.LOCAL_API.split(',') || []).reduce((acc, curr) => {
         const [appName, appConfig] = (curr || '').split(':');
-        const [appPort = 8003, protocol = 'http'] = appConfig.split('~');
+        const [appPort = 8003, protocol = 'http', host = 'localhost'] =
+          appConfig.split('~');
         return {
           ...acc,
-          [`/apps/${appName}`]: { host: `${protocol}://localhost:${appPort}` },
+          [`/apps/${appName}`]: { host: `${protocol}://${host}:${appPort}` },
           [`/beta/apps/${appName}`]: {
-            host: `${protocol}://localhost:${appPort}`,
+            host: `${protocol}://${host}:${appPort}`,
           },
         };
       }, {}),


### PR DESCRIPTION
This PR adds the ability to customize the host (default to localhost to prevent any regression)  in the `LOCAL_API` env var.
This change  will allow us to run containerized  image-builder-frontend and provisioning (in federated mode) apps locally, as we do  in https://github.com/RHEnVision/provisioning-compose/pull/9