### PR TITLE
HMS-2322: Wizard: Update registration step activation key link URL

### DIFF
--- a/src/Components/CreateImageWizard/steps/registration.js
+++ b/src/Components/CreateImageWizard/steps/registration.js
@@ -119,7 +119,7 @@ export default {
           icon={<ExternalLinkAltIcon />}
           iconPosition="right"
           isInline
-          href="https://access.redhat.com/management/activation_keys"
+          href="https://console.redhat.com/insights/connector/activation-keys"
         >
           Create and manage activation keys here
         </Button>


### PR DESCRIPTION
Fixes HMS-2322: On the Register step of the image build wizard, the link to "Create and manage activation keys here" should point to https://console.redhat.com/insights/connector/activation-keys.