### PR TITLE
router: lazy loading requires a suspense tag

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -1,4 +1,4 @@
-import React, { lazy } from 'react';
+import React, { lazy, Suspense } from 'react';
 
 import { useFlag } from '@unleash/proxy-client-react';
 import { Route, Routes } from 'react-router-dom';
@@ -16,8 +16,22 @@ export const Router = () => {
   const edgeParityFlag = useFlag('edgeParity.image-list');
   return (
     <Routes>
-      <Route path="*" element={<LandingPage />}>
-        <Route path="imagewizard/:composeId?" element={<CreateImageWizard />} />
+      <Route
+        path="*"
+        element={
+          <Suspense>
+            <LandingPage />
+          </Suspense>
+        }
+      >
+        <Route
+          path="imagewizard/:composeId?"
+          element={
+            <Suspense>
+              <CreateImageWizard />
+            </Suspense>
+          }
+        />
         <Route path="share/:composeId" element={<ShareImageModal />} />
       </Route>
 


### PR DESCRIPTION
According to the React documentation[0], a suspense tag is needed to
encapsulate a lazy loaded component. Some bad behavior have been fix in
the UI thanks to that tag (i.e notification popup unclosable after
wizard creation).

[0] https://react.dev/reference/react/lazy#suspense-for-code-splitting

The notification bug began in 1b01cfba. 