### PR TITLE
HMS-1492: Change rhc to non-capitalized

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Registration.js
+++ b/src/Components/CreateImageWizard/formComponents/Registration.js
@@ -44,7 +44,7 @@ const RHSMPopover = () => {
       <Button
         variant="plain"
         className="pf-c-form__group-label-help"
-        aria-label="About Remote Host Configuration (RHC)"
+        aria-label="About remote host configuration (rhc)"
         isInline
       >
         <HelpIcon />
@@ -84,7 +84,7 @@ const InsightsPopover = () => {
       <Button
         variant="plain"
         className="pf-c-form__group-label-help"
-        aria-label="About Remote Host Configuration (RHC)"
+        aria-label="About remote host configuration (rhc)"
         isInline
       >
         <HelpIcon />
@@ -93,18 +93,18 @@ const InsightsPopover = () => {
   );
 };
 
-const RHCPopover = () => {
+const RhcPopover = () => {
   return (
     <Popover
-      headerContent="About Remote Host Configuration (RHC)"
+      headerContent="About remote host configuration (rhc)"
       position="right"
       minWidth="30rem"
       bodyContent={
         <TextContent>
           <Text>
-            RHC allows Red Hat Enterprise Linux hosts to connect to Red Hat
-            Insights. RHC is required to use the Red Hat Insights Remediations
-            service.
+            Remote host configuration allows Red Hat Enterprise Linux hosts to
+            connect to Red Hat Insights. Remote host configuration is required
+            to use the Red Hat Insights Remediations service.
           </Text>
           <Button
             component="a"
@@ -115,7 +115,7 @@ const RHCPopover = () => {
             isInline
             href="https://access.redhat.com/articles/rhc"
           >
-            Learn more about Remote Host Configuration
+            Learn more about remote host configuration
           </Button>
         </TextContent>
       }
@@ -123,7 +123,7 @@ const RHCPopover = () => {
       <Button
         variant="plain"
         className="pf-c-form__group-label-help"
-        aria-label="About Remote Host Configuration (RHC)"
+        aria-label="About remote host configuration (rhc)"
         isInline
       >
         <HelpIcon />
@@ -207,7 +207,7 @@ const Registration = ({ label, ...props }) => {
                         <>
                           Enable remote remediations and system management with
                           automation
-                          <RHCPopover />
+                          <RhcPopover />
                         </>
                       }
                       data-testid="registration-checkbox-rhc"

--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -489,7 +489,7 @@ export const RegisterNowList = () => {
               {getState()?.values?.['register-system'] ===
                 'register-now-rhc' && (
                 <TextListItem>
-                  Use remote host configuration (RHC) utility
+                  Use remote host configuration (rhc) utility
                   <br />
                 </TextListItem>
               )}

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -621,7 +621,7 @@ describe('Step Registration', () => {
     );
     expect(review).toHaveTextContent('Connect to Red Hat Insights');
     expect(review).toHaveTextContent(
-      'Use remote host configuration (RHC) utility'
+      'Use remote host configuration (rhc) utility'
     );
     screen.getAllByText('012345678901');
   });
@@ -688,7 +688,7 @@ describe('Step Registration', () => {
     expect(review).toHaveTextContent('Connect to Red Hat Insights');
     screen.getAllByText('012345678901');
     expect(review).not.toHaveTextContent(
-      'Use remote host configuration (RHC) utility'
+      'Use remote host configuration (rhc) utility'
     );
   });
 
@@ -756,7 +756,7 @@ describe('Step Registration', () => {
     screen.getAllByText('012345678901');
     expect(review).not.toHaveTextContent('Connect to Red Hat Insights');
     expect(review).not.toHaveTextContent(
-      'Use remote host configuration (RHC) utility'
+      'Use remote host configuration (rhc) utility'
     );
   });
 
@@ -1320,7 +1320,7 @@ describe('Click through all steps', () => {
     });
     const review = screen.getByTestId('review-registration');
     expect(review).toHaveTextContent(
-      'Use remote host configuration (RHC) utility'
+      'Use remote host configuration (rhc) utility'
     );
 
     const imageDetailsExpandable = await screen.findByTestId(


### PR DESCRIPTION
Fixes HMS-1492

This changes all occurences of "rhc" and "remote host configuration" from capitalized to lowercase. In cases where the sentence started with "rhc" this was changed to "remote host configuration" to avoid starting the sentence with "Rhc".