### PR TITLE
add contentRepoLinkProp to edge AsyncComponent

### DIFF
--- a/src/Components/edge/ImagesTable.js
+++ b/src/Components/edge/ImagesTable.js
@@ -25,6 +25,7 @@ const ImagesTable = () => {
       ErrorComponent={<ErrorState />}
       navigateProp={useNavigate}
       locationProp={useLocation}
+      contentRepoLinkProp={false}
       showHeaderProp={false}
       docLinkProp={
         'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/creating_customized_images_by_using_insights_image_builder/index'


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/THEEDGE-3533 this commit add contentRepoLinkProp that give us the ability to define if we are working on Edge enviornemt or image builder environemt to be able to open different link of custom repositories respetivally.