### PR TITLE
edge: setup an unleash toggle for the image table

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,39 @@ And voilà!
 To add a new endpoint, simply update the `api/config/foobar.ts` file with new
 endpoints in the `filterEndpoints` table.
 
+
+#### Unleash feature flags for the frontend
+
+Your user needs to have the corresponding rights, do the
+same as this MR in internal gitlab https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/79225
+you can ask on the slack channel https://redhat-internal.slack.com/archives/C023YSA47A4 for a merge if your MR stays unchecked for a little while.
+
+Then connect to the following platforms:
+* https://insights-stage.unleash.devshift.net/ for stage
+* https://insights.unleash.devshift.net prod
+
+Once you have a toggle to work with, on the frontend code there's just need to
+import the `useFlag` hook and to use it. You can get some inspiration from
+existing flags:
+
+https://github.com/RedHatInsights/image-builder-frontend/blob/c84b493eba82ce83a7844943943d91112ffe8322/src/Components/ImagesTable/ImageLink.js#L99
+
+##### Mocking flags for tests
+
+Flags can be mocked for the unit tests to access some feature. Checkout:
+https://github.com/RedHatInsights/image-builder-frontend/blob/c84b493eba82ce83a7844943943d91112ffe8322/src/test/Components/CreateImageWizard/CreateImageWizard.test.js#L74
+
+If the two possible code path accessible via the toggles are defined in the code
+base, then it's good practice to test the two of them. If not, only test what's
+actually owned by the frontend project.
+
+
+##### Cleaning the flags
+
+Unleash toggles are expected to live for a limited amount of time, documentation
+specify 40 days for a release, we should keep that in mind for each toggle
+we're planning on using.
+
 ### Backend Development
 
 To develop both the frontend and the backend you can again use the proxy to run both the

--- a/src/Components/edge/ImageDetails.js
+++ b/src/Components/edge/ImageDetails.js
@@ -16,9 +16,15 @@ import { resolveRelPath } from '../../Utilities/path';
 const ImageDetail = () => {
   const dispatch = useDispatch();
   const notificationProp = getNotificationProp(dispatch);
+  // Feature flag for the federated modules
   const edgeParityFlag = useFlag('edgeParity.image-list');
+  // Feature flag to access the 'local' images table list
+  const edgeLocalImageTable = useFlag('image-builder.edge.local-image-table');
 
-  return edgeParityFlag ? (
+  if (edgeLocalImageTable) {
+    return <div />;
+  }
+  if (edgeParityFlag) {
     <AsyncComponent
       appName="edge"
       module="./ImagesDetail"
@@ -29,10 +35,9 @@ const ImageDetail = () => {
       pathPrefix={resolveRelPath('')}
       urlName={manageEdgeImagesUrlName}
       paramsProp={useParams}
-    />
-  ) : (
-    <Unavailable />
-  );
+    />;
+  }
+  return <Unavailable />;
 };
 
 export default ImageDetail;

--- a/src/Components/edge/ImagesTable.js
+++ b/src/Components/edge/ImagesTable.js
@@ -16,26 +16,33 @@ import { resolveRelPath } from '../../Utilities/path';
 const ImagesTable = () => {
   const dispatch = useDispatch();
   const notificationProp = getNotificationProp(dispatch);
+  // Feature flag for the federated modules
   const edgeParityFlag = useFlag('edgeParity.image-list');
+  // Feature flag to access the 'local' images table list
+  const edgeLocalImageTable = useFlag('image-builder.edge.local-image-table');
 
-  return edgeParityFlag ? (
-    <AsyncComponent
-      appName="edge"
-      module="./Images"
-      ErrorComponent={<ErrorState />}
-      navigateProp={useNavigate}
-      locationProp={useLocation}
-      showHeaderProp={false}
-      docLinkProp={
-        'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/creating_customized_images_by_using_insights_image_builder/index'
-      }
-      notificationProp={notificationProp}
-      pathPrefix={resolveRelPath('')}
-      urlName={manageEdgeImagesUrlName}
-    />
-  ) : (
-    <Unavailable />
-  );
+  if (edgeLocalImageTable) {
+    return <div />;
+  }
+  if (edgeParityFlag) {
+    return (
+      <AsyncComponent
+        appName="edge"
+        module="./Images"
+        ErrorComponent={<ErrorState />}
+        navigateProp={useNavigate}
+        locationProp={useLocation}
+        showHeaderProp={false}
+        docLinkProp={
+          'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/creating_customized_images_by_using_insights_image_builder/index'
+        }
+        notificationProp={notificationProp}
+        pathPrefix={resolveRelPath('')}
+        urlName={manageEdgeImagesUrlName}
+      />
+    );
+  }
+  return <Unavailable />;
 };
 
 export default ImagesTable;

--- a/src/test/Components/edge/EdgeImagesTable.test.js
+++ b/src/test/Components/edge/EdgeImagesTable.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import { useFlag } from '@unleash/proxy-client-react';
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  useUnleashContext: () => jest.fn(),
+  useFlag: jest.fn((flag) =>
+    flag === 'image-builder.edge.local-image-table' ? true : false
+  ),
+}));
+
+describe('mocking unleash calls', () => {
+  test('the ege local image table is set to true', () => {
+    const edgeLocalImageTable = useFlag('image-builder.edge.local-image-table');
+    expect(edgeLocalImageTable).toBe(true);
+  });
+});

--- a/src/test/Components/edge/ImageDetails.test.js
+++ b/src/test/Components/edge/ImageDetails.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import { useFlag } from '@unleash/proxy-client-react';
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  useUnleashContext: () => jest.fn(),
+  useFlag: jest.fn((flag) =>
+    flag === 'image-builder.edge.local-image-table' ? true : false
+  ),
+}));
+
+describe('mocking unleash calls', () => {
+  test('the ege local image table is set to true', () => {
+    const edgeLocalImageTable = useFlag('image-builder.edge.local-image-table');
+    expect(edgeLocalImageTable).toBe(true);
+  });
+});


### PR DESCRIPTION
The edge images table is going to be integrated in the frontend code base in the coming weeks. To help smooth that development process there is need for a feature flag that would keep the current behavior running on stage and prod while the new image table is being developed.

For now dummy code is returned for when the flag is on, and legacy behavior keeps on going when the flag is off.

The stage flag can be seen there:
- https://insights-stage.unleash.devshift.net/projects/default/features/image-builder.edge.local-image-table

The prod flag can be seen there:
- https://insights.unleash.devshift.net/projects/default/features/image-builder.edge.local-image-table

The commit brings in some documentation in the Readme. Any member of the team should be able to follow these steps to add in new feature flags and use them in the code base.

The commit also brings in two new testing files for the future components to come. For now these tests only check that the mocking value for the unleash flag is properly set.