### PR TITLE
api: ci checks that the api is not changed by hand + doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ node_js:
   - '16'
 install:
   - npm ci
+before_script: |
+  npm run api && [ -z "$(git status --porcelain=v1 2>/dev/null)" ] && echo "✓ No manual API changes." || echo "✗ API manually changed, please refer to the README for the procedure to follow for programmatically generated API endpoints." && [ -z "$(git status --porcelain=v1 2>/dev/null)" ]
 script:
   - NODE_ENV=production npm run build
   - npm run lint

--- a/README.md
+++ b/README.md
@@ -81,6 +81,82 @@ The UI should be running on
 https://prod.foo.redhat.com:1337/beta/insights/image-builder/landing.
 Note that this requires you to have access to either production or stage (plus VPN and proxy config) of insights.
 
+#### API endpoints
+
+API endpoints are programmatically generated with the RTKQ library. This
+sections overview the steps to add new APIs and endpoints.
+
+##### Add a new API
+
+For an hypothetical API called foobar
+
+1. Download the foobar api openapi json or yaml representation under
+`api/schema/foobar.json`
+
+2. Create a new "empty" api file under `src/store/emptyFoobarApi.ts` that has for
+content:
+
+```{ts}
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+import { FOOBAR_API } from '../constants';
+
+// initialize an empty api service that we'll inject endpoints into later as needed
+export const emptyFoobarApi = createApi({
+  reducerPath: 'foobarApi',
+  baseQuery: fetchBaseQuery({ baseUrl: FOO_BAR }),
+  endpoints: () => ({}),
+});
+```
+
+3. Declare the new constat `FOOBAR_API` to the API url in `src/constants.js`
+
+```
+export const FOOBAR_API = 'api/foobar/v1'
+```
+
+4. Create the config file for code generation in `api/config/foobar.ts` containing:
+
+```
+import type { ConfigFile } from '@rtk-query/codegen-openapi';
+
+const config: ConfigFile = {
+  schemaFile: '../schema/foobar.json',
+  apiFile: '../../src/store/emptyFoobarApi.ts',
+  apiImport: 'emptyEdgeApi',
+  outputFile: '../../src/store/foobarApi.ts',
+  exportName: 'foobarApi',
+  hooks: true,
+  filterEndpoints: ['getFoo', 'getBar', 'getFoobar'],
+};
+```
+
+5. Update the `api.sh` script by adding a new line for npx to generate the code:
+
+```
+npx @rtk-query/codegen-openapi ./api/config/foobar.ts &
+```
+
+
+6. Update the `.eslintignore` file by adding a new line for the generated code:
+
+```
+foobarApi.ts
+```
+
+7. run api generation
+
+```
+rpn run api
+```
+
+And voilà!
+
+##### Add a new endpoint
+
+To add a new endpoint, simply update the `api/config/foobar.ts` file with new
+endpoints in the `filterEndpoints` table.
+
 ### Backend Development
 
 To develop both the frontend and the backend you can again use the proxy to run both the


### PR DESCRIPTION
This PR adds a check to ensure nobody is updating the API by hand.
Also adds documentation on how to update the endpoints and apis in the README.

Manual changes on the api are detected by running `npm run api` and then `git status`, when there are some, travis will fail:

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/0a59073e-162f-4d4f-b4cd-e07aca18a843)

And this check let the rest of the CI execute when there's no manual changes on the API files:

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/36ca7ae6-66d7-44df-8846-76d0e9876342)
