### PR TITLE
Filter content-sources repos by origin and content_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ foobarApi.ts
 7. run api generation
 
 ```
-rpn run api
+npm run api
 ```
 
 And voilà!

--- a/api/schema/contentSources.json
+++ b/api/schema/contentSources.json
@@ -277,6 +277,10 @@
                         "readOnly": true,
                         "type": "string"
                     },
+                    "content_type": {
+                        "description": "Content Type (rpm) of the repository",
+                        "type": "string"
+                    },
                     "distribution_arch": {
                         "description": "Architecture to restrict client usage to",
                         "example": "x86_64",
@@ -309,6 +313,17 @@
                         "description": "Timestamp of last attempted introspection",
                         "type": "string"
                     },
+                    "last_snapshot": {
+                        "$ref": "#/components/schemas/api.SnapshotResponse"
+                    },
+                    "last_snapshot_task_uuid": {
+                        "description": "UUID of the last snapshot task",
+                        "type": "string"
+                    },
+                    "last_snapshot_uuid": {
+                        "description": "UUID of the last dao.Snapshot",
+                        "type": "string"
+                    },
                     "last_success_introspection_time": {
                         "description": "Timestamp of last successful introspection",
                         "type": "string"
@@ -328,6 +343,10 @@
                     "org_id": {
                         "description": "Organization ID of the owner",
                         "readOnly": true,
+                        "type": "string"
+                    },
+                    "origin": {
+                        "description": "Origin of the repository",
                         "type": "string"
                     },
                     "package_count": {
@@ -525,6 +544,13 @@
             },
             "api.SnapshotResponse": {
                 "properties": {
+                    "added_counts": {
+                        "additionalProperties": {
+                            "type": "integer"
+                        },
+                        "description": "Count of each content type",
+                        "type": "object"
+                    },
                     "content_counts": {
                         "additionalProperties": {
                             "type": "integer"
@@ -536,8 +562,15 @@
                         "description": "Datetime the snapshot was created",
                         "type": "string"
                     },
-                    "distribution_path": {
-                        "description": "Path to pulp distribution",
+                    "removed_counts": {
+                        "additionalProperties": {
+                            "type": "integer"
+                        },
+                        "description": "Count of each content type",
+                        "type": "object"
+                    },
+                    "repository_path": {
+                        "description": "Path to repository snapshot contents",
                         "type": "string"
                     }
                 },
@@ -579,8 +612,20 @@
                         "description": "Organization ID of the owner",
                         "type": "string"
                     },
+                    "repository_name": {
+                        "description": "Name of the associated repository",
+                        "type": "string"
+                    },
+                    "repository_uuid": {
+                        "description": "UUID of the associated repository",
+                        "type": "string"
+                    },
                     "status": {
                         "description": "Status of task (running, failed, completed, canceled, pending)",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Type of task",
                         "type": "string"
                     },
                     "uuid": {
@@ -731,6 +776,32 @@
             "get": {
                 "description": "Get popular repositories",
                 "operationId": "listPopularRepositories",
+                "parameters": [
+                    {
+                        "description": "Offset into the list of results to return in the response",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Limit the number of items returned",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Search term for name and url.",
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -958,6 +1029,22 @@
                         "description": "Comma separated list of statuses to optionally filter on",
                         "in": "query",
                         "name": "status",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Comma separated list of origins to filter (red_hat,external)",
+                        "in": "query",
+                        "name": "origin",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "content type of a repository to filter on (rpm)",
+                        "in": "query",
+                        "name": "content_type",
                         "schema": {
                             "type": "string"
                         }
@@ -2169,6 +2256,22 @@
                         "description": "Filter tasks by status using an exact match",
                         "in": "query",
                         "name": "status",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter tasks by type using an exact match",
+                        "in": "query",
+                        "name": "type",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter tasks by associated repository UUID using an exact match",
+                        "in": "query",
+                        "name": "repository_uuid",
                         "schema": {
                             "type": "string"
                         }

--- a/src/Components/CreateImageWizard/formComponents/CustomButtons.js
+++ b/src/Components/CreateImageWizard/formComponents/CustomButtons.js
@@ -49,6 +49,8 @@ const CustomButtons = ({
       prefetchRepositories({
         availableForArch: 'x86_64',
         availableForVersion: version,
+        contentType: 'rpm',
+        origin: 'external',
       });
     }
   };

--- a/src/Components/CreateImageWizard/formComponents/Repositories.js
+++ b/src/Components/CreateImageWizard/formComponents/Repositories.js
@@ -212,6 +212,8 @@ const Repositories = (props) => {
     {
       availableForArch: 'x86_64',
       availableForVersion: version,
+      contentType: 'rpm',
+      origin: 'external',
       limit: 100,
       offset: 0,
     },
@@ -230,6 +232,8 @@ const Repositories = (props) => {
     {
       availableForArch: 'x86_64',
       availableForVersion: version,
+      contentType: 'rpm',
+      origin: 'external',
       limit: firstRequest?.data?.meta?.count,
       offset: 0,
     },

--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTables.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTables.js
@@ -18,6 +18,8 @@ import { useListRepositoriesQuery } from '../../../store/contentSourcesApi';
 const RepoName = ({ repoUrl }) => {
   const { data, isSuccess, isFetching, isError } = useListRepositoriesQuery({
     url: repoUrl,
+    contentType: 'rpm',
+    origin: 'external',
   });
 
   const errorLoading = () => {

--- a/src/Utilities/checkRepositoriesAvailability.js
+++ b/src/Utilities/checkRepositoriesAvailability.js
@@ -25,6 +25,8 @@ export const useCheckRepositoriesAvailability = () => {
   const firstRequest = useListRepositoriesQuery({
     availableForArch: 'x86_64',
     availableForVersion: version,
+    contentType: 'rpm',
+    origin: 'external',
   });
 
   const skip =
@@ -36,6 +38,8 @@ export const useCheckRepositoriesAvailability = () => {
     {
       availableForArch: 'x86_64',
       availableForVersion: version,
+      contentType: 'rpm',
+      origin: 'external',
       limit: firstRequest?.data?.meta?.count,
       offset: 0,
     },

--- a/src/store/contentSourcesApi.ts
+++ b/src/store/contentSourcesApi.ts
@@ -19,6 +19,8 @@ const injectedRtkApi = api.injectEndpoints({
           url: queryArg.url,
           sort_by: queryArg.sortBy,
           status: queryArg.status,
+          origin: queryArg.origin,
+          content_type: queryArg.contentType,
         },
       }),
     }),
@@ -65,6 +67,10 @@ export type ListRepositoriesApiArg = {
   sortBy?: string;
   /** Comma separated list of statuses to optionally filter on */
   status?: string;
+  /** Comma separated list of origins to filter (red_hat,external) */
+  origin?: string;
+  /** content type of a repository to filter on (rpm) */
+  contentType?: string;
 };
 export type ListRepositoriesRpmsApiResponse =
   /** status 200 OK */ ApiRepositoryRpmCollectionResponse;
@@ -80,19 +86,37 @@ export type ListRepositoriesRpmsApiArg = {
   /** Sets the sort order of the results. */
   sortBy?: string;
 };
+export type ApiSnapshotResponse = {
+  added_counts?: {
+    [key: string]: number;
+  };
+  content_counts?: {
+    [key: string]: number;
+  };
+  created_at?: string;
+  removed_counts?: {
+    [key: string]: number;
+  };
+  repository_path?: string;
+};
 export type ApiRepositoryResponse = {
   account_id?: string;
+  content_type?: string;
   distribution_arch?: string;
   distribution_versions?: string[];
   failed_introspections_count?: number;
   gpg_key?: string;
   last_introspection_error?: string;
   last_introspection_time?: string;
+  last_snapshot?: ApiSnapshotResponse;
+  last_snapshot_task_uuid?: string;
+  last_snapshot_uuid?: string;
   last_success_introspection_time?: string;
   last_update_introspection_time?: string;
   metadata_verification?: boolean;
   name?: string;
   org_id?: string;
+  origin?: string;
   package_count?: number;
   snapshot?: boolean;
   status?: string;


### PR DESCRIPTION
These params will be added to content-sources soon.  And in the short future there will be other origin's available (Red Hat for example).  In the far future there will be other content_types (most likely). 

I haven't tested this change so tread lightly :)

Content sources PR: https://github.com/content-services/content-sources-backend/pull/383

But this shouldn't cause any problem going in earlier.