### PR TITLE
LaunchWizard: Correct architecture prop

### DIFF
--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -130,8 +130,7 @@ const ProvisioningLink = ({
                 image={{
                   name: compose.image_name || compose.id,
                   id: compose.id,
-                  architecture:
-                    compose.request.image_requests[0].upload_request.options,
+                  architecture: compose.request.image_requests[0].architecture,
                   provider: provider,
                   sourceIDs: sourceIds,
                   accountIDs: accountIds,


### PR DESCRIPTION
The `<LaunchWizard>` architecture prop was specified incorrectly, which caused the Instance dropdown in the Launch wizard to fail to load instance types.