### PR TITLE
ImageTable: THEEDGE-3450 - add ignoreImageType to getComposes endpoint

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -72,6 +72,12 @@ const ImagesTable = () => {
   const { data, isSuccess } = useGetComposesQuery({
     limit: perPage,
     offset: perPage * (page - 1),
+    ignoreImageTypes: [
+      'rhel-edge-commit',
+      'rhel-edge-installer',
+      'edge-commit',
+      'edge-installer',
+    ],
   });
 
   if (!isSuccess) {

--- a/src/store/emptyImageBuilderApi.ts
+++ b/src/store/emptyImageBuilderApi.ts
@@ -5,6 +5,35 @@ import { IMAGE_BUILDER_API } from '../constants';
 // initialize an empty api service that we'll inject endpoints into later as needed
 export const emptyImageBuilderApi = createApi({
   reducerPath: 'imageBuilderApi',
-  baseQuery: fetchBaseQuery({ baseUrl: IMAGE_BUILDER_API }),
+  baseQuery: fetchBaseQuery({
+    baseUrl: IMAGE_BUILDER_API,
+    paramsSerializer: (params) => {
+      /*
+       * Image builder backend requires the arrays in get requests to be
+       * exploded, see the default behavior for swagger in the documentation:
+       * https://swagger.io/docs/specification/serialization/
+       *
+       * To accommodate to that, make sure that when the request is sent with
+       * an array we do explode properly unlike the default behavior of
+       * URLSearchParams.
+       */
+      const searchParams = new URLSearchParams();
+      for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) {
+          // avoid sending undefined parameters
+          continue;
+        }
+        if (Array.isArray(value)) {
+          for (const v of value) {
+            searchParams.append(key, v);
+          }
+        } else {
+          searchParams.append(key, value);
+        }
+      }
+
+      return searchParams.toString();
+    },
+  }),
   endpoints: () => ({}),
 });


### PR DESCRIPTION
This commit introduces a filter for the "image_type" to the "getComposes" endpoint, thereby improving the functionality of the Image Builder frontend table. This table consists of two tabs: RPM and OSTree. With this enhancement, users gain the ability to filter out OSTree images from the RPM tab, thus avoiding duplication.
this change is the impact of changes in the backend side in this pr https://github.com/osbuild/image-builder/pull/825





