### PR TITLE
Openscap: allow customers to configure an oscap policy in the wizard

### DIFF
--- a/api/config/imageBuilder.ts
+++ b/api/config/imageBuilder.ts
@@ -16,6 +16,8 @@ const config: ConfigFile = {
     'getCloneStatus',
     'getArchitectures',
     'getPackages',
+    'getOscapProfiles',
+    'getOscapCustomizations',
   ],
 };
 

--- a/api/schema/imageBuilder.yaml
+++ b/api/schema/imageBuilder.yaml
@@ -51,11 +51,13 @@ paths:
                 type: object
   /distributions:
     get:
-      summary: get the available distributions
+      summary: get the distributions available to this user
       operationId: getDistributions
       responses:
         '200':
-          description: a list of available distributions
+          description: |
+            A list of distributions this user has access to. Some distributions are restricted, so
+            this list might not correspond to the Distributions (enum) schema for a given user.
           content:
             application/json:
               schema:
@@ -67,7 +69,7 @@ paths:
         - in: path
           name: distribution
           schema:
-            type: string
+            $ref: '#/components/schemas/Distributions'
           required: true
           description: distribution for which to look up available architectures
           example: 'rhel-84'
@@ -79,6 +81,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Architectures'
+        '403':
+          description: user is not allowed to build or query this distribution
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
   /composes:
     get:
       summary: get a collection of previous compose requests for the logged in user
@@ -98,6 +106,16 @@ paths:
             default: 0
             minimum: 0
           description: composes page offset, default 0
+        - in: query
+          name: ignoreImageTypes
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ImageTypes'
+              example: ['rhel-edge-installer', 'rhel-edge-commit', ...]
+          description: |
+            Filter the composes on image type. The filter is optional and can be specified multiple times.
       responses:
         '200':
           description: a list of composes
@@ -267,6 +285,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPErrorList'
+        '403':
+          description: user is not allowed to build this distribution
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
   /packages:
     get:
       parameters:
@@ -311,6 +335,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PackagesResponse'
+        '403':
+          description: user is not allowed to build or query this distribution
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPErrorList'
+  /oscap/{distribution}/profiles:
+    parameters:
+      - in: path
+        name: distribution
+        schema:
+          $ref: '#/components/schemas/Distributions'
+        required: true
+    get:
+      summary: get the available profiles for a given distribution. This is a temporary endpoint meant to be removed soon.
+      operationId: getOscapProfiles
+      responses:
+        '200':
+          description: |
+            A list of profiles configurable for this distribution.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DistributionProfileResponse'
+  /oscap/{distribution}/{profile}/customizations:
+    parameters:
+      - in: path
+        name: distribution
+        schema:
+          $ref: '#/components/schemas/Distributions'
+        required: true
+      - in: path
+        name: profile
+        schema:
+          $ref: '#/components/schemas/DistributionProfileItem'
+        required: true
+        description: Name of the profile to retrieve customizations from
+    get:
+      summary: get the customizations for a given distribution and profile. This is a temporary endpoint meant to be removed soon.
+      operationId: getOscapCustomizations
+      responses:
+        '200':
+          description: |
+            A customizations array updated with the needed elements.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customizations'
 
 components:
   schemas:
@@ -346,6 +418,8 @@ components:
           type: string
     DistributionsResponse:
       type: array
+      description: |
+        List of distributions this user is allowed to build.
       items:
         $ref: '#/components/schemas/DistributionItem'
     DistributionItem:
@@ -501,6 +575,11 @@ components:
             $ref: '#/components/schemas/Customizations'
     Distributions:
       type: string
+      description: |
+        List of all distributions that image builder supports. A user might not have access to
+        restricted distributions.
+
+        Restricted distributions include the RHEL nightlies and the Fedora distributions.
       enum:
         - rhel-8
         - rhel-8-nightly
@@ -519,6 +598,7 @@ components:
         - fedora-37
         - fedora-38
         - fedora-39
+        - fedora-40
     ImageRequest:
       type: object
       additionalProperties: false
@@ -651,8 +731,6 @@ components:
       type: object
     GCPUploadRequestOptions:
       type: object
-      required:
-        - share_with_accounts
       properties:
         share_with_accounts:
           type: array
@@ -1075,3 +1153,29 @@ components:
           type: string
           format: uuid
           example: '123e4567-e89b-12d3-a456-426655440000'
+    DistributionProfileResponse:
+      type: array
+      description: |
+        List of profiles for a given distribution
+      items:
+        $ref: '#/components/schemas/DistributionProfileItem'
+    DistributionProfileItem:
+      type: string
+      enum:
+        - xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced
+        - xccdf_org.ssgproject.content_profile_anssi_bp28_high
+        - xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary
+        - xccdf_org.ssgproject.content_profile_anssi_bp28_minimal
+        - xccdf_org.ssgproject.content_profile_cis
+        - xccdf_org.ssgproject.content_profile_cis_server_l1
+        - xccdf_org.ssgproject.content_profile_cis_workstation_l1
+        - xccdf_org.ssgproject.content_profile_cis_workstation_l2
+        - xccdf_org.ssgproject.content_profile_cui
+        - xccdf_org.ssgproject.content_profile_e8
+        - xccdf_org.ssgproject.content_profile_hipaa
+        - xccdf_org.ssgproject.content_profile_ism_o
+        - xccdf_org.ssgproject.content_profile_ospp
+        - xccdf_org.ssgproject.content_profile_pci-dss
+        - xccdf_org.ssgproject.content_profile_standard
+        - xccdf_org.ssgproject.content_profile_stig
+        - xccdf_org.ssgproject.content_profile_stig_gui

--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -478,8 +478,10 @@ const requestToState = (composeRequest, distroInfo, isBeta, isProd) => {
     }
 
     // oscap policy
-    formState['oscap-policy'] =
-      composeRequest?.customizations?.openscap?.profile_id;
+    if (isBeta) {
+      formState['oscap-policy'] =
+        composeRequest?.customizations?.openscap?.profile_id;
+    }
 
     return formState;
   } else {
@@ -487,7 +489,7 @@ const requestToState = (composeRequest, distroInfo, isBeta, isProd) => {
   }
 };
 
-const formStepHistory = (composeRequest, contentSourcesEnabled) => {
+const formStepHistory = (composeRequest, contentSourcesEnabled, isBeta) => {
   if (composeRequest) {
     const imageRequest = composeRequest.image_requests[0];
     const uploadRequest = imageRequest.upload_request;
@@ -506,7 +508,9 @@ const formStepHistory = (composeRequest, contentSourcesEnabled) => {
       steps.push('registration');
     }
 
-    steps.push('Compliance');
+    if (isBeta) {
+      steps.push('Compliance');
+    }
 
     if (contentSourcesEnabled) {
       steps.push('File system configuration', 'packages', 'repositories');
@@ -564,7 +568,11 @@ const CreateImageWizard = () => {
     isBeta(),
     isProd()
   );
-  const stepHistory = formStepHistory(composeRequest, contentSourcesEnabled);
+  const stepHistory = formStepHistory(
+    composeRequest,
+    contentSourcesEnabled,
+    isBeta()
+  );
 
   if (initialState) {
     initialState.isBeta = isBeta();

--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -19,6 +19,7 @@ import {
   registration,
   repositories,
   review,
+  oscap,
 } from './steps';
 import {
   fileSystemConfigurationValidator,
@@ -93,6 +94,12 @@ const onSave = (values) => {
         min_size: fsc.size * fsc.unit,
       });
     }
+  }
+
+  if (values['oscap-policy']) {
+    customizations.openscap = {
+      profile_id: values['oscap-policy'],
+    };
   }
 
   const requests = [];
@@ -470,6 +477,10 @@ const requestToState = (composeRequest, distroInfo, isBeta, isProd) => {
       formState['register-system'] = 'register-later';
     }
 
+    // oscap policy
+    formState['oscap-policy'] =
+      composeRequest?.customizations?.openscap?.profile_id;
+
     return formState;
   } else {
     return;
@@ -494,6 +505,8 @@ const formStepHistory = (composeRequest, contentSourcesEnabled) => {
     if (isRhel(composeRequest?.distribution)) {
       steps.push('registration');
     }
+
+    steps.push('Compliance');
 
     if (contentSourcesEnabled) {
       steps.push('File system configuration', 'packages', 'repositories');
@@ -654,6 +667,7 @@ const CreateImageWizard = () => {
               fileSystemConfiguration,
               imageName,
               review,
+              oscap,
             ],
             initialState: {
               activeStep: initialStep || 'image-output', // name of the active step

--- a/src/Components/CreateImageWizard/ImageCreator.js
+++ b/src/Components/CreateImageWizard/ImageCreator.js
@@ -16,6 +16,7 @@ import CentOSAcknowledgement from './formComponents/CentOSAcknowledgement';
 import FileSystemConfiguration from './formComponents/FileSystemConfiguration';
 import GalleryLayout from './formComponents/GalleryLayout';
 import ImageOutputReleaseSelect from './formComponents/ImageOutputReleaseSelect';
+import { Oscap } from './formComponents/Oscap';
 import {
   ContentSourcesPackages,
   RedHatPackages,
@@ -72,6 +73,7 @@ const ImageCreator = ({
         'azure-sources-select': AzureSourcesSelect,
         'azure-resource-groups': AzureResourceGroups,
         'gallery-layout': GalleryLayout,
+        'oscap-profile-selector': Oscap,
         registration: Registration,
         ...customComponentMapper,
       }}

--- a/src/Components/CreateImageWizard/formComponents/MountPoint.js
+++ b/src/Components/CreateImageWizard/formComponents/MountPoint.js
@@ -10,26 +10,27 @@ import {
 } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
+export const MountPointValidPrefixes = [
+  '/app',
+  '/boot',
+  '/data',
+  '/home',
+  '/opt',
+  '/srv',
+  '/tmp',
+  '/usr',
+  '/usr/local',
+  '/var',
+];
+
 const MountPoint = ({ ...props }) => {
-  const validPrefixes = [
-    '/app',
-    '/boot',
-    '/data',
-    '/home',
-    '/opt',
-    '/srv',
-    '/tmp',
-    '/usr',
-    '/usr/local',
-    '/var',
-  ];
   const [isOpen, setIsOpen] = useState(false);
   const [prefix, setPrefix] = useState('/');
   const [suffix, setSuffix] = useState('');
 
   // split
   useEffect(() => {
-    for (const p of validPrefixes) {
+    for (const p of MountPointValidPrefixes) {
       if (props.mountpoint.startsWith(p)) {
         setPrefix(p);
         setSuffix(props.mountpoint.substring(p.length));
@@ -73,7 +74,7 @@ const MountPoint = ({ ...props }) => {
         variant={SelectVariant.single}
         isDisabled={prefix === '/' ? true : false}
       >
-        {validPrefixes.map((pfx, index) => {
+        {MountPointValidPrefixes.map((pfx, index) => {
           return <SelectOption key={index} value={pfx} />;
         })}
       </Select>

--- a/src/Components/CreateImageWizard/formComponents/Oscap.js
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.js
@@ -14,6 +14,17 @@ import {
 import PropTypes from 'prop-types';
 
 import { useGetOscapProfilesQuery } from '../../../store/imageBuilderApi';
+import { reinitFileSystemConfiguratioStep } from '../steps/fileSystemConfiguration';
+
+/**
+ * Every time there is change on this form step's state, reinitialise the steps
+ * that are depending on it. This will ensure that if the user goes back and
+ * change their mind, going forward again leaves them in a coherent and workable
+ * form state.
+ */
+const reinitDependingSteps = (change) => {
+  reinitFileSystemConfiguratioStep(change);
+};
 
 /**
  * Component for the user to select the policy to apply to their image.
@@ -49,12 +60,15 @@ const PolicySelector = ({ input, showSelector }) => {
   const handleClear = () => {
     selectPolicy(undefined);
     change(input.name, undefined);
+    reinitDependingSteps(change);
   };
 
   const setPolicy = (_, selection) => {
     selectPolicy(selection);
     setIsOpen(false);
     change(input.name, selection);
+    reinitDependingSteps(change);
+    change('file-system-config-radio', 'manual');
   };
 
   return (
@@ -125,6 +139,7 @@ const AddPolicy = ({ input }) => {
           isChecked={wantsPolicy}
           onChange={() => {
             setWantsPolicy(true);
+            reinitDependingSteps(change);
           }}
         />
         <Radio
@@ -137,6 +152,7 @@ const AddPolicy = ({ input }) => {
           onChange={() => {
             setWantsPolicy(false);
             change(input.name, undefined);
+            reinitDependingSteps(change);
           }}
         />
       </FormGroup>

--- a/src/Components/CreateImageWizard/formComponents/Oscap.js
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.js
@@ -1,0 +1,155 @@
+import React, { useState } from 'react';
+
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import {
+  Alert,
+  Radio,
+  FormGroup,
+  Select,
+  SelectOption,
+  SelectVariant,
+  Spinner,
+} from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+
+import { useGetOscapProfilesQuery } from '../../../store/imageBuilderApi';
+
+/**
+ * Component for the user to select the policy to apply to their image.
+ * The selected policy will be stored in the `oscap-policy` form state variable.
+ * The Component is shown or not depending on the ShowSelector variable.
+ */
+const PolicySelector = ({ input, showSelector }) => {
+  const { change, getState } = useFormApi();
+  const [policy, selectPolicy] = useState(getState()?.values?.['oscap-policy']);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { data, isFetching, isSuccess, isError, refetch } =
+    useGetOscapProfilesQuery(
+      {
+        distribution: getState()?.values?.['release'],
+      },
+      {
+        skip: !showSelector,
+      }
+    );
+
+  if (!showSelector) {
+    return undefined;
+  }
+
+  const handleToggle = () => {
+    if (!isOpen) {
+      refetch();
+    }
+    setIsOpen(!isOpen);
+  };
+
+  const handleClear = () => {
+    selectPolicy(undefined);
+    change(input.name, undefined);
+  };
+
+  const setPolicy = (_, selection) => {
+    selectPolicy(selection);
+    setIsOpen(false);
+    change(input.name, selection);
+  };
+
+  return (
+    <FormGroup
+      isRequired={true}
+      label={'Policy to use for this image'}
+      data-testid="policies-form-group"
+    >
+      <Select
+        ouiaId="policySelect"
+        variant={SelectVariant.typeahead}
+        onToggle={handleToggle}
+        onSelect={setPolicy}
+        onClear={handleClear}
+        selections={policy}
+        isOpen={isOpen}
+        placeholderText="Select a policy"
+        typeAheadAriaLabel="Select a policy"
+        isDisabled={!isSuccess}
+      >
+        {isSuccess &&
+          data.map((key, index) => <SelectOption key={index} value={key} />)}
+        {isFetching && (
+          <SelectOption isNoResultsOption={true} data-testid="policies-loading">
+            <Spinner isSVG size="md" />
+          </SelectOption>
+        )}
+      </Select>
+      {isError && (
+        <Alert
+          title="Error fetching the policies"
+          variant="danger"
+          isPlain
+          isInline
+        >
+          Cannot get the list of policies
+        </Alert>
+      )}
+    </FormGroup>
+  );
+};
+
+PolicySelector.propTypes = {
+  input: PropTypes.any,
+  showSelector: PropTypes.bool,
+};
+
+/**
+ * Component to prompt the use with two choices:
+ * - to add a policy, in which case the PolicySelector will allow the user to
+ *   pick a policy to be stored in the `oscap-policy` variable.
+ * - to not add a policy, in which case the `oscap-policy` form state goes
+ *   undefined.
+ */
+const AddPolicy = ({ input }) => {
+  const { change, getState } = useFormApi();
+  const oscapPolicy = getState()?.values?.['oscap-policy'];
+  const [wantsPolicy, setWantsPolicy] = useState(oscapPolicy !== undefined);
+  return (
+    <>
+      <FormGroup label="Compliance policy">
+        <Radio
+          name="add-a-policy"
+          className="pf-u-mt-md"
+          data-testid="add-a-policy-radio"
+          id="add-a-policy"
+          label="Add a policy"
+          isChecked={wantsPolicy}
+          onChange={() => {
+            setWantsPolicy(true);
+          }}
+        />
+        <Radio
+          name="dont-add-a-policy"
+          className="pf-u-mt-md"
+          data-testid="dont-add-a-policy-radio"
+          id="dont-add-a-policy"
+          label="Do not add a policy"
+          isChecked={!wantsPolicy}
+          onChange={() => {
+            setWantsPolicy(false);
+            change(input.name, undefined);
+          }}
+        />
+      </FormGroup>
+      <PolicySelector input={input} showSelector={wantsPolicy} />
+    </>
+  );
+};
+
+AddPolicy.propTypes = {
+  input: PropTypes.object,
+};
+
+export const Oscap = ({ ...props }) => {
+  const { input } = useFieldApi(props);
+  return <AddPolicy input={input} />;
+};

--- a/src/Components/CreateImageWizard/formComponents/Oscap.js
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
 
 import { useGetOscapProfilesQuery } from '../../../store/imageBuilderApi';
 import { reinitFileSystemConfiguratioStep } from '../steps/fileSystemConfiguration';
+import { reinitPackagesStep } from '../steps/packages';
 
 /**
  * Every time there is change on this form step's state, reinitialise the steps
@@ -24,6 +25,7 @@ import { reinitFileSystemConfiguratioStep } from '../steps/fileSystemConfigurati
  */
 const reinitDependingSteps = (change) => {
   reinitFileSystemConfiguratioStep(change);
+  reinitPackagesStep(change);
 };
 
 /**

--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -30,7 +30,10 @@ import {
 import PropTypes from 'prop-types';
 
 import api from '../../../api';
-import { useGetArchitecturesQuery } from '../../../store/imageBuilderApi';
+import {
+  useGetArchitecturesQuery,
+  useGetOscapCustomizationsQuery,
+} from '../../../store/imageBuilderApi';
 
 const ExactMatch = ({
   pkgList,
@@ -125,6 +128,28 @@ const Packages = ({ getAllPackages, isSuccess }) => {
     new Set()
   );
   const firstInputElement = useRef(null);
+
+  const oscapPolicy = getState()?.values?.['oscap-policy'];
+
+  const { data: customizations, isSuccess: isSuccessCustomizations } =
+    useGetOscapCustomizationsQuery(
+      {
+        distribution: getState()?.values?.['release'],
+        profile: oscapPolicy,
+      },
+      {
+        skip: !oscapPolicy,
+      }
+    );
+  useEffect(() => {
+    if (customizations && customizations.packages && isSuccessCustomizations) {
+      const oscapPackages = {};
+      for (const pkg of customizations.packages) {
+        oscapPackages[pkg] = { name: pkg };
+      }
+      updateState(oscapPackages);
+    }
+  }, [customizations, isSuccessCustomizations]);
 
   // this effect only triggers on mount
   useEffect(() => {

--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -15,6 +15,7 @@ import {
   FSCList,
   ImageDetailsList,
   ImageOutputList,
+  OscapList,
   RegisterLaterList,
   RegisterNowList,
   TargetEnvAWSList,
@@ -33,6 +34,7 @@ const ReviewStep = () => {
   const [isExpandedContent, setIsExpandedContent] = useState(false);
   const [isExpandedRegistration, setIsExpandedRegistration] = useState(false);
   const [isExpandedImageDetail, setIsExpandedImageDetail] = useState(false);
+  const [isExpandedOscapDetail, setIsExpandedOscapDetail] = useState(false);
   const { change, getState } = useFormApi();
 
   useEffect(() => {
@@ -57,6 +59,8 @@ const ReviewStep = () => {
     setIsExpandedRegistration(isExpandedRegistration);
   const onToggleImageDetail = (isExpandedImageDetail) =>
     setIsExpandedImageDetail(isExpandedImageDetail);
+  const onToggleOscapDetails = (isExpandedOscapDetail) =>
+    setIsExpandedOscapDetail(isExpandedOscapDetail);
 
   return (
     <>
@@ -167,6 +171,17 @@ const ReviewStep = () => {
           data-testid="image-details-expandable"
         >
           <ImageDetailsList />
+        </ExpandableSection>
+      )}
+      {getState()?.values?.['oscap-policy'] && (
+        <ExpandableSection
+          toggleContent={'OpenSCAP Compliance'}
+          onToggle={onToggleOscapDetails}
+          isExpanded={isExpandedOscapDetail}
+          isIndented
+          data-testid="oscap-detail-expandable"
+        >
+          <OscapList />
         </ExpandableSection>
       )}
     </>

--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -589,3 +589,24 @@ export const ImageDetailsList = () => {
     </TextContent>
   );
 };
+
+export const OscapList = () => {
+  const { getState } = useFormApi();
+  const oscapPolicy = getState()?.values?.['oscap-policy'];
+  return (
+    <TextContent>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Policy
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          {oscapPolicy}
+        </TextListItem>
+      </TextList>
+      <br />
+    </TextContent>
+  );
+};

--- a/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
@@ -15,6 +15,11 @@ import StepTemplate from './stepTemplate';
 
 import FileSystemConfigButtons from '../formComponents/FileSystemConfigButtons';
 
+export const reinitFileSystemConfiguratioStep = (change) => {
+  change('file-system-configuration', undefined);
+  change('file-system-config-radio', 'automatic');
+};
+
 const fileSystemConfigurationStep = {
   StepTemplate,
   id: 'wizard-systemconfiguration-filesystem',
@@ -63,6 +68,10 @@ const fileSystemConfigurationStep = {
           className: 'pf-u-mt-sm',
         },
       ],
+      condition: {
+        when: 'oscap-policy',
+        is: undefined,
+      },
     },
     {
       component: 'file-system-configuration',
@@ -73,8 +82,13 @@ const fileSystemConfigurationStep = {
         { type: validatorTypes.REQUIRED },
       ],
       condition: {
-        when: 'file-system-config-radio',
-        is: 'manual',
+        or: [
+          {
+            when: 'file-system-config-radio',
+            is: 'manual',
+          },
+          { not: [{ when: 'oscap-policy', is: undefined }] },
+        ],
       },
     },
     {
@@ -111,7 +125,10 @@ const fileSystemConfigurationStep = {
         </TextContent>
       ),
       condition: {
-        or: [{ when: 'file-system-config-radio', is: 'automatic' }],
+        or: [
+          { when: 'file-system-config-radio', is: 'automatic' },
+          { when: 'oscap-policy', is: undefined },
+        ],
       },
     },
   ],

--- a/src/Components/CreateImageWizard/steps/imageOutputStepMapper.js
+++ b/src/Components/CreateImageWizard/steps/imageOutputStepMapper.js
@@ -1,7 +1,7 @@
 import isRhel from '../../../Utilities/isRhel.js';
 
 const imageOutputStepMapper = (
-  { 'target-environment': targetEnv, release } = {},
+  { 'target-environment': targetEnv, release, isBeta } = {},
   { skipAws, skipGoogle, skipAzure } = {}
 ) => {
   if (!skipAws && targetEnv?.aws) {
@@ -16,7 +16,13 @@ const imageOutputStepMapper = (
     return 'ms-azure-target-env';
   }
 
-  return isRhel(release) ? 'registration' : 'File system configuration';
+  if (isRhel(release)) {
+    return 'registration';
+  }
+  if (isBeta) {
+    return 'Compliance';
+  }
+  return 'File system configuration';
 };
 
 export default imageOutputStepMapper;

--- a/src/Components/CreateImageWizard/steps/index.js
+++ b/src/Components/CreateImageWizard/steps/index.js
@@ -1,6 +1,7 @@
 export { default as awsTarget } from './aws';
 export { default as googleCloudTarget } from './googleCloud';
 export { default as msAzureTarget } from './msAzure';
+export { default as oscap } from './oscap';
 export { default as packages } from './packages';
 export { default as packagesContentSources } from './packagesContentSources';
 export { default as registration } from './registration';

--- a/src/Components/CreateImageWizard/steps/oscap.js
+++ b/src/Components/CreateImageWizard/steps/oscap.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
+import { Text } from '@patternfly/react-core';
+
+import StepTemplate from './stepTemplate';
+
+import CustomButtons from '../formComponents/CustomButtons';
+
+const oscapStep = {
+  StepTemplate,
+  id: 'wizard-systemconfiguration-oscap',
+  title: 'OpenSCAP Compliance',
+  name: 'Compliance',
+  nextStep: 'File system configuration',
+  buttons: CustomButtons,
+  fields: [
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'oscap-text-component',
+      label: (
+        <Text>
+          Monitor regulatory compliance policies of registered RHEL systems you
+          must adhere to via OpenSCAP.
+        </Text>
+      ),
+    },
+    {
+      component: 'oscap-profile-selector',
+      name: 'oscap-policy',
+      label: 'Available profiles for the distribution',
+    },
+  ],
+};
+
+export default oscapStep;

--- a/src/Components/CreateImageWizard/steps/packages.js
+++ b/src/Components/CreateImageWizard/steps/packages.js
@@ -7,6 +7,10 @@ import StepTemplate from './stepTemplate';
 
 import CustomButtons from '../formComponents/CustomButtons';
 
+export const reinitPackagesStep = (change) => {
+  change('selected-packages', undefined);
+};
+
 const packagesStep = {
   StepTemplate,
   id: 'wizard-systemconfiguration-packages',

--- a/src/Components/CreateImageWizard/steps/registration.js
+++ b/src/Components/CreateImageWizard/steps/registration.js
@@ -69,7 +69,13 @@ const registrationStep = {
     </Title>
   ),
   name: 'registration',
-  nextStep: 'Compliance',
+  nextStep: ({ values }) => {
+    if (values.isBeta) {
+      return 'Compliance';
+    } else {
+      return 'File system configuration';
+    }
+  },
   buttons: CustomButtons,
   fields: [
     {

--- a/src/Components/CreateImageWizard/steps/registration.js
+++ b/src/Components/CreateImageWizard/steps/registration.js
@@ -69,7 +69,7 @@ const registrationStep = {
     </Title>
   ),
   name: 'registration',
-  nextStep: 'File system configuration',
+  nextStep: 'Compliance',
   buttons: CustomButtons,
   fields: [
     {

--- a/src/Components/ImagesTable/ImageDetails.tsx
+++ b/src/Components/ImagesTable/ImageDetails.tsx
@@ -118,8 +118,10 @@ const AwsSourceName = ({ id }: AwsSourceNamePropTypes) => {
 const parseGcpSharedWith = (
   sharedWith: GcpUploadRequestOptions['share_with_accounts']
 ) => {
-  const splitGCPSharedWith = sharedWith[0].split(':');
-  return splitGCPSharedWith[1];
+  if (sharedWith) {
+    const splitGCPSharedWith = sharedWith[0].split(':');
+    return splitGCPSharedWith[1];
+  }
 };
 
 type AwsDetailsPropTypes = {

--- a/src/Components/ImagesTable/Release.tsx
+++ b/src/Components/ImagesTable/Release.tsx
@@ -27,6 +27,7 @@ const Release = ({ release }: ReleaseProps) => {
     'fedora-37': 'Fedora 37',
     'fedora-38': 'Fedora 38',
     'fedora-39': 'Fedora 39',
+    'fedora-40': 'Fedora 40',
   };
 
   return <p>{releaseDisplayValue[release]}</p>;

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
@@ -1,0 +1,148 @@
+import React from 'react';
+
+import '@testing-library/jest-dom';
+
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
+import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
+import {
+  clickNext,
+  renderCustomRoutesWithReduxRouter,
+  renderWithReduxRouter,
+} from '../../testUtils';
+
+const routes = [
+  {
+    path: 'insights/image-builder/*',
+    element: <div />,
+  },
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+  {
+    path: 'insights/image-builder/share/:composeId',
+    element: <ShareImageModal />,
+  },
+];
+
+let router = undefined;
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => true,
+    isProd: () => false,
+    getEnvironment: () => 'stage',
+  }),
+}));
+
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Step Compliance', () => {
+  test('create an image with an oscap policy', async () => {
+    const user = userEvent.setup();
+    ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
+
+    // select aws as upload destination
+    await user.click(await screen.findByTestId('upload-aws'));
+    await clickNext();
+
+    // aws step
+    await user.click(
+      screen.getByRole('radio', { name: /manually enter an account id\./i })
+    );
+    await user.type(screen.getByTestId('aws-account-id'), '012345678901');
+
+    await clickNext();
+    // skip registration
+    await user.click(screen.getByLabelText('Register later'));
+    await clickNext();
+
+    // Now we should be in the Compliance step
+    await screen.findByRole('heading', { name: /OpenSCAP Compliance/i });
+    expect(
+      await screen.findByRole('radio', { name: /do not add a policy/i })
+    ).toBeChecked();
+    await user.click(
+      await screen.findByRole('radio', { name: 'Add a policy' })
+    );
+    expect(
+      await screen.findByRole('radio', { name: 'Add a policy' })
+    ).toBeChecked();
+    await user.click(
+      await screen.findByRole('textbox', { name: /select a policy/i })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /xccdf_org\.ssgproject\.content_profile_cis_workstation/i,
+      })
+    );
+
+    // check that the FSC contains a /tmp partition
+    await clickNext();
+    await screen.findByRole('heading', { name: /File system configuration/i });
+    await screen.findByText('/tmp');
+
+    // check that the Packages contain a nftable package
+    await clickNext();
+    await screen.findByRole('heading', {
+      name: /Additional Red Hat packages/i,
+    });
+    await screen.findByText('nftables');
+  });
+});
+
+describe('On Recreate', () => {
+  const setup = async () => {
+    ({ router } = renderWithReduxRouter(
+      'imagewizard/1679d95b-8f1d-4982-8c53-8c2afa4ab04c'
+    ));
+  };
+  test('with oscap policy', async () => {
+    const user = userEvent.setup();
+    await setup();
+
+    await screen.findByRole('heading', { name: /review/i });
+    const createImageButton = await screen.findByRole('button', {
+      name: /create image/i,
+    });
+    await waitFor(() => expect(createImageButton).toBeEnabled());
+
+    // check that the FSC contains a /tmp partition
+    const navigation = screen.getByRole('navigation');
+    await user.click(
+      await within(navigation).findByRole('button', {
+        name: /file system configuration/i,
+      })
+    );
+    await screen.findByRole('heading', { name: /file system configuration/i });
+    await screen.findByText('/tmp');
+
+    // check that the Packages contain a nftable package
+    await clickNext();
+    await screen.findByRole('heading', {
+      name: /Additional Red Hat packages/i,
+    });
+    await screen.findByText('nftables');
+  });
+});

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -44,6 +44,11 @@ export const composesEndpoint = (
   } as ComposesResponse;
 };
 
+/**
+ * Upon adding an entry in the mockComposes, add it at the very end of the array
+ * and add a corresponding ComposeStatus object (at the same position in the
+ * mockStatus call, for easier tracking).
+ */
 export const mockComposes: ComposesResponseItem[] = [
   {
     id: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
@@ -275,8 +280,47 @@ export const mockComposes: ComposesResponseItem[] = [
       ],
     },
   },
+  {
+    id: '1679d95b-8f1d-4982-8c53-8c2afa4ab04c',
+    image_name: 'testOscapImageName',
+    created_at: '2021-04-27T12:31:12Z',
+    request: {
+      distribution: RHEL_8,
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'guest-image',
+          upload_request: {
+            options: {},
+            type: 'aws.s3',
+          },
+        },
+      ],
+      customizations: {
+        filesystem: [
+          { min_size: 10 * 1024 * 1024 * 1024, mountpoint: '/' },
+          { min_size: 1073741824, mountpoint: '/tmp' },
+        ],
+        packages: [
+          'aide',
+          'sudo',
+          'rsyslog',
+          'firewalld',
+          'nftables',
+          'libselinux',
+        ],
+        openscap: {
+          profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+        },
+      },
+    },
+  },
 ];
 
+/**
+ * MockStatus should have the same composeRequest as the one defined in the
+ * composes, and the order should be identical.
+ */
 export const mockStatus = (composeId: string): ComposeStatus => {
   const mockComposes: { [key: string]: ComposeStatus } = {
     '1579d95b-8f1d-4982-8c53-8c2afa4ab04c': {
@@ -643,6 +687,49 @@ export const mockStatus = (composeId: string): ComposeStatus => {
             },
           },
         ],
+      },
+    },
+    '1679d95b-8f1d-4982-8c53-8c2afa4ab04c': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://s3.amazonaws.com/1679d95b-8f1d-4982-8c53-8c2afa4ab04c-disk.qcow2',
+          },
+          status: 'success',
+          type: 'aws.s3',
+        },
+      },
+      request: {
+        distribution: RHEL_8,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'guest-image',
+            upload_request: {
+              type: 'aws.s3',
+              options: {},
+            },
+          },
+        ],
+        customizations: {
+          filesystem: [
+            { min_size: 10 * 1024 * 1024 * 1024, mountpoint: '/' },
+            { min_size: 1073741824, mountpoint: '/tmp' },
+          ],
+          packages: [
+            'aide',
+            'sudo',
+            'rsyslog',
+            'firewalld',
+            'nftables',
+            'libselinux',
+          ],
+          openscap: {
+            profile_id:
+              'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+          },
+        },
       },
     },
   };

--- a/src/test/fixtures/oscap.ts
+++ b/src/test/fixtures/oscap.ts
@@ -1,0 +1,27 @@
+import {
+  GetOscapProfilesApiResponse,
+  GetOscapCustomizationsApiResponse,
+} from '../../store/imageBuilderApi';
+
+export const distributionOscapProfiles = (
+  _distribution: string
+): GetOscapProfilesApiResponse => {
+  return ['xccdf_org.ssgproject.content_profile_cis_workstation_l1'];
+};
+
+export const oscapCustomizations = (
+  _distribution: string,
+  _profile: string
+): GetOscapCustomizationsApiResponse => {
+  return {
+    filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],
+    packages: [
+      'aide',
+      'sudo',
+      'rsyslog',
+      'firewalld',
+      'nftables',
+      'libselinux',
+    ],
+  };
+};

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -19,6 +19,10 @@ import {
   mockStatus,
 } from '../fixtures/composes';
 import {
+  distributionOscapProfiles,
+  oscapCustomizations,
+} from '../fixtures/oscap';
+import {
   mockPackagesResults,
   mockSourcesPackagesResults,
 } from '../fixtures/packages';
@@ -91,4 +95,16 @@ export const handlers = [
   rest.post(`${IMAGE_BUILDER_API}/compose`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.json({}));
   }),
+  rest.get(
+    `${IMAGE_BUILDER_API}/oscap/:distribution/profiles`,
+    (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(distributionOscapProfiles(req)));
+    }
+  ),
+  rest.get(
+    `${IMAGE_BUILDER_API}/oscap/:distribution/:profile/customizations`,
+    (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(oscapCustomizations(req)));
+    }
+  ),
 ];


### PR DESCRIPTION
This pull request adds to the wizard a new step to let the user pick an oscap policy.
Applying a policy has for effect to add (depending on the required customizations of the policy):

* Filesystem customizations
* Packages

The chosen policy is also added to the compose request send to IB.
This work is compatible with the recreate functionality as long as the policy is included in the compose request to recreate.

**Some design choices:**
When the user chose a policy, the next steps of FSC and Packages are impacted. And we took the choice to reinitialize these two steps every time the user makes changes in the policy steps. That means that if a user selects a policy, goes to the packages step to add some and then changes back their policy, the packages step will get reinitialized again.
Same goes on for the recreate use case.

Maybe we can add a small note on the Compliance step to make it clear that any changes in that step will trigger a re-initialization of the FSC and Packages steps ?

**Here are a couple of screenshots for the functionality in action:**

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/adf588c2-3191-415a-9852-05f10187d05b)

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/858f97e3-04ac-4202-a810-4dde8b30738e)

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/560c616f-efe8-44ae-9b4b-b1a28f11bb93)

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/89393a63-e88b-4fb7-8d8a-cf303fe0c122)

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/8e87c071-50cf-4a32-a6f8-094dd1758985)

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/96c7f9e5-3a71-4036-afb3-c2d48d23884e)

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/2cc418a7-be2b-47ea-adcf-41e88ddfeadb)

Big thanks to @regexowl for the pair programming sessions on this PR!