### PR TITLE
API: Move notification dispatch to Image Builder API slice

### DIFF
--- a/src/store/enhancedImageBuilderApi.ts
+++ b/src/store/enhancedImageBuilderApi.ts
@@ -1,3 +1,5 @@
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+
 import { imageBuilderApi } from './imageBuilderApi';
 
 const enhancedApi = imageBuilderApi.enhanceEndpoints({
@@ -18,15 +20,32 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
         { composeId, cloneRequest },
         { dispatch, queryFulfilled }
       ) => {
-        queryFulfilled.then(() => {
-          dispatch(
-            imageBuilderApi.util.invalidateTags([
-              // Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
-              // @ts-expect-error
-              { type: 'Clone', id: composeId },
-            ])
-          );
-        });
+        queryFulfilled
+          .then(() => {
+            dispatch(
+              imageBuilderApi.util.invalidateTags([
+                // Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
+                // @ts-expect-error
+                { type: 'Clone', id: composeId },
+              ])
+            );
+
+            dispatch(
+              addNotification({
+                variant: 'success',
+                title: 'Your image is being shared',
+              })
+            );
+          })
+          .catch((err) => {
+            dispatch(
+              addNotification({
+                variant: 'danger',
+                title: 'Your image could not be shared',
+                description: `Status code ${err.status}: ${err.data.errors[0].detail}`,
+              })
+            );
+          });
       },
     },
     composeImage: {
@@ -34,11 +53,32 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
         { composeRequest },
         { dispatch, queryFulfilled }
       ) => {
-        queryFulfilled.then(() => {
-          // Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
-          // @ts-expect-error
-          dispatch(imageBuilderApi.util.invalidateTags(['Compose']));
-        });
+        queryFulfilled
+          .then(() => {
+            // Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
+            // @ts-expect-error
+            dispatch(imageBuilderApi.util.invalidateTags(['Compose']));
+            dispatch(
+              addNotification({
+                variant: 'success',
+                title: 'Your image is being created',
+              })
+            );
+          })
+          .catch((err) => {
+            let msg = err.response.statusText;
+            if (err.response.data?.errors[0]?.detail) {
+              msg = err.response.data?.errors[0]?.detail;
+            }
+
+            dispatch(
+              addNotification({
+                variant: 'danger',
+                title: 'Your image could not be created',
+                description: 'Status code ' + err.response.status + ': ' + msg,
+              })
+            );
+          });
       },
     },
   },


### PR DESCRIPTION
This commit moves the notification dispatching for creating composes and
clones into a more sensible location – the Image Builder API slice.

It is more sensible because it separates the logic of the React
component (the wizard or share images modal) from the logic of handling
the request life cycle (which is now handled entirely in the slice).

There is a subtle but significant change – a new request will be
dispatched for every request. This is the correct way to do things as it
is possible that some requests succeed, and that others fail. Insights
causes the notifications to stack on top of each other neatly, so there
is no UI problem.

To facilitate this, we also need to use use Promise.allSettled instead
of Promise.all.