### PR TITLE
eslint: Disabled rulesdir/forbid-pf-relative-imports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -11,6 +11,7 @@ globals:
 plugins:
   - import
 rules:
+  rulesdir/forbid-pf-relative-imports: off
   import/order:
     - error
     - groups:


### PR DESCRIPTION
Commit #3e84abba3f43e4945d84faf2f2210df670bfb9d8 bumped @redhat-cloud-services/eslint-config-redhat-cloud-services from 1.3.0 to 2.0.3.

This introduced a new rule that broke a number of our imports. This commit forbids the rule for now.

(rulesdir/forbid-pf-relative-imports: off)