### PR TITLE
fsc: fix the oscap fs customizations

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -83,9 +83,13 @@ const FileSystemConfiguration = ({ ...props }) => {
     if (customizations && customizations.filesystem && isSuccess) {
       const newRows = rows;
 
-      // Only keep the required partitions that have a valid mount points
+      // The filesystem customizations required by the OpenSCAP profile may
+      // contain some unsupported mountpoints. They need to be filtered out to
+      // prevent undefined behaviour in the frontend and the backend
       const fss = customizations.filesystem.filter((fs) =>
-        MountPointValidPrefixes.includes(fs.mountpoint)
+        MountPointValidPrefixes.includes(
+          '/'.concat(fs.mountpoint.split('/')[1])
+        )
       );
 
       // And add them all to the list.


### PR DESCRIPTION
There was a bug preventing all the partitions required by an oscap policy to show up in the fsc step. That bug was because the FSC customizations were only accepted if they matched exactly the fix set of base partitions directories.

So now there's a bit of string manipulation to avoid that but it's all patched up.

fixes https://github.com/RedHatInsights/image-builder-frontend/issues/1385