### PR TITLE
wizard: allow the creation of aarch64 images

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -112,7 +112,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'aws',
           upload_request: {
             type: 'aws',
@@ -151,7 +151,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'gcp',
           upload_request: {
             type: 'gcp',
@@ -182,7 +182,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'azure',
           upload_request: {
             type: 'azure',
@@ -205,7 +205,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'vsphere',
           upload_request: {
             type: 'aws.s3',
@@ -225,7 +225,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'vsphere-ova',
           upload_request: {
             type: 'aws.s3',
@@ -245,7 +245,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'guest-image',
           upload_request: {
             type: 'aws.s3',
@@ -265,7 +265,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'image-installer',
           upload_request: {
             type: 'aws.s3',
@@ -285,7 +285,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'wsl',
           upload_request: {
             type: 'aws.s3',
@@ -330,6 +330,7 @@ const requestToState = (composeRequest, distroInfo, isProd, enableOscap) => {
     formState['image-description'] = composeRequest.image_description;
 
     formState.release = composeRequest?.distribution;
+    formState.arch = imageRequest.architecture;
     // set defaults for target environment first
     formState['target-environment'] = {
       aws: false,

--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -31,6 +31,7 @@
 
 .tile {
     flex: 1 0 0px;
+    max-width: 250px;
 }
 
 .pf-c-tile:focus {

--- a/src/Components/CreateImageWizard/ImageCreator.js
+++ b/src/Components/CreateImageWizard/ImageCreator.js
@@ -8,6 +8,7 @@ import { Spinner } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
 import ActivationKeys from './formComponents/ActivationKeys';
+import ArchSelect from './formComponents/ArchSelect';
 import { AWSSourcesSelect } from './formComponents/AWSSourcesSelect';
 import AzureAuthButton from './formComponents/AzureAuthButton';
 import AzureResourceGroups from './formComponents/AzureResourceGroups';
@@ -74,6 +75,7 @@ const ImageCreator = ({
         'azure-resource-groups': AzureResourceGroups,
         'gallery-layout': GalleryLayout,
         'oscap-profile-selector': Oscap,
+        'image-output-arch-select': ArchSelect,
         registration: Registration,
         ...customComponentMapper,
       }}

--- a/src/Components/CreateImageWizard/formComponents/ArchSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/ArchSelect.js
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+
+import { FormSpy } from '@data-driven-forms/react-form-renderer';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import { FormGroup } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
+import PropTypes from 'prop-types';
+
+import { ARCHS } from '../../../constants';
+
+const ArchSelect = ({ label, isRequired, ...props }) => {
+  const { change, getState } = useFormApi();
+  const { input } = useFieldApi(props);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const setArch = (_, selection) => {
+    change(input.name, selection);
+    setIsOpen(false);
+  };
+
+  const setSelectOptions = () => {
+    var options = [];
+    ARCHS.forEach((arch) => {
+      options.push(
+        <SelectOption key={arch} value={arch}>
+          {arch}
+        </SelectOption>
+      );
+    });
+
+    return options;
+  };
+
+  return (
+    <FormSpy>
+      {() => (
+        <FormGroup isRequired={isRequired} label={label}>
+          <Select
+            ouiaId="arch_select"
+            variant={SelectVariant.single}
+            onToggle={() => setIsOpen(!isOpen)}
+            onSelect={setArch}
+            selections={getState()?.values?.[input.name]}
+            isOpen={isOpen}
+          >
+            {setSelectOptions()}
+          </Select>
+        </FormGroup>
+      )}
+    </FormSpy>
+  );
+};
+
+ArchSelect.propTypes = {
+  label: PropTypes.node,
+  isRequired: PropTypes.bool,
+};
+
+export default ArchSelect;

--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -25,7 +25,7 @@ import {
   RepositoriesTable,
 } from './ReviewStepTables';
 
-import { RELEASES, UNIT_GIB } from '../../../constants';
+import { ARCHS, RELEASES, UNIT_GIB } from '../../../constants';
 import { extractProvisioningList } from '../../../store/helpers';
 import { useGetSourceListQuery } from '../../../store/provisioningApi';
 import { useShowActivationKeyQuery } from '../../../store/rhsmApi';
@@ -57,7 +57,9 @@ export const ImageOutputList = () => {
         <TextListItem component={TextListItemVariants.dt}>
           Architecture
         </TextListItem>
-        <TextListItem component={TextListItemVariants.dd}>x86_64</TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          {getState()?.values?.arch}
+        </TextListItem>
       </TextList>
       <br />
     </TextContent>

--- a/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
+++ b/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
@@ -3,10 +3,13 @@ import React, { useEffect, useState } from 'react';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import {
+  Alert,
+  Bullseye,
   Checkbox,
   FormGroup,
   Popover,
   Radio,
+  Spinner,
   Text,
   TextContent,
   TextVariants,
@@ -14,10 +17,33 @@ import {
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
+import { useField } from 'react-final-form';
 
-import { RHEL_8, CENTOS_8 } from '../../../constants.js';
+import { useGetArchitecturesQuery } from '../../../store/imageBuilderApi';
 import { provisioningApi } from '../../../store/provisioningApi';
 import { useGetEnvironment } from '../../../Utilities/useGetEnvironment';
+
+const useGetAllowedTargets = ({ architecture, release }) => {
+  const { data, isFetching, isSuccess, isError } = useGetArchitecturesQuery({
+    distribution: release,
+  });
+
+  let image_types = [];
+  if (isSuccess && data) {
+    data.forEach((elem) => {
+      if (elem.arch === architecture) {
+        image_types = elem.image_types;
+      }
+    });
+  }
+
+  return {
+    data: image_types,
+    isFetching: isFetching,
+    isSuccess: isSuccess,
+    isError: isError,
+  };
+};
 
 const TargetEnvironment = ({ label, isRequired, ...props }) => {
   const { getState, change } = useFormApi();
@@ -52,17 +78,67 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
       return newEnv;
     });
 
-  // hack, wsl isn't supported in el9, causes a rerender
-  if (environment.wsl && ![RHEL_8, CENTOS_8].includes(release)) {
-    handleSetEnvironment('wsl', false);
-  }
-
   const handleKeyDown = (e, env, checked) => {
     if (e.key === ' ') {
       handleSetEnvironment(env, checked);
     }
   };
 
+  // Load all the allowed targets from the backend
+  const architecture = useField('arch').input.value;
+
+  const {
+    data: allowedTargets,
+    isFetching,
+    isSuccess,
+    isError,
+  } = useGetAllowedTargets({
+    architecture: architecture,
+    release: release,
+  });
+
+  if (isFetching) {
+    return (
+      <Bullseye>
+        <Spinner size="lg" />
+      </Bullseye>
+    );
+  }
+
+  if (isError || !isSuccess) {
+    return (
+      <Alert
+        variant={'danger'}
+        isPlain
+        isInline
+        title={'Allowed targets unavailable'}
+      >
+        Allowed targets cannot be reached, try again later.
+      </Alert>
+    );
+  }
+
+  // If the user already made a choice for some targets but then changes their
+  // architecture or distribution, only keep the target choices that are still
+  // compatible.
+  const allTargets = [
+    'aws',
+    'gcp',
+    'azure',
+    'vsphere',
+    'vsphere-ova',
+    'guest-image',
+    'image-installer',
+    'wsl',
+  ];
+  allTargets.forEach((target) => {
+    if (environment[target] && !allowedTargets.includes(target)) {
+      handleSetEnvironment(target, false);
+    }
+  });
+
+  // each item the user can select is depending on what's compatible with the
+  // architecture and the distribution they previously selected
   return (
     <FormGroup
       isRequired={isRequired}
@@ -74,195 +150,208 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
         data-testid="target-public"
       >
         <div className="tiles">
-          <Tile
-            className="tile pf-u-mr-sm"
-            data-testid="upload-aws"
-            title="Amazon Web Services"
-            icon={
-              <img
-                className="provider-icon"
-                src={'/apps/frontend-assets/partners-icons/aws.svg'}
-                alt="Amazon Web Services logo"
-              />
-            }
-            onClick={() => handleSetEnvironment('aws', !environment.aws)}
-            onKeyDown={(e) => handleKeyDown(e, 'aws', !environment.aws)}
-            onMouseEnter={() => prefetchSources({ provider: 'aws' })}
-            isSelected={environment.aws}
-            isStacked
-            isDisplayLarge
-          />
-          <Tile
-            className="tile pf-u-mr-sm"
-            data-testid="upload-google"
-            title="Google Cloud Platform"
-            icon={
-              <img
-                className="provider-icon"
-                src={
-                  '/apps/frontend-assets/partners-icons/google-cloud-short.svg'
-                }
-                alt="Google Cloud Platform logo"
-              />
-            }
-            onClick={() => handleSetEnvironment('gcp', !environment.gcp)}
-            isSelected={environment.gcp}
-            onKeyDown={(e) => handleKeyDown(e, 'gcp', !environment.gcp)}
-            onMouseEnter={() => prefetchSources({ provider: 'gcp' })}
-            isStacked
-            isDisplayLarge
-          />
-          <Tile
-            className="tile pf-u-mr-sm"
-            data-testid="upload-azure"
-            title="Microsoft Azure"
-            icon={
-              <img
-                className="provider-icon"
-                src={
-                  '/apps/frontend-assets/partners-icons/microsoft-azure-short.svg'
-                }
-                alt="Microsoft Azure logo"
-              />
-            }
-            onClick={() => handleSetEnvironment('azure', !environment.azure)}
-            onKeyDown={(e) => handleKeyDown(e, 'azure', !environment.azure)}
-            onMouseEnter={() => prefetchSources({ provider: 'azure' })}
-            isSelected={environment.azure}
-            isStacked
-            isDisplayLarge
-          />
+          {allowedTargets.includes('aws') && (
+            <Tile
+              className="tile pf-u-mr-sm"
+              data-testid="upload-aws"
+              title="Amazon Web Services"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={'/apps/frontend-assets/partners-icons/aws.svg'}
+                  alt="Amazon Web Services logo"
+                />
+              }
+              onClick={() => handleSetEnvironment('aws', !environment.aws)}
+              onKeyDown={(e) => handleKeyDown(e, 'aws', !environment.aws)}
+              onMouseEnter={() => prefetchSources({ provider: 'aws' })}
+              isSelected={environment.aws}
+              isStacked
+              isDisplayLarge
+            />
+          )}
+          {allowedTargets.includes('gcp') && (
+            <Tile
+              className="tile pf-u-mr-sm"
+              data-testid="upload-google"
+              title="Google Cloud Platform"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={
+                    '/apps/frontend-assets/partners-icons/google-cloud-short.svg'
+                  }
+                  alt="Google Cloud Platform logo"
+                />
+              }
+              onClick={() => handleSetEnvironment('gcp', !environment.gcp)}
+              isSelected={environment.gcp}
+              onKeyDown={(e) => handleKeyDown(e, 'gcp', !environment.gcp)}
+              onMouseEnter={() => prefetchSources({ provider: 'gcp' })}
+              isStacked
+              isDisplayLarge
+            />
+          )}
+          {allowedTargets.includes('azure') && (
+            <Tile
+              className="tile pf-u-mr-sm"
+              data-testid="upload-azure"
+              title="Microsoft Azure"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={
+                    '/apps/frontend-assets/partners-icons/microsoft-azure-short.svg'
+                  }
+                  alt="Microsoft Azure logo"
+                />
+              }
+              onClick={() => handleSetEnvironment('azure', !environment.azure)}
+              onKeyDown={(e) => handleKeyDown(e, 'azure', !environment.azure)}
+              onMouseEnter={() => prefetchSources({ provider: 'azure' })}
+              isSelected={environment.azure}
+              isStacked
+              isDisplayLarge
+            />
+          )}
         </div>
       </FormGroup>
-      <FormGroup
-        label={<Text component={TextVariants.small}>Private cloud</Text>}
-        className="pf-u-mt-sm"
-        data-testid="target-private"
-      >
-        <Checkbox
-          label="VMWare vSphere"
-          isChecked={environment.vsphere || environment['vsphere-ova']}
-          onChange={(_event, checked) => {
-            handleSetEnvironment('vsphere-ova', checked);
-            handleSetEnvironment('vsphere', false);
-          }}
-          aria-label="VMWare checkbox"
-          id="checkbox-vmware"
-          name="VMWare"
-          data-testid="checkbox-vmware"
-        />
-      </FormGroup>
-      <FormGroup
-        className="pf-u-mt-sm pf-u-mb-sm pf-u-ml-xl"
-        data-testid="target-private-vsphere-radio"
-      >
-        <Radio
-          name="vsphere-radio"
-          aria-label="VMWare vSphere radio button OVA"
-          id="vsphere-radio-ova"
-          label={
-            <>
-              Open virtualization format (.ova)
-              <Popover
-                maxWidth="30rem"
-                position="right"
-                bodyContent={
-                  <TextContent>
-                    <Text>
-                      An OVA file is a virtual appliance used by virtualization
-                      platforms such as VMWare vSphere. It is a package that
-                      contains files used to describe a virtual machine, which
-                      includes a VMDK image, OVF descriptor file and a manifest
-                      file.
-                    </Text>
-                  </TextContent>
-                }
-              >
-                <HelpIcon className="pf-u-ml-sm" />
-              </Popover>
-            </>
-          }
-          onChange={(_event, checked) => {
-            handleSetEnvironment('vsphere-ova', checked);
-            handleSetEnvironment('vsphere', !checked);
-          }}
-          isChecked={environment['vsphere-ova']}
-          isDisabled={!(environment.vsphere || environment['vsphere-ova'])}
-        />
-        <Radio
+      {allowedTargets.includes('vsphere') && (
+        <FormGroup
+          label={<Text component={TextVariants.small}>Private cloud</Text>}
           className="pf-u-mt-sm"
-          name="vsphere-radio"
-          aria-label="VMWare vSphere radio button VMDK"
-          id="vsphere-radio-vmdk"
-          label={
-            <>
-              Virtual disk (.vmdk)
-              <Popover
-                maxWidth="30rem"
-                position="right"
-                bodyContent={
-                  <TextContent>
-                    <Text>
-                      A VMDK file is a virtual disk that stores the contents of
-                      a virtual machine. This disk has to be imported into
-                      vSphere using govc import.vmdk, use the OVA version when
-                      using the vSphere UI.
-                    </Text>
-                  </TextContent>
-                }
-              >
-                <HelpIcon className="pf-u-ml-sm" />
-              </Popover>
-            </>
-          }
-          onChange={(_event, checked) => {
-            handleSetEnvironment('vsphere-ova', !checked);
-            handleSetEnvironment('vsphere', checked);
-          }}
-          isChecked={environment.vsphere}
-          isDisabled={!(environment.vsphere || environment['vsphere-ova'])}
-        />
-      </FormGroup>
+          data-testid="target-private"
+        >
+          <Checkbox
+            label="VMWare vSphere"
+            isChecked={environment.vsphere || environment['vsphere-ova']}
+            onChange={(_event, checked) => {
+              handleSetEnvironment('vsphere-ova', checked);
+              handleSetEnvironment('vsphere', false);
+            }}
+            aria-label="VMWare checkbox"
+            id="checkbox-vmware"
+            name="VMWare"
+            data-testid="checkbox-vmware"
+          />
+        </FormGroup>
+      )}
+      {allowedTargets.includes('vsphere') && (
+        <FormGroup
+          className="pf-u-mt-sm pf-u-mb-sm pf-u-ml-xl"
+          data-testid="target-private-vsphere-radio"
+        >
+          {allowedTargets.includes('vsphere-ova') && (
+            <Radio
+              name="vsphere-radio"
+              aria-label="VMWare vSphere radio button OVA"
+              id="vsphere-radio-ova"
+              label={
+                <>
+                  Open virtualization format (.ova)
+                  <Popover
+                    maxWidth="30rem"
+                    position="right"
+                    bodyContent={
+                      <TextContent>
+                        <Text>
+                          An OVA file is a virtual appliance used by
+                          virtualization platforms such as VMWare vSphere. It is
+                          a package that contains files used to describe a
+                          virtual machine, which includes a VMDK image, OVF
+                          descriptor file and a manifest file.
+                        </Text>
+                      </TextContent>
+                    }
+                  >
+                    <HelpIcon className="pf-u-ml-sm" />
+                  </Popover>
+                </>
+              }
+              onChange={(_event, checked) => {
+                handleSetEnvironment('vsphere-ova', checked);
+                handleSetEnvironment('vsphere', !checked);
+              }}
+              isChecked={environment['vsphere-ova']}
+              isDisabled={!(environment.vsphere || environment['vsphere-ova'])}
+            />
+          )}
+          <Radio
+            className="pf-u-mt-sm"
+            name="vsphere-radio"
+            aria-label="VMWare vSphere radio button VMDK"
+            id="vsphere-radio-vmdk"
+            label={
+              <>
+                Virtual disk (.vmdk)
+                <Popover
+                  maxWidth="30rem"
+                  position="right"
+                  bodyContent={
+                    <TextContent>
+                      <Text>
+                        A VMDK file is a virtual disk that stores the contents
+                        of a virtual machine. This disk has to be imported into
+                        vSphere using govc import.vmdk, use the OVA version when
+                        using the vSphere UI.
+                      </Text>
+                    </TextContent>
+                  }
+                >
+                  <HelpIcon className="pf-u-ml-sm" />
+                </Popover>
+              </>
+            }
+            onChange={(_event, checked) => {
+              handleSetEnvironment('vsphere-ova', !checked);
+              handleSetEnvironment('vsphere', checked);
+            }}
+            isChecked={environment.vsphere}
+            isDisabled={!(environment.vsphere || environment['vsphere-ova'])}
+          />
+        </FormGroup>
+      )}
       <FormGroup
         label={<Text component={TextVariants.small}>Other</Text>}
         data-testid="target-other"
       >
-        <Checkbox
-          label="Virtualization - Guest image (.qcow2)"
-          isChecked={environment['guest-image']}
-          onChange={(_event, checked) =>
-            handleSetEnvironment('guest-image', checked)
-          }
-          aria-label="Virtualization guest image checkbox"
-          id="checkbox-guest-image"
-          name="Virtualization guest image"
-          data-testid="checkbox-guest-image"
-        />
-        <Checkbox
-          label="Bare metal - Installer (.iso)"
-          isChecked={environment['image-installer']}
-          onChange={(_event, checked) =>
-            handleSetEnvironment('image-installer', checked)
-          }
-          aria-label="Bare metal installer checkbox"
-          id="checkbox-image-installer"
-          name="Bare metal installer"
-          data-testid="checkbox-image-installer"
-        />
-        {[RHEL_8, CENTOS_8].includes(getState()?.values?.release) &&
-          isBeta() && (
-            <Checkbox
-              label="WSL - Windows Subsystem for Linux (.tar.gz)"
-              isChecked={environment['wsl']}
-              onChange={(_event, checked) =>
-                handleSetEnvironment('wsl', checked)
-              }
-              aria-label="windows subsystem for linux checkbox"
-              id="checkbox-wsl"
-              name="WSL"
-              data-testid="checkbox-wsl"
-            />
-          )}
+        {allowedTargets.includes('guest-image') && (
+          <Checkbox
+            label="Virtualization - Guest image (.qcow2)"
+            isChecked={environment['guest-image']}
+            onChange={(_event, checked) =>
+              handleSetEnvironment('guest-image', checked)
+            }
+            aria-label="Virtualization guest image checkbox"
+            id="checkbox-guest-image"
+            name="Virtualization guest image"
+            data-testid="checkbox-guest-image"
+          />
+        )}
+        {allowedTargets.includes('image-installer') && (
+          <Checkbox
+            label="Bare metal - Installer (.iso)"
+            isChecked={environment['image-installer']}
+            onChange={(_event, checked) =>
+              handleSetEnvironment('image-installer', checked)
+            }
+            aria-label="Bare metal installer checkbox"
+            id="checkbox-image-installer"
+            name="Bare metal installer"
+            data-testid="checkbox-image-installer"
+          />
+        )}
+        {allowedTargets.includes('wsl') && isBeta && (
+          <Checkbox
+            label="WSL - Windows Subsystem for Linux (.tar.gz)"
+            isChecked={environment['wsl']}
+            onChange={(_event, checked) => handleSetEnvironment('wsl', checked)}
+            aria-label="windows subsystem for linux checkbox"
+            id="checkbox-wsl"
+            name="WSL"
+            data-testid="checkbox-wsl"
+          />
+        )}
       </FormGroup>
     </FormGroup>
   );

--- a/src/Components/CreateImageWizard/steps/imageOutput.js
+++ b/src/Components/CreateImageWizard/steps/imageOutput.js
@@ -7,7 +7,7 @@ import { Text } from '@patternfly/react-core';
 import nextStepMapper from './imageOutputStepMapper';
 import StepTemplate from './stepTemplate';
 
-import { RHEL_9 } from '../../../constants.js';
+import { RHEL_9, X86_64 } from '../../../constants.js';
 import DocumentationButton from '../../sharedComponents/DocumentationButton';
 import CustomButtons from '../formComponents/CustomButtons';
 
@@ -36,6 +36,18 @@ const imageOutputStep = {
       label: 'Release',
       name: 'release',
       initialValue: RHEL_9,
+      isRequired: true,
+      validate: [
+        {
+          type: validatorTypes.REQUIRED,
+        },
+      ],
+    },
+    {
+      component: 'image-output-arch-select',
+      label: 'Architecture',
+      name: 'arch',
+      initialValue: X86_64,
       isRequired: true,
       validate: [
         {

--- a/src/constants.js
+++ b/src/constants.js
@@ -7,6 +7,8 @@ export const RHEL_8 = 'rhel-88';
 export const RHEL_9 = 'rhel-92';
 export const CENTOS_8 = 'centos-8';
 export const CENTOS_9 = 'centos-9';
+export const X86_64 = 'x86_64';
+export const AARCH64 = 'aarch64';
 
 export const UNIT_KIB = 1024 ** 1;
 export const UNIT_MIB = 1024 ** 2;
@@ -18,6 +20,8 @@ export const RELEASES = new Map([
   [CENTOS_9, 'CentOS Stream 9'],
   [CENTOS_8, 'CentOS Stream 8'],
 ]);
+
+export const ARCHS = [X86_64, AARCH64];
 
 export const DEFAULT_AWS_REGION = 'us-east-1';
 

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
@@ -511,7 +511,9 @@ describe('Step Packages', () => {
       ));
 
       // select aws as upload destination
-      user.click(screen.getByTestId('upload-aws'));
+      await waitFor(
+        async () => await user.click(await screen.findByTestId('upload-aws'))
+      );
       await clickNext();
 
       // aws step

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -193,9 +193,9 @@ describe('Step Image output', () => {
   test('expect only RHEL releases before expansion', async () => {
     await setUp();
 
-    const releaseMenu = screen.getByRole('button', {
+    const releaseMenu = screen.getAllByRole('button', {
       name: /options menu/i,
-    });
+    })[0];
     await user.click(releaseMenu);
 
     await screen.findByRole('option', {
@@ -214,9 +214,9 @@ describe('Step Image output', () => {
   test('expect all releases after expansion', async () => {
     await setUp();
 
-    const releaseMenu = screen.getByRole('button', {
+    const releaseMenu = screen.getAllByRole('button', {
       name: /options menu/i,
-    });
+    })[0];
     await user.click(releaseMenu);
 
     const showOptionsButton = screen.getByRole('button', {
@@ -245,9 +245,9 @@ describe('Step Image output', () => {
   test('CentOS acknowledgement appears', async () => {
     await setUp();
 
-    const releaseMenu = screen.getByRole('button', {
+    const releaseMenu = screen.getAllByRole('button', {
       name: /options menu/i,
-    });
+    })[0];
     await user.click(releaseMenu);
 
     const showOptionsButton = screen.getByRole('button', {
@@ -915,9 +915,9 @@ describe('Step Review', () => {
   const setUpCentOS = async () => {
     ({ router } = renderCustomRoutesWithReduxRouter('imagewizard', {}, routes));
 
-    const releaseMenu = screen.getByRole('button', {
+    const releaseMenu = screen.getAllByRole('button', {
       name: /options menu/i,
-    });
+    })[0];
     await user.click(releaseMenu);
 
     const showOptionsButton = screen.getByRole('button', {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -276,7 +276,9 @@ describe('Step Upload to AWS', () => {
     ));
 
     // select aws as upload destination
-    user.click(screen.getByTestId('upload-aws'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
 
     await clickNext();
 
@@ -444,7 +446,9 @@ describe('Step Upload to Google', () => {
     ));
 
     // select gcp as upload destination
-    user.click(screen.getByTestId('upload-google'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-google'))
+    );
 
     await clickNext();
 
@@ -525,7 +529,9 @@ describe('Step Registration', () => {
     ));
 
     // select aws as upload destination
-    user.click(screen.getByTestId('upload-aws'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
 
     await clickNext();
     await user.click(
@@ -717,7 +723,9 @@ describe('Step File system configuration', () => {
     ));
 
     // select aws as upload destination
-    user.click(screen.getByTestId('upload-aws'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
     await clickNext();
 
     // aws step
@@ -796,7 +804,9 @@ describe('Step Details', () => {
     ));
 
     // select aws as upload destination
-    user.click(screen.getByTestId('upload-aws'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
     await clickNext();
 
     // aws step
@@ -869,7 +879,9 @@ describe('Step Review', () => {
     ));
 
     // select aws as upload destination
-    user.click(screen.getByTestId('upload-aws'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
     await clickNext();
 
     // aws step
@@ -919,7 +931,9 @@ describe('Step Review', () => {
     await user.click(centos);
 
     // select aws as upload destination
-    user.click(await screen.findByTestId('upload-aws'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
     await clickNext();
 
     // aws step
@@ -1024,16 +1038,19 @@ describe('Click through all steps', () => {
     await setUp();
 
     // select image output
-    const releaseMenu = screen.getByRole('button', {
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
+    const releaseMenu = screen.getAllByRole('button', {
       name: /options menu/i,
-    });
+    })[0];
     await user.click(releaseMenu);
     const releaseOption = screen.getByRole('option', {
       name: 'Red Hat Enterprise Linux (RHEL) 8',
     });
     await user.click(releaseOption);
 
-    await user.click(screen.getByTestId('upload-aws'));
+    await waitFor(() => screen.findByTestId('upload-aws'));
     await user.click(screen.getByTestId('upload-azure'));
     await user.click(screen.getByTestId('upload-google'));
     await user.click(screen.getByTestId('checkbox-vmware'));
@@ -1379,11 +1396,13 @@ describe('Keyboard accessibility', () => {
     await clickNext();
   };
 
-  const selectAllEnvironments = () => {
-    user.click(screen.getByTestId('upload-aws'));
-    user.click(screen.getByTestId('upload-google'));
-    user.click(screen.getByTestId('upload-azure'));
-    user.click(
+  const selectAllEnvironments = async () => {
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
+    await user.click(screen.getByTestId('upload-google'));
+    await user.click(screen.getByTestId('upload-azure'));
+    await user.click(
       screen.getByRole('checkbox', {
         name: /virtualization guest image checkbox/i,
       })
@@ -1394,7 +1413,7 @@ describe('Keyboard accessibility', () => {
     await setUp();
 
     // Image output
-    selectAllEnvironments();
+    await selectAllEnvironments();
     await clickNext();
 
     // Target environment aws
@@ -1470,14 +1489,18 @@ describe('Keyboard accessibility', () => {
   test('pressing Esc closes the wizard', async () => {
     await setUp();
     // wizard needs to be interacted with for the esc key to work
-    await user.click(screen.getByTestId('upload-aws'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
     await user.keyboard('{escape}');
     expect(router.state.location.pathname).toBe('/insights/image-builder');
   });
 
   test('pressing Enter does not advance the wizard', async () => {
     await setUp();
-    await user.click(screen.getByTestId('upload-aws'));
+    await waitFor(
+      async () => await user.click(await screen.findByTestId('upload-aws'))
+    );
     await user.keyboard('{enter}');
     screen.getByRole('heading', {
       name: /image output/i,
@@ -1496,6 +1519,7 @@ describe('Keyboard accessibility', () => {
     await setUp();
     await clickNext();
 
+    await waitFor(() => screen.findByTestId('upload-aws'));
     testTile(screen.getByTestId('upload-aws'));
     testTile(screen.getByTestId('upload-google'));
     testTile(screen.getByTestId('upload-azure'));

--- a/src/test/Components/CreateImageWizard/formComponents/TargetEnvironment.test.js
+++ b/src/test/Components/CreateImageWizard/formComponents/TargetEnvironment.test.js
@@ -1,0 +1,284 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+
+import CreateImageWizard from '../../../../Components/CreateImageWizard/CreateImageWizard';
+import { AARCH64, RHEL_8, RHEL_9, X86_64 } from '../../../../constants';
+import { mockArchitecturesByDistro } from '../../../fixtures/architectures';
+import { server } from '../../../mocks/server';
+import { renderCustomRoutesWithReduxRouter } from '../../../testUtils';
+
+const routes = [
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+];
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
+let router = undefined;
+
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  router = undefined;
+  server.resetHandlers();
+});
+
+describe('Check that the target filtering is in accordance to mock content', () => {
+  test('rhel9 x86_64', async () => {
+    const user = userEvent.setup();
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+
+    // select x86_64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'x86_64' }));
+
+    // make sure this test is in SYNC with the mocks
+    let images_types = [];
+    mockArchitecturesByDistro(RHEL_9).forEach((elem) => {
+      if (elem.arch === X86_64) {
+        images_types = elem.image_types;
+      }
+    });
+    expect(images_types).toContain('aws');
+    expect(images_types).toContain('gcp');
+    expect(images_types).toContain('azure');
+    expect(images_types).toContain('guest-image');
+    expect(images_types).toContain('image-installer');
+    expect(images_types).toContain('vsphere');
+    expect(images_types).toContain('vsphere-ova');
+    expect(images_types).not.toContain('wsl');
+    // make sure the UX conforms to the mocks
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    await screen.findByTestId('upload-google');
+    await screen.findByTestId('upload-azure');
+    await screen.findByTestId('checkbox-guest-image');
+    await screen.findByTestId('checkbox-image-installer');
+    await screen.findByText(/vmware vsphere/i);
+    await screen.findByText(/open virtualization format \(\.ova\)/i);
+    expect(
+      screen.queryByText(/wsl - windows subsystem for linux \(\.tar\.gz\)/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('rhel8 x86_64', async () => {
+    const user = userEvent.setup();
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+
+    // select rhel8
+    const releaseMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[0];
+    await user.click(releaseMenu);
+    await user.click(
+      screen.getByRole('option', {
+        name: 'Red Hat Enterprise Linux (RHEL) 8',
+      })
+    );
+
+    // select x86_64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'x86_64' }));
+
+    // make sure this test is in SYNC with the mocks
+    let images_types = [];
+    mockArchitecturesByDistro(RHEL_8).forEach((elem) => {
+      if (elem.arch === X86_64) {
+        images_types = elem.image_types;
+      }
+    });
+    expect(images_types).toContain('aws');
+    expect(images_types).toContain('gcp');
+    expect(images_types).toContain('azure');
+    expect(images_types).toContain('guest-image');
+    expect(images_types).toContain('image-installer');
+    expect(images_types).toContain('vsphere');
+    expect(images_types).toContain('vsphere-ova');
+    expect(images_types).toContain('wsl');
+    // make sure the UX conforms to the mocks
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    await screen.findByTestId('upload-google');
+    await screen.findByTestId('upload-azure');
+    await screen.findByTestId('checkbox-guest-image');
+    await screen.findByTestId('checkbox-image-installer');
+    await screen.findByText(/vmware vsphere/i);
+    await screen.findByText(/open virtualization format \(\.ova\)/i);
+    await screen.findByText(/wsl - windows subsystem for linux \(\.tar\.gz\)/i);
+  });
+
+  test('rhel9 aarch64', async () => {
+    const user = userEvent.setup();
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+
+    // select aarch64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'aarch64' }));
+
+    // make sure this test is in SYNC with the mocks
+    let images_types = [];
+    mockArchitecturesByDistro(RHEL_9).forEach((elem) => {
+      if (elem.arch === AARCH64) {
+        images_types = elem.image_types;
+      }
+    });
+    expect(images_types).toContain('aws');
+    expect(images_types).not.toContain('gcp');
+    expect(images_types).not.toContain('azure');
+    expect(images_types).toContain('guest-image');
+    expect(images_types).toContain('image-installer');
+    expect(images_types).not.toContain('vsphere');
+    expect(images_types).not.toContain('vsphere-ova');
+    expect(images_types).not.toContain('wsl');
+    // make sure the UX conforms to the mocks
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    expect(screen.queryByTestId('upload-google')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('upload-azure')).not.toBeInTheDocument();
+    await screen.findByTestId('checkbox-guest-image');
+    await screen.findByTestId('checkbox-image-installer');
+    expect(screen.queryByText(/vmware vsphere/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/open virtualization format \(\.ova\)/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/wsl - windows subsystem for linux \(\.tar\.gz\)/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('rhel8 aarch64', async () => {
+    const user = userEvent.setup();
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+
+    // select rhel8
+    const releaseMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[0];
+    await user.click(releaseMenu);
+    await user.click(
+      screen.getByRole('option', {
+        name: 'Red Hat Enterprise Linux (RHEL) 8',
+      })
+    );
+
+    // select x86_64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'aarch64' }));
+
+    // make sure this test is in SYNC with the mocks
+    let images_types = [];
+    mockArchitecturesByDistro(RHEL_8).forEach((elem) => {
+      if (elem.arch === AARCH64) {
+        images_types = elem.image_types;
+      }
+    });
+    expect(images_types).toContain('aws');
+    expect(images_types).not.toContain('gcp');
+    expect(images_types).not.toContain('azure');
+    expect(images_types).toContain('guest-image');
+    expect(images_types).toContain('image-installer');
+    expect(images_types).not.toContain('vsphere');
+    expect(images_types).not.toContain('vsphere-ova');
+    expect(images_types).not.toContain('wsl');
+    // make sure the UX conforms to the mocks
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    expect(screen.queryByTestId('upload-google')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('upload-azure')).not.toBeInTheDocument();
+    await screen.findByTestId('checkbox-guest-image');
+    await screen.findByTestId('checkbox-image-installer');
+    expect(screen.queryByText(/vmware vsphere/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/open virtualization format \(\.ova\)/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/wsl - windows subsystem for linux \(\.tar\.gz\)/i)
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('Check step consistency', () => {
+  test('going back and forth with selected options only keeps the one compatible', async () => {
+    const user = userEvent.setup();
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+
+    // select x86_64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'x86_64' }));
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    // select GCP, it's available for x86_64
+    await user.click(screen.getByTestId('upload-google'));
+    const next = await screen.findByRole('button', { name: /Next/ });
+    await waitFor(() => expect(next).toBeEnabled());
+    // Change to aarch
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'aarch64' }));
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    // GCP not being compatible with arch, the next button is disabled
+    await waitFor(() => expect(next).toBeDisabled());
+    // clicking on AWS the user can go next
+    await user.click(screen.getByTestId('upload-aws'));
+    await waitFor(() => expect(next).toBeEnabled());
+    // and going back to x86_64 the user should keep the next button visible
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'x86_64' }));
+    await waitFor(() => expect(next).toBeEnabled());
+  });
+});

--- a/src/test/fixtures/architectures.ts
+++ b/src/test/fixtures/architectures.ts
@@ -55,6 +55,7 @@ export const mockArchitecturesByDistro = (
           'image-installer',
           'vsphere',
           'vsphere-ova',
+          'wsl',
         ],
         repositories: [
           {


### PR DESCRIPTION
This commit extends the supported architectures to aarch64. In the image output step (the first one of the wizard) the user is now faced with a new select choices to pickup the architecture they want to build.

Now the set of compatible targets to build is dynamically loaded from the backend and the UX changes what's accessible on the fly depending on what the user has selected.

HMS-1135: done

- [x] Manually tested
- [x] Unit tests


[Screencast from 2023-10-16 12-59-58.webm](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/f200004d-f911-4576-91a0-1e2c70312d82)
