### PR TITLE
deps: bump @data-driven-forms/react-form-renderer from 3.21.6 to 3.21.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "dependencies": {
         "@data-driven-forms/pf4-component-mapper": "3.20.13",
-        "@data-driven-forms/react-form-renderer": "3.21.6",
+        "@data-driven-forms/react-form-renderer": "3.21.7",
         "@patternfly/patternfly": "4.224.2",
         "@patternfly/react-core": "4.276.8",
         "@patternfly/react-table": "4.113.3",
@@ -2449,9 +2449,9 @@
       }
     },
     "node_modules/@data-driven-forms/react-form-renderer": {
-      "version": "3.21.6",
-      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.21.6.tgz",
-      "integrity": "sha512-HrdOdFcm2xNmpBdUIEV2bzNI8ARzF2UPl2C4fVh7dXz7s0L8Bk7erypGs4OBjHCxeckZ89VnKGYdvmdYxOK1Yg==",
+      "version": "3.21.7",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.21.7.tgz",
+      "integrity": "sha512-HTBWelDj0Uf2LVGw017v1I9ftkaLhL7T/qDomqG/VF33+8ONYRV9Jt1UBCu9vMlsVLSVzgsZm19542vFgi1bQA==",
       "dependencies": {
         "final-form": "^4.20.4",
         "final-form-arrays": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@data-driven-forms/pf4-component-mapper": "3.20.13",
-    "@data-driven-forms/react-form-renderer": "3.21.6",
+    "@data-driven-forms/react-form-renderer": "3.21.7",
     "@patternfly/patternfly": "4.224.2",
     "@patternfly/react-core": "4.276.8",
     "@patternfly/react-table": "4.113.3",


### PR DESCRIPTION
This version includes a bugfix for the wizard navigation bar.