### PR TITLE
HMS-2782: Expose OCI in the Wizard

### DIFF
--- a/api/schema/imageBuilder.yaml
+++ b/api/schema/imageBuilder.yaml
@@ -506,6 +506,7 @@ components:
             - $ref: '#/components/schemas/AWSS3UploadStatus'
             - $ref: '#/components/schemas/GCPUploadStatus'
             - $ref: '#/components/schemas/AzureUploadStatus'
+            - $ref: '#/components/schemas/OCIUploadStatus'
     AWSUploadStatus:
       type: object
       required:
@@ -545,6 +546,13 @@ components:
         image_name:
           type: string
           example: 'my-image'
+    OCIUploadStatus:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
     ComposeRequest:
       type: object
       additionalProperties: false
@@ -636,6 +644,7 @@ components:
         - gcp
         - guest-image
         - image-installer
+        - oci
         - vsphere
         - vsphere-ova
         - wsl
@@ -709,9 +718,15 @@ components:
             - $ref: '#/components/schemas/AWSS3UploadRequestOptions'
             - $ref: '#/components/schemas/GCPUploadRequestOptions'
             - $ref: '#/components/schemas/AzureUploadRequestOptions'
+            - $ref: '#/components/schemas/OCIUploadRequestOptions'
     UploadTypes:
       type: string
-      enum: ['aws', 'gcp', 'azure', 'aws.s3']
+      enum:
+      - aws
+      - gcp
+      - azure
+      - aws.s3
+      - oci.objectstorage
     AWSUploadRequestOptions:
       type: object
       properties:
@@ -796,6 +811,8 @@ components:
             Name of the created image.
             Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens.
             The total length is limited to 60 characters.
+    OCIUploadRequestOptions:
+      type: object
     Customizations:
       type: object
       properties:

--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -198,6 +198,26 @@ const onSave = (values) => {
     requests.push(request);
   }
 
+  if (values['target-environment']?.oci) {
+    const request = {
+      distribution: values.release,
+      image_name: values?.['image-name'],
+      image_description: values?.['image-description'],
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'oci',
+          upload_request: {
+            type: 'oci.objectstorage',
+            options: {},
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
   if (values['target-environment']?.vsphere) {
     const request = {
       distribution: values.release,
@@ -336,13 +356,17 @@ const requestToState = (composeRequest, distroInfo, isProd, enableOscap) => {
       aws: false,
       azure: false,
       gcp: false,
+      oci: false,
       'guest-image': false,
     };
     // then select the one from the request
     // if the image type is to a cloud provider we use the upload_request.type
     // or if the image is intended for download we use the image_type
     let targetEnvironment;
-    if (uploadRequest.type === 'aws.s3') {
+    if (
+      uploadRequest.type === 'aws.s3' ||
+      uploadRequest.type === 'oci.objectstorage'
+    ) {
       targetEnvironment = imageRequest.image_type;
     } else {
       targetEnvironment = uploadRequest.type;

--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -21,6 +21,7 @@ import {
   TargetEnvAWSList,
   TargetEnvAzureList,
   TargetEnvGCPList,
+  TargetEnvOciList,
   TargetEnvOtherList,
 } from './ReviewStepTextLists';
 
@@ -93,6 +94,9 @@ const ReviewStep = () => {
         )}
         {getState()?.values?.['target-environment']?.azure && (
           <TargetEnvAzureList />
+        )}
+        {getState()?.values?.['target-environment']?.oci && (
+          <TargetEnvOciList />
         )}
         {getState()?.values?.['target-environment']?.vsphere && (
           <TextContent>

--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -236,6 +236,27 @@ export const TargetEnvAzureList = () => {
   );
 };
 
+export const TargetEnvOciList = () => {
+  return (
+    <TextContent>
+      <Text component={TextVariants.h3}>Oracle Cloud Infrastructure</Text>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Object Storage URL
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          The URL for the built image will be ready to copy
+          <br />
+        </TextListItem>
+      </TextList>
+      <br />
+    </TextContent>
+  );
+};
+
 export const TargetEnvOtherList = () => {
   return (
     <>

--- a/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
+++ b/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
@@ -52,6 +52,7 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
     aws: false,
     azure: false,
     gcp: false,
+    oci: false,
     'vsphere-ova': false,
     vsphere: false,
     'guest-image': false,
@@ -210,6 +211,25 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
               onKeyDown={(e) => handleKeyDown(e, 'azure', !environment.azure)}
               onMouseEnter={() => prefetchSources({ provider: 'azure' })}
               isSelected={environment.azure}
+              isStacked
+              isDisplayLarge
+            />
+          )}
+          {allowedTargets.includes('oci') && isBeta() && (
+            <Tile
+              className="tile pf-u-mr-sm"
+              data-testid="upload-oci"
+              title="Oracle Cloud Infrastructure"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={'/apps/frontend-assets/partners-icons/oracle-short.svg'}
+                  alt="Oracle Cloud Infrastructure logo"
+                />
+              }
+              onClick={() => handleSetEnvironment('oci', !environment.oci)}
+              onKeyDown={(e) => handleKeyDown(e, 'oci', !environment.oci)}
+              isSelected={environment.oci}
               isStacked
               isDisplayLarge
             />

--- a/src/Components/ImagesTable/ImageDetails.tsx
+++ b/src/Components/ImagesTable/ImageDetails.tsx
@@ -28,6 +28,7 @@ import {
   isAzureUploadStatus,
   isGcpUploadRequestOptions,
   isGcpUploadStatus,
+  isOciUploadStatus,
 } from '../../store/typeGuards';
 
 const SourceNotFoundPopover = () => {
@@ -352,6 +353,66 @@ export const GcpDetails = ({ compose }: GcpDetailsPropTypes) => {
                 variant="inline-compact"
               >
                 {uploadStatus?.image_name}
+              </ClipboardCopy>
+            )}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+    </>
+  );
+};
+
+type OciDetailsPropTypes = {
+  compose: ComposesResponseItem;
+};
+
+export const OciDetails = ({ compose }: OciDetailsPropTypes) => {
+  const { data: composeStatus } = useGetComposeStatusQuery({
+    composeId: compose.id,
+  });
+
+  const options = composeStatus?.image_status.upload_status?.options;
+
+  if (options && !isOciUploadStatus(options)) {
+    throw TypeError(
+      `Error: uploadStatus must be of type OciUploadStatus, not ${typeof options}.`
+    );
+  }
+
+  return (
+    <>
+      <div className="pf-u-font-weight-bold pf-u-pb-md">Build Information</div>
+      <DescriptionList isHorizontal isCompact className=" pf-u-pl-xl">
+        <DescriptionListGroup>
+          <DescriptionListTerm>UUID</DescriptionListTerm>
+          <DescriptionListDescription>
+            <ClipboardCopy
+              hoverTip="Copy"
+              clickTip="Copied"
+              variant="inline-compact"
+              ouiaId="gcp-uuid"
+            >
+              {compose.id}
+            </ClipboardCopy>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+      </DescriptionList>
+      <br />
+      <div className="pf-u-font-weight-bold pf-u-pb-md">
+        Cloud Provider Identifiers
+      </div>
+      <DescriptionList isHorizontal isCompact className=" pf-u-pl-xl">
+        <DescriptionListGroup>
+          <DescriptionListTerm>Object Storage URL</DescriptionListTerm>
+          <DescriptionListDescription>
+            {composeStatus?.image_status.status === 'success' && (
+              <ClipboardCopy
+                hoverTip="Copy"
+                clickTip="Copied"
+                variant="inline-compact"
+                isBlock
+              >
+                {options?.url}
               </ClipboardCopy>
             )}
           </DescriptionListDescription>

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -40,11 +40,12 @@ import {
 } from './ImageDetails';
 import { AwsS3Instance, CloudInstance, OciInstance } from './Instance';
 import Release from './Release';
-import { AwsS3Status, CloudStatus } from './Status';
+import { ExpiringStatus, CloudStatus } from './Status';
 import { AwsTarget, Target } from './Target';
 
 import {
   AWS_S3_EXPIRATION_TIME_IN_HOURS,
+  OCI_STORAGE_EXPIRATION_TIME_IN_DAYS,
   STATUS_POLLING_INTERVAL,
 } from '../../constants';
 import {
@@ -337,9 +338,20 @@ type OciRowPropTypes = {
 };
 
 const OciRow = ({ compose, rowIndex }: OciRowPropTypes) => {
+  const daysToExpiration = Math.floor(
+    computeHoursToExpiration(compose.created_at) / 24
+  );
+  const isExpired = daysToExpiration >= OCI_STORAGE_EXPIRATION_TIME_IN_DAYS;
+
   const details = <OciDetails compose={compose} />;
-  const instance = <OciInstance compose={compose} />;
-  const status = <CloudStatus compose={compose} />;
+  const instance = <OciInstance compose={compose} isExpired={isExpired} />;
+  const status = (
+    <ExpiringStatus
+      compose={compose}
+      isExpired={isExpired}
+      timeToExpiration={daysToExpiration}
+    />
+  );
 
   return (
     <Row
@@ -364,10 +376,10 @@ const AwsS3Row = ({ compose, rowIndex }: AwsS3RowPropTypes) => {
   const details = <AwsS3Details compose={compose} />;
   const instance = <AwsS3Instance compose={compose} isExpired={isExpired} />;
   const status = (
-    <AwsS3Status
+    <ExpiringStatus
       compose={compose}
       isExpired={isExpired}
-      hoursToExpiration={hoursToExpiration}
+      timeToExpiration={hoursToExpiration}
     />
   );
 

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -36,8 +36,9 @@ import {
   AwsS3Details,
   AzureDetails,
   GcpDetails,
+  OciDetails,
 } from './ImageDetails';
-import { AwsS3Instance, CloudInstance } from './Instance';
+import { AwsS3Instance, CloudInstance, OciInstance } from './Instance';
 import Release from './Release';
 import { AwsS3Status, CloudStatus } from './Status';
 import { AwsTarget, Target } from './Target';
@@ -281,6 +282,8 @@ const ImagesTableRow = ({ compose, rowIndex }: ImagesTableRowPropTypes) => {
       return <GcpRow compose={compose} rowIndex={rowIndex} />;
     case 'azure':
       return <AzureRow compose={compose} rowIndex={rowIndex} />;
+    case 'oci.objectstorage':
+      return <OciRow compose={compose} rowIndex={rowIndex} />;
     case 'aws.s3':
       return <AwsS3Row compose={compose} rowIndex={rowIndex} />;
   }
@@ -315,6 +318,27 @@ type AzureRowPropTypes = {
 const AzureRow = ({ compose, rowIndex }: AzureRowPropTypes) => {
   const details = <AzureDetails compose={compose} />;
   const instance = <CloudInstance compose={compose} />;
+  const status = <CloudStatus compose={compose} />;
+
+  return (
+    <Row
+      compose={compose}
+      rowIndex={rowIndex}
+      details={details}
+      instance={instance}
+      status={status}
+    />
+  );
+};
+
+type OciRowPropTypes = {
+  compose: ComposesResponseItem;
+  rowIndex: number;
+};
+
+const OciRow = ({ compose, rowIndex }: OciRowPropTypes) => {
+  const details = <OciDetails compose={compose} />;
+  const instance = <OciInstance compose={compose} />;
   const status = <CloudStatus compose={compose} />;
 
   return (

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -180,9 +180,11 @@ const getImageProvider = (compose: ComposesResponseItem) => {
 
 type OciInstancePropTypes = {
   compose: ComposesResponseItem;
+  isExpired: boolean;
 };
 
-export const OciInstance = ({ compose }: OciInstancePropTypes) => {
+export const OciInstance = ({ compose, isExpired }: OciInstancePropTypes) => {
+  const navigate = useNavigate();
   const { data, isSuccess, isFetching, isError } = useGetComposeStatusQuery({
     composeId: compose.id,
   });
@@ -199,79 +201,93 @@ export const OciInstance = ({ compose }: OciInstancePropTypes) => {
     );
   }
 
-  return (
-    <Popover
-      position="bottom"
-      headerContent={<div>Launch an OCI image</div>}
-      minWidth="30rem"
-      bodyContent={
-        <>
-          <p>
-            To run the image copy the link below and follow the steps below:
-          </p>
-          <List component={ListComponent.ol} type={OrderType.number}>
-            <ListItem>
-              Go to &quot;Compute&quot; in Oracle Cloud and choose &quot;Custom
-              Images&quot;.
-            </ListItem>
-            <ListItem>
-              Click on &quot;Import image&quot;, choose &quot;Import from an
-              object storage URL&quot;.
-            </ListItem>
-            <ListItem>
-              Choose &quot;Import from an object storage URL&quot; and paste the
-              URL in the &quot;Object Storage URL&quot; field. The image type
-              has to be set to QCOW2 and the launch mode should be
-              paravirtualized.
-            </ListItem>
-          </List>
-          <br />
-          {isSuccess && (
-            <ClipboardCopy
-              hoverTip="Copy"
-              clickTip="Copied"
-              variant="inline-compact"
-              ouiaId="oci-link"
-              isBlock
-            >
-              {options?.url}
-            </ClipboardCopy>
-          )}
-          {isFetching && <Skeleton />}
-          {isError && (
-            <Alert
-              title="The link to launch the image could not be loaded. Please refresh
-              the page and try again."
-              variant="danger"
-              isPlain
-              isInline
-            />
-          )}
-          <br />
-          <Button
-            component="a"
-            target="_blank"
-            variant="link"
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="right"
-            // TO DO update the link after documentation is up
-            href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_images_by_using_insights_image_builder/customizing-file-systems-during-the-image-creation"
-            className="pf-u-pl-0"
-          >
-            Read more about launching OCI images
-          </Button>
-        </>
-      }
-    >
+  if (isExpired) {
+    return (
       <Button
+        component="a"
+        target="_blank"
         variant="link"
-        className="pf-u-p-0 pf-u-font-size-sm"
-        isDisabled={data?.image_status.status === 'success' ? false : true}
+        onClick={() => navigate(resolveRelPath(`imagewizard/${compose.id}`))}
+        isInline
       >
-        Image link
+        Recreate image
       </Button>
-    </Popover>
-  );
+    );
+  } else {
+    return (
+      <Popover
+        position="bottom"
+        headerContent={<div>Launch an OCI image</div>}
+        minWidth="30rem"
+        bodyContent={
+          <>
+            <p>
+              To run the image copy the link below and follow the steps below:
+            </p>
+            <List component={ListComponent.ol} type={OrderType.number}>
+              <ListItem>
+                Go to &quot;Compute&quot; in Oracle Cloud and choose &quot;
+                Custom Images&quot;.
+              </ListItem>
+              <ListItem>
+                Click on &quot;Import image&quot;, choose &quot;Import from an
+                object storage URL&quot;.
+              </ListItem>
+              <ListItem>
+                Choose &quot;Import from an object storage URL&quot; and paste
+                the URL in the &quot;Object Storage URL&quot; field. The image
+                type has to be set to QCOW2 and the launch mode should be
+                paravirtualized.
+              </ListItem>
+            </List>
+            <br />
+            {isSuccess && (
+              <ClipboardCopy
+                hoverTip="Copy"
+                clickTip="Copied"
+                variant="inline-compact"
+                ouiaId="oci-link"
+                isBlock
+              >
+                {options?.url}
+              </ClipboardCopy>
+            )}
+            {isFetching && <Skeleton />}
+            {isError && (
+              <Alert
+                title="The link to launch the image could not be loaded. Please refresh
+                the page and try again."
+                variant="danger"
+                isPlain
+                isInline
+              />
+            )}
+            <br />
+            <Button
+              component="a"
+              target="_blank"
+              variant="link"
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="right"
+              // TO DO update the link after documentation is up
+              href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_images_by_using_insights_image_builder/customizing-file-systems-during-the-image-creation"
+              className="pf-u-pl-0"
+            >
+              Read more about launching OCI images
+            </Button>
+          </>
+        }
+      >
+        <Button
+          variant="link"
+          className="pf-u-p-0 pf-u-font-size-sm"
+          isDisabled={data?.image_status.status === 'success' ? false : true}
+        >
+          Image link
+        </Button>
+      </Popover>
+    );
+  }
 };
 
 type AwsS3InstancePropTypes = {

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -203,6 +203,7 @@ export const OciInstance = ({ compose }: OciInstancePropTypes) => {
     <Popover
       position="bottom"
       headerContent={<div>Launch an OCI image</div>}
+      minWidth="30rem"
       bodyContent={
         <>
           <p>

--- a/src/Components/ImagesTable/Target.tsx
+++ b/src/Components/ImagesTable/Target.tsx
@@ -23,6 +23,7 @@ const targetOptions: { [key in ImageTypes]: string } = {
   'rhel-edge-commit': 'RHEL Edge Commit',
   'rhel-edge-installer': 'RHEL Edge Installer',
   vhd: '',
+  oci: 'Oracle Cloud Infrastructure',
 };
 
 type TargetPropTypes = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -122,6 +122,7 @@ export const AWS_REGIONS = [
 ];
 
 export const AWS_S3_EXPIRATION_TIME_IN_HOURS = 6;
+export const OCI_STORAGE_EXPIRATION_TIME_IN_DAYS = 7;
 
 // Anchor element for all modals that we display so that they play nice with top-most components like Quickstarts
 export const MODAL_ANCHOR = '.pf-c-page.chr-c-page';

--- a/src/store/imageBuilderApi.ts
+++ b/src/store/imageBuilderApi.ts
@@ -215,6 +215,7 @@ export type ImageTypes =
   | "gcp"
   | "guest-image"
   | "image-installer"
+  | "oci"
   | "vsphere"
   | "vsphere-ova"
   | "wsl"
@@ -222,7 +223,12 @@ export type ImageTypes =
   | "rhel-edge-commit"
   | "rhel-edge-installer"
   | "vhd";
-export type UploadTypes = "aws" | "gcp" | "azure" | "aws.s3";
+export type UploadTypes =
+  | "aws"
+  | "gcp"
+  | "azure"
+  | "aws.s3"
+  | "oci.objectstorage";
 export type AwsUploadRequestOptions = {
   share_with_accounts?: string[];
   share_with_sources?: string[];
@@ -238,13 +244,15 @@ export type AzureUploadRequestOptions = {
   resource_group: string;
   image_name?: string;
 };
+export type OciUploadRequestOptions = object;
 export type UploadRequest = {
   type: UploadTypes;
   options:
     | AwsUploadRequestOptions
     | Awss3UploadRequestOptions
     | GcpUploadRequestOptions
-    | AzureUploadRequestOptions;
+    | AzureUploadRequestOptions
+    | OciUploadRequestOptions;
 };
 export type OsTree = {
   url?: string;
@@ -339,6 +347,9 @@ export type GcpUploadStatus = {
 export type AzureUploadStatus = {
   image_name: string;
 };
+export type OciUploadStatus = {
+  url: string;
+};
 export type UploadStatus = {
   status: "success" | "failure" | "pending" | "running";
   type: UploadTypes;
@@ -346,7 +357,8 @@ export type UploadStatus = {
     | AwsUploadStatus
     | Awss3UploadStatus
     | GcpUploadStatus
-    | AzureUploadStatus;
+    | AzureUploadStatus
+    | OciUploadStatus;
 };
 export type ComposeStatusError = {
   id: number;

--- a/src/store/typeGuards.ts
+++ b/src/store/typeGuards.ts
@@ -5,6 +5,7 @@ import {
   AzureUploadStatus,
   GcpUploadRequestOptions,
   GcpUploadStatus,
+  OciUploadStatus,
   UploadRequest,
   UploadStatus,
 } from './imageBuilderApi';
@@ -31,6 +32,12 @@ export const isGcpUploadStatus = (
   status: UploadStatus['options']
 ): status is GcpUploadStatus => {
   return (status as GcpUploadStatus).project_id !== undefined;
+};
+
+export const isOciUploadStatus = (
+  status: UploadStatus['options']
+): status is OciUploadStatus => {
+  return (status as OciUploadStatus).url !== undefined;
 };
 
 export const isAwss3UploadStatus = (

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -351,6 +351,46 @@ export const mockComposes: ComposesResponseItem[] = [
       ],
     },
   },
+  {
+    id: '0c1ec8d8-be39-47f2-9bd4-a3fff8244fce',
+    created_at: '2023-10-17T00:01:02Z',
+    image_name: 'oci-image',
+    request: {
+      distribution: 'rhel-92',
+      image_name: 'oci-image',
+      customizations: {},
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'oci',
+          upload_request: {
+            type: 'oci.objectstorage',
+            options: {},
+          },
+        },
+      ],
+    },
+  },
+  {
+    id: 'ea23cfd6-fd8b-43ed-adfc-9f76bb8487ef',
+    created_at: currentDateInString,
+    image_name: 'expiring-oci-image',
+    request: {
+      distribution: 'rhel-92',
+      image_name: 'oci-image',
+      customizations: {},
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'oci',
+          upload_request: {
+            type: 'oci.objectstorage',
+            options: {},
+          },
+        },
+      ],
+    },
+  },
 ];
 
 /**
@@ -827,6 +867,60 @@ export const mockStatus = (composeId: string): ComposeStatus => {
             upload_request: {
               options: {},
               type: 'azure',
+            },
+          },
+        ],
+      },
+    },
+    '0c1ec8d8-be39-47f2-9bd4-a3fff8244fce': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://oci-link-to-the.objectstorage.in-a-region.oci.customer-oci.com/p/there-is-a-lot-of-characters/b/image-builder-crc-stage/o/osbuild-upload-1234567890123456789',
+          },
+          status: 'success',
+          type: 'oci.objectstorage',
+        },
+      },
+      request: {
+        distribution: 'rhel-92',
+        image_name: 'oci-image',
+        customizations: {},
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'oci',
+            upload_request: {
+              type: 'oci.objectstorage',
+              options: {},
+            },
+          },
+        ],
+      },
+    },
+    'ea23cfd6-fd8b-43ed-adfc-9f76bb8487ef': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://oci-link-to-the.objectstorage.in-a-region.oci.customer-oci.com/p/there-is-a-lot-of-characters/b/image-builder-crc-stage/o/osbuild-upload-9876543210987654321',
+          },
+          status: 'success',
+          type: 'oci.objectstorage',
+        },
+      },
+      request: {
+        distribution: 'rhel-92',
+        image_name: 'oci-image',
+        customizations: {},
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'oci',
+            upload_request: {
+              type: 'oci.objectstorage',
+              options: {},
             },
           },
         ],


### PR DESCRIPTION
This exposes the option to create OCI images in the Wizard. The feature is available only for Preview for now.

I've also added mock fixtures for an OCI image to have an example of how the data are displayed.