### PR TITLE
ImagesTable: Fix padding of disabled download links

### DIFF
--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -211,7 +211,7 @@ export const AwsS3Instance = ({
 
   if (status !== 'success') {
     return (
-      <Button isDisabled variant="link" isInline>
+      <Button component="a" isDisabled variant="link" isInline>
         Download ({fileExtensions[compose.request.image_requests[0].image_type]}
         )
       </Button>


### PR DESCRIPTION
This fixes an uneven padding for disabled "Download (....)" links.