### PR TITLE
workflows: Add a workflow with dev checks

### DIFF
--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -1,0 +1,29 @@
+name: Development checks
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x, 18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Run build
+      run: npm run build
+    - name: Run lint check
+      run: npm run lint
+    - name: Run unit tests
+      run: npm run test


### PR DESCRIPTION
As Travis CI is getting removed from RedHatInsights this should replace it in what we used to use Travis for.

This workflow is triggered on pull requests to main and runs clean install of dependencies, lint check and the unit test suite.

The main motivation of this workflow being separated from the IQE tests is to allow to quickly check if the basic tests pass during development without the need to wait for the IQE tests to finish their run.