### PR TITLE
ImageTable: add region name to new region message

### DIFF
--- a/src/store/enhancedImageBuilderApi.ts
+++ b/src/store/enhancedImageBuilderApi.ts
@@ -33,7 +33,10 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
             dispatch(
               addNotification({
                 variant: 'success',
-                title: 'Your image is being shared',
+                title:
+                  'Your image is being shared to ' +
+                  cloneRequest.region +
+                  ' region',
               })
             );
           })


### PR DESCRIPTION
FIX # https://github.com/RedHatInsights/image-builder-frontend/issues/1410 
this commit add region name when user share to new region for image
<img width="589" alt="Screenshot 2023-11-05 at 15 54 35" src="https://github.com/RedHatInsights/image-builder-frontend/assets/73419853/c1ac493c-496c-415e-ab6c-0e4630deef08">
<img width="1279" alt="Screenshot 2023-11-05 at 15 56 08" src="https://github.com/RedHatInsights/image-builder-frontend/assets/73419853/0ada9d79-81e5-4b87-922c-710fea03b27e">
