### PR TITLE
Wizard/MountPoint: hotfix for updated mountpoint policy

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/MountPoint.js
+++ b/src/Components/CreateImageWizard/formComponents/MountPoint.js
@@ -19,7 +19,6 @@ export const MountPointValidPrefixes = [
   '/srv',
   '/tmp',
   '/usr',
-  '/usr/local',
   '/var',
 ];
 
@@ -81,15 +80,17 @@ const MountPoint = ({ ...props }) => {
         </Select>
       </GridItem>
       <GridItem span={6}>
-        {prefix !== '/' && !prefix.startsWith('/boot') && (
-          <TextInput
-            ouiaId="mount-suffix"
-            type="text"
-            value={suffix}
-            aria-label="Mount point suffix text input"
-            onChange={(_event, v) => setSuffix(v)}
-          />
-        )}
+        {prefix !== '/' &&
+          !prefix.startsWith('/boot') &&
+          !prefix.startsWith('/usr') && (
+            <TextInput
+              ouiaId="mount-suffix"
+              type="text"
+              value={suffix}
+              aria-label="Mount point suffix text input"
+              onChange={(_event, v) => setSuffix(v)}
+            />
+          )}
       </GridItem>
     </Grid>
   );


### PR DESCRIPTION
The updated mountpoint policy merged in osbuild-composer upstream does not allow sub-directories of `/usr` to be placed on a separate partition. There are other changes, but this fix prevents users from making an obvious error during image creation, until the updated policy is reflected in the UI.

Related to https://issues.redhat.com/browse/COMPOSER-2030