### PR TITLE
HMS-2861: add the TargetEnvironment step to the wizardV2

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -1,186 +1,50 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 
-import {
-  Button,
-  Wizard,
-  WizardFooterWrapper,
-  WizardStep,
-  useWizardContext,
-} from '@patternfly/react-core';
+import { Wizard, WizardStep } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 
+import CustomWizardFooter from './CustomWizardFooter';
 import {
-  EnvironmentStateType,
-  filterEnvironment,
-  hasUserSelectedAtLeastOneEnv,
-  useGetAllowedTargets,
-} from './steps/ImageOutput/Environment';
+  ImageWizardContext,
+  useInitializeImageWizardContext,
+} from './ImageWizardContext';
+import { ValidateImageOutputStep } from './steps/ImageOutput/Environment';
 import ImageOutputStep from './steps/ImageOutput/ImageOutput';
 import ReviewStep from './steps/Review/ReviewStep';
 import AWSTarget, {
-  validateAWSAccountID,
+  ValidateAWSStep,
 } from './steps/TargetEnvironment/AWS/AWSTarget';
 import AzureTarget, {
-  validateAzureId,
+  ValidateAzureStep,
 } from './steps/TargetEnvironment/Azure/AzureTarget';
 import GCPTarget, {
-  GCPAccountTypes,
-  validateGCPData,
+  ValidateGCPStep,
 } from './steps/TargetEnvironment/GCP/GCPTarget';
-import { useGetAccountData } from './steps/TargetEnvironment/SourcesSelect';
 
-import { RHEL_9, X86_64 } from '../../constants';
 import './CreateImageWizard.scss';
-import { ArchitectureItem, Distributions } from '../../store/imageBuilderApi';
 import { resolveRelPath } from '../../Utilities/path';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
-/**
- * @return true if the array in prevAllowedTargets is equivalent to the array
- * allowedTargets, false otherwise
- */
-const isIdenticalToPrev = (
-  prevAllowedTargets: string[],
-  allowedTargets: string[]
-) => {
-  let identicalToPrev = true;
-  if (allowedTargets.length === prevAllowedTargets.length) {
-    allowedTargets.forEach((elem) => {
-      if (!prevAllowedTargets.includes(elem)) {
-        identicalToPrev = false;
-      }
-    });
-  } else {
-    identicalToPrev = false;
-  }
-  return identicalToPrev;
-};
-
-type CustomWizardFooterPropType = {
-  isNextDisabled?: boolean;
-  isBackDisabled?: boolean;
-};
-/**
- * The custom wizard footer is only switching the order of the buttons compared
- * to the default wizard footer from the PF5 library.
- */
-const CustomWizardFooter = ({
-  isNextDisabled = false,
-  isBackDisabled = false,
-}: CustomWizardFooterPropType) => {
-  const { goToNextStep, goToPrevStep, close } = useWizardContext();
-  return (
-    <WizardFooterWrapper>
-      <Button
-        variant="primary"
-        onClick={goToNextStep}
-        isDisabled={isNextDisabled}
-      >
-        Next
-      </Button>
-      <Button
-        variant="secondary"
-        onClick={goToPrevStep}
-        isDisabled={isBackDisabled}
-      >
-        Back
-      </Button>
-      <Button variant="link" onClick={close}>
-        Cancel
-      </Button>
-    </WizardFooterWrapper>
-  );
-};
-
 const CreateImageWizard = () => {
-  const navigate = useNavigate();
-  //
-  // Image output step states
-  //
-  const [release, setRelease] = useState<Distributions>(RHEL_9);
-  const [arch, setArch] = useState<ArchitectureItem['arch']>(X86_64);
-  const {
-    data: allowedTargets,
-    isFetching,
-    isSuccess,
-    isError,
-  } = useGetAllowedTargets({
-    architecture: arch,
-    release: release,
-  });
-  const [environment, setEnvironment] = useState<EnvironmentStateType>(
-    filterEnvironment(
-      {
-        aws: { selected: false, authorized: false },
-        azure: { selected: false, authorized: false },
-        gcp: { selected: false, authorized: false },
-        oci: { selected: false, authorized: false },
-        'vsphere-ova': { selected: false, authorized: false },
-        vsphere: { selected: false, authorized: false },
-        'guest-image': { selected: false, authorized: false },
-        'image-installer': { selected: false, authorized: false },
-        wsl: { selected: false, authorized: false },
-      },
-      allowedTargets
-    )
+  return (
+    <ImageWizardContext.Provider value={useInitializeImageWizardContext()}>
+      <ContextedImageWizard />
+    </ImageWizardContext.Provider>
   );
-  // Update of the environment when the architecture and release are changed.
-  // This pattern prevents the usage of a useEffect See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-  const [prevAllowedTargets, setPrevAllowedTargets] = useState(allowedTargets);
-  if (!isIdenticalToPrev(prevAllowedTargets, allowedTargets)) {
-    setPrevAllowedTargets(allowedTargets);
-    setEnvironment(filterEnvironment(environment, allowedTargets));
-  }
+};
 
-  //
-  // Target environment states
-  //
+const ContextedImageWizard = () => {
+  const navigate = useNavigate();
+  const isImageOutputStepValid = ValidateImageOutputStep();
+  const isAwsStepValid = ValidateAWSStep();
+  const isGcpStepValid = ValidateGCPStep();
+  const isAzureStepValid = ValidateAzureStep();
+  const { environmentState } = useContext(ImageWizardContext);
+  const [environment] = environmentState;
   const showTargetEnv =
     (environment.aws.selected && environment.aws.authorized) ||
     (environment.gcp.selected && environment.gcp.authorized) ||
     (environment.azure.selected && environment.azure.authorized);
-  // AWS
-  const [awsManual, setAwsManual] = useState(false);
-  const [awsSource, setAwsSource] = useState<[number, string]>([0, '']);
-  const { accountId: awsID, isError: awsIDError } = useGetAccountData(
-    awsSource[0],
-    'aws'
-  );
-  const [awsAccountId, setAwsAccountId] = useState(awsID);
-  const [prevAwsID, setPrevAwsID] = useState(awsID);
-  if (awsID !== prevAwsID) {
-    setPrevAwsID(awsID);
-    setAwsAccountId(awsID);
-  }
-  // GCP
-  const [shareGoogleAccount, setShareGoogleAccount] = useState(true);
-  const [gcpAccountType, setGcpAccountType] =
-    useState<GCPAccountTypes>('googleAccount');
-  const [gcpAccountEmail, setGcpAccountEmail] = useState('');
-  const [gcpDomain, setGcpDomain] = useState('');
-  // Azure
-  const [azureManual, setAzureManual] = useState(false);
-  const [azureSource, setAzureSource] = useState<[number, string]>([0, '']);
-  const {
-    tenantId,
-    subscriptionId,
-    resourceGroups,
-    isError: azureIDError,
-  } = useGetAccountData(azureSource[0], 'azure');
-  const [azureTenantId, setAzureTenantId] = useState(tenantId);
-  const [azureSubId, setAzureSubId] = useState(subscriptionId);
-  const [azureResourceGroup, setAzureResourceGroup] = useState('');
-  const [prevTenantId, setPrevTenantId] = useState(tenantId);
-  const [prevSubscriptionId, setPrevSubscriptionId] = useState(subscriptionId);
-  if (prevTenantId !== tenantId || prevSubscriptionId !== subscriptionId) {
-    setPrevTenantId(tenantId);
-    setPrevSubscriptionId(subscriptionId);
-    setAzureTenantId(tenantId);
-    setAzureSubId(subscriptionId);
-    // when the tenant id or the subscription_id is changing, reset the resource
-    // group as the user will need to update it from a new list.
-    setAzureResourceGroup('');
-  }
   return (
     <>
       <ImageBuilderHeader />
@@ -191,22 +55,12 @@ const CreateImageWizard = () => {
             id="step-image-output"
             footer={
               <CustomWizardFooter
-                isNextDisabled={!hasUserSelectedAtLeastOneEnv(environment)}
+                isNextDisabled={!isImageOutputStepValid}
                 isBackDisabled
               />
             }
           >
-            <ImageOutputStep
-              release={release}
-              setRelease={setRelease}
-              arch={arch}
-              setArch={setArch}
-              environment={environment}
-              setEnvironment={setEnvironment}
-              isFetching={isFetching}
-              isError={isError}
-              isSuccess={isSuccess}
-            />
+            <ImageOutputStep />
           </WizardStep>
           <WizardStep
             name="Target environment"
@@ -220,21 +74,9 @@ const CreateImageWizard = () => {
                 isHidden={
                   !(environment.aws.selected && environment.aws.authorized)
                 }
-                footer={
-                  <CustomWizardFooter
-                    isNextDisabled={!validateAWSAccountID(awsAccountId)}
-                  />
-                }
+                footer={<CustomWizardFooter isNextDisabled={!isAwsStepValid} />}
               >
-                <AWSTarget
-                  manual={awsManual}
-                  setManual={setAwsManual}
-                  source={awsSource}
-                  setSource={setAwsSource}
-                  isErrorFetchingDetails={awsIDError}
-                  associatedAccountId={awsAccountId}
-                  setAssociatedAccountId={setAwsAccountId}
-                />
+                <AWSTarget />
               </WizardStep>,
               <WizardStep
                 name="Google Cloud Platform"
@@ -243,29 +85,9 @@ const CreateImageWizard = () => {
                 isHidden={
                   !(environment.gcp.selected && environment.gcp.authorized)
                 }
-                footer={
-                  <CustomWizardFooter
-                    isNextDisabled={
-                      !validateGCPData(
-                        shareGoogleAccount,
-                        gcpAccountType,
-                        gcpAccountEmail,
-                        gcpDomain
-                      )
-                    }
-                  />
-                }
+                footer={<CustomWizardFooter isNextDisabled={!isGcpStepValid} />}
               >
-                <GCPTarget
-                  shareGoogleAccount={shareGoogleAccount}
-                  setShareGoogleAccount={setShareGoogleAccount}
-                  accountType={gcpAccountType}
-                  setAccountType={setGcpAccountType}
-                  accountEmail={gcpAccountEmail}
-                  setAccountEmail={setGcpAccountEmail}
-                  domain={gcpDomain}
-                  setDomain={setGcpDomain}
-                />
+                <GCPTarget />
               </WizardStep>,
               <WizardStep
                 name="Microsoft Azure"
@@ -275,31 +97,10 @@ const CreateImageWizard = () => {
                   !(environment.azure.selected && environment.azure.authorized)
                 }
                 footer={
-                  <CustomWizardFooter
-                    isNextDisabled={
-                      !(
-                        validateAzureId(azureTenantId) &&
-                        validateAzureId(azureSubId) &&
-                        azureResourceGroup
-                      )
-                    }
-                  />
+                  <CustomWizardFooter isNextDisabled={!isAzureStepValid} />
                 }
               >
-                <AzureTarget
-                  manual={azureManual}
-                  setManual={setAzureManual}
-                  source={azureSource}
-                  setSource={setAzureSource}
-                  tenantId={azureTenantId}
-                  setTenantId={setAzureTenantId}
-                  subscriptionId={azureSubId}
-                  setSubscriptionId={setAzureSubId}
-                  isErrorFetchingDetails={azureIDError}
-                  resourceGroups={resourceGroups}
-                  resourceGroup={azureResourceGroup}
-                  setResourceGroup={setAzureResourceGroup}
-                />
+                <AzureTarget />
               </WizardStep>,
             ]}
           />
@@ -308,22 +109,7 @@ const CreateImageWizard = () => {
             id="step-review"
             footer={<CustomWizardFooter isNextDisabled={true} />}
           >
-            <ReviewStep
-              release={release}
-              arch={arch}
-              environment={environment}
-              awsManual={awsManual}
-              awsAccountId={awsAccountId}
-              awsSource={awsSource}
-              gcpAccountType={gcpAccountType}
-              gcpAccountEmail={gcpAccountEmail}
-              gcpDomain={gcpDomain}
-              azureManual={azureManual}
-              azureSource={azureSource}
-              azureTenantId={azureTenantId}
-              azureSubscriptionId={azureSubId}
-              azureResourceGroup={azureResourceGroup}
-            />
+            <ReviewStep />
           </WizardStep>
         </Wizard>
       </section>

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -299,7 +299,22 @@ const CreateImageWizard = () => {
             id="step-review"
             footer={<CustomWizardFooter isNextDisabled={true} />}
           >
-            <ReviewStep release={release} arch={arch} />
+            <ReviewStep
+              release={release}
+              arch={arch}
+              environment={environment}
+              awsManual={awsManual}
+              awsAccountId={awsAccountId}
+              awsSource={awsSource}
+              gcpAccountType={gcpAccountType}
+              gcpAccountEmail={gcpAccountEmail}
+              gcpDomain={gcpDomain}
+              azureManual={azureManual}
+              azureSource={azureSource}
+              azureTenantId={azureTenantId}
+              azureSubscriptionId={azureSubId}
+              azureResourceGroup={azureResourceGroup}
+            />
           </WizardStep>
         </Wizard>
       </section>

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -57,13 +57,17 @@ const isIdenticalToPrev = (
 };
 
 type CustomWizardFooterPropType = {
-  isNextDisabled: boolean;
+  isNextDisabled?: boolean;
+  isBackDisabled?: boolean;
 };
 /**
  * The custom wizard footer is only switching the order of the buttons compared
  * to the default wizard footer from the PF5 library.
  */
-const CustomWizardFooter = ({ isNextDisabled }: CustomWizardFooterPropType) => {
+const CustomWizardFooter = ({
+  isNextDisabled = false,
+  isBackDisabled = false,
+}: CustomWizardFooterPropType) => {
   const { goToNextStep, goToPrevStep, close } = useWizardContext();
   return (
     <WizardFooterWrapper>
@@ -74,7 +78,11 @@ const CustomWizardFooter = ({ isNextDisabled }: CustomWizardFooterPropType) => {
       >
         Next
       </Button>
-      <Button variant="secondary" onClick={goToPrevStep}>
+      <Button
+        variant="secondary"
+        onClick={goToPrevStep}
+        isDisabled={isBackDisabled}
+      >
         Back
       </Button>
       <Button variant="link" onClick={close}>
@@ -184,6 +192,7 @@ const CreateImageWizard = () => {
             footer={
               <CustomWizardFooter
                 isNextDisabled={!hasUserSelectedAtLeastOneEnv(environment)}
+                isBackDisabled
               />
             }
           >

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -20,6 +20,11 @@ import ReviewStep from './steps/Review/ReviewStep';
 import AWSTarget, {
   validateAWSAccountID,
 } from './steps/TargetEnvironment/AWS/AWSTarget';
+import GCPTarget, {
+  GCPAccountTypes,
+  validateGCPData,
+} from './steps/TargetEnvironment/GCP/GCPTarget';
+import { useGetAccountData } from './steps/TargetEnvironment/SourcesSelect';
 
 import { RHEL_9, X86_64 } from '../../constants';
 import './CreateImageWizard.scss';
@@ -136,6 +141,12 @@ const CreateImageWizard = () => {
     setPrevAwsID(awsID);
     setAwsAccountId(awsID);
   }
+  // GCP
+  const [shareGoogleAccount, setShareGoogleAccount] = useState(true);
+  const [gcpAccountType, setGcpAccountType] =
+    useState<GCPAccountTypes>('googleAccount');
+  const [gcpAccountEmail, setGcpAccountEmail] = useState('');
+  const [gcpDomain, setGcpDomain] = useState('');
   return (
     <>
       <ImageBuilderHeader />
@@ -188,6 +199,37 @@ const CreateImageWizard = () => {
                   isErrorFetchingDetails={awsIDError}
                   associatedAccountId={awsAccountId}
                   setAssociatedAccountId={setAwsAccountId}
+                />
+              </WizardStep>,
+              <WizardStep
+                name="Google Cloud Platform"
+                id="gcp-sub-step"
+                key="gcp-sub-step"
+                isHidden={
+                  !(environment.gcp.selected && environment.gcp.authorized)
+                }
+                footer={
+                  <CustomWizardFooter
+                    isNextDisabled={
+                      !validateGCPData(
+                        shareGoogleAccount,
+                        gcpAccountType,
+                        gcpAccountEmail,
+                        gcpDomain
+                      )
+                    }
+                  />
+                }
+              >
+                <GCPTarget
+                  shareGoogleAccount={shareGoogleAccount}
+                  setShareGoogleAccount={setShareGoogleAccount}
+                  accountType={gcpAccountType}
+                  setAccountType={setGcpAccountType}
+                  accountEmail={gcpAccountEmail}
+                  setAccountEmail={setGcpAccountEmail}
+                  domain={gcpDomain}
+                  setDomain={setGcpDomain}
                 />
               </WizardStep>,
             ]}

--- a/src/Components/CreateImageWizardV2/CustomWizardFooter.tsx
+++ b/src/Components/CreateImageWizardV2/CustomWizardFooter.tsx
@@ -1,0 +1,45 @@
+import React, { useContext, useEffect, useState } from 'react';
+
+import {
+  Button,
+  WizardFooterWrapper,
+  useWizardContext,
+} from '@patternfly/react-core';
+type CustomWizardFooterPropType = {
+  isNextDisabled?: boolean;
+  isBackDisabled?: boolean;
+};
+
+/**
+ * The custom wizard footer is only switching the order of the buttons compared
+ * to the default wizard footer from the PF5 library.
+ */
+const CustomWizardFooter = ({
+  isNextDisabled = false,
+  isBackDisabled = false,
+}: CustomWizardFooterPropType) => {
+  const { goToNextStep, goToPrevStep, close } = useWizardContext();
+  return (
+    <WizardFooterWrapper>
+      <Button
+        variant="primary"
+        onClick={goToNextStep}
+        isDisabled={isNextDisabled}
+      >
+        Next
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={goToPrevStep}
+        isDisabled={isBackDisabled}
+      >
+        Back
+      </Button>
+      <Button variant="link" onClick={close}>
+        Cancel
+      </Button>
+    </WizardFooterWrapper>
+  );
+};
+
+export default CustomWizardFooter;

--- a/src/Components/CreateImageWizardV2/ImageWizardContext.tsx
+++ b/src/Components/CreateImageWizardV2/ImageWizardContext.tsx
@@ -1,0 +1,208 @@
+import React, { useState } from 'react';
+
+import {
+  EnvironmentStateType,
+  filterEnvironment,
+  useGetAllowedTargets,
+} from './steps/ImageOutput/Environment';
+import { GCPAccountTypes } from './steps/TargetEnvironment/GCP/GCPTarget';
+import { useGetAccountData } from './steps/TargetEnvironment/SourcesSelect';
+
+import { RHEL_9, X86_64 } from '../../constants';
+import { ArchitectureItem, Distributions } from '../../store/imageBuilderApi';
+
+type ImageWizardContextPropType = {
+  releaseState: [
+    Distributions,
+    React.Dispatch<React.SetStateAction<Distributions>>
+  ];
+  architectureState: [
+    ArchitectureItem['arch'],
+    React.Dispatch<React.SetStateAction<ArchitectureItem['arch']>>
+  ];
+  environmentState: [
+    EnvironmentStateType,
+    React.Dispatch<React.SetStateAction<EnvironmentStateType>>
+  ];
+  isAwsManualState: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+  awsSourceState: [
+    [number, string],
+    React.Dispatch<React.SetStateAction<[number, string]>>
+  ];
+  associatedAwsAccountIdState: [
+    string,
+    React.Dispatch<React.SetStateAction<string>>
+  ];
+  isShareGoogleAccountState: [
+    boolean,
+    React.Dispatch<React.SetStateAction<boolean>>
+  ];
+  gcpAccountTypeState: [
+    GCPAccountTypes,
+    React.Dispatch<React.SetStateAction<GCPAccountTypes>>
+  ];
+  gcpAccountEmailState: [string, React.Dispatch<React.SetStateAction<string>>];
+  gcpDomainState: [string, React.Dispatch<React.SetStateAction<string>>];
+  isAzureManualState: [boolean, React.Dispatch<React.SetStateAction<boolean>>];
+  azureSourceState: [
+    [number, string],
+    React.Dispatch<React.SetStateAction<[number, string]>>
+  ];
+  azureTenantIdState: [string, React.Dispatch<React.SetStateAction<string>>];
+  azureSubscriptionIdState: [
+    string,
+    React.Dispatch<React.SetStateAction<string>>
+  ];
+  azureResourceGroupState: [
+    string,
+    React.Dispatch<React.SetStateAction<string>>
+  ];
+};
+
+export const ImageWizardContext =
+  React.createContext<ImageWizardContextPropType>({
+    releaseState: [RHEL_9, () => {}],
+    architectureState: [X86_64, () => {}],
+    environmentState: [
+      {
+        aws: { selected: false, authorized: false },
+        azure: { selected: false, authorized: false },
+        gcp: { selected: false, authorized: false },
+        oci: { selected: false, authorized: false },
+        'vsphere-ova': { selected: false, authorized: false },
+        vsphere: { selected: false, authorized: false },
+        'guest-image': { selected: false, authorized: false },
+        'image-installer': { selected: false, authorized: false },
+        wsl: { selected: false, authorized: false },
+      },
+      () => {},
+    ],
+    isAwsManualState: [false, () => {}],
+    awsSourceState: [[0, ''], () => {}],
+    associatedAwsAccountIdState: ['', () => {}],
+    isShareGoogleAccountState: [false, () => {}],
+    gcpAccountTypeState: ['googleAccount', () => {}],
+    gcpAccountEmailState: ['', () => {}],
+    gcpDomainState: ['', () => {}],
+    isAzureManualState: [false, () => {}],
+    azureSourceState: [[0, ''], () => {}],
+    azureTenantIdState: ['', () => {}],
+    azureSubscriptionIdState: ['', () => {}],
+    azureResourceGroupState: ['', () => {}],
+  });
+
+export const useInitializeImageWizardContext = () => {
+  //
+  // Image output step states
+  //
+  const [release, setRelease] = useState<Distributions>(RHEL_9);
+  const [arch, setArch] = useState<ArchitectureItem['arch']>(X86_64);
+  const { data: allowedTargets } = useGetAllowedTargets({
+    architecture: arch,
+    release: release,
+  });
+  const [environment, setEnvironment] = useState<EnvironmentStateType>(
+    filterEnvironment(
+      {
+        aws: { selected: false, authorized: false },
+        azure: { selected: false, authorized: false },
+        gcp: { selected: false, authorized: false },
+        oci: { selected: false, authorized: false },
+        'vsphere-ova': { selected: false, authorized: false },
+        vsphere: { selected: false, authorized: false },
+        'guest-image': { selected: false, authorized: false },
+        'image-installer': { selected: false, authorized: false },
+        wsl: { selected: false, authorized: false },
+      },
+      allowedTargets
+    )
+  );
+  // Update of the environment when the architecture and release are changed.
+  // This pattern prevents the usage of a useEffect See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const [prevAllowedTargets, setPrevAllowedTargets] = useState(allowedTargets);
+  if (!isIdenticalToPrev(prevAllowedTargets, allowedTargets)) {
+    setPrevAllowedTargets(allowedTargets);
+    setEnvironment(filterEnvironment(environment, allowedTargets));
+  }
+
+  //
+  // Target environment states
+  //
+  // AWS
+  const [awsManual, setAwsManual] = useState(false);
+  const [awsSource, setAwsSource] = useState<[number, string]>([0, '']);
+  const { accountId: awsID } = useGetAccountData(awsSource[0], 'aws');
+  const [awsAccountId, setAwsAccountId] = useState(awsID);
+  const [prevAwsID, setPrevAwsID] = useState(awsID);
+  if (awsID !== prevAwsID) {
+    setPrevAwsID(awsID);
+    setAwsAccountId(awsID);
+  }
+  // GCP
+  const [shareGoogleAccount, setShareGoogleAccount] = useState(true);
+  const [gcpAccountType, setGcpAccountType] =
+    useState<GCPAccountTypes>('googleAccount');
+  const [gcpAccountEmail, setGcpAccountEmail] = useState('');
+  const [gcpDomain, setGcpDomain] = useState('');
+  // Azure
+  const [azureManual, setAzureManual] = useState(false);
+  const [azureSource, setAzureSource] = useState<[number, string]>([0, '']);
+  const { tenantId, subscriptionId } = useGetAccountData(
+    azureSource[0],
+    'azure'
+  );
+  const [azureTenantId, setAzureTenantId] = useState(tenantId);
+  const [azureSubId, setAzureSubId] = useState(subscriptionId);
+  const [azureResourceGroup, setAzureResourceGroup] = useState('');
+  const [prevTenantId, setPrevTenantId] = useState(tenantId);
+  const [prevSubscriptionId, setPrevSubscriptionId] = useState(subscriptionId);
+  if (prevTenantId !== tenantId || prevSubscriptionId !== subscriptionId) {
+    setPrevTenantId(tenantId);
+    setPrevSubscriptionId(subscriptionId);
+    setAzureTenantId(tenantId);
+    setAzureSubId(subscriptionId);
+    // when the tenant id or the subscription_id is changing, reset the resource
+    // group as the user will need to update it from a new list.
+    setAzureResourceGroup('');
+  }
+  const context: ImageWizardContextPropType = {
+    releaseState: [release, setRelease],
+    architectureState: [arch, setArch],
+    environmentState: [environment, setEnvironment],
+    isAwsManualState: [awsManual, setAwsManual],
+    awsSourceState: [awsSource, setAwsSource],
+    associatedAwsAccountIdState: [awsAccountId, setAwsAccountId],
+    isShareGoogleAccountState: [shareGoogleAccount, setShareGoogleAccount],
+    gcpAccountTypeState: [gcpAccountType, setGcpAccountType],
+    gcpAccountEmailState: [gcpAccountEmail, setGcpAccountEmail],
+    gcpDomainState: [gcpDomain, setGcpDomain],
+    isAzureManualState: [azureManual, setAzureManual],
+    azureSourceState: [azureSource, setAzureSource],
+    azureTenantIdState: [azureTenantId, setAzureTenantId],
+    azureSubscriptionIdState: [azureSubId, setAzureSubId],
+    azureResourceGroupState: [azureResourceGroup, setAzureResourceGroup],
+  };
+  return context;
+};
+
+/**
+ * Helper function to avoid having an extra useEffect.
+ * @return true if the array in prevAllowedTargets is equivalent to the array
+ * allowedTargets, false otherwise
+ */
+const isIdenticalToPrev = (
+  prevAllowedTargets: string[],
+  allowedTargets: string[]
+) => {
+  let identicalToPrev = true;
+  if (allowedTargets.length === prevAllowedTargets.length) {
+    allowedTargets.forEach((elem) => {
+      if (!prevAllowedTargets.includes(elem)) {
+        identicalToPrev = false;
+      }
+    });
+  } else {
+    identicalToPrev = false;
+  }
+  return identicalToPrev;
+};

--- a/src/Components/CreateImageWizardV2/common/TypeAheadSelect.tsx
+++ b/src/Components/CreateImageWizardV2/common/TypeAheadSelect.tsx
@@ -1,0 +1,390 @@
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  Select,
+  SelectOption,
+  SelectList,
+  SelectOptionProps,
+  MenuToggle,
+  MenuToggleElement,
+  TextInputGroup,
+  TextInputGroupMain,
+  TextInputGroupUtilities,
+  Button,
+  Spinner,
+} from '@patternfly/react-core';
+import { TimesIcon } from '@patternfly/react-icons';
+import {
+  BaseQueryFn,
+  FetchArgs,
+  FetchBaseQueryError,
+  FetchBaseQueryMeta,
+  QueryDefinition,
+} from '@reduxjs/toolkit/dist/query';
+import { QueryActionCreatorResult } from '@reduxjs/toolkit/dist/query/core/buildInitiate';
+
+import {
+  GetSourceListApiArg,
+  V1ListSourceResponse,
+} from '../../../store/provisioningApi';
+
+function mapInputOptions(
+  inputOptions: [string | number, string][] | string[]
+): SelectOptionProps[] {
+  if (inputOptions.length === 0) {
+    return [
+      {
+        isDisabled: true,
+        children: `No results"`,
+        value: 'no results',
+      },
+    ];
+  }
+  return inputOptions.map((input) => {
+    if (typeof input === 'string') {
+      return { isDisabled: false, value: input, children: input };
+    }
+    return { isDisabled: false, value: input[0], children: input[1] };
+  });
+}
+
+function getLabel(
+  val: string | number,
+  inputOptions: [string | number, string][] | string[]
+): string {
+  if (typeof val === 'string') {
+    return val;
+  }
+  let ret: string = '';
+  inputOptions.forEach((input) => {
+    if (input[0] === val) {
+      ret = input[1];
+    }
+  });
+  return ret;
+}
+
+type TypeAheadSelectPropType<T extends string | number> = {
+  inputOptions: [T, string][] | string[];
+  fieldID: string;
+  placeholderText: string;
+  selected: [T, string] | string;
+  setSelected: Dispatch<SetStateAction<[T, string] | string>>;
+  isFetching?: boolean;
+  isError?: boolean;
+  refetch?: () => QueryActionCreatorResult<
+    QueryDefinition<
+      GetSourceListApiArg,
+      BaseQueryFn<
+        string | FetchArgs,
+        unknown,
+        FetchBaseQueryError,
+        {},
+        FetchBaseQueryMeta
+      >,
+      never,
+      V1ListSourceResponse,
+      'provisioningApi'
+    >
+  >;
+};
+
+/**
+ * Enhanced TypeAheadSelect from the pattern fly
+ * pattern https://www.patternfly.org/components/menus/select#typeahead
+ *
+ * The TypeAheadSelect component allows a user to select an element form a list
+ * of options. The user can also filter the elements by entering some text in
+ * the text input.
+ *
+ * The component can function in two different modes. Either in a mode where the
+ * key and value of the selectable items are the same, or in a mode where they
+ * and value are different. In the second operational mode, the key can be some
+ * number and the value a label of any kind.
+ *
+ * @param inputOptions a list of elements to be turned into select options.
+ * Either be a list of tuples or a list of string depending on the mode the
+ * component must operate in. If a tuple is passed, the first element of the
+ * tuple will end up being the key and the second element will be the value.
+ *
+ * @param selected the currently selected element. Either be a tuple or a string
+ * depending of the operating mode.
+ * @param setSelected a function to update the selected value.
+ *
+ * @param isFetching if provided and set to true, the component will show a
+ * loading spinner when the data is on the fly.
+ * @param isError if provided and set to true, the component will disable
+ * itself.
+ * @param refetch if provided, the component will use the refetch function to
+ * ask for a refresh of the data that makes the select options.
+ */
+function TypeAheadSelect<T extends string | number>({
+  inputOptions,
+  selected,
+  setSelected,
+  fieldID,
+  placeholderText,
+  isFetching,
+  isError,
+  refetch,
+}: TypeAheadSelectPropType<T>) {
+  const [isOpen, setIsOpen] = useState(false);
+  // The label of the selected element is displayed in the toggle menu. Since
+  // the component is accepting two kinds of options (tuples or string), find
+  // out which one it is and extract the keys and labels accordingly.
+  const selectedTypeIsdStringOnly = typeof selected === 'string';
+  const selectedKey = selectedTypeIsdStringOnly ? selected : selected[0];
+  const selectedLabel = selectedTypeIsdStringOnly ? selected : selected[1];
+  const [inputValue, setInputValue] = useState<string>(selectedLabel);
+  // keep the inputValue in sync with the selectedLabel
+  const [prevSelectedLabel, setPrevSelectedLabel] = useState(selectedLabel);
+  if (prevSelectedLabel !== selectedLabel) {
+    setPrevSelectedLabel(selectedLabel);
+    setInputValue(selectedLabel);
+  }
+  const [filterValue, setFilterValue] = useState<string>('');
+  const [selectOptions, setSelectOptions] = useState<SelectOptionProps[]>(
+    mapInputOptions(inputOptions)
+  );
+  const [focusedItemIndex, setFocusedItemIndex] = useState<number | null>(null);
+  const [activeItem, setActiveItem] = useState<string | null>(null);
+  const textInputRef = useRef<HTMLInputElement>();
+
+  useEffect(() => {
+    let newSelectOptions: SelectOptionProps[] = mapInputOptions(inputOptions);
+
+    // Filter menu items based on the text input value when one exists
+    if (filterValue) {
+      newSelectOptions = newSelectOptions.filter((menuItem) =>
+        String(menuItem.children)
+          .toLowerCase()
+          .includes(filterValue.toLowerCase())
+      );
+
+      // When no options are found after filtering, display 'No results found'
+      if (!newSelectOptions.length) {
+        newSelectOptions = [
+          {
+            isDisabled: false,
+            children: `No results found for "${filterValue}"`,
+            value: 'no results',
+          },
+        ];
+      }
+
+      // Open the menu when the input value changes and the new value is not empty
+      if (!isOpen) {
+        setIsOpen(true);
+      }
+    }
+
+    setSelectOptions(newSelectOptions);
+    setActiveItem(null);
+    setFocusedItemIndex(null);
+  }, [filterValue, inputOptions]);
+
+  const onToggleClick = () => {
+    setIsOpen(!isOpen);
+    if (!isOpen && refetch) {
+      refetch();
+    }
+  };
+
+  const onSelect = (
+    _event: React.MouseEvent<Element, MouseEvent> | undefined,
+    value: string | number | undefined
+  ) => {
+    if (value && value !== 'no results') {
+      setInputValue(getLabel(value, inputOptions));
+      setFilterValue('');
+      if (selectedTypeIsdStringOnly) {
+        setSelected(value as string);
+      } else {
+        setSelected([value as T, getLabel(value, inputOptions)]);
+      }
+    }
+    setIsOpen(false);
+    setFocusedItemIndex(null);
+    setActiveItem(null);
+  };
+
+  const onTextInputChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    value: string
+  ) => {
+    setInputValue(value);
+    setFilterValue(value);
+  };
+
+  const handleMenuArrowKeys = (key: string) => {
+    let indexToFocus;
+
+    if (isOpen) {
+      if (key === 'ArrowUp') {
+        // When no index is set or at the first index, focus to the last, otherwise decrement focus index
+        if (focusedItemIndex === null || focusedItemIndex === 0) {
+          indexToFocus = selectOptions.length - 1;
+        } else {
+          indexToFocus = focusedItemIndex - 1;
+        }
+      }
+
+      if (key === 'ArrowDown') {
+        // When no index is set or at the last index, focus to the first, otherwise increment focus index
+        if (
+          focusedItemIndex === null ||
+          focusedItemIndex === selectOptions.length - 1
+        ) {
+          indexToFocus = 0;
+        } else {
+          indexToFocus = focusedItemIndex + 1;
+        }
+      }
+
+      setFocusedItemIndex(indexToFocus ? indexToFocus : 0);
+      const focusedItem = selectOptions.filter((option) => !option.isDisabled)[
+        indexToFocus ? indexToFocus : 0
+      ];
+      setActiveItem(
+        `select-typeahead-${String(focusedItem.value).replace(' ', '-')}`
+      );
+    }
+  };
+
+  const onInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const enabledMenuItems = selectOptions.filter(
+      (option) => !option.isDisabled
+    );
+    const [firstMenuItem] = enabledMenuItems;
+    const focusedItem = focusedItemIndex
+      ? enabledMenuItems[focusedItemIndex]
+      : firstMenuItem;
+
+    switch (event.key) {
+      // Select the first available option
+      case 'Enter':
+        if (isOpen && focusedItem.value !== 'no results') {
+          setInputValue(String(focusedItem.children));
+          setFilterValue('');
+          if (selectedTypeIsdStringOnly) {
+            setSelected(focusedItem.value as string);
+          } else {
+            setSelected([focusedItem.value as T, String(focusedItem.children)]);
+          }
+        }
+
+        setIsOpen((prevIsOpen) => !prevIsOpen);
+        setFocusedItemIndex(null);
+        setActiveItem(null);
+
+        break;
+      case 'Tab':
+      case 'Escape':
+        setIsOpen(false);
+        setActiveItem(null);
+        break;
+      case 'ArrowUp':
+      case 'ArrowDown':
+        event.preventDefault();
+        handleMenuArrowKeys(event.key);
+        break;
+    }
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      variant="typeahead"
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      isFullWidth
+    >
+      <TextInputGroup isPlain>
+        <TextInputGroupMain
+          value={inputValue}
+          onClick={onToggleClick}
+          onChange={onTextInputChange}
+          onKeyDown={onInputKeyDown}
+          aria-label={fieldID + 'typeahead-select-input'}
+          autoComplete="off"
+          innerRef={textInputRef}
+          placeholder={placeholderText}
+          {...(activeItem && { 'aria-activedescendant': activeItem })}
+          role="combobox"
+          isExpanded={isOpen}
+          aria-controls={fieldID + 'typeahead-select-input'}
+        />
+
+        <TextInputGroupUtilities>
+          {!!inputValue && (
+            <Button
+              variant="plain"
+              onClick={() => {
+                if (selectedTypeIsdStringOnly) {
+                  setSelected('');
+                } else {
+                  setSelected([0 as T, '']);
+                }
+                setInputValue('');
+                setFilterValue('');
+                textInputRef?.current?.focus();
+              }}
+              aria-label="Clear input value"
+            >
+              <TimesIcon aria-hidden />
+            </Button>
+          )}
+        </TextInputGroupUtilities>
+      </TextInputGroup>
+    </MenuToggle>
+  );
+
+  return (
+    <Select
+      id={fieldID}
+      isOpen={isOpen}
+      selected={selectedKey}
+      onSelect={onSelect}
+      onOpenChange={() => {
+        setIsOpen(false);
+      }}
+      toggle={toggle}
+      aria-disabled={isError}
+    >
+      <SelectList id={fieldID + '-listbox'}>
+        {selectOptions.map((option, index) => (
+          <SelectOption
+            key={option.value}
+            isFocused={focusedItemIndex === index}
+            className={option.className}
+            onClick={() => {
+              if (option.value) {
+                if (selectedTypeIsdStringOnly) {
+                  setSelected(option.value as string);
+                } else {
+                  setSelected([option.value as T, String(option.children)]);
+                }
+              }
+            }}
+            id={fieldID + `-${String(option.value).replace(' ', '-')}`}
+            {...option}
+            ref={null}
+          />
+        ))}
+        {isFetching && (
+          <SelectOption>
+            <Spinner size="lg" />
+          </SelectOption>
+        )}
+      </SelectList>
+    </Select>
+  );
+}
+
+export default TypeAheadSelect;

--- a/src/Components/CreateImageWizardV2/common/ValidatedTextField.tsx
+++ b/src/Components/CreateImageWizardV2/common/ValidatedTextField.tsx
@@ -1,0 +1,77 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+
+import {
+  FormGroup,
+  FormHelperText,
+  HelperTextItem,
+  TextInput,
+} from '@patternfly/react-core';
+
+type ValidatedTextFieldPropType = {
+  label: string;
+  aria: string;
+  fieldId: string;
+  value: string;
+  setValue: Dispatch<SetStateAction<string>>;
+  validateFunction: (value: string) => boolean;
+  helperText: string;
+};
+
+/**
+ * A text field in a FormGroup that does the validation of its content in order
+ * to provide a visual clue to the user that an action is required. The clue
+ * is only displayed if the user has entered some text.
+ *
+ * @param aria the aria-label for the inner TextInput
+ * @param fieldId the html id for the inner TextInput
+ * @param helperText the text to display when the input doesn't validate
+ * @param label the FormGroup label
+ * @param value set value the user types in the TextInput
+ * @param setValue a function to update the value
+ * @param validateFunction a function that takes a string as a parameter and
+ * returns true if it meets some criteria.
+ *
+ * Follows the PF5 patterns found in
+ * https://www.patternfly.org/components/forms/text-input
+ */
+const ValidatedTextField = ({
+  aria,
+  fieldId,
+  helperText,
+  label,
+  value,
+  setValue,
+  validateFunction,
+}: ValidatedTextFieldPropType) => {
+  const [isValid, setIsValid] = useState(validateFunction(value));
+  const validated = isValid || value.length === 0 ? 'default' : 'error';
+
+  const handleTextInputChange = (
+    _event: React.FormEvent<HTMLElement>,
+    value: string
+  ) => {
+    setValue(value);
+    setIsValid(validateFunction(value));
+  };
+
+  return (
+    <FormGroup label={label} fieldId={fieldId} isRequired>
+      <TextInput
+        validated={validated}
+        value={value}
+        label={aria}
+        aria-label={aria}
+        onChange={handleTextInputChange}
+      />
+      <FormHelperText>
+        <HelperTextItem>
+          <HelperTextItem variant={validated}>
+            {validated === 'error' ? helperText : ''}
+          </HelperTextItem>
+        </HelperTextItem>
+      </FormHelperText>
+    </FormGroup>
+  );
+};
+
+export default ValidatedTextField;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ArchSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ArchSelect.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FormEvent, SetStateAction } from 'react';
+import React, { FormEvent, useContext } from 'react';
 
 import {
   FormGroup,
@@ -7,17 +7,14 @@ import {
 } from '@patternfly/react-core';
 
 import { ARCHS } from '../../../../constants';
-import { ArchitectureItem } from '../../../../store/imageBuilderApi';
-
-type ArchSelectType = {
-  setArch: Dispatch<SetStateAction<ArchitectureItem['arch']>>;
-  arch: ArchitectureItem['arch'];
-};
+import { ImageWizardContext } from '../../ImageWizardContext';
 
 /**
  * Allows the user to pick the architecture to build
  */
-const ArchSelect = ({ setArch, arch }: ArchSelectType) => {
+const ArchSelect = () => {
+  const { architectureState } = useContext(ImageWizardContext);
+  const [arch, setArch] = architectureState;
   const onChange = (_event: FormEvent<HTMLSelectElement>, value: string) => {
     setArch(value);
   };

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/Environment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/Environment.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { useContext } from 'react';
 
 import {
   Checkbox,
@@ -19,6 +19,7 @@ import {
 } from '../../../../store/imageBuilderApi';
 import { provisioningApi } from '../../../../store/provisioningApi';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
+import { ImageWizardContext } from '../../ImageWizardContext';
 
 type useGetAllowedTargetsPropType = {
   architecture: ArchitectureItem['arch'];
@@ -113,26 +114,23 @@ export const filterEnvironment = (
  * authorized set to true
  * @param env the environment to scan
  */
-export const hasUserSelectedAtLeastOneEnv = (
-  env: EnvironmentStateType
-): boolean => {
+export const ValidateImageOutputStep = (): boolean => {
   let atLeastOne = false;
-  Object.values(env).forEach(({ selected, authorized }) => {
+  const { environmentState } = useContext(ImageWizardContext);
+  const [environment] = environmentState;
+  Object.values(environment).forEach(({ selected, authorized }) => {
     atLeastOne = atLeastOne || (selected && authorized);
   });
   return atLeastOne;
-};
-
-type EnvironmentPropType = {
-  environment: EnvironmentStateType;
-  setEnvironment: Dispatch<SetStateAction<EnvironmentStateType>>;
 };
 
 /**
  * Displays a component that allows the user to pick the target they want
  * to build on.
  */
-const Environment = ({ setEnvironment, environment }: EnvironmentPropType) => {
+const Environment = () => {
+  const { environmentState } = useContext(ImageWizardContext);
+  const [environment, setEnvironment] = environmentState;
   const prefetchSources = provisioningApi.usePrefetch('getSourceList');
   const { isBeta } = useGetEnvironment();
 

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ImageOutput.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ImageOutput.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { useContext } from 'react';
 
 import {
   Text,
@@ -11,26 +11,11 @@ import {
 
 import ArchSelect from './ArchSelect';
 import CentOSAcknowledgement from './CentOSAcknowledgement';
-import Environment, { EnvironmentStateType } from './Environment';
+import Environment, { useGetAllowedTargets } from './Environment';
 import ReleaseSelect from './ReleaseSelect';
 
-import {
-  ArchitectureItem,
-  Distributions,
-} from '../../../../store/imageBuilderApi';
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
-
-type ImageOutputPropTypes = {
-  release: Distributions;
-  setRelease: Dispatch<SetStateAction<Distributions>>;
-  arch: ArchitectureItem['arch'];
-  setArch: Dispatch<SetStateAction<ArchitectureItem['arch']>>;
-  environment: EnvironmentStateType;
-  setEnvironment: Dispatch<SetStateAction<EnvironmentStateType>>;
-  isFetching: boolean;
-  isError: boolean;
-  isSuccess: boolean;
-};
+import { ImageWizardContext } from '../../ImageWizardContext';
 
 /**
  * Manages the form for the image output step by providing the user with a
@@ -39,17 +24,14 @@ type ImageOutputPropTypes = {
  * - a release
  * - a set of environments
  */
-const ImageOutputStep = ({
-  release,
-  setRelease,
-  arch,
-  setArch,
-  setEnvironment,
-  environment,
-  isFetching,
-  isError,
-  isSuccess,
-}: ImageOutputPropTypes) => {
+const ImageOutputStep = () => {
+  const { releaseState, architectureState } = useContext(ImageWizardContext);
+  const [release] = releaseState;
+  const [architecture] = architectureState;
+  const { isFetching, isError, isSuccess } = useGetAllowedTargets({
+    architecture: architecture,
+    release: release,
+  });
   return (
     <Form>
       <Title headingLevel="h2">Image output</Title>
@@ -59,8 +41,8 @@ const ImageOutputStep = ({
         <br />
         <DocumentationButton />
       </Text>
-      <ReleaseSelect setRelease={setRelease} release={release} />
-      <ArchSelect setArch={setArch} arch={arch} />
+      <ReleaseSelect />
+      <ArchSelect />
       {release.match('centos-*') && <CentOSAcknowledgement />}
       {isFetching && (
         <Bullseye>
@@ -77,12 +59,7 @@ const ImageOutputStep = ({
           API cannot be reached, try again later.
         </Alert>
       )}
-      {isSuccess && !isFetching && (
-        <Environment
-          setEnvironment={setEnvironment}
-          environment={environment}
-        />
-      )}
+      {isSuccess && !isFetching && <Environment />}
     </Form>
   );
 };

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseSelect.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Dispatch,
-  ReactElement,
-  SetStateAction,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactElement, useContext, useRef, useState } from 'react';
 
 import {
   Select,
@@ -17,17 +11,15 @@ import {
 import { RELEASES } from '../../../../constants';
 import { Distributions } from '../../../../store/imageBuilderApi';
 import isRhel from '../../../../Utilities/isRhel';
-
-type ReleaseSelectType = {
-  setRelease: Dispatch<SetStateAction<Distributions>>;
-  release: Distributions;
-};
+import { ImageWizardContext } from '../../ImageWizardContext';
 
 /**
  * Allows the user to choose the release they want to build.
  * Follows the PF5 pattern: https://www.patternfly.org/components/menus/select#view-more
  */
-const ReleaseSelect = ({ setRelease, release }: ReleaseSelectType) => {
+const ReleaseSelect = () => {
+  const { releaseState } = useContext(ImageWizardContext);
+  const [release, setRelease] = releaseState;
   // By default the component doesn't show the Centos releases and only the RHEL
   // ones. The user has the option to click on a button to make them appear.
   const [showDevelopmentOptions, setShowDevelopmentOptions] = useState(false);

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStep.tsx
@@ -1,24 +1,70 @@
 import React, { useState } from 'react';
 
-import { ExpandableSection, Form, Title } from '@patternfly/react-core';
+import {
+  ExpandableSection,
+  Form,
+  Text,
+  TextContent,
+  TextVariants,
+  Title,
+} from '@patternfly/react-core';
 
 import { ImageOutputList } from './imageOutput';
+import {
+  TargetEnvAWSList,
+  TargetEnvAzureList,
+  TargetEnvGCPList,
+  TargetEnvOciList,
+  TargetEnvOtherList,
+} from './targetEnvironment';
 
 import {
   ArchitectureItem,
   Distributions,
 } from '../../../../store/imageBuilderApi';
+import { EnvironmentStateType } from '../ImageOutput/Environment';
+import { GCPAccountTypes } from '../TargetEnvironment/GCP/GCPTarget';
 
 type ReviewStepPropTypes = {
   release: Distributions;
   arch: ArchitectureItem['arch'];
+  environment: EnvironmentStateType;
+  awsManual: boolean;
+  awsAccountId: string;
+  awsSource: [number, string];
+  gcpAccountType: GCPAccountTypes;
+  gcpAccountEmail: string;
+  gcpDomain: string;
+  azureManual: boolean;
+  azureSource: [number, string];
+  azureTenantId: string;
+  azureSubscriptionId: string;
+  azureResourceGroup: string;
 };
 
-const ReviewStep = ({ release, arch }: ReviewStepPropTypes) => {
+const ReviewStep = ({
+  release,
+  arch,
+  environment,
+  awsManual,
+  awsAccountId,
+  awsSource,
+  gcpAccountType,
+  gcpAccountEmail,
+  gcpDomain,
+  azureManual,
+  azureSource,
+  azureTenantId,
+  azureSubscriptionId,
+  azureResourceGroup,
+}: ReviewStepPropTypes) => {
   const [isExpandedImageOutput, setIsExpandedImageOutput] = useState(false);
+  const [isExpandedTargetEnvs, setIsExpandedTargetEnvs] = useState(false);
 
   const onToggleImageOutput = (isExpandedImageOutput: boolean) =>
     setIsExpandedImageOutput(isExpandedImageOutput);
+  const onToggleTargetEnvs = (isExpandedTargetEnvs: boolean) =>
+    setIsExpandedTargetEnvs(isExpandedTargetEnvs);
   return (
     <>
       <Form>
@@ -33,6 +79,81 @@ const ReviewStep = ({ release, arch }: ReviewStepPropTypes) => {
           data-testid="image-output-expandable"
         >
           <ImageOutputList release={release} arch={arch} />
+        </ExpandableSection>
+        <ExpandableSection
+          toggleContent={'Target environments'}
+          onToggle={(_event, isExpandedTargetEnvs) =>
+            onToggleTargetEnvs(isExpandedTargetEnvs)
+          }
+          isExpanded={isExpandedTargetEnvs}
+          isIndented
+          data-testid="target-environments-expandable"
+        >
+          {environment.aws.selected && environment.aws.authorized && (
+            <TargetEnvAWSList
+              manual={awsManual}
+              accountId={awsAccountId}
+              source={awsSource}
+            />
+          )}
+          {environment.gcp.selected && environment.gcp.authorized && (
+            <TargetEnvGCPList
+              accountType={gcpAccountType}
+              accountEmail={gcpAccountEmail}
+              domain={gcpDomain}
+            />
+          )}
+          {environment.azure.selected && environment.azure.authorized && (
+            <TargetEnvAzureList
+              manual={azureManual}
+              source={azureSource}
+              tenantId={azureTenantId}
+              subscriptionId={azureSubscriptionId}
+              resourceGroup={azureResourceGroup}
+            />
+          )}
+          {environment.oci.selected && environment.oci.authorized && (
+            <TargetEnvOciList />
+          )}
+          {environment.vsphere.selected && environment.vsphere.authorized && (
+            <TextContent>
+              <Text component={TextVariants.h3}>VMWare vSphere (.vmdk)</Text>
+              <TargetEnvOtherList />
+            </TextContent>
+          )}
+          {environment['vsphere-ova'].selected &&
+            environment['vsphere-ova'].authorized && (
+              <TextContent>
+                <Text component={TextVariants.h3}>VMWare vSphere (.ova)</Text>
+                <TargetEnvOtherList />
+              </TextContent>
+            )}
+          {environment['guest-image'].selected &&
+            environment['guest-image'].authorized && (
+              <TextContent>
+                <Text component={TextVariants.h3}>
+                  Virtualization - Guest image (.qcow2)
+                </Text>
+                <TargetEnvOtherList />
+              </TextContent>
+            )}
+          {environment['image-installer'].selected &&
+            environment['image-installer'].authorized && (
+              <TextContent>
+                <Text component={TextVariants.h3}>
+                  Bare metal - Installer (.iso)
+                </Text>
+                <TargetEnvOtherList />
+              </TextContent>
+            )}
+          {environment.wsl.selected && environment.wsl.authorized && (
+            <TextContent>
+              <Text component={TextVariants.h3}>
+                WSL - Windows Subsystem for Linux (.tar.gz)
+              </Text>
+              <TargetEnvOtherList />
+            </TextContent>
+          )}
         </ExpandableSection>
       </Form>
     </>

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 
 import {
   ExpandableSection,
@@ -18,46 +18,11 @@ import {
   TargetEnvOtherList,
 } from './targetEnvironment';
 
-import {
-  ArchitectureItem,
-  Distributions,
-} from '../../../../store/imageBuilderApi';
-import { EnvironmentStateType } from '../ImageOutput/Environment';
-import { GCPAccountTypes } from '../TargetEnvironment/GCP/GCPTarget';
+import { ImageWizardContext } from '../../ImageWizardContext';
 
-type ReviewStepPropTypes = {
-  release: Distributions;
-  arch: ArchitectureItem['arch'];
-  environment: EnvironmentStateType;
-  awsManual: boolean;
-  awsAccountId: string;
-  awsSource: [number, string];
-  gcpAccountType: GCPAccountTypes;
-  gcpAccountEmail: string;
-  gcpDomain: string;
-  azureManual: boolean;
-  azureSource: [number, string];
-  azureTenantId: string;
-  azureSubscriptionId: string;
-  azureResourceGroup: string;
-};
-
-const ReviewStep = ({
-  release,
-  arch,
-  environment,
-  awsManual,
-  awsAccountId,
-  awsSource,
-  gcpAccountType,
-  gcpAccountEmail,
-  gcpDomain,
-  azureManual,
-  azureSource,
-  azureTenantId,
-  azureSubscriptionId,
-  azureResourceGroup,
-}: ReviewStepPropTypes) => {
+const ReviewStep = () => {
+  const { environmentState } = useContext(ImageWizardContext);
+  const [environment] = environmentState;
   const [isExpandedImageOutput, setIsExpandedImageOutput] = useState(false);
   const [isExpandedTargetEnvs, setIsExpandedTargetEnvs] = useState(false);
 
@@ -78,7 +43,7 @@ const ReviewStep = ({
           isIndented
           data-testid="image-output-expandable"
         >
-          <ImageOutputList release={release} arch={arch} />
+          <ImageOutputList />
         </ExpandableSection>
         <ExpandableSection
           toggleContent={'Target environments'}
@@ -90,27 +55,13 @@ const ReviewStep = ({
           data-testid="target-environments-expandable"
         >
           {environment.aws.selected && environment.aws.authorized && (
-            <TargetEnvAWSList
-              manual={awsManual}
-              accountId={awsAccountId}
-              source={awsSource}
-            />
+            <TargetEnvAWSList />
           )}
           {environment.gcp.selected && environment.gcp.authorized && (
-            <TargetEnvGCPList
-              accountType={gcpAccountType}
-              accountEmail={gcpAccountEmail}
-              domain={gcpDomain}
-            />
+            <TargetEnvGCPList />
           )}
           {environment.azure.selected && environment.azure.authorized && (
-            <TargetEnvAzureList
-              manual={azureManual}
-              source={azureSource}
-              tenantId={azureTenantId}
-              subscriptionId={azureSubscriptionId}
-              resourceGroup={azureResourceGroup}
-            />
+            <TargetEnvAzureList />
           )}
           {environment.oci.selected && environment.oci.authorized && (
             <TargetEnvOciList />

--- a/src/Components/CreateImageWizardV2/steps/Review/imageOutput.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/imageOutput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 import {
   TextContent,
@@ -9,20 +9,12 @@ import {
 } from '@patternfly/react-core';
 
 import { RELEASES } from '../../../../constants';
-import {
-  ArchitectureItem,
-  Distributions,
-} from '../../../../store/imageBuilderApi';
+import { ImageWizardContext } from '../../ImageWizardContext';
 
-type ImageOutputListPropTypes = {
-  release: Distributions;
-  arch: ArchitectureItem['arch'];
-};
-
-export const ImageOutputList = ({
-  release,
-  arch,
-}: ImageOutputListPropTypes) => {
+export const ImageOutputList = () => {
+  const { releaseState, architectureState } = useContext(ImageWizardContext);
+  const [release] = releaseState;
+  const [arch] = architectureState;
   return (
     <TextContent>
       <TextList component={TextListVariants.dl}>

--- a/src/Components/CreateImageWizardV2/steps/Review/targetEnvironment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/targetEnvironment.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 
 import {
   Text,
@@ -11,10 +11,8 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
-import {
-  GCPAccountTypes,
-  gcpAccountToString,
-} from '../TargetEnvironment/GCP/GCPTarget';
+import { ImageWizardContext } from '../../ImageWizardContext';
+import { gcpAccountToString } from '../TargetEnvironment/GCP/GCPTarget';
 
 const ExpirationWarning = () => {
   return (
@@ -24,17 +22,12 @@ const ExpirationWarning = () => {
   );
 };
 
-type TargetEnvAWSListPropTypes = {
-  manual: boolean;
-  accountId: string;
-  source: [number, string];
-};
-
-export const TargetEnvAWSList = ({
-  manual,
-  accountId,
-  source,
-}: TargetEnvAWSListPropTypes) => {
+export const TargetEnvAWSList = () => {
+  const { isAwsManualState, associatedAwsAccountIdState, awsSourceState } =
+    useContext(ImageWizardContext);
+  const [accountId] = associatedAwsAccountIdState;
+  const [source] = awsSourceState;
+  const [isManual] = isAwsManualState;
   return (
     <TextContent>
       <Text component={TextVariants.h3}>AWS</Text>
@@ -57,10 +50,10 @@ export const TargetEnvAWSList = ({
           {accountId}
         </TextListItem>
         <TextListItem component={TextListItemVariants.dt}>
-          {!manual ? 'Source' : null}
+          {!isManual ? 'Source' : null}
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
-          {!manual && source[1]}
+          {!isManual && source[1]}
         </TextListItem>
         <TextListItem component={TextListItemVariants.dt}>
           Default region
@@ -74,17 +67,12 @@ export const TargetEnvAWSList = ({
   );
 };
 
-type TargetEnvGCPListPropTypes = {
-  accountType: GCPAccountTypes;
-  accountEmail: string;
-  domain: string;
-};
-
-export const TargetEnvGCPList = ({
-  accountType,
-  accountEmail,
-  domain,
-}: TargetEnvGCPListPropTypes) => {
+export const TargetEnvGCPList = () => {
+  const { gcpAccountTypeState, gcpAccountEmailState, gcpDomainState } =
+    useContext(ImageWizardContext);
+  const [accountType] = gcpAccountTypeState;
+  const [accountEmail] = gcpAccountEmailState;
+  const [domain] = gcpDomainState;
   return (
     <TextContent>
       <Text component={TextVariants.h3}>GCP</Text>
@@ -138,21 +126,19 @@ export const TargetEnvGCPList = ({
   );
 };
 
-type TargetEnvAzureListPropTypes = {
-  manual: boolean;
-  source: [number, string];
-  tenantId: string;
-  subscriptionId: string;
-  resourceGroup: string;
-};
-
-export const TargetEnvAzureList = ({
-  manual,
-  source,
-  tenantId,
-  subscriptionId,
-  resourceGroup,
-}: TargetEnvAzureListPropTypes) => {
+export const TargetEnvAzureList = () => {
+  const {
+    azureTenantIdState,
+    azureSourceState,
+    azureSubscriptionIdState,
+    azureResourceGroupState,
+    isAzureManualState,
+  } = useContext(ImageWizardContext);
+  const [tenantId] = azureTenantIdState;
+  const [subscriptionId] = azureSubscriptionIdState;
+  const [source] = azureSourceState;
+  const [resourceGroup] = azureResourceGroupState;
+  const [manual] = isAzureManualState;
   return (
     <TextContent>
       <Text component={TextVariants.h3}>Microsoft Azure</Text>

--- a/src/Components/CreateImageWizardV2/steps/Review/targetEnvironment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/targetEnvironment.tsx
@@ -1,0 +1,247 @@
+import React, { useEffect, useState } from 'react';
+
+import {
+  Text,
+  TextContent,
+  TextList,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+  TextVariants,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+import {
+  GCPAccountTypes,
+  gcpAccountToString,
+} from '../TargetEnvironment/GCP/GCPTarget';
+
+const ExpirationWarning = () => {
+  return (
+    <div className="pf-u-mr-sm pf-u-font-size-sm pf-u-warning-color-100">
+      <ExclamationTriangleIcon /> Expires 14 days after creation
+    </div>
+  );
+};
+
+type TargetEnvAWSListPropTypes = {
+  manual: boolean;
+  accountId: string;
+  source: [number, string];
+};
+
+export const TargetEnvAWSList = ({
+  manual,
+  accountId,
+  source,
+}: TargetEnvAWSListPropTypes) => {
+  return (
+    <TextContent>
+      <Text component={TextVariants.h3}>AWS</Text>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Image type
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          Red Hat hosted image
+          <br />
+          <ExpirationWarning />
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dt}>
+          Shared to account
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          {accountId}
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dt}>
+          {!manual ? 'Source' : null}
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          {!manual && source[1]}
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dt}>
+          Default region
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          us-east-1
+        </TextListItem>
+      </TextList>
+      <br />
+    </TextContent>
+  );
+};
+
+type TargetEnvGCPListPropTypes = {
+  accountType: GCPAccountTypes;
+  accountEmail: string;
+  domain: string;
+};
+
+export const TargetEnvGCPList = ({
+  accountType,
+  accountEmail,
+  domain,
+}: TargetEnvGCPListPropTypes) => {
+  return (
+    <TextContent>
+      <Text component={TextVariants.h3}>GCP</Text>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Image type
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          Red Hat hosted image
+          <br />
+          <ExpirationWarning />
+        </TextListItem>
+        {(accountEmail || domain) && (
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              Shared with
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              A Google account
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>
+              Account type
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {gcpAccountToString(accountType)}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>
+              {accountType === 'domain' ? 'Domain' : 'Principal'}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {accountEmail || domain}
+            </TextListItem>
+          </>
+        )}
+        {!(accountEmail || domain) && (
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              Shared with
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              Red Hat Insights only
+            </TextListItem>
+          </>
+        )}
+      </TextList>
+      <br />
+    </TextContent>
+  );
+};
+
+type TargetEnvAzureListPropTypes = {
+  manual: boolean;
+  source: [number, string];
+  tenantId: string;
+  subscriptionId: string;
+  resourceGroup: string;
+};
+
+export const TargetEnvAzureList = ({
+  manual,
+  source,
+  tenantId,
+  subscriptionId,
+  resourceGroup,
+}: TargetEnvAzureListPropTypes) => {
+  return (
+    <TextContent>
+      <Text component={TextVariants.h3}>Microsoft Azure</Text>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Image type
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          Red Hat hosted image
+          <br />
+          <ExpirationWarning />
+        </TextListItem>
+        {!manual && source[1] && (
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              Azure Source
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {source[1]}
+            </TextListItem>
+          </>
+        )}
+        {manual && (
+          <>
+            <TextListItem component={TextListItemVariants.dt}>
+              Azure Tenant GUID
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {tenantId}
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>
+              Subscription ID
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {subscriptionId}
+            </TextListItem>
+          </>
+        )}
+        <TextListItem component={TextListItemVariants.dt}>
+          Resource group
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          {resourceGroup}
+        </TextListItem>
+      </TextList>
+      <br />
+    </TextContent>
+  );
+};
+
+export const TargetEnvOciList = () => {
+  return (
+    <TextContent>
+      <Text component={TextVariants.h3}>Oracle Cloud Infrastructure</Text>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Object Storage URL
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          The URL for the built image will be ready to copy
+          <br />
+        </TextListItem>
+      </TextList>
+      <br />
+    </TextContent>
+  );
+};
+
+export const TargetEnvOtherList = () => {
+  return (
+    <>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Image type
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          Built image will be available for download
+        </TextListItem>
+      </TextList>
+      <br />
+    </>
+  );
+};

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/AWS/AWSTarget.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/AWS/AWSTarget.tsx
@@ -1,0 +1,215 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+
+import {
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  Gallery,
+  GalleryItem,
+  HelperText,
+  HelperTextItem,
+  Radio,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import { DEFAULT_AWS_REGION } from '../../../../../constants';
+import ValidatedTextField from '../../../common/ValidatedTextField';
+import { SourcesSelect } from '../SourcesSelect';
+
+const SourcesButton = () => {
+  return (
+    <Button
+      component="a"
+      target="_blank"
+      variant="link"
+      icon={<ExternalLinkAltIcon />}
+      iconPosition="right"
+      isInline
+      href={'settings/sources'}
+    >
+      Create and manage sources here
+    </Button>
+  );
+};
+
+export const validateAWSAccountID = (accountId: string) => {
+  return /^\d+$/.test(accountId) && accountId.length === 12;
+};
+
+type AWSTargetPropTypes = {
+  manual: boolean;
+  setManual: Dispatch<SetStateAction<boolean>>;
+  associatedAccountId: string;
+  setAssociatedAccountId: Dispatch<SetStateAction<string>>;
+  source: [number, string];
+  setSource: Dispatch<SetStateAction<[number, string]>>;
+  isErrorFetchingDetails: boolean;
+};
+
+/**
+ * Component to display the configuration form for the user to enter their aws
+ * account ID.
+ *
+ * @param manual shall the user enter the account ID manually if set to true or
+ * go use the sources if set to false
+ * @param setManual function to update the `manual` value
+ * @param associatedAccountId the account ID either computed via the
+ * selectedSourceId or manually entered by the user
+ * @param setAssociatedAccountId a function to update the associatedAccountId
+ * @param selectedSource the source the user has selected
+ * @param setSelectedSource a function to update selectedSource
+ * @param isErrorDetails shall be set to true if the associatedAccountId
+ * couldn't get retrieved from the selectedSourceId
+ */
+const AWSTarget = ({
+  manual,
+  setManual,
+  associatedAccountId,
+  setAssociatedAccountId,
+  source,
+  setSource,
+  isErrorFetchingDetails,
+}: AWSTargetPropTypes) => {
+  const clearAwsTarget = () => {
+    // reset the selected source state so the UI doesn't keep
+    // previously entered data when the user goes back to their
+    // previous choice
+    setAssociatedAccountId('');
+    setSource([0, '']);
+  };
+  const [isErrorFetchingSources, setIsErrorFetchingSources] = useState(false);
+  return (
+    <>
+      <Form>
+        <Title headingLevel="h2">
+          Target environment - Amazon Web Services
+        </Title>
+        <p>
+          Your image will be uploaded to AWS and shared with the account you
+          provide below.
+        </p>
+        <p>
+          <b>The shared image will expire within 14 days.</b> To permanently
+          access the image, copy the image, which will be shared to your account
+          by Red Hat, to your own AWS account.
+        </p>
+        <FormGroup label="Share method:">
+          <Radio
+            name="aws-from-sources"
+            id="aws-from-sources"
+            label="Use an account configured from Sources."
+            description="Use a configured source to launch environments directly from the console."
+            checked={!manual}
+            isChecked={!manual}
+            onClick={() => {
+              setManual(false);
+              clearAwsTarget();
+            }}
+          />
+          <Radio
+            name="aws-from-manual"
+            id="aws-from-manual"
+            label="Manually enter an account ID."
+            checked={manual}
+            isChecked={manual}
+            onClick={() => {
+              setManual(true);
+              clearAwsTarget();
+            }}
+          />
+        </FormGroup>
+        {!manual && (
+          <>
+            <SourcesSelect
+              provider="aws"
+              selectedSource={source}
+              setSelectedSource={setSource}
+              setFetchingError={setIsErrorFetchingSources}
+            />
+            <>
+              {isErrorFetchingSources && (
+                <Alert
+                  variant={'danger'}
+                  isPlain={true}
+                  isInline={true}
+                  title={'Sources unavailable'}
+                >
+                  Sources cannot be reached, try again later or enter an AWS
+                  account ID manually.
+                </Alert>
+              )}
+              {isErrorFetchingDetails && (
+                <Alert
+                  variant={'danger'}
+                  isPlain
+                  isInline
+                  title={'AWS details unavailable'}
+                >
+                  The AWS account ID for the selected source could not be
+                  resolved. There might be a problem with the source. Verify
+                  that the source is valid in Sources or select a different
+                  source.
+                </Alert>
+              )}
+            </>
+            <SourcesButton />
+          </>
+        )}
+        {manual && (
+          <ValidatedTextField
+            aria="AWS account ID"
+            label="AWS account ID"
+            fieldId="aws-account-id-textbox"
+            value={associatedAccountId}
+            setValue={setAssociatedAccountId}
+            validateFunction={validateAWSAccountID}
+            helperText="Account ID must be composed of 12 numbers"
+          />
+        )}
+        <Gallery hasGutter>
+          <GalleryItem>
+            <FormGroup label="Default Region" isRequired>
+              <TextInput
+                value={DEFAULT_AWS_REGION}
+                type="text"
+                readOnlyVariant="default"
+                aria-label="Default Region"
+                isRequired
+              />
+              <HelperText>
+                <HelperTextItem component="div" variant="indeterminate">
+                  Images are built in the default region but can be copied to
+                  other regions later.
+                </HelperTextItem>
+              </HelperText>
+            </FormGroup>
+          </GalleryItem>
+          {!manual && (
+            <GalleryItem>
+              <FormGroup label="Associated Account ID" isRequired>
+                <TextInput
+                  value={associatedAccountId}
+                  type="text"
+                  readOnlyVariant="default"
+                  label="Associated Account ID"
+                  aria-label="Associated Account ID"
+                  isRequired
+                />
+                <HelperText>
+                  <HelperTextItem component="div" variant="indeterminate">
+                    This is the account associated with the source.
+                  </HelperTextItem>
+                </HelperText>
+              </FormGroup>
+            </GalleryItem>
+          )}
+        </Gallery>
+      </Form>
+    </>
+  );
+};
+
+export default AWSTarget;

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureTarget.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureTarget.tsx
@@ -1,0 +1,302 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+
+import {
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  Gallery,
+  GalleryItem,
+  Radio,
+  Text,
+  TextContent,
+  TextInput,
+  Title,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import TypeAheadSelect from '../../../common/TypeAheadSelect';
+import ValidatedTextField from '../../../common/ValidatedTextField';
+import { SourcesSelect } from '../SourcesSelect';
+
+type AzureAuthButtonPropTypes = {
+  tenantId: string;
+};
+
+const AzureAuthButton = ({ tenantId }: AzureAuthButtonPropTypes) => {
+  return (
+    <FormGroup>
+      <Button
+        component="a"
+        target="_blank"
+        variant="secondary"
+        isDisabled={!validateAzureId(tenantId)}
+        href={
+          'https://login.microsoftonline.com/' +
+          tenantId +
+          '/oauth2/v2.0/authorize?client_id=b94bb246-b02c-4985-9c22-d44e66f657f4&scope=openid&' +
+          'response_type=code&response_mode=query&redirect_uri=https://portal.azure.com'
+        }
+      >
+        Authorize Image Builder
+      </Button>
+    </FormGroup>
+  );
+};
+
+const SourcesButton = () => {
+  return (
+    <Button
+      component="a"
+      target="_blank"
+      variant="link"
+      icon={<ExternalLinkAltIcon />}
+      iconPosition="right"
+      isInline
+      href={'settings/sources'}
+    >
+      Create and manage sources here
+    </Button>
+  );
+};
+
+export const validateAzureId = (value: string) => {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value
+  );
+};
+
+export const validateResourceGroup = (value: string) => {
+  return /^[-\w._()]+[-\w_()]$/.test(value);
+};
+
+type AzureTargetPropTypes = {
+  manual: boolean;
+  setManual: Dispatch<SetStateAction<boolean>>;
+  isErrorFetchingDetails: boolean;
+  source: [number, string];
+  setSource: Dispatch<SetStateAction<[number, string]>>;
+  subscriptionId: string;
+  setSubscriptionId: Dispatch<SetStateAction<string>>;
+  tenantId: string;
+  setTenantId: Dispatch<SetStateAction<string>>;
+  resourceGroup: string;
+  setResourceGroup: Dispatch<SetStateAction<string>>;
+  resourceGroups: string[];
+};
+
+/**
+ * Component that enables the user to enter the necessary information to upload
+ * to azure.
+ * @param manual set to true if the user will enter the information manually, set to
+ * false if they are fetched from the sources
+ * @param setManual a function to update the `manual` value
+ * @param source if not in manual mode holds the selected source by
+ * the user.
+ * @param setsource a function to update the sourceId
+ * @param tenantId a value either computed via the sources if a sourceId
+ * was selected or manually entered by the user
+ * @param setTenantId a function to update the tenantId
+ * @param subscriptionId a value either computed via the sources if a sourceId
+ * was selected or manually entered by the user
+ * @param setSubscriptionId a function to update the subscriptionId
+ * @param resourceGroup holds a resource group the user either selected
+ * in a set of possibilities or entered manually
+ * @param setResourceGroup a function to update the
+ * ResourceGroup
+ * @param resourceGroups a list of resource groups computed via the sources if a
+ * sourceId was selected that contains choices for the user to select
+ * the resourceGroup.
+ */
+const AzureTarget = ({
+  manual,
+  setManual,
+  isErrorFetchingDetails,
+  source,
+  setSource,
+  tenantId,
+  setTenantId,
+  subscriptionId,
+  setSubscriptionId,
+  resourceGroup,
+  setResourceGroup,
+  resourceGroups,
+}: AzureTargetPropTypes) => {
+  const [isErrorFetchingSources, setIsErrorFetchingSources] = useState(false);
+  const clearState = () => {
+    // when the user switches from manual to automatic, reset everything
+    setSource([0, '']);
+    setTenantId('');
+    setResourceGroup('');
+    setSubscriptionId('');
+  };
+
+  return (
+    <>
+      <Form>
+        <Title headingLevel="h2">Target environment - Microsoft Azure</Title>
+        <TextContent>
+          <Text>
+            Upon build, Image Builder sends the image to the selected authorized
+            Azure account. The image will be uploaded to the resource group in
+            the subscription you specify.
+          </Text>
+          <Text>
+            To authorize Image Builder to push images to Microsoft Azure, the
+            account owner must configure Image Builder as an authorized
+            application for a specific tenant GUID and give it the role of
+            &quot;Contributor&quot; for the resource group you want to upload
+            to. This applies even when defining target by Source selection.
+            <br />
+            <Button
+              component="a"
+              target="_blank"
+              variant="link"
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="right"
+              isInline
+              href="https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow"
+            >
+              Learn more about OAuth 2.0
+            </Button>
+          </Text>
+        </TextContent>
+        <FormGroup label="Share method:">
+          <Radio
+            name="azure-share-source"
+            id="azure-share-source"
+            label="Use an account configured from Sources."
+            description={
+              'Use a configured source to launch environments directly from the console.'
+            }
+            checked={!manual}
+            isChecked={!manual}
+            onClick={() => {
+              setManual(false);
+              clearState();
+            }}
+          />
+          <Radio
+            name="azure-share-manual"
+            id="azure-share-manual"
+            label="Manually enter the account information."
+            checked={manual}
+            isChecked={manual}
+            onClick={() => {
+              setManual(true);
+              clearState();
+            }}
+          />
+        </FormGroup>
+        {!manual && (
+          <>
+            <SourcesSelect
+              provider="azure"
+              selectedSource={source}
+              setSelectedSource={setSource}
+              setFetchingError={setIsErrorFetchingSources}
+            />
+            <>
+              {isErrorFetchingSources && (
+                <Alert
+                  variant={'danger'}
+                  isPlain={true}
+                  isInline={true}
+                  title={'Sources unavailable'}
+                >
+                  Sources cannot be reached, try again later or enter an account
+                  info for upload manually.
+                </Alert>
+              )}
+              {isErrorFetchingDetails && (
+                <Alert
+                  variant={'danger'}
+                  isPlain
+                  isInline
+                  title={'Azure details unavailable'}
+                >
+                  Could not fetch Tenant GUID and Subscription ID from Azure for
+                  given Source. Check Sources page for the source availability
+                  or select a different Source.
+                </Alert>
+              )}
+            </>
+            <SourcesButton />
+          </>
+        )}
+        {!manual && (
+          <>
+            <Gallery hasGutter>
+              <GalleryItem>
+                <FormGroup label="Azure Tenant GUID" isRequired>
+                  <TextInput
+                    value={tenantId}
+                    type="text"
+                    readOnlyVariant="default"
+                    aria-label="Azure Tenant GUID"
+                    isRequired
+                  />
+                </FormGroup>
+              </GalleryItem>
+              <GalleryItem>
+                <FormGroup label="Subscription ID" isRequired>
+                  <TextInput
+                    value={subscriptionId}
+                    type="text"
+                    readOnlyVariant="default"
+                    aria-label="Subscription ID"
+                    isRequired
+                  />
+                </FormGroup>
+              </GalleryItem>
+            </Gallery>
+            <AzureAuthButton tenantId={tenantId} />
+            <FormGroup label="Resource group" isRequired>
+              <TypeAheadSelect
+                inputOptions={resourceGroups}
+                fieldID="resource-group-select"
+                selected={resourceGroup}
+                setSelected={setResourceGroup}
+                placeholderText="Select a resource group"
+              />
+            </FormGroup>
+          </>
+        )}
+        {manual && (
+          <>
+            <ValidatedTextField
+              aria="Azure tenant id"
+              label="Azure Tenant GUID"
+              fieldId="azure-tenant-id"
+              value={tenantId}
+              setValue={setTenantId}
+              validateFunction={validateAzureId}
+              helperText="Please enter a valid tenant GUID"
+            />
+            <AzureAuthButton tenantId={tenantId} />
+            <ValidatedTextField
+              aria="Azure subscription id"
+              label="Subscription ID"
+              fieldId="azure-subscription-id"
+              value={subscriptionId}
+              setValue={setSubscriptionId}
+              validateFunction={validateAzureId}
+              helperText="Please enter a valid subscription ID"
+            />
+            <ValidatedTextField
+              aria="Azure resource group"
+              label="Resource group"
+              fieldId="azure-resource-group"
+              value={resourceGroup}
+              setValue={setResourceGroup}
+              validateFunction={validateResourceGroup}
+              helperText="Resource group names only allow alphanumeric characters,
+            periods, underscores, hyphens, and parenthesis and cannot end in a period"
+            />
+          </>
+        )}
+      </Form>
+    </>
+  );
+};
+export default AzureTarget;

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/GCP/GCPTarget.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/GCP/GCPTarget.tsx
@@ -23,6 +23,19 @@ export type GCPAccountTypes =
   | 'googleGroup'
   | 'domain';
 
+export const gcpAccountToString = (type: GCPAccountTypes) => {
+  switch (type) {
+    case 'googleAccount':
+      return 'Google account';
+    case 'serviceAccount':
+      return 'Service account';
+    case 'googleGroup':
+      return 'Google group';
+    case 'domain':
+      return 'Domain';
+  }
+};
+
 type GCPTargetPropTypes = {
   shareGoogleAccount: boolean;
   setShareGoogleAccount: Dispatch<SetStateAction<boolean>>;

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/GCP/GCPTarget.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/GCP/GCPTarget.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { useContext } from 'react';
 
 import {
   Form,
@@ -16,6 +16,7 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 
 import ValidatedTextField from '../../../common/ValidatedTextField';
+import { ImageWizardContext } from '../../../ImageWizardContext';
 
 export type GCPAccountTypes =
   | 'googleAccount'
@@ -36,17 +37,6 @@ export const gcpAccountToString = (type: GCPAccountTypes) => {
   }
 };
 
-type GCPTargetPropTypes = {
-  shareGoogleAccount: boolean;
-  setShareGoogleAccount: Dispatch<SetStateAction<boolean>>;
-  accountType: GCPAccountTypes;
-  setAccountType: Dispatch<SetStateAction<GCPAccountTypes>>;
-  accountEmail: string;
-  setAccountEmail: Dispatch<SetStateAction<string>>;
-  domain: string;
-  setDomain: Dispatch<SetStateAction<string>>;
-};
-
 export const validateEmail = (email: string) => {
   return /^[a-z0-9._%+-]+@[a-z0-9.-]+.[a-z]{2,}$/.test(email);
 };
@@ -58,12 +48,17 @@ export const validateEmail = (email: string) => {
  * - the domain has some text if the user chose it
  * - the user only wants to share with insights
  */
-export const validateGCPData = (
-  shareGoogleAccount: boolean,
-  accountType: GCPAccountTypes,
-  email: string,
-  domain: string
-) => {
+export const ValidateGCPStep = () => {
+  const {
+    isShareGoogleAccountState,
+    gcpAccountTypeState,
+    gcpAccountEmailState,
+    gcpDomainState,
+  } = useContext(ImageWizardContext);
+  const [shareGoogleAccount] = isShareGoogleAccountState;
+  const [accountType] = gcpAccountTypeState;
+  const [email] = gcpAccountEmailState;
+  const [domain] = gcpDomainState;
   if (shareGoogleAccount) {
     if (accountType !== 'domain') {
       return validateEmail(email);
@@ -124,32 +119,17 @@ const AccountTypePopoverInfo = () => {
   );
 };
 
-/**
- * Component to display the available customization for sharing on google cloud
- * platform.
- *
- * @param shareGoogleAccount is set to true is the data is shared with a google
- * account, false if only shared with insights.
- * @param setShareGoogleAccount a function to update shareGoogleAccount
- * @param accountType the type of google account to share with (see the propType
- * for more details
- * @param setAccountType a function to update the accountType
- * @param accountEmail the account email, if the type if a google/service
- * account or a google group
- * @param setAccountEmail a function to update the account email
- * @param domain if the account type is domain, domain must be filled up
- * @param setDomain a function to update the domain
- */
-const GCPTarget = ({
-  shareGoogleAccount,
-  setShareGoogleAccount,
-  accountType,
-  setAccountType,
-  accountEmail,
-  setAccountEmail,
-  domain,
-  setDomain,
-}: GCPTargetPropTypes) => {
+const GCPTarget = () => {
+  const {
+    gcpAccountTypeState,
+    gcpAccountEmailState,
+    gcpDomainState,
+    isShareGoogleAccountState,
+  } = useContext(ImageWizardContext);
+  const [accountType, setAccountType] = gcpAccountTypeState;
+  const [accountEmail, setAccountEmail] = gcpAccountEmailState;
+  const [domain, setDomain] = gcpDomainState;
+  const [shareGoogleAccount, setShareGoogleAccount] = isShareGoogleAccountState;
   const clearState = () => {
     // resets when the user switches from sharing to a google account or insights,
     setAccountType('googleAccount');

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/GCP/GCPTarget.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/GCP/GCPTarget.tsx
@@ -1,0 +1,280 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+
+import {
+  Form,
+  FormGroup,
+  Radio,
+  TextInput,
+  Title,
+  Popover,
+  TextContent,
+  Text,
+  TextList,
+  TextListItem,
+  Button,
+} from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+
+import ValidatedTextField from '../../../common/ValidatedTextField';
+
+export type GCPAccountTypes =
+  | 'googleAccount'
+  | 'serviceAccount'
+  | 'googleGroup'
+  | 'domain';
+
+type GCPTargetPropTypes = {
+  shareGoogleAccount: boolean;
+  setShareGoogleAccount: Dispatch<SetStateAction<boolean>>;
+  accountType: GCPAccountTypes;
+  setAccountType: Dispatch<SetStateAction<GCPAccountTypes>>;
+  accountEmail: string;
+  setAccountEmail: Dispatch<SetStateAction<string>>;
+  domain: string;
+  setDomain: Dispatch<SetStateAction<string>>;
+};
+
+export const validateEmail = (email: string) => {
+  return /^[a-z0-9._%+-]+@[a-z0-9.-]+.[a-z]{2,}$/.test(email);
+};
+
+/**
+ * @return true if:
+ * - the user has a valid email address in the case where the
+ *   account type is googleAccount, serviceAccount or googleGroup.
+ * - the domain has some text if the user chose it
+ * - the user only wants to share with insights
+ */
+export const validateGCPData = (
+  shareGoogleAccount: boolean,
+  accountType: GCPAccountTypes,
+  email: string,
+  domain: string
+) => {
+  if (shareGoogleAccount) {
+    if (accountType !== 'domain') {
+      return validateEmail(email);
+    }
+    return domain.length > 0;
+  }
+  return true;
+};
+
+const AccountTypePopoverInfo = () => {
+  return (
+    <Popover
+      hasAutoWidth
+      maxWidth="35rem"
+      headerContent={'Valid account types'}
+      flipBehavior={['right', 'bottom', 'top', 'left']}
+      bodyContent={
+        <TextContent>
+          <Text>
+            The following account types can have an image shared with them:
+          </Text>
+          <TextList className="pf-u-ml-0">
+            <TextListItem>
+              <strong>Google account:</strong> A Google account represents a
+              developer, an administrator, or any other person who interacts
+              with Google Cloud. For example: <em>`alice@gmail.com`</em>.
+            </TextListItem>
+            <TextListItem>
+              <strong>Service account:</strong> A service account is an account
+              for an application instead of an individual end user. For example:{' '}
+              <em>`myapp@appspot.gserviceaccount.com`</em>.
+            </TextListItem>
+            <TextListItem>
+              <strong>Google group:</strong> A Google group is a named
+              collection of Google accounts and service accounts. For example:{' '}
+              <em>`admins@example.com`</em>.
+            </TextListItem>
+            <TextListItem>
+              <strong>Google Workspace domain or Cloud Identity domain:</strong>{' '}
+              A Google workspace or cloud identity domain represents a virtual
+              group of all the Google accounts in an organization. These domains
+              represent your organization&apos;s internet domain name. For
+              example: <em>`mycompany.com`</em>.
+            </TextListItem>
+          </TextList>
+        </TextContent>
+      }
+    >
+      <Button
+        variant="plain"
+        aria-label="Account info"
+        aria-describedby="google-account-type"
+        className="pf-c-form__group-label-help"
+      >
+        <HelpIcon />
+      </Button>
+    </Popover>
+  );
+};
+
+/**
+ * Component to display the available customization for sharing on google cloud
+ * platform.
+ *
+ * @param shareGoogleAccount is set to true is the data is shared with a google
+ * account, false if only shared with insights.
+ * @param setShareGoogleAccount a function to update shareGoogleAccount
+ * @param accountType the type of google account to share with (see the propType
+ * for more details
+ * @param setAccountType a function to update the accountType
+ * @param accountEmail the account email, if the type if a google/service
+ * account or a google group
+ * @param setAccountEmail a function to update the account email
+ * @param domain if the account type is domain, domain must be filled up
+ * @param setDomain a function to update the domain
+ */
+const GCPTarget = ({
+  shareGoogleAccount,
+  setShareGoogleAccount,
+  accountType,
+  setAccountType,
+  accountEmail,
+  setAccountEmail,
+  domain,
+  setDomain,
+}: GCPTargetPropTypes) => {
+  const clearState = () => {
+    // resets when the user switches from sharing to a google account or insights,
+    setAccountType('googleAccount');
+    clearValues();
+  };
+  const clearValues = () => {
+    // resets when the user switches the account type
+    setAccountEmail('');
+    setDomain('');
+  };
+  return (
+    <>
+      <Form>
+        <Title headingLevel="h2">
+          Target environment - Google Cloud Platform
+        </Title>
+        <p>
+          Select how to share your image. The image you create can be used to
+          launch instances on GCP, regardless of which method you select.
+        </p>
+        <FormGroup label="Select image sharing" isRequired>
+          <Radio
+            name="gcp-share-google-account"
+            id="gcp-share-google-account"
+            label="Share image with a Google account"
+            description={
+              <p>
+                Your image will be uploaded to GCP and shared with the account
+                you provide below.
+                <b>The image expires in 14 days.</b> To keep permanent access to
+                your image, copy it to your GCP project.
+              </p>
+            }
+            checked={shareGoogleAccount}
+            isChecked={shareGoogleAccount}
+            onClick={() => {
+              setShareGoogleAccount(true);
+              clearState();
+            }}
+          />
+          <Radio
+            name="gcp-share-insights-only"
+            id="gcp-share-insights-only"
+            label="Share image with Red Hat Insights only"
+            description={
+              <p>
+                Your image will be uploaded to GCP and shared with Red Hat
+                Insights.
+                <b> The image expires in 14 days.</b> You cannot access or
+                recreate this image in your GCP project.
+              </p>
+            }
+            checked={!shareGoogleAccount}
+            isChecked={!shareGoogleAccount}
+            onClick={() => {
+              setShareGoogleAccount(false);
+              clearState();
+            }}
+          />
+        </FormGroup>
+        {shareGoogleAccount && (
+          <FormGroup
+            label="Account type"
+            isRequired
+            labelIcon={<AccountTypePopoverInfo />}
+          >
+            <Radio
+              name="gcp-type-google-account"
+              id="gcp-type-google-account"
+              label="Google account"
+              aria-label="Google account"
+              checked={accountType === 'googleAccount'}
+              isChecked={accountType === 'googleAccount'}
+              onClick={() => {
+                setAccountType('googleAccount');
+                clearValues();
+              }}
+            />
+            <Radio
+              name="gcp-type-service-account"
+              id="gcp-type-service-account"
+              label="Service account"
+              checked={accountType === 'serviceAccount'}
+              isChecked={accountType === 'serviceAccount'}
+              onClick={() => {
+                setAccountType('serviceAccount');
+                clearValues();
+              }}
+            />
+            <Radio
+              name="gcp-type-google-group"
+              id="gcp-type-google-group"
+              label="Google group"
+              checked={accountType === 'googleGroup'}
+              isChecked={accountType === 'googleGroup'}
+              onClick={() => {
+                setAccountType('googleGroup');
+                clearValues();
+              }}
+            />
+            <Radio
+              name="gcp-type-domaing"
+              id="gcp-type-domaing"
+              label="Google Workspace domain or Cloud Identity domain"
+              checked={accountType === 'domain'}
+              isChecked={accountType === 'domain'}
+              onClick={() => {
+                setAccountType('domain');
+                clearValues();
+              }}
+            />
+          </FormGroup>
+        )}
+        {shareGoogleAccount && accountType !== 'domain' && (
+          <ValidatedTextField
+            aria="GCP account email"
+            label="Principal (e.g e-mail address)"
+            fieldId="gcp-account-email"
+            value={accountEmail}
+            setValue={setAccountEmail}
+            validateFunction={validateEmail}
+            helperText="Must be a valid e-mail address"
+          />
+        )}
+        {shareGoogleAccount && accountType === 'domain' && (
+          <FormGroup label="Domain" isRequired>
+            <TextInput
+              value={domain}
+              type="text"
+              onChange={(_event, value) => setDomain(value)}
+              label="google-domain"
+              aria-label="google-domain"
+            />
+          </FormGroup>
+        )}
+      </Form>
+    </>
+  );
+};
+
+export default GCPTarget;

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/SourcesSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/SourcesSelect.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useEffect } from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 
 import { extractProvisioningList } from '../../../../store/helpers';
 import {
@@ -60,7 +60,6 @@ type SourcesSelectPropType = {
   provider: 'aws' | 'azure' | 'gcp';
   selectedSource: [number, string];
   setSelectedSource: Dispatch<SetStateAction<[number, string]>>;
-  setFetchingError: Dispatch<SetStateAction<boolean>>;
 };
 
 /**
@@ -70,14 +69,12 @@ type SourcesSelectPropType = {
  * @param provider azure or aws depending on the context
  * @param selectedSource the source the user has selected from the select menue
  * @param setSelectedSource a function to update the selected source
- * @param setFetchingError a function to notify if accessing the data for the
  * source ended up in an error.
  */
 export const SourcesSelect = ({
   provider,
   selectedSource,
   setSelectedSource,
-  setFetchingError,
 }: SourcesSelectPropType) => {
   const {
     data: rawSources,
@@ -85,11 +82,6 @@ export const SourcesSelect = ({
     isError,
     refetch,
   } = useGetSourceListQuery({ provider: provider });
-  // If an error occurs during data acquisition, notify the parent component so
-  // that a customized error can get displayed.
-  useEffect(() => {
-    setFetchingError(isError);
-  }, [isError]);
 
   const sources =
     rawSources !== undefined ? extractProvisioningList(rawSources) : [];

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/SourcesSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/SourcesSelect.tsx
@@ -1,0 +1,114 @@
+import React, { Dispatch, SetStateAction, useEffect } from 'react';
+
+import { extractProvisioningList } from '../../../../store/helpers';
+import {
+  useGetSourceListQuery,
+  useGetSourceUploadInfoQuery,
+} from '../../../../store/provisioningApi';
+import TypeAheadSelect from '../../common/TypeAheadSelect';
+
+/**
+ * @return unpacked data for the given provide.
+ *  - For aws: accountId
+ *  - For azure: tenantId and subscriptionId
+ * is error is set to true if anything went wrong fetching data.
+ */
+export const useGetAccountData = (
+  sourceId: number,
+  provider: 'aws' | 'azure'
+) => {
+  const { data, isError } = useGetSourceUploadInfoQuery(
+    { id: sourceId },
+    {
+      skip: !sourceId,
+    }
+  );
+  if (!sourceId) {
+    return {
+      accountId: '',
+      tenantId: '',
+      subscriptionId: '',
+      resourceGroups: [],
+      isError: false,
+    };
+  }
+  switch (provider) {
+    case 'aws':
+      return {
+        accountId: data?.aws?.account_id ? data.aws.account_id : '',
+        tenantId: '',
+        subscriptionId: '',
+        resourceGroups: [],
+        isError: isError,
+      };
+    case 'azure':
+      return {
+        accountId: '',
+        tenantId: data?.azure?.tenant_id ? data.azure.tenant_id : '',
+        subscriptionId: data?.azure?.subscription_id
+          ? data.azure.subscription_id
+          : '',
+        resourceGroups: data?.azure?.resource_groups
+          ? data.azure.resource_groups
+          : [],
+        isError: isError,
+      };
+  }
+};
+
+type SourcesSelectPropType = {
+  provider: 'aws' | 'azure' | 'gcp';
+  selectedSource: [number, string];
+  setSelectedSource: Dispatch<SetStateAction<[number, string]>>;
+  setFetchingError: Dispatch<SetStateAction<boolean>>;
+};
+
+/**
+ * Component to allow the user to select a source (id and label) through a
+ * TypeAheadSelect component.
+ *
+ * @param provider azure or aws depending on the context
+ * @param selectedSource the source the user has selected from the select menue
+ * @param setSelectedSource a function to update the selected source
+ * @param setFetchingError a function to notify if accessing the data for the
+ * source ended up in an error.
+ */
+export const SourcesSelect = ({
+  provider,
+  selectedSource,
+  setSelectedSource,
+  setFetchingError,
+}: SourcesSelectPropType) => {
+  const {
+    data: rawSources,
+    isFetching,
+    isError,
+    refetch,
+  } = useGetSourceListQuery({ provider: provider });
+  // If an error occurs during data acquisition, notify the parent component so
+  // that a customized error can get displayed.
+  useEffect(() => {
+    setFetchingError(isError);
+  }, [isError]);
+
+  const sources =
+    rawSources !== undefined ? extractProvisioningList(rawSources) : [];
+  const options: [number, string][] = [];
+  sources?.forEach((val) => {
+    if (val.id && val.name) {
+      options.push([parseInt(val.id), val.name]);
+    }
+  });
+  return (
+    <TypeAheadSelect
+      inputOptions={options}
+      fieldID="source-"
+      selected={selectedSource}
+      setSelected={setSelectedSource}
+      placeholderText="Select a source"
+      isFetching={isFetching}
+      isError={isError}
+      refetch={refetch}
+    />
+  );
+};

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -76,14 +76,36 @@ describe('Create Image Wizard', () => {
 });
 
 describe('Step Image output', () => {
-  test('clicking Next loads the review step with correct information about the image output', async () => {
+  test('clicking Next until the review step with correct information about the image output', async () => {
     const user = userEvent.setup();
     await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
 
-    // select aws as upload destination
+    // select every upload target
     await user.click(await screen.findByTestId('upload-aws'));
-    await screen.findByRole('heading', { name: 'Image output' });
+    await user.click(await screen.findByTestId('upload-google'));
+    await user.click(await screen.findByTestId('upload-azure'));
+    await user.click(
+      await screen.findByRole('checkbox', {
+        name: /vmware checkbox/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('checkbox', {
+        name: /virtualization guest image checkbox/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /open virtualization format \(\.ova\)/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('checkbox', {
+        name: /bare metal installer checkbox/i,
+      })
+    );
 
+    // go to aws target page
     await clickNext();
     // enter a source to be able to click next
     await user.click(
@@ -139,6 +161,17 @@ describe('Step Image output', () => {
     expect(
       await screen.findByText(/red hat enterprise linux \(rhel\) 9/i)
     ).not.toBeNaN();
+    // check the environment
+    const targetEnvironmentsExpandable = await screen.findByTestId(
+      'target-environments-expandable'
+    );
+    await user.click(targetEnvironmentsExpandable);
+    await screen.findAllByText('AWS');
+    await screen.findAllByText('GCP');
+    await screen.findAllByText('Microsoft Azure');
+    await screen.findByText('VMWare vSphere (.ova)');
+    await screen.findByText('Virtualization - Guest image (.qcow2)');
+    await screen.findByText('Bare metal - Installer (.iso)');
   });
 
   test('selecting rhel8 and aarch64 shows accordingly in the review step', async () => {
@@ -167,6 +200,7 @@ describe('Step Image output', () => {
     // select aws as upload destination
     await user.click(await screen.findByTestId('upload-aws'));
 
+    // go to aws target page
     await clickNext();
     // enter a source to be able to click next
     await user.click(
@@ -179,6 +213,8 @@ describe('Step Image output', () => {
     });
     await user.click(source);
 
+    // go to review page
+    await clickNext();
     await screen.findByRole('heading', { name: 'Review' });
     const view = screen.getByTestId('image-output-expandable');
     await user.click(await within(view).findByText(/image output/i));

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -66,12 +66,12 @@ afterEach(() => {
 });
 
 describe('Create Image Wizard', () => {
-  test('renders component', () => {
+  test('renders component', async () => {
     renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
     // check heading
-    screen.getByRole('heading', { name: /Image Builder/ });
+    await screen.findByRole('heading', { name: /Image Builder/ });
 
-    screen.getByRole('button', { name: 'Image output' });
+    await screen.findByRole('button', { name: 'Image output' });
   });
 });
 
@@ -155,7 +155,7 @@ describe('Step Image output', () => {
     // go to review page
     await clickNext();
     await screen.findByRole('heading', { name: 'Review' });
-    const view = screen.getByTestId('image-output-expandable');
+    const view = await screen.findByTestId('image-output-expandable');
     await user.click(await within(view).findByText(/image output/i));
     expect(await screen.findByText(/x86_64/i)).not.toBeNaN();
     expect(
@@ -216,7 +216,7 @@ describe('Step Image output', () => {
     // go to review page
     await clickNext();
     await screen.findByRole('heading', { name: 'Review' });
-    const view = screen.getByTestId('image-output-expandable');
+    const view = await screen.findByTestId('image-output-expandable');
     await user.click(await within(view).findByText(/image output/i));
     expect(await screen.findByText(/aarch64/i)).not.toBeNaN();
     expect(

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -85,6 +85,16 @@ describe('Step Image output', () => {
     await screen.findByRole('heading', { name: 'Image output' });
 
     await clickNext();
+    // enter a source to be able to click next
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    const source = await screen.findByRole('option', {
+      name: /my_source/i,
+    });
+    await user.click(source);
 
     await screen.findByRole('heading', { name: 'Review' });
     const view = screen.getByTestId('image-output-expandable');
@@ -122,6 +132,16 @@ describe('Step Image output', () => {
     await user.click(await screen.findByTestId('upload-aws'));
 
     await clickNext();
+    // enter a source to be able to click next
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    const source = await screen.findByRole('option', {
+      name: /my_source/i,
+    });
+    await user.click(source);
 
     await screen.findByRole('heading', { name: 'Review' });
     const view = screen.getByTestId('image-output-expandable');

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -96,6 +96,15 @@ describe('Step Image output', () => {
     });
     await user.click(source);
 
+    // go to gcp page
+    await clickNext();
+    //enter an email address
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /gcp account email/i,
+      }),
+      'a@a.fr'
+    );
     await screen.findByRole('heading', { name: 'Review' });
     const view = screen.getByTestId('image-output-expandable');
     await user.click(await within(view).findByText(/image output/i));

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -105,6 +105,33 @@ describe('Step Image output', () => {
       }),
       'a@a.fr'
     );
+
+    // go to azure page
+    await clickNext();
+    // enter a source and a resource group
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /azureSource1/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /resource-group-selecttypeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /myResourceGroup1/i,
+      })
+    );
+
+    // go to review page
+    await clickNext();
     await screen.findByRole('heading', { name: 'Review' });
     const view = screen.getByTestId('image-output-expandable');
     await user.click(await within(view).findByText(/image output/i));

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/AWSTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/AWSTarget.test.tsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import CreateImageWizard from '../../../../../Components/CreateImageWizardV2/CreateImageWizard';
+import { server } from '../../../../mocks/server';
+import {
+  clickNext,
+  renderCustomRoutesWithReduxRouter,
+} from '../../../../testUtils';
+
+const routes = [
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+];
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  server.resetHandlers();
+});
+
+describe('Check the AWS Target step', () => {
+  test('Check that selecting a source sets up the aws account id', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select aws as upload destination
+    await user.click(await screen.findByTestId('upload-aws'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to aws target page
+    await clickNext();
+
+    // enter a source
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /my_source/i,
+      })
+    );
+    // check that selecting a source sets up correctly the aws account id
+    expect(
+      await screen.findByRole('textbox', {
+        name: /associated account id/i,
+      })
+    ).toHaveValue('123456789012');
+    // check that the user can click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeEnabled();
+  });
+
+  test('Check that clearing a selected source frees up the aws account id', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select aws as upload destination
+    await user.click(await screen.findByTestId('upload-aws'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to aws target page
+    await clickNext();
+
+    // enter a source
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /my_source/i,
+      })
+    );
+    // clear the source
+    await user.click(
+      await screen.findByRole('button', {
+        name: /clear input value/i,
+      })
+    );
+    // check that clearing the source removes the aws account id
+    expect(
+      await screen.findByRole('textbox', {
+        name: /associated account id/i,
+      })
+    ).not.toHaveValue('123456789012');
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+
+  test('Check that switching to manual after selecting a source frees up the aws account id', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select aws as upload destination
+    await user.click(await screen.findByTestId('upload-aws'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to aws target page
+    await clickNext();
+
+    // enter a source
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /my_source/i,
+      })
+    );
+    // switch to manual
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
+    );
+    expect(
+      await screen.findByRole('textbox', {
+        name: /AWS account id/i,
+      })
+    ).not.toHaveValue('123456789012');
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+
+  test('Check that manual ID validates only with 12 numbers', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select aws as upload destination
+    await user.click(await screen.findByTestId('upload-aws'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to aws target page
+    await clickNext();
+
+    // enter a source
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /my_source/i,
+      })
+    );
+    // switch to manual
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
+    );
+    // entering 12 letters doesn't allow the user to proceed
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /AWS account id/i,
+      }),
+      'aaaaaaaaaaaa'
+    );
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+    await user.clear(
+      await screen.findByRole('textbox', {
+        name: /AWS account id/i,
+      })
+    );
+    // entering less than 12 numbers doesn't allow the user to proceed
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /AWS account id/i,
+      }),
+      '123'
+    );
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+    await user.clear(
+      await screen.findByRole('textbox', {
+        name: /AWS account id/i,
+      })
+    );
+    // entering exactly 12 numbers allows the user to proceed
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /AWS account id/i,
+      }),
+      '123456789012'
+    );
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeEnabled();
+  });
+
+  test('Check that after manual ID setup switching to automatic clears the aws account id', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select aws as upload destination
+    await user.click(await screen.findByTestId('upload-aws'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to aws target page
+    await clickNext();
+
+    // enter a source
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /my_source/i,
+      })
+    );
+    // switch to manual
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
+    );
+    // entering 12 numbers
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /AWS account id/i,
+      }),
+      '123456789012'
+    );
+    // switch to automatic
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /use an account configured from sources\./i,
+      })
+    );
+    // check that switching to automatic cleared up the account id text field
+    expect(
+      await screen.findByRole('textbox', {
+        name: /associated account id/i,
+      })
+    ).not.toHaveValue('123456789012');
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+});

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/AzureTarget.test.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import CreateImageWizard from '../../../../../Components/CreateImageWizardV2/CreateImageWizard';
+import { server } from '../../../../mocks/server';
+import {
+  clickNext,
+  renderCustomRoutesWithReduxRouter,
+} from '../../../../testUtils';
+
+const routes = [
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+];
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  server.resetHandlers();
+});
+
+describe('Check the Azure Target step', () => {
+  test('Check that selecting a source sets up the azure account id, subscription id and allows the user to select a resource group', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select azure as upload destination
+    await user.click(await screen.findByTestId('upload-azure'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to the azure target page
+    await clickNext();
+
+    // enter a source
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /azureSource1/i,
+      })
+    );
+    // check that selecting a source sets up correctly the accountId and
+    // subscriptionId account id
+    expect(
+      await screen.findByRole('textbox', {
+        name: /azure tenant guid/i,
+      })
+    ).toHaveValue('2fd7c95c-0d63-4e81-b914-3fbd5288daf7');
+    expect(
+      await screen.findByRole('textbox', {
+        name: /subscription id/i,
+      })
+    ).toHaveValue('dfb83267-e016-4429-ae6e-b0768bf36d65');
+
+    // The user can then select a group
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /resource-group-selecttypeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /myResourceGroup1/i,
+      })
+    );
+    // check that the user can click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeEnabled();
+  });
+
+  test('Check that selecting a source, then switching to manual and back to the source cleans up the fields', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select azure as upload destination
+    await user.click(await screen.findByTestId('upload-azure'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to the azure target page
+    await clickNext();
+
+    // enter a source
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /source-typeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /azureSource1/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('combobox', {
+        name: /resource-group-selecttypeahead-select-input/i,
+      })
+    );
+    await user.click(
+      await screen.findByRole('option', {
+        name: /myResourceGroup1/i,
+      })
+    );
+    // check that the user can click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeEnabled();
+    // click to manual
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /manually enter the account information\./i,
+      })
+    );
+    // click to sources
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /use an account configured from sources\./i,
+      })
+    );
+    // account id and subscriptionId must be empty
+    expect(
+      await screen.findByRole('textbox', {
+        name: /azure tenant guid/i,
+      })
+    ).toHaveValue('');
+    expect(
+      await screen.findByRole('textbox', {
+        name: /subscription id/i,
+      })
+    ).toHaveValue('');
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+
+  test('Check entering wrong data in manual mode prevents the user to get through', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select azure as upload destination
+    await user.click(await screen.findByTestId('upload-azure'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to the azure target page
+    await clickNext();
+
+    // click to manual
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /manually enter the account information\./i,
+      })
+    );
+    // entering wrong data doesn't allow the user to get to the next step
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /azure tenant id/i,
+      }),
+      'aaaaaaaaaaaa'
+    );
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /azure subscription id/i,
+      }),
+      'aaaaaaaaaaaa'
+    );
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /azure resource group/i,
+      }),
+      'aaaaaaaaaaaa'
+    );
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+
+  test('Check entering correct data in manual mode allows the user to get through', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select azure as upload destination
+    await user.click(await screen.findByTestId('upload-azure'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to the azure target page
+    await clickNext();
+
+    // click to manual
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /manually enter the account information\./i,
+      })
+    );
+    // entering wrong data doesn't allow the user to get to the next step
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /azure tenant id/i,
+      }),
+      '2fd7c95c-0d63-4e81-b914-3fbd5288daf7'
+    );
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /azure subscription id/i,
+      }),
+      '2fd7c95c-0d63-4e81-b914-3fbd5288daf7'
+    );
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /azure resource group/i,
+      }),
+      'aaaaaaaaaaaa'
+    );
+    // check that the user can't click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeEnabled();
+  });
+});

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import CreateImageWizard from '../../../../../Components/CreateImageWizardV2/CreateImageWizard';
+import { server } from '../../../../mocks/server';
+import {
+  clickNext,
+  renderCustomRoutesWithReduxRouter,
+} from '../../../../testUtils';
+
+const routes = [
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+];
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  server.resetHandlers();
+});
+
+describe('Check the GCP Target step', () => {
+  test('Check that selecting sharingAccount shows the email section', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select gcp as upload destination
+    await user.click(await screen.findByTestId('upload-google'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to gcp target page
+    await clickNext();
+    // click on share with google account
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /share image with a google account/i,
+      })
+    );
+    expect(
+      await screen.findByRole('textbox', {
+        name: /gcp account email/i,
+      })
+    ).toBeInTheDocument();
+    // ensure the user can't click next without more interactions
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+
+  test('Check that selecting sharing with insights allows the user to directly go next', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select gcp as upload destination
+    await user.click(await screen.findByTestId('upload-google'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to gcp target page
+    await clickNext();
+    // click on share with insights
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /share image with red hat insights only/i,
+      })
+    );
+    expect(screen.queryByText('e-mail address')).not.toBeInTheDocument();
+    // ensure the user can't click next without more interactions
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeEnabled();
+  });
+
+  test('Check that selecting serviceAccount, googleAccount and googleGroup proposes to enter an email address', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select gcp as upload destination
+    await user.click(await screen.findByTestId('upload-google'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to gcp target page
+    await clickNext();
+    // check email field is visible
+    expect(
+      await screen.findByRole('textbox', {
+        name: /gcp account email/i,
+      })
+    ).toBeInTheDocument();
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /service account/i,
+      })
+    );
+    expect(
+      await screen.findByRole('textbox', {
+        name: /gcp account email/i,
+      })
+    ).toBeInTheDocument();
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /google group/i,
+      })
+    );
+    expect(
+      await screen.findByRole('textbox', {
+        name: /gcp account email/i,
+      })
+    ).toBeInTheDocument();
+    // ensure the user can't click next without more interactions
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+
+  test('Check that selecting domain proposes to enter a domain', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select gcp as upload destination
+    await user.click(await screen.findByTestId('upload-google'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to gcp target page
+    await clickNext();
+    // check domain field is visible
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /google workspace domain or cloud identity domain/i,
+      })
+    );
+    expect(
+      await screen.findByRole('textbox', {
+        name: /google-domain/i,
+      })
+    ).toBeInTheDocument();
+    // ensure the user can't click next without more interactions
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+  });
+
+  test('Check email validation', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select gcp as upload destination
+    await user.click(await screen.findByTestId('upload-google'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to gcp target page
+    await clickNext();
+    // check email field is visible
+    expect(
+      await screen.findByRole('textbox', {
+        name: /gcp account email/i,
+      })
+    ).toBeInTheDocument();
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /gcp account email/i,
+      }),
+      'aaaaaaaaaaaa'
+    );
+    // invalid address mail can't let the user click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /gcp account email/i,
+      }),
+      '@aaaaaaaaaaaa.fr'
+    );
+    // finishing to type the address email lets the user click next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeEnabled();
+  });
+
+  test('Check domain validation', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+    // select gcp as upload destination
+    await user.click(await screen.findByTestId('upload-google'));
+    await screen.findByRole('heading', { name: 'Image output' });
+    // go to gcp target page
+    await clickNext();
+    // check domain field is visible
+    await user.click(
+      await screen.findByRole('radio', {
+        name: /google workspace domain or cloud identity domain/i,
+      })
+    );
+    expect(
+      await screen.findByRole('textbox', {
+        name: /google-domain/i,
+      })
+    ).toBeInTheDocument();
+    // ensure the user can't click next without more interactions
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeDisabled();
+    // type some data in the domain
+    await user.type(
+      await screen.findByRole('textbox', {
+        name: /google-domain/i,
+      }),
+      'aaaaaaaaaaaa'
+    );
+    // the user can now go next
+    expect(await screen.findByRole('button', { name: /Next/ })).toBeEnabled();
+  });
+});


### PR DESCRIPTION
In this PR we add the support for the second step of the wizard: The TargetEnvironment.

3 sub steps are added:
- AWS
- GCP
- Azure

The behavior is identical to the DDF wizard.