### PR TITLE
Wizard: Disable `/usr` sub-directories on Recreate

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -465,7 +465,9 @@ const requestToState = (composeRequest, distroInfo, isProd, enableOscap) => {
       for (const fsc of fs) {
         const [size, unit] = parseSizeUnit(fsc.min_size);
         fileSystemConfiguration.push({
-          mountpoint: fsc.mountpoint,
+          mountpoint: fsc.mountpoint.includes('/usr/')
+            ? '/usr'
+            : fsc.mountpoint,
           size,
           unit,
         });

--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -24,6 +24,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import MountPoint, { MountPointValidPrefixes } from './MountPoint';
 import SizeUnit from './SizeUnit';
+import UsrSubDirectoriesDisabled from './UsrSubDirectoriesDisabled';
 
 import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../../constants';
 import { useGetOscapCustomizationsQuery } from '../../../store/imageBuilderApi';
@@ -307,6 +308,9 @@ const FileSystemConfiguration = ({ ...props }) => {
           <TextContent>
             <Text component={TextVariants.h3}>Configure partitions</Text>
           </TextContent>
+          {getState()?.values?.['file-system-configuration']?.find((mp) =>
+            mp.mountpoint.includes('/usr')
+          ) && <UsrSubDirectoriesDisabled />}
           {rows.length > 1 &&
             getState()?.errors?.['file-system-configuration']?.duplicates
               ?.length !== 0 &&

--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -24,6 +24,7 @@ import {
   TargetEnvOciList,
   TargetEnvOtherList,
 } from './ReviewStepTextLists';
+import UsrSubDirectoriesDisabled from './UsrSubDirectoriesDisabled';
 
 import isRhel from '../../../Utilities/isRhel';
 
@@ -66,6 +67,9 @@ const ReviewStep = () => {
   return (
     <>
       <RepositoryUnavailable />
+      {getState()?.values?.['file-system-configuration']?.find((mp) =>
+        mp.mountpoint.includes('/usr')
+      ) && <UsrSubDirectoriesDisabled />}
       <ExpandableSection
         toggleContent={'Image output'}
         onToggle={(_event, isExpandedImageOutput) =>

--- a/src/Components/CreateImageWizard/formComponents/UsrSubDirectoriesDisabled.js
+++ b/src/Components/CreateImageWizard/formComponents/UsrSubDirectoriesDisabled.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { Alert } from '@patternfly/react-core';
+
+const UsrSubDirectoriesDisabled = () => {
+  return (
+    <Alert
+      variant="warning"
+      title="Sub-directories for the /usr mount point are no longer supported"
+      isInline
+    >
+      Please note that including sub-directories in the /usr path is no longer
+      supported. Previously included mount points with /usr sub-directory are
+      replaced by /usr when recreating an image.
+    </Alert>
+  );
+};
+
+export default UsrSubDirectoriesDisabled;

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -216,6 +216,12 @@ export const mockComposes: ComposesResponseItem[] = [
     created_at: '2021-04-27T12:31:12Z',
     id: 'b7193673-8dcc-4a5f-ac30-e9f4940d8346',
     request: {
+      customizations: {
+        filesystem: [
+          { min_size: 10737418240, mountpoint: '/' },
+          { min_size: 1073741824, mountpoint: '/usr/test' },
+        ],
+      },
       distribution: RHEL_8,
       image_requests: [
         {
@@ -633,6 +639,10 @@ export const mockStatus = (composeId: string): ComposeStatus => {
                 '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGN9300BEAC1FLODu0cL6saMMHa7yJY1JZUc+jQUI/HdECQrrsTaPXlcc7nM\nykYMMv6amPqbnhH/R5BW2Ano+OMse+PXtUr0NXU4OcvxbnnXkrVBVUf8mXI9DzLZ\njw8KoD+4/s0BuzO78zAJF5uhuyHMAK0ll9v0r92kK45Fas9iZTfRFcqFAzvgjScf\n5jeBnbRs5U3UTz9mtDy802mk357o1A8BD0qlu3kANDpjLbORGWdAj21A6sMJDYXy\nHS9FBNV54daNcr+weky2L9gaF2yFjeu2rSEHCSfkbWfpSiVUx/bDTj7XS6XDOuJT\nJqvGS8jHqjHAIFBirhCA4cY/jLKxWyMr5N6IbXpPAYgt8/YYz2aOYVvdyB8tZ1u1\nkVsMYSGcvTBexZCn1cDkbO6I+waIlsc0uxGqUGBKF83AVYCQqOkBjF1uNnu9qefE\nkEc9obr4JZsAgnisboU25ss5ZJddKlmFMKSi66g4S5ChLEPFq7MB06PhLFioaD3L\nEXza7XitoW5VBwr0BSVKAHMC0T2xbm70zY06a6gQRlvr9a10lPmv4Tptc7xgQReg\nu1TlFPbrkGJ0d8O6vHQRAd3zdsNaVr4gX0Tg7UYiqT9ZUkP7hOc8PYXQ28hHrHTB\nA63MTq0aiPlJ/ivTuX8M6+Bi25dIV6N6IOUi/NQKIYxgovJCDSdCAAM0fQARAQAB\ntCFMdWNhcyBHYXJmaWVsZCA8bHVjYXNAcmVkaGF0LmNvbT6JAlcEEwEIAEEWIQTO\nQZeiHnXqdjmfUURc6PeuecS2PAUCY33fTQIbAwUJA8JnAAULCQgHAgIiAgYVCgkI\nCwIEFgIDAQIeBwIXgAAKCRBc6PeuecS2PCk3D/9jW7xrBB/2MQFKd5l+mNMFyKwc\nL9M/M5RFI9GaQRo55CwnPb0nnxOJR1V5GzZ/YGii53H2ose65CfBOE2L/F/RvKF0\nH9S9MInixlahzzKtV3TpDoZGk5oZIHEMuPmPS4XaHggolrzExY0ib0mQuBBE/uEV\n/HlyHEunBKPhTkAe+6Q+2dl22SUuVfWr4Uzlp65+DkdN3M37WI1a3Suhnef3rOSM\nV6puUzWRR7qcYs5C2In87AcYPn92P5ur1y/C32r8Ftg3fRWnEzI9QfRG52ojNOLK\nyGQ8ZC9PGe0q7VFcF7ridT/uzRU+NVKldbJg+rvBnszb1MjNuR7rUQHyvGmbsUVQ\nRCsgdovkee3lP4gfZHzk2SSLVSo0+NJRNaM90EmPk14Pgi/yfRSDGBVvLBbEanYI\nv1ZtdIPRyKi+/IaMOu/l7nayM/8RzghdU+0f1FAif5qf9nXuI13P8fqcqfu67gNd\nkh0UUF1XyR5UHHEZQQDqCuKEkZJ/+27jYlsG1ZiLb1odlIWoR44RP6k5OJl0raZb\nyLXbAfpITsXiJJBpCam9P9+XR5VSfgkqp5hIa7J8piN3DoMpoExg4PPQr6PbLAJy\nOUCOnuB7yYVbj0wYuMXTuyrcBHh/UymQnS8AMpQoEkCLWS/A/Hze/pD23LgiBoLY\nXIn5A2EOAf7t2IMSlA==\n=OanT\n-----END PGP PUBLIC KEY BLOCK-----',
               rhsm: false,
             },
+          ],
+          filesystem: [
+            { min_size: 10737418240, mountpoint: '/' },
+            { min_size: 1073741824, mountpoint: '/usr/test' },
           ],
         },
         distribution: RHEL_8,


### PR DESCRIPTION
Paths with `/usr` sub-directories are no longer supported in file system configuration. This meant that an attempt to create an image with the erroneous path ended in an image build not starting but there was also no error displayed. 

The option to add a sub-directory to the `/usr` path was removed in https://github.com/RedHatInsights/image-builder-frontend/pull/1429. This is a follow up PR, that handles the same problem specifically for the Recreate action.

