### PR TITLE
Fix HMS-3031

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -149,7 +149,7 @@ const Packages = ({ getAllPackages, isSuccess }) => {
       }
       updateState(oscapPackages);
     }
-  }, [customizations, isSuccessCustomizations]);
+  }, [customizations, isSuccessCustomizations, updateState]);
 
   // this effect only triggers on mount
   useEffect(() => {
@@ -203,7 +203,7 @@ const Packages = ({ getAllPackages, isSuccess }) => {
 
       return 0;
     };
-  });
+  }, []);
 
   const availablePackagesDisplayList = useMemo(() => {
     if (availablePackages === undefined) {
@@ -213,14 +213,14 @@ const Packages = ({ getAllPackages, isSuccess }) => {
       searchResultsComparator(packagesSearchName)
     );
     return availablePackagesList;
-  }, [availablePackages]);
+  }, [availablePackages, packagesSearchName, searchResultsComparator]);
 
   const chosenPackagesDisplayList = useMemo(() => {
     const chosenPackagesList = Object.values(chosenPackages)
       .filter((pkg) => (pkg.name.includes(filterChosen) ? true : false))
       .sort(searchResultsComparator(filterChosen));
     return chosenPackagesList;
-  }, [chosenPackages, filterChosen]);
+  }, [chosenPackages, filterChosen, searchResultsComparator]);
 
   // call api to list available packages
   const handleAvailablePackagesSearch = async () => {
@@ -255,12 +255,15 @@ const Packages = ({ getAllPackages, isSuccess }) => {
     };
   });
 
-  const updateState = (newChosenPackages) => {
-    setSelectedAvailablePackages(new Set());
-    setSelectedChosenPackages(new Set());
-    setChosenPackages(newChosenPackages);
-    change('selected-packages', Object.values(newChosenPackages));
-  };
+  const updateState = useCallback(
+    (newChosenPackages) => {
+      setSelectedAvailablePackages(new Set());
+      setSelectedChosenPackages(new Set());
+      setChosenPackages(newChosenPackages);
+      change('selected-packages', Object.values(newChosenPackages));
+    },
+    [change]
+  );
 
   const moveSelectedToChosen = () => {
     const newChosenPackages = { ...chosenPackages };

--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -253,7 +253,7 @@ const Packages = ({ getAllPackages, isSuccess }) => {
     return () => {
       document.removeEventListener('keydown', keydownHandler, true);
     };
-  });
+  }, []);
 
   const updateState = useCallback(
     (newChosenPackages) => {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
@@ -134,7 +134,7 @@ describe('On Recreate', () => {
     // check that the FSC contains a /tmp partition
     // There are two buttons with the same name but cannot easily select the DDF rendered sidenav.
     // The sidenav will be the first node found out of all buttons.
-    const buttonsFSC = screen.getAllByRole('button', {
+    const buttonsFSC = await screen.findAllByRole('button', {
       name: /file system configuration/i,
     });
     await user.click(buttonsFSC[0]);


### PR DESCRIPTION
The first commit cleans up some of the warnings related to the exhaustive dependencies rule.

The second commit fixes the bug in the packages search where hitting 'enter' causes a re-render and return to the first page of the wizard.