### PR TITLE
feat(HMS-2789): simplify activation key creation

### DIFF
--- a/api/config/rhsm.ts
+++ b/api/config/rhsm.ts
@@ -7,7 +7,7 @@ const config: ConfigFile = {
   outputFile: '../../src/store/rhsmApi.ts',
   exportName: 'rhsmApi',
   hooks: true,
-  filterEndpoints: ['listActivationKeys', 'showActivationKey'],
+  filterEndpoints: ['listActivationKeys', 'showActivationKey', 'createActivationKeys'],
 };
 
 export default config;

--- a/src/Components/CreateImageWizard/steps/registration.js
+++ b/src/Components/CreateImageWizard/steps/registration.js
@@ -118,17 +118,21 @@ const registrationStep = {
       component: componentTypes.PLAIN_TEXT,
       name: 'subscription-activation-description',
       label: (
-        <Button
-          component="a"
-          target="_blank"
-          variant="link"
-          icon={<ExternalLinkAltIcon />}
-          iconPosition="right"
-          isInline
-          href="https://console.redhat.com/insights/connector/activation-keys"
-        >
-          Create and manage activation keys here
-        </Button>
+        <span>
+          By default, activation key is generated and preset for you. Admins can
+          create and manage keys by visiting the&nbsp;
+          <Button
+            component="a"
+            target="_blank"
+            variant="link"
+            icon={<ExternalLinkAltIcon />}
+            iconPosition="right"
+            isInline
+            href="https://console.redhat.com/insights/connector/activation-keys"
+          >
+            Activation keys page
+          </Button>
+        </span>
       ),
       condition: {
         or: [

--- a/src/store/rhsmApi.ts
+++ b/src/store/rhsmApi.ts
@@ -7,6 +7,16 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: () => ({ url: `/activation_keys` }),
     }),
+    createActivationKeys: build.mutation<
+      CreateActivationKeysApiResponse,
+      CreateActivationKeysApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/activation_keys`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+    }),
     showActivationKey: build.query<
       ShowActivationKeyApiResponse,
       ShowActivationKeyApiArg
@@ -22,6 +32,22 @@ export type ListActivationKeysApiResponse =
     body?: ActivationKeys[];
   };
 export type ListActivationKeysApiArg = void;
+export type CreateActivationKeysApiResponse = /** status 200 Activation key */ {
+  body?: ActivationKeys;
+};
+export type CreateActivationKeysApiArg = {
+  /** Create an activation key */
+  body: {
+    additionalRepositories?: {
+      repositoryLabel?: string;
+    }[];
+    name: string;
+    releaseVersion?: string;
+    role?: string;
+    serviceLevel?: string;
+    usage?: string;
+  };
+};
 export type ShowActivationKeyApiResponse = /** status 200 Activation key */ {
   body?: ActivationKeys;
 };
@@ -45,5 +71,8 @@ export type ErrorDetails = {
   code?: number;
   message?: string;
 };
-export const { useListActivationKeysQuery, useShowActivationKeyQuery } =
-  injectedRtkApi;
+export const {
+  useListActivationKeysQuery,
+  useCreateActivationKeysMutation,
+  useShowActivationKeyQuery,
+} = injectedRtkApi;

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -13,7 +13,7 @@ import { rest } from 'msw';
 
 import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
 import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
-import { PROVISIONING_API } from '../../../constants.js';
+import { PROVISIONING_API, RHSM_API } from '../../../constants.js';
 import { server } from '../../mocks/server.js';
 import {
   clickBack,
@@ -572,6 +572,20 @@ describe('Step Registration', () => {
     await setUp();
 
     await verifyCancelButton(router);
+  });
+
+  test('activation key dropdown empty state', async () => {
+    server.use(
+      rest.get(`${RHSM_API}/activation_keys`, (req, res, ctx) =>
+        res(ctx.status(200), ctx.json({ body: [] }))
+      )
+    );
+    await setUp();
+    const activationKeyDropdown = await screen.findByRole('textbox', {
+      name: 'Select activation key',
+    });
+    await user.click(activationKeyDropdown);
+    await screen.findByText('No activation keys found');
   });
 
   test('should allow registering with rhc', async () => {


### PR DESCRIPTION
This PR adds an empty state to the activation key select, enabling a fast and convenient default activation key creation from the wizard's screen.


https://github.com/RedHatInsights/image-builder-frontend/assets/11807069/21b2e35e-5a23-4540-8747-7830b0d08834

