### PR TITLE
Wizard: Remove hard coded architecture from OCI request

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -205,7 +205,7 @@ const onSave = (values) => {
       image_description: values?.['image-description'],
       image_requests: [
         {
-          architecture: 'x86_64',
+          architecture: values['arch'],
           image_type: 'oci',
           upload_request: {
             type: 'oci.objectstorage',


### PR DESCRIPTION
This replaces hard coded 'x86_64' architecture with the value based on a form state for OCI images.