### PR TITLE
wizard/oscap: update the oscap step to latest specifications

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizard/formComponents/OscapProfileInformation.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import {
+  Spinner,
+  TextContent,
+  TextList,
+  TextListItem,
+  TextListItemVariants,
+  TextListVariants,
+} from '@patternfly/react-core';
+
+import { RELEASES } from '../../../constants';
+import { useGetOscapCustomizationsQuery } from '../../../store/imageBuilderApi';
+
+const OscapProfileInformation = (): JSX.Element => {
+  const { getState } = useFormApi();
+
+  const oscapProfile = getState()?.values?.['oscap-profile'];
+
+  const {
+    data: oscapProfileInfo,
+    isFetching: isFetchingOscapProfileInfo,
+    isSuccess: isSuccessOscapProfileInfo,
+  } = useGetOscapCustomizationsQuery(
+    { distribution: getState()?.values?.['release'], profile: oscapProfile },
+    {
+      skip: !oscapProfile,
+    }
+  );
+
+  return (
+    <>
+      {isFetchingOscapProfileInfo && <Spinner size="lg" />}
+      {isSuccessOscapProfileInfo && (
+        <TextContent>
+          <br />
+          <TextList component={TextListVariants.dl}>
+            <TextListItem
+              component={TextListItemVariants.dt}
+              className="pf-u-min-width"
+            >
+              Profile description:
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {oscapProfileInfo.openscap?.profile_description}
+            </TextListItem>
+          </TextList>
+          <TextList component={TextListVariants.dl}>
+            <TextListItem
+              component={TextListItemVariants.dt}
+              className="pf-u-min-width"
+            >
+              Operating system:
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {RELEASES.get(getState()?.values?.['release'])}
+            </TextListItem>
+          </TextList>
+          <TextList component={TextListVariants.dl}>
+            <TextListItem
+              component={TextListItemVariants.dt}
+              className="pf-u-min-width"
+            >
+              Reference ID:
+            </TextListItem>
+            <TextListItem component={TextListItemVariants.dd}>
+              {oscapProfileInfo.openscap?.profile_id}
+            </TextListItem>
+          </TextList>
+        </TextContent>
+      )}
+    </>
+  );
+};
+
+export default OscapProfileInformation;

--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -193,7 +193,7 @@ const ReviewStep = () => {
       )}
       {getState()?.values?.['oscap-profile'] && (
         <ExpandableSection
-          toggleContent={'OpenSCAP Compliance'}
+          toggleContent={'OpenSCAP'}
           onToggle={(_event, isExpandedOscapDetail) =>
             onToggleOscapDetails(isExpandedOscapDetail)
           }

--- a/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStepTextLists.js
@@ -28,6 +28,7 @@ import {
 
 import { RELEASES, UNIT_GIB } from '../../../constants';
 import { extractProvisioningList } from '../../../store/helpers';
+import { useGetOscapCustomizationsQuery } from '../../../store/imageBuilderApi';
 import { useGetSourceListQuery } from '../../../store/provisioningApi';
 import { useShowActivationKeyQuery } from '../../../store/rhsmApi';
 import { useGetEnvironment } from '../../../Utilities/useGetEnvironment';
@@ -618,6 +619,11 @@ export const ImageDetailsList = () => {
 export const OscapList = () => {
   const { getState } = useFormApi();
   const oscapProfile = getState()?.values?.['oscap-profile'];
+  const { data } = useGetOscapCustomizationsQuery({
+    distribution: getState()?.values?.['release'],
+    profile: oscapProfile,
+  });
+
   return (
     <TextContent>
       <TextList component={TextListVariants.dl}>
@@ -625,7 +631,29 @@ export const OscapList = () => {
           component={TextListItemVariants.dt}
           className="pf-u-min-width"
         >
-          Profile
+          Profile name:
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          {data?.openscap?.profile_name}
+        </TextListItem>
+      </TextList>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Profile description:
+        </TextListItem>
+        <TextListItem component={TextListItemVariants.dd}>
+          {data?.openscap?.profile_description}
+        </TextListItem>
+      </TextList>
+      <TextList component={TextListVariants.dl}>
+        <TextListItem
+          component={TextListItemVariants.dt}
+          className="pf-u-min-width"
+        >
+          Reference ID:
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
           {oscapProfile}

--- a/src/Components/CreateImageWizard/steps/oscap.js
+++ b/src/Components/CreateImageWizard/steps/oscap.js
@@ -1,17 +1,23 @@
 import React from 'react';
 
 import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
-import { Text } from '@patternfly/react-core';
+import { Text, Title } from '@patternfly/react-core';
 
 import StepTemplate from './stepTemplate';
 
+import DocumentationButton from '../../sharedComponents/DocumentationButton';
 import CustomButtons from '../formComponents/CustomButtons';
 
 const oscapStep = {
   StepTemplate,
   id: 'wizard-systemconfiguration-oscap',
-  title: 'OpenSCAP Compliance',
+  title: 'OpenSCAP',
   name: 'Compliance',
+  customTitle: (
+    <Title headingLevel="h1" size="xl">
+      OpenSCAP profile
+    </Title>
+  ),
   nextStep: 'File system configuration',
   buttons: CustomButtons,
   fields: [
@@ -20,8 +26,8 @@ const oscapStep = {
       name: 'oscap-text-component',
       label: (
         <Text>
-          Monitor regulatory compliance profiles of registered RHEL systems you
-          must adhere to via OpenSCAP.
+          Use OpenSCAP to monitor the adherence of your registered RHEL systems
+          to a selected regulatory compliance profile. <DocumentationButton />
         </Text>
       ),
     },

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -317,6 +317,10 @@ export const mockComposes: ComposesResponseItem[] = [
         ],
         openscap: {
           profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+          profile_name:
+            'CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Workstation',
+          profile_description:
+            'This  is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
         },
       },
     },
@@ -814,6 +818,10 @@ export const mockStatus = (composeId: string): ComposeStatus => {
           openscap: {
             profile_id:
               'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+            profile_name:
+              ' CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Workstation',
+            profile_description:
+              'This  is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
           },
         },
       },

--- a/src/test/fixtures/oscap.ts
+++ b/src/test/fixtures/oscap.ts
@@ -4,12 +4,64 @@ import {
 } from '../../store/imageBuilderApi';
 
 export const distributionOscapProfiles = (): GetOscapProfilesApiResponse => {
-  return ['xccdf_org.ssgproject.content_profile_cis_workstation_l1'];
+  return [
+    'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+    'xccdf_org.ssgproject.content_profile_cis_workstation_l2',
+    'xccdf_org.ssgproject.content_profile_stig_gui',
+  ];
 };
 
-export const oscapCustomizations = (): GetOscapCustomizationsApiResponse => {
+export const oscapCustomizations = (
+  profile: string
+): GetOscapCustomizationsApiResponse => {
+  if (profile === 'xccdf_org.ssgproject.content_profile_cis_workstation_l1') {
+    return {
+      filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],
+      openscap: {
+        profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+        profile_name:
+          'CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Workstation',
+        profile_description:
+          'This is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
+      },
+      packages: [
+        'aide',
+        'sudo',
+        'rsyslog',
+        'firewalld',
+        'nftables',
+        'libselinux',
+      ],
+    };
+  }
+  if (profile === 'xccdf_org.ssgproject.content_profile_cis_workstation_l2') {
+    return {
+      filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],
+      openscap: {
+        profile_id: 'content_profile_cis_workstation_l2',
+        profile_name:
+          'CIS Red Hat Enterprise Linux 8 Benchmark for Level 2 - Workstation',
+        profile_description:
+          'This is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
+      },
+      packages: [
+        'aide',
+        'sudo',
+        'rsyslog',
+        'firewalld',
+        'nftables',
+        'libselinux',
+      ],
+    };
+  }
   return {
     filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],
+    openscap: {
+      profile_id: 'content_profile_stig_gui',
+      profile_name: 'DISA STIG with GUI for Red Hat Enterprise Linux 8',
+      profile_description:
+        'This is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
+    },
     packages: [
       'aide',
       'sudo',

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -103,7 +103,8 @@ export const handlers = [
   rest.get(
     `${IMAGE_BUILDER_API}/oscap/:distribution/:profile/customizations`,
     (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json(oscapCustomizations(req)));
+      const { profile } = req.params;
+      return res(ctx.status(200), ctx.json(oscapCustomizations(profile)));
     }
   ),
 ];


### PR DESCRIPTION
Before, in the Oscap step, the drop down select menu was only listing profile_ids
Now, it shows the profiles names. When the user selects one, the details about the
profile are displayed under the selection, improving user experience.

FIXES # - HMS-3087
<img width="1429" alt="Screenshot 2023-11-21 at 15 40 23" src="https://github.com/RedHatInsights/image-builder-frontend/assets/73419853/637cbbbc-ddef-4276-91e2-2119ab7ddb37">

