### PR TITLE
Wizard: Fix HMS-2036, bug in file system customization steps

### DIFF
--- a/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
@@ -125,7 +125,8 @@ const fileSystemConfigurationStep = {
         </TextContent>
       ),
       condition: {
-        or: [{ when: 'file-system-config-radio', is: 'automatic' }],
+        when: 'file-system-config-radio',
+        is: 'automatic',
       },
     },
   ],

--- a/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/steps/fileSystemConfiguration.js
@@ -125,10 +125,7 @@ const fileSystemConfigurationStep = {
         </TextContent>
       ),
       condition: {
-        or: [
-          { when: 'file-system-config-radio', is: 'automatic' },
-          { when: 'oscap-profile', is: undefined },
-        ],
+        or: [{ when: 'file-system-config-radio', is: 'automatic' }],
       },
     },
   ],


### PR DESCRIPTION
Information about automatic partioning was also being displayed when manual partioning was selected. This commit fixes the bug.