### PR TITLE
API: Update image-builder API

### DIFF
--- a/api/schema/imageBuilder.yaml
+++ b/api/schema/imageBuilder.yaml
@@ -602,8 +602,7 @@ components:
           example: "MyImageDescription"
           maxLength: 250
         client_id:
-          type: string
-          example: "ui"
+          $ref: '#/components/schemas/ClientId'
         image_requests:
           type: array
           minItems: 1
@@ -771,7 +770,11 @@ components:
         image_name:
           type: string
         client_id:
-          type: string
+          $ref: '#/components/schemas/ClientId'
+    ClientId:
+      type: string
+      enum: ["api", "ui"]
+      default: "api"
     ComposeResponse:
       required:
         - id
@@ -1172,6 +1175,13 @@ components:
         profile_id:
           type: string
           example: "xccdf_org.ssgproject.content_profile_cis"
+          description: "The policy reference ID"
+        profile_name:
+          type: string
+          description: "The policy type"
+        profile_description:
+          type: string
+          description: "The longform policy description"
     ClonesResponse:
       required:
         - meta

--- a/src/store/imageBuilderApi.ts
+++ b/src/store/imageBuilderApi.ts
@@ -209,6 +209,7 @@ export type Distributions =
   | "fedora-38"
   | "fedora-39"
   | "fedora-40";
+export type ClientId = "api" | "ui";
 export type ImageTypes =
   | "aws"
   | "azure"
@@ -294,6 +295,8 @@ export type CustomRepository = {
 };
 export type OpenScap = {
   profile_id: string;
+  profile_name?: string;
+  profile_description?: string;
 };
 export type Filesystem = {
   mountpoint: string;
@@ -317,7 +320,7 @@ export type ComposeRequest = {
   distribution: Distributions;
   image_name?: string;
   image_description?: string;
-  client_id?: string;
+  client_id?: ClientId;
   image_requests: ImageRequest[];
   customizations?: Customizations;
 };
@@ -326,7 +329,7 @@ export type ComposesResponseItem = {
   request: ComposeRequest;
   created_at: string;
   image_name?: string;
-  client_id?: string;
+  client_id?: ClientId;
 };
 export type ComposesResponse = {
   meta: {


### PR DESCRIPTION
This commit updates the image-builder API due to these two recent changes:

A new type added for the ClientId, used when differentiating between API and UI users.
https://github.com/osbuild/image-builder/commit/fce3d1c355e54f97c1cf4d4065ab273e1839d629

OpenSCAP profile names and descriptions.
https://github.com/osbuild/image-builder/commit/1d292917d15f8a92e1b32bf134917a351da6d8e7