### PR TITLE
test: Await asynchronous `setUp()`

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.js
@@ -194,7 +194,7 @@ describe('Step Upload to Azure', () => {
   }, 10000);
 
   test('handles change of selected Source', async () => {
-    setUp();
+    await setUp();
 
     const sourceDropdown = await getSourceDropdown();
 
@@ -237,7 +237,7 @@ describe('Step Upload to Azure', () => {
       )
     );
 
-    setUp();
+    await setUp();
 
     await screen.findByText(
       /Sources cannot be reached, try again later or enter an account info for upload manually\./i


### PR DESCRIPTION
This adds await to call of asynchronous `setUp()` function. Previously this wasn't awaited which sometimes caused the tests to continue without being properly set up first.