### PR TITLE
CreateImageWizard: proprely gate WSL images

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
+++ b/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
@@ -361,7 +361,7 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
             data-testid="checkbox-image-installer"
           />
         )}
-        {allowedTargets.includes('wsl') && isBeta && (
+        {allowedTargets.includes('wsl') && isBeta() && (
           <Checkbox
             label="WSL - Windows Subsystem for Linux (.tar.gz)"
             isChecked={environment['wsl']}


### PR DESCRIPTION
`isBeta` is a function, so the check would also return true in stable.