### PR TITLE
HMS-2861: Use RTK for state management

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -100,22 +100,6 @@ const CreateImageWizard = () => {
               >
                 <Aws />
               </WizardStep>,
-              <WizardStep
-                name="Google Cloud Platform"
-                id="expand-steps-sub-b"
-                key="expand-steps-sub-b"
-                footer={<CustomWizardFooter isNextDisabled={false} />}
-              >
-                Substep GCP
-              </WizardStep>,
-              <WizardStep
-                name="Azure"
-                id="expand-steps-sub-c"
-                key="expand-steps-sub-c"
-                footer={<CustomWizardFooter isNextDisabled={false} />}
-              >
-                Substep Azure
-              </WizardStep>,
             ]}
           />
           <WizardStep

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -11,10 +11,16 @@ import { useNavigate } from 'react-router-dom';
 
 import ImageOutputStep from './steps/ImageOutput/ImageOutput';
 import ReviewStep from './steps/Review/ReviewStep';
+import { Aws } from './steps/TargetEnvironment/Aws';
+import { isAwsAccountIdValid } from './validators';
 
-import { useAppDispatch } from '../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import './CreateImageWizard.scss';
-import { initializeWizard } from '../../store/wizardSlice';
+import {
+  initializeWizard,
+  selectAwsAccountId,
+  selectImageTypes,
+} from '../../store/wizardSlice';
 import { resolveRelPath } from '../../Utilities/path';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
@@ -74,6 +80,44 @@ const CreateImageWizard = () => {
           >
             <ImageOutputStep />
           </WizardStep>
+          <WizardStep
+            name="Target Environment"
+            id="step-target-environment"
+            steps={[
+              <WizardStep
+                name="Amazon Web Services"
+                id="expand-steps-sub-a"
+                key="expand-steps-sub-a"
+                footer={
+                  <CustomWizardFooter
+                    isNextDisabled={
+                      !isAwsAccountIdValid(
+                        useAppSelector((state) => selectAwsAccountId(state))
+                      )
+                    }
+                  />
+                }
+              >
+                <Aws />
+              </WizardStep>,
+              <WizardStep
+                name="Google Cloud Platform"
+                id="expand-steps-sub-b"
+                key="expand-steps-sub-b"
+                footer={<CustomWizardFooter isNextDisabled={false} />}
+              >
+                Substep GCP
+              </WizardStep>,
+              <WizardStep
+                name="Azure"
+                id="expand-steps-sub-c"
+                key="expand-steps-sub-c"
+                footer={<CustomWizardFooter isNextDisabled={false} />}
+              >
+                Substep Azure
+              </WizardStep>,
+            ]}
+          />
           <WizardStep
             name="Review"
             id="step-review"

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -9,41 +9,14 @@ import {
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 
-import {
-  EnvironmentStateType,
-  filterEnvironment,
-  hasUserSelectedAtLeastOneEnv,
-  useGetAllowedTargets,
-} from './steps/ImageOutput/Environment';
 import ImageOutputStep from './steps/ImageOutput/ImageOutput';
 import ReviewStep from './steps/Review/ReviewStep';
 
-import { RHEL_9, X86_64 } from '../../constants';
+import { useAppDispatch } from '../../store/hooks';
 import './CreateImageWizard.scss';
-import { ArchitectureItem, Distributions } from '../../store/imageBuilderApi';
+import { initializeWizard } from '../../store/wizardSlice';
 import { resolveRelPath } from '../../Utilities/path';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
-
-/**
- * @return true if the array in prevAllowedTargets is equivalent to the array
- * allowedTargets, false otherwise
- */
-const isIdenticalToPrev = (
-  prevAllowedTargets: string[],
-  allowedTargets: string[]
-) => {
-  let identicalToPrev = true;
-  if (allowedTargets.length === prevAllowedTargets.length) {
-    allowedTargets.forEach((elem) => {
-      if (!prevAllowedTargets.includes(elem)) {
-        identicalToPrev = false;
-      }
-    });
-  } else {
-    identicalToPrev = false;
-  }
-  return identicalToPrev;
-};
 
 type CustomWizardFooterPropType = {
   isNextDisabled: boolean;
@@ -52,7 +25,9 @@ type CustomWizardFooterPropType = {
  * The custom wizard footer is only switching the order of the buttons compared
  * to the default wizard footer from the PF5 library.
  */
-const CustomWizardFooter = ({ isNextDisabled }: CustomWizardFooterPropType) => {
+export const CustomWizardFooter = ({
+  isNextDisabled,
+}: CustomWizardFooterPropType) => {
   const { goToNextStep, goToPrevStep, close } = useWizardContext();
   return (
     <WizardFooterWrapper>
@@ -75,41 +50,11 @@ const CustomWizardFooter = ({ isNextDisabled }: CustomWizardFooterPropType) => {
 
 const CreateImageWizard = () => {
   const navigate = useNavigate();
-  // Image output step states
-  const [release, setRelease] = useState<Distributions>(RHEL_9);
-  const [arch, setArch] = useState<ArchitectureItem['arch']>(X86_64);
-  const {
-    data: allowedTargets,
-    isFetching,
-    isSuccess,
-    isError,
-  } = useGetAllowedTargets({
-    architecture: arch,
-    release: release,
-  });
-  const [environment, setEnvironment] = useState<EnvironmentStateType>(
-    filterEnvironment(
-      {
-        aws: { selected: false, authorized: false },
-        azure: { selected: false, authorized: false },
-        gcp: { selected: false, authorized: false },
-        oci: { selected: false, authorized: false },
-        'vsphere-ova': { selected: false, authorized: false },
-        vsphere: { selected: false, authorized: false },
-        'guest-image': { selected: false, authorized: false },
-        'image-installer': { selected: false, authorized: false },
-        wsl: { selected: false, authorized: false },
-      },
-      allowedTargets
-    )
-  );
-  // Update of the environment when the architecture and release are changed.
-  // This pattern prevents the usage of a useEffect See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
-  const [prevAllowedTargets, setPrevAllowedTargets] = useState(allowedTargets);
-  if (!isIdenticalToPrev(prevAllowedTargets, allowedTargets)) {
-    setPrevAllowedTargets(allowedTargets);
-    setEnvironment(filterEnvironment(environment, allowedTargets));
-  }
+  const dispatch = useAppDispatch();
+
+  // Ensure the wizard starts with a fresh initial state
+  dispatch(initializeWizard);
+
   return (
     <>
       <ImageBuilderHeader />
@@ -120,28 +65,21 @@ const CreateImageWizard = () => {
             id="step-image-output"
             footer={
               <CustomWizardFooter
-                isNextDisabled={!hasUserSelectedAtLeastOneEnv(environment)}
+                isNextDisabled={
+                  useAppSelector((state) => selectImageTypes(state)).length ===
+                  0
+                }
               />
             }
           >
-            <ImageOutputStep
-              release={release}
-              setRelease={setRelease}
-              arch={arch}
-              setArch={setArch}
-              environment={environment}
-              setEnvironment={setEnvironment}
-              isFetching={isFetching}
-              isError={isError}
-              isSuccess={isSuccess}
-            />
+            <ImageOutputStep />
           </WizardStep>
           <WizardStep
             name="Review"
             id="step-review"
             footer={<CustomWizardFooter isNextDisabled={true} />}
           >
-            <ReviewStep release={release} arch={arch} />
+            <ReviewStep />
           </WizardStep>
         </Wizard>
       </section>

--- a/src/Components/CreateImageWizardV2/ValidatedTextInput.tsx
+++ b/src/Components/CreateImageWizardV2/ValidatedTextInput.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+import {
+  HelperText,
+  HelperTextItem,
+  TextInput,
+  TextInputProps,
+} from '@patternfly/react-core';
+
+interface ValidatedTextInputPropTypes extends TextInputProps {
+  validator: (value: string | undefined) => Boolean;
+  value: string | undefined;
+}
+
+export const ValidatedTextInput = ({
+  validator,
+  value,
+  onChange,
+}: ValidatedTextInputPropTypes) => {
+  const [isPristine, setIsPristine] = useState(!value ? true : false);
+
+  const handleBlur = () => {
+    setIsPristine(false);
+  };
+
+  const handleValidation = () => {
+    // Prevent premature validation during user's first entry
+    if (isPristine) {
+      return 'default';
+    }
+    return validator(value) ? 'success' : 'error';
+  };
+
+  return (
+    <>
+      <TextInput
+        value={value}
+        type="text"
+        onChange={onChange}
+        validated={handleValidation()}
+        aria-label="TODO"
+        onBlur={handleBlur}
+      />
+      {!isPristine && !validator(value) && (
+        <HelperText>
+          <HelperTextItem variant="error" hasIcon>
+            This is error helper text
+          </HelperTextItem>
+        </HelperText>
+      )}
+    </>
+  );
+};

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ArchSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ArchSelect.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FormEvent, SetStateAction } from 'react';
+import React, { FormEvent } from 'react';
 
 import {
   FormGroup,
@@ -7,19 +7,25 @@ import {
 } from '@patternfly/react-core';
 
 import { ARCHS } from '../../../../constants';
-import { ArchitectureItem } from '../../../../store/imageBuilderApi';
-
-type ArchSelectType = {
-  setArch: Dispatch<SetStateAction<ArchitectureItem['arch']>>;
-  arch: ArchitectureItem['arch'];
-};
+import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { ImageRequest } from '../../../../store/imageBuilderApi';
+import {
+  changeArchitecture,
+  selectArchitecture,
+} from '../../../../store/wizardSlice';
 
 /**
  * Allows the user to pick the architecture to build
  */
-const ArchSelect = ({ setArch, arch }: ArchSelectType) => {
-  const onChange = (_event: FormEvent<HTMLSelectElement>, value: string) => {
-    setArch(value);
+const ArchSelect = () => {
+  const architecture = useAppSelector((state) => selectArchitecture(state));
+  const dispatch = useAppDispatch();
+
+  const onChange = (
+    _event: FormEvent<HTMLSelectElement>,
+    value: ImageRequest['architecture']
+  ) => {
+    dispatch(changeArchitecture(value));
   };
 
   return (
@@ -29,7 +35,7 @@ const ArchSelect = ({ setArch, arch }: ArchSelectType) => {
       data-testid="architecture-select"
     >
       <FormSelect
-        value={arch}
+        value={architecture}
         onChange={onChange}
         aria-label="Architecture"
         ouiaId="arch_select"

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/Environment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/Environment.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { useState } from 'react';
 
 import {
   Checkbox,
@@ -12,138 +12,52 @@ import {
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
+import { useAppSelector, useAppDispatch } from '../../../../store/hooks';
 import {
+  ImageTypes,
   useGetArchitecturesQuery,
-  Distributions,
-  ArchitectureItem,
 } from '../../../../store/imageBuilderApi';
 import { provisioningApi } from '../../../../store/provisioningApi';
+import {
+  addImageType,
+  removeImageType,
+  selectArchitecture,
+  selectDistribution,
+  selectImageTypes,
+} from '../../../../store/wizardSlice';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
-
-type useGetAllowedTargetsPropType = {
-  architecture: ArchitectureItem['arch'];
-  release: Distributions;
-};
-
-/**
- * Contacts the backend to get a list of valid targets based on the user
- * requirements (release & architecture)
- *
- * @return an array of strings which contains the names of the authorized
- * targets. Alongside the array, a couple of flags indicate the status of the
- * request. isFetching stays true while the data are in transit. isError is set
- * to true if anything wrong happened. isSuccess is set to true otherwise.
- *
- * @param architecture the selected arch (x86_64 or aarch64)
- * @param release the selected release (see RELEASES in constants)
- */
-export const useGetAllowedTargets = ({
-  architecture,
-  release,
-}: useGetAllowedTargetsPropType) => {
-  const { data, isFetching, isSuccess, isError } = useGetArchitecturesQuery({
-    distribution: release,
-  });
-
-  let image_types: string[] = [];
-  if (isSuccess && data) {
-    data.forEach((elem) => {
-      if (elem.arch === architecture) {
-        image_types = elem.image_types;
-      }
-    });
-  }
-
-  return {
-    data: image_types,
-    isFetching: isFetching,
-    isSuccess: isSuccess,
-    isError: isError,
-  };
-};
-
-/**
- * Type to represent the state of a target.
- * A target can be selected and/or authorized. An authorized target means the
- * target can be displayed to the user, selected means the user has selected
- * the target.
- */
-type TargetType = {
-  selected: boolean;
-  authorized: boolean;
-};
-
-/**
- * Defines all the possible targets a user can build.
- */
-export type EnvironmentStateType = {
-  aws: TargetType;
-  azure: TargetType;
-  gcp: TargetType;
-  oci: TargetType;
-  'vsphere-ova': TargetType;
-  vsphere: TargetType;
-  'guest-image': TargetType;
-  'image-installer': TargetType;
-  wsl: TargetType;
-};
-
-/**
- * Takes an environment, a list of allowedTargets and updates the authorized
- * status of each targets in the environment accordingly.
- *
- * @param environment the environment to update
- * @param allowedTargets the list of targets authorized to get built
- * @return an updated environment
- */
-export const filterEnvironment = (
-  environment: EnvironmentStateType,
-  allowedTargets: string[]
-) => {
-  const newEnv = { ...environment };
-  Object.keys(environment).forEach((target) => {
-    newEnv[target as keyof EnvironmentStateType].authorized =
-      allowedTargets.includes(target);
-  });
-  return newEnv;
-};
-
-/**
- * @return true if at least one target has both its flags selected and
- * authorized set to true
- * @param env the environment to scan
- */
-export const hasUserSelectedAtLeastOneEnv = (
-  env: EnvironmentStateType
-): boolean => {
-  let atLeastOne = false;
-  Object.values(env).forEach(({ selected, authorized }) => {
-    atLeastOne = atLeastOne || (selected && authorized);
-  });
-  return atLeastOne;
-};
-
-type EnvironmentPropType = {
-  environment: EnvironmentStateType;
-  setEnvironment: Dispatch<SetStateAction<EnvironmentStateType>>;
-};
 
 /**
  * Displays a component that allows the user to pick the target they want
  * to build on.
  */
-const Environment = ({ setEnvironment, environment }: EnvironmentPropType) => {
+const Environment = () => {
+  const arch = useAppSelector((state) => selectArchitecture(state));
+  const environments = useAppSelector((state) => selectImageTypes(state));
+  const distribution = useAppSelector((state) => selectDistribution(state));
+  const { data } = useGetArchitecturesQuery({
+    distribution: distribution,
+  });
+
+  const [hasVSphere, setHasVSphere] = useState(false);
+
+  const dispatch = useAppDispatch();
   const prefetchSources = provisioningApi.usePrefetch('getSourceList');
   const { isBeta } = useGetEnvironment();
+  // TODO: Handle isFetching state (use skeletons)
+  // TODO: Handle isError state (very unlikely...)
 
-  const handleSetEnvironment = (env: string, checked: boolean) =>
-    setEnvironment((prevEnv) => {
-      const newEnv: EnvironmentStateType = {
-        ...prevEnv,
-      };
-      newEnv[env as keyof EnvironmentStateType].selected = checked;
-      return newEnv;
-    });
+  const supportedEnvironments = data?.find(
+    (elem) => elem.arch === arch
+  )?.image_types;
+
+  const handleToggleEnvironment = (environment: ImageTypes) => {
+    if (environments.includes(environment)) {
+      dispatch(removeImageType(environment));
+    } else {
+      dispatch(addImageType(environment));
+    }
+  };
 
   // each item the user can select is depending on what's compatible with the
   // architecture and the distribution they previously selected. That's why
@@ -160,7 +74,7 @@ const Environment = ({ setEnvironment, environment }: EnvironmentPropType) => {
         data-testid="target-public"
       >
         <div className="tiles">
-          {environment['aws'].authorized && (
+          {supportedEnvironments?.includes('aws') && (
             <Tile
               className="tile pf-u-mr-sm"
               data-testid="upload-aws"
@@ -172,16 +86,16 @@ const Environment = ({ setEnvironment, environment }: EnvironmentPropType) => {
                   alt="Amazon Web Services logo"
                 />
               }
-              onClick={() =>
-                handleSetEnvironment('aws', !environment.aws.selected)
-              }
+              onClick={() => {
+                handleToggleEnvironment('aws');
+              }}
               onMouseEnter={() => prefetchSources({ provider: 'aws' })}
-              isSelected={environment.aws.selected}
+              isSelected={environments.includes('aws')}
               isStacked
               isDisplayLarge
             />
           )}
-          {environment['gcp'].authorized && (
+          {supportedEnvironments?.includes('gcp') && (
             <Tile
               className="tile pf-u-mr-sm"
               data-testid="upload-google"
@@ -195,16 +109,16 @@ const Environment = ({ setEnvironment, environment }: EnvironmentPropType) => {
                   alt="Google Cloud Platform logo"
                 />
               }
-              onClick={() =>
-                handleSetEnvironment('gcp', !environment.gcp.selected)
-              }
-              isSelected={environment.gcp.selected}
+              onClick={() => {
+                handleToggleEnvironment('gcp');
+              }}
+              isSelected={environments.includes('gcp')}
               onMouseEnter={() => prefetchSources({ provider: 'gcp' })}
               isStacked
               isDisplayLarge
             />
           )}
-          {environment['azure'].authorized && (
+          {supportedEnvironments?.includes('azure') && (
             <Tile
               className="tile pf-u-mr-sm"
               data-testid="upload-azure"
@@ -218,16 +132,16 @@ const Environment = ({ setEnvironment, environment }: EnvironmentPropType) => {
                   alt="Microsoft Azure logo"
                 />
               }
-              onClick={() =>
-                handleSetEnvironment('azure', !environment.azure.selected)
-              }
+              onClick={() => {
+                handleToggleEnvironment('azure');
+              }}
               onMouseEnter={() => prefetchSources({ provider: 'azure' })}
-              isSelected={environment.azure.selected}
+              isSelected={environments.includes('azure')}
               isStacked
               isDisplayLarge
             />
           )}
-          {environment.oci.authorized && isBeta() && (
+          {supportedEnvironments?.includes('oci') && isBeta() && (
             <Tile
               className="tile pf-u-mr-sm"
               data-testid="upload-oci"
@@ -239,63 +153,101 @@ const Environment = ({ setEnvironment, environment }: EnvironmentPropType) => {
                   alt="Oracle Cloud Infrastructure logo"
                 />
               }
-              onClick={() =>
-                handleSetEnvironment('oci', !environment.oci.selected)
-              }
-              isSelected={environment.oci.selected}
+              onClick={() => {
+                handleToggleEnvironment('oci');
+              }}
+              isSelected={environments.includes('oci')}
               isStacked
               isDisplayLarge
             />
           )}
         </div>
       </FormGroup>
-      {environment['vsphere'].authorized && (
-        <FormGroup
-          label={<Text component={TextVariants.small}>Private cloud</Text>}
-          className="pf-u-mt-sm"
-          data-testid="target-private"
-        >
-          <Checkbox
-            label="VMware vSphere"
-            isChecked={
-              environment.vsphere.selected ||
-              environment['vsphere-ova'].selected
-            }
-            onChange={(_event, checked) => {
-              handleSetEnvironment('vsphere-ova', checked);
-              handleSetEnvironment('vsphere', false);
-            }}
-            aria-label="VMware checkbox"
-            id="checkbox-vmware"
-            name="VMware"
-            data-testid="checkbox-vmware"
-          />
-        </FormGroup>
-      )}
-      {environment['vsphere'].authorized && (
-        <FormGroup
-          className="pf-u-mt-sm pf-u-mb-sm pf-u-ml-xl"
-          data-testid="target-private-vsphere-radio"
-        >
-          {environment['vsphere-ova'].authorized && (
+      {supportedEnvironments?.includes('vsphere') && (
+        <>
+          <FormGroup
+            label={<Text component={TextVariants.small}>Private cloud</Text>}
+            className="pf-u-mt-sm"
+            data-testid="target-private"
+          >
+            <Checkbox
+              label="VMWare vSphere"
+              isChecked={
+                environments.includes('vsphere') ||
+                environments.includes('vsphere-ova')
+              }
+              onChange={() => {
+                setHasVSphere(!hasVSphere);
+                handleToggleEnvironment('vsphere-ova');
+              }}
+              aria-label="VMWare checkbox"
+              id="checkbox-vmware"
+              name="VMWare"
+              data-testid="checkbox-vmware"
+            />
+          </FormGroup>
+          <FormGroup
+            className="pf-u-mt-sm pf-u-mb-sm pf-u-ml-xl"
+            data-testid="target-private-vsphere-radio"
+          >
+            {supportedEnvironments?.includes('vsphere-ova') && (
+              <Radio
+                name="vsphere-radio"
+                aria-label="VMWare vSphere radio button OVA"
+                id="vsphere-radio-ova"
+                label={
+                  <>
+                    Open virtualization format (.ova)
+                    <Popover
+                      maxWidth="30rem"
+                      position="right"
+                      bodyContent={
+                        <TextContent>
+                          <Text>
+                            An OVA file is a virtual appliance used by
+                            virtualization platforms such as VMWare vSphere. It
+                            is a package that contains files used to describe a
+                            virtual machine, which includes a VMDK image, OVF
+                            descriptor file and a manifest file.
+                          </Text>
+                        </TextContent>
+                      }
+                    >
+                      <HelpIcon className="pf-u-ml-sm" />
+                    </Popover>
+                  </>
+                }
+                onChange={() => {
+                  handleToggleEnvironment('vsphere-ova');
+                  handleToggleEnvironment('vsphere');
+                }}
+                isChecked={environments.includes('vsphere-ova')}
+                isDisabled={
+                  !(
+                    environments.includes('vsphere') ||
+                    environments.includes('vsphere-ova')
+                  )
+                }
+              />
+            )}
             <Radio
+              className="pf-u-mt-sm"
               name="vsphere-radio"
-              aria-label="VMware vSphere radio button OVA"
-              id="vsphere-radio-ova"
+              aria-label="VMWare vSphere radio button VMDK"
+              id="vsphere-radio-vmdk"
               label={
                 <>
-                  Open virtualization format (.ova)
+                  Virtual disk (.vmdk)
                   <Popover
                     maxWidth="30rem"
                     position="right"
                     bodyContent={
                       <TextContent>
                         <Text>
-                          An OVA file is a virtual appliance used by
-                          virtualization platforms such as VMware vSphere. It is
-                          a package that contains files used to describe a
-                          virtual machine, which includes a VMDK image, OVF
-                          descriptor file and a manifest file.
+                          A VMDK file is a virtual disk that stores the contents
+                          of a virtual machine. This disk has to be imported
+                          into vSphere using govc import.vmdk, use the OVA
+                          version when using the vSphere UI.
                         </Text>
                       </TextContent>
                     }
@@ -304,94 +256,58 @@ const Environment = ({ setEnvironment, environment }: EnvironmentPropType) => {
                   </Popover>
                 </>
               }
-              onChange={(_event, checked) => {
-                handleSetEnvironment('vsphere-ova', checked);
-                handleSetEnvironment('vsphere', !checked);
+              onChange={() => {
+                handleToggleEnvironment('vsphere-ova');
+                handleToggleEnvironment('vsphere');
               }}
-              isChecked={environment['vsphere-ova'].selected}
+              isChecked={environments.includes('vsphere')}
               isDisabled={
                 !(
-                  environment.vsphere.selected ||
-                  environment['vsphere-ova'].selected
+                  environments.includes('vsphere') ||
+                  environments.includes('vsphere-ova')
                 )
               }
             />
-          )}
-          <Radio
-            className="pf-u-mt-sm"
-            name="vsphere-radio"
-            aria-label="VMware vSphere radio button VMDK"
-            id="vsphere-radio-vmdk"
-            label={
-              <>
-                Virtual disk (.vmdk)
-                <Popover
-                  maxWidth="30rem"
-                  position="right"
-                  bodyContent={
-                    <TextContent>
-                      <Text>
-                        A VMDK file is a virtual disk that stores the contents
-                        of a virtual machine. This disk has to be imported into
-                        vSphere using govc import.vmdk, use the OVA version when
-                        using the vSphere UI.
-                      </Text>
-                    </TextContent>
-                  }
-                >
-                  <HelpIcon className="pf-u-ml-sm" />
-                </Popover>
-              </>
-            }
-            onChange={(_event, checked) => {
-              handleSetEnvironment('vsphere-ova', !checked);
-              handleSetEnvironment('vsphere', checked);
-            }}
-            isChecked={environment.vsphere.selected}
-            isDisabled={
-              !(
-                environment.vsphere.selected ||
-                environment['vsphere-ova'].selected
-              )
-            }
-          />
-        </FormGroup>
+          </FormGroup>
+        </>
       )}
       <FormGroup
         label={<Text component={TextVariants.small}>Other</Text>}
         data-testid="target-other"
       >
-        {environment['guest-image'].authorized && (
+        {supportedEnvironments?.includes('guest-image') && (
           <Checkbox
             label="Virtualization - Guest image (.qcow2)"
-            isChecked={environment['guest-image'].selected}
-            onChange={(_event, checked) =>
-              handleSetEnvironment('guest-image', checked)
-            }
+            isChecked={environments.includes('guest-image')}
+            onChange={() => {
+              handleToggleEnvironment('guest-image');
+            }}
             aria-label="Virtualization guest image checkbox"
             id="checkbox-guest-image"
             name="Virtualization guest image"
             data-testid="checkbox-guest-image"
           />
         )}
-        {environment['image-installer'].authorized && (
+        {supportedEnvironments?.includes('image-installer') && (
           <Checkbox
             label="Bare metal - Installer (.iso)"
-            isChecked={environment['image-installer'].selected}
-            onChange={(_event, checked) =>
-              handleSetEnvironment('image-installer', checked)
-            }
+            isChecked={environments.includes('image-installer')}
+            onChange={() => {
+              handleToggleEnvironment('image-installer');
+            }}
             aria-label="Bare metal installer checkbox"
             id="checkbox-image-installer"
             name="Bare metal installer"
             data-testid="checkbox-image-installer"
           />
         )}
-        {environment['wsl'].authorized && isBeta() && (
+        {supportedEnvironments?.includes('wsl') && isBeta() && (
           <Checkbox
             label="WSL - Windows Subsystem for Linux (.tar.gz)"
-            isChecked={environment['wsl'].selected}
-            onChange={(_event, checked) => handleSetEnvironment('wsl', checked)}
+            isChecked={environments.includes('wsl')}
+            onChange={() => {
+              handleToggleEnvironment('wsl');
+            }}
             aria-label="windows subsystem for linux checkbox"
             id="checkbox-wsl"
             name="WSL"

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ImageOutput.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ImageOutput.tsx
@@ -11,13 +11,6 @@ import { useAppSelector } from '../../../../store/hooks';
 import { selectDistribution } from '../../../../store/wizardSlice';
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
 
-/**
- * Manages the form for the image output step by providing the user with a
- * choice for:
- * - a distribution
- * - a release
- * - a set of environments
- */
 const ImageOutputStep = () => {
   const distribution = useAppSelector((state) => selectDistribution(state));
 

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ImageOutput.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ImageOutput.tsx
@@ -1,36 +1,15 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 
-import {
-  Text,
-  Alert,
-  Bullseye,
-  Form,
-  Spinner,
-  Title,
-} from '@patternfly/react-core';
+import { Text, Form, Title } from '@patternfly/react-core';
 
 import ArchSelect from './ArchSelect';
 import CentOSAcknowledgement from './CentOSAcknowledgement';
-import Environment, { EnvironmentStateType } from './Environment';
+import Environment from './Environment';
 import ReleaseSelect from './ReleaseSelect';
 
-import {
-  ArchitectureItem,
-  Distributions,
-} from '../../../../store/imageBuilderApi';
+import { useAppSelector } from '../../../../store/hooks';
+import { selectDistribution } from '../../../../store/wizardSlice';
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
-
-type ImageOutputPropTypes = {
-  release: Distributions;
-  setRelease: Dispatch<SetStateAction<Distributions>>;
-  arch: ArchitectureItem['arch'];
-  setArch: Dispatch<SetStateAction<ArchitectureItem['arch']>>;
-  environment: EnvironmentStateType;
-  setEnvironment: Dispatch<SetStateAction<EnvironmentStateType>>;
-  isFetching: boolean;
-  isError: boolean;
-  isSuccess: boolean;
-};
 
 /**
  * Manages the form for the image output step by providing the user with a
@@ -39,17 +18,9 @@ type ImageOutputPropTypes = {
  * - a release
  * - a set of environments
  */
-const ImageOutputStep = ({
-  release,
-  setRelease,
-  arch,
-  setArch,
-  setEnvironment,
-  environment,
-  isFetching,
-  isError,
-  isSuccess,
-}: ImageOutputPropTypes) => {
+const ImageOutputStep = () => {
+  const distribution = useAppSelector((state) => selectDistribution(state));
+
   return (
     <Form>
       <Title headingLevel="h2">Image output</Title>
@@ -59,30 +30,10 @@ const ImageOutputStep = ({
         <br />
         <DocumentationButton />
       </Text>
-      <ReleaseSelect setRelease={setRelease} release={release} />
-      <ArchSelect setArch={setArch} arch={arch} />
-      {release.match('centos-*') && <CentOSAcknowledgement />}
-      {isFetching && (
-        <Bullseye>
-          <Spinner size="lg" />
-        </Bullseye>
-      )}
-      {isError && (
-        <Alert
-          variant={'danger'}
-          isPlain
-          isInline
-          title={'Environments unavailable'}
-        >
-          API cannot be reached, try again later.
-        </Alert>
-      )}
-      {isSuccess && !isFetching && (
-        <Environment
-          setEnvironment={setEnvironment}
-          environment={environment}
-        />
-      )}
+      <ReleaseSelect />
+      <ArchSelect />
+      {distribution.match('centos-*') && <CentOSAcknowledgement />}
+      <Environment />
     </Form>
   );
 };

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseSelect.tsx
@@ -1,10 +1,4 @@
-import React, {
-  Dispatch,
-  ReactElement,
-  SetStateAction,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactElement, useRef, useState } from 'react';
 
 import {
   Select,
@@ -15,21 +9,23 @@ import {
 } from '@patternfly/react-core';
 
 import { RELEASES } from '../../../../constants';
+import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import { Distributions } from '../../../../store/imageBuilderApi';
+import {
+  changeDistribution,
+  selectDistribution,
+} from '../../../../store/wizardSlice';
 import isRhel from '../../../../Utilities/isRhel';
-
-type ReleaseSelectType = {
-  setRelease: Dispatch<SetStateAction<Distributions>>;
-  release: Distributions;
-};
 
 /**
  * Allows the user to choose the release they want to build.
  * Follows the PF5 pattern: https://www.patternfly.org/components/menus/select#view-more
  */
-const ReleaseSelect = ({ setRelease, release }: ReleaseSelectType) => {
+const ReleaseSelect = () => {
   // By default the component doesn't show the Centos releases and only the RHEL
   // ones. The user has the option to click on a button to make them appear.
+  const distribution = useAppSelector((state) => selectDistribution(state));
+  const dispatch = useAppDispatch();
   const [showDevelopmentOptions, setShowDevelopmentOptions] = useState(false);
   const releaseOptions = () => {
     const options: ReactElement[] = [];
@@ -63,11 +59,11 @@ const ReleaseSelect = ({ setRelease, release }: ReleaseSelectType) => {
   const toggleRef = useRef<HTMLButtonElement>(null);
   const onSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
-    value: string | number | undefined
+    value: 'loader' | Distributions | undefined
   ) => {
     if (value !== 'loader') {
       if (typeof value === 'string') {
-        setRelease(value as Distributions);
+        dispatch(changeDistribution(value));
       }
       setIsOpen(false);
       toggleRef?.current?.focus(); // Only focus the toggle when a non-loader option is selected
@@ -81,7 +77,7 @@ const ReleaseSelect = ({ setRelease, release }: ReleaseSelectType) => {
       isExpanded={isOpen}
       isFullWidth
     >
-      {RELEASES.get(release)}
+      {RELEASES.get(distribution)}
     </MenuToggle>
   );
 
@@ -91,7 +87,7 @@ const ReleaseSelect = ({ setRelease, release }: ReleaseSelectType) => {
         ouiaId="release_select"
         id="release_select"
         isOpen={isOpen}
-        selected={release}
+        selected={distribution}
         onSelect={onSelect}
         onOpenChange={(isOpen) => setIsOpen(isOpen)}
         toggle={{ toggleNode: toggle, toggleRef }}

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStep.tsx
@@ -4,17 +4,7 @@ import { ExpandableSection, Form, Title } from '@patternfly/react-core';
 
 import { ImageOutputList } from './imageOutput';
 
-import {
-  ArchitectureItem,
-  Distributions,
-} from '../../../../store/imageBuilderApi';
-
-type ReviewStepPropTypes = {
-  release: Distributions;
-  arch: ArchitectureItem['arch'];
-};
-
-const ReviewStep = ({ release, arch }: ReviewStepPropTypes) => {
+const ReviewStep = () => {
   const [isExpandedImageOutput, setIsExpandedImageOutput] = useState(false);
 
   const onToggleImageOutput = (isExpandedImageOutput: boolean) =>
@@ -32,7 +22,7 @@ const ReviewStep = ({ release, arch }: ReviewStepPropTypes) => {
           isIndented
           data-testid="image-output-expandable"
         >
-          <ImageOutputList release={release} arch={arch} />
+          <ImageOutputList />
         </ExpandableSection>
       </Form>
     </>

--- a/src/Components/CreateImageWizardV2/steps/Review/imageOutput.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/imageOutput.tsx
@@ -9,20 +9,15 @@ import {
 } from '@patternfly/react-core';
 
 import { RELEASES } from '../../../../constants';
+import { useAppSelector } from '../../../../store/hooks';
 import {
-  ArchitectureItem,
-  Distributions,
-} from '../../../../store/imageBuilderApi';
+  selectArchitecture,
+  selectDistribution,
+} from '../../../../store/wizardSlice';
 
-type ImageOutputListPropTypes = {
-  release: Distributions;
-  arch: ArchitectureItem['arch'];
-};
-
-export const ImageOutputList = ({
-  release,
-  arch,
-}: ImageOutputListPropTypes) => {
+export const ImageOutputList = () => {
+  const release = useAppSelector((state) => selectDistribution(state));
+  const arch = useAppSelector((state) => selectArchitecture(state));
   return (
     <TextContent>
       <TextList component={TextListVariants.dl}>

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws.tsx
@@ -1,0 +1,142 @@
+import React, { useState } from 'react';
+
+import {
+  Radio,
+  Text,
+  Form,
+  Title,
+  FormGroup,
+  TextInput,
+  Gallery,
+  GalleryItem,
+  HelperText,
+  HelperTextItem,
+  Button,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import { AWSSourcesSelect } from './AwsSourcesSelect';
+
+import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import {
+  changeAwsAccountId,
+  selectAwsAccountId,
+} from '../../../../store/wizardSlice';
+import { ValidatedTextInput } from '../../ValidatedTextInput';
+import { isAwsAccountIdValid } from '../../validators';
+
+type ShareMethod = 'manual' | 'sources';
+
+const SourcesButton = () => {
+  return (
+    <Button
+      component="a"
+      target="_blank"
+      variant="link"
+      icon={<ExternalLinkAltIcon />}
+      iconPosition="right"
+      isInline
+      href={'settings/sources'}
+    >
+      Create and manage sources here
+    </Button>
+  );
+};
+
+export const Aws = () => {
+  const dispatch = useAppDispatch();
+  const awsAccountId = useAppSelector((state) => selectAwsAccountId(state));
+  const [shareMethod, setShareMethod] = useState<ShareMethod>('manual');
+
+  return (
+    <Form>
+      <Title headingLevel="h2">Target environment - Amazon Web Services</Title>
+      <Text>
+        Your image will be uploaded to AWS and shared with the account you
+        provide below.
+      </Text>
+      <Text>
+        <b>The shared image will expire within 14 days.</b> To permanently
+        access the image, copy the image, which will be shared to your account
+        by Red Hat, to your own AWS account.
+      </Text>
+      <FormGroup label="Share method:">
+        <Radio
+          id="radio-with-description"
+          label="Use an account configured from Sources."
+          name="radio-7"
+          description="Use a configured sources to launch environments directly from the console."
+          isChecked={shareMethod === 'sources'}
+          onChange={() => {
+            dispatch(changeAwsAccountId(undefined));
+            setShareMethod('sources');
+          }}
+        />
+        <Radio
+          id="radio"
+          label="Manually enter an account ID."
+          name="radio-8"
+          isChecked={shareMethod === 'manual'}
+          onChange={() => {
+            dispatch(changeAwsAccountId(undefined));
+            setShareMethod('manual');
+          }}
+        />
+      </FormGroup>
+      {shareMethod === 'sources' && (
+        <>
+          <AWSSourcesSelect />
+          <SourcesButton />
+          <Gallery hasGutter>
+            <GalleryItem>
+              <TextInput
+                readOnlyVariant="default"
+                isRequired
+                id="someid"
+                value="us-east-1"
+              />
+              <HelperText>
+                <HelperTextItem component="div" variant="indeterminate">
+                  Images are built in the default region but can be copied to
+                  other regions later.
+                </HelperTextItem>
+              </HelperText>
+            </GalleryItem>
+            <GalleryItem>
+              <TextInput
+                readOnlyVariant="default"
+                isRequired
+                id="someid2"
+                value={awsAccountId}
+              />
+              <HelperText>
+                <HelperTextItem component="div" variant="indeterminate">
+                  This is the account associated with the source.
+                </HelperTextItem>
+              </HelperText>
+            </GalleryItem>
+          </Gallery>
+        </>
+      )}
+      {shareMethod === 'manual' && (
+        <>
+          <FormGroup label="AWS account ID" isRequired>
+            <ValidatedTextInput
+              value={awsAccountId}
+              validator={isAwsAccountIdValid}
+              onChange={(_event, value) => dispatch(changeAwsAccountId(value))}
+            />
+          </FormGroup>
+          <FormGroup label="Default Region" isRequired>
+            <TextInput
+              value={'us-east-1'}
+              type="text"
+              aria-label="TODO"
+              readOnlyVariant="default"
+            />
+          </FormGroup>
+        </>
+      )}
+    </Form>
+  );
+};

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/AwsSourcesSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/AwsSourcesSelect.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from 'react';
+
+import { Alert } from '@patternfly/react-core';
+import { FormGroup, Spinner } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
+
+import { extractProvisioningList } from '../../../../store/helpers';
+import { useAppDispatch } from '../../../../store/hooks';
+import {
+  useGetSourceListQuery,
+  useGetSourceUploadInfoQuery,
+} from '../../../../store/provisioningApi';
+import { changeAwsAccountId } from '../../../../store/wizardSlice';
+
+type V1ListSourceResponseItem = {
+  id?: string;
+  name?: string;
+  source_type_id?: string;
+  uid?: string;
+};
+
+export const AWSSourcesSelect = () => {
+  const dispatch = useAppDispatch();
+  const [isOpen, setIsOpen] = useState(false);
+  const [source, setSource] = useState<V1ListSourceResponseItem | undefined>(
+    undefined
+  );
+
+  const { data, isFetching, isSuccess, isError, refetch } =
+    useGetSourceListQuery({ provider: 'aws' });
+
+  const sources = data?.data;
+
+  const {
+    data: sourceDetails,
+    isFetching: isFetchingDetails,
+    isSuccess: isSuccessDetails,
+    isError: isErrorDetails,
+  } = useGetSourceUploadInfoQuery(
+    { id: parseInt(source?.id) },
+    {
+      skip: !source,
+    }
+  );
+
+  useEffect(() => {
+    dispatch(changeAwsAccountId(sourceDetails?.aws?.account_id));
+  }, [dispatch, sourceDetails]);
+
+  const handleSelect = (
+    _event: React.MouseEvent<Element, MouseEvent>,
+    value: string
+  ) => {
+    const source = sources.find((source) => source.name === value);
+    setSource(source);
+    setIsOpen(false);
+  };
+
+  const handleClear = () => {
+    setSource(undefined);
+    dispatch(changeAwsAccountId(undefined));
+  };
+
+  const handleToggle = () => {
+    // Refetch upon opening (but not upon closing)
+    if (!isOpen) {
+      refetch();
+    }
+
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <>
+      <FormGroup isRequired label={'Source Name'} data-testid="sources">
+        <Select
+          ouiaId="source_select"
+          variant={SelectVariant.typeahead}
+          onToggle={handleToggle}
+          onSelect={handleSelect}
+          onClear={handleClear}
+          selections={source?.name}
+          isOpen={isOpen}
+          placeholderText="Select source"
+          typeAheadAriaLabel="Select source"
+          isDisabled={!isSuccess}
+        >
+          {sources.map((source) => (
+            <SelectOption key={source.id} value={source.name} />
+          ))}
+          {/*isFetching && (
+            <SelectOption isNoResultsOption={true}>
+              <Spinner size="lg" />
+            </SelectOption>
+          )*/}
+        </Select>
+      </FormGroup>
+      <>
+        {isError && (
+          <Alert
+            variant={'danger'}
+            isPlain={true}
+            isInline={true}
+            title={'Sources unavailable'}
+          >
+            Sources cannot be reached, try again later or enter an AWS account
+            ID manually.
+          </Alert>
+        )}
+        {!isError && isErrorDetails && (
+          <Alert
+            variant={'danger'}
+            isPlain
+            isInline
+            title={'AWS details unavailable'}
+          >
+            The AWS account ID for the selected source could not be resolved.
+            There might be a problem with the source. Verify that the source is
+            valid in Sources or select a different source.
+          </Alert>
+        )}
+      </>
+    </>
+  );
+};

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/AwsSourcesSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/AwsSourcesSelect.tsx
@@ -1,14 +1,13 @@
 import React, { useEffect, useState } from 'react';
 
 import { Alert } from '@patternfly/react-core';
-import { FormGroup, Spinner } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 import {
   Select,
   SelectOption,
   SelectVariant,
 } from '@patternfly/react-core/deprecated';
 
-import { extractProvisioningList } from '../../../../store/helpers';
 import { useAppDispatch } from '../../../../store/hooks';
 import {
   useGetSourceListQuery,
@@ -16,6 +15,7 @@ import {
 } from '../../../../store/provisioningApi';
 import { changeAwsAccountId } from '../../../../store/wizardSlice';
 
+// The TODO API only defines a V1ListSourceResponseItem[] type
 type V1ListSourceResponseItem = {
   id?: string;
   name?: string;
@@ -30,22 +30,19 @@ export const AWSSourcesSelect = () => {
     undefined
   );
 
-  const { data, isFetching, isSuccess, isError, refetch } =
-    useGetSourceListQuery({ provider: 'aws' });
+  const { data, isSuccess, isError, refetch } = useGetSourceListQuery({
+    provider: 'aws',
+  });
 
   const sources = data?.data;
 
-  const {
-    data: sourceDetails,
-    isFetching: isFetchingDetails,
-    isSuccess: isSuccessDetails,
-    isError: isErrorDetails,
-  } = useGetSourceUploadInfoQuery(
-    { id: parseInt(source?.id) },
-    {
-      skip: !source,
-    }
-  );
+  const { data: sourceDetails, isError: isErrorDetails } =
+    useGetSourceUploadInfoQuery(
+      { id: parseInt(source?.id) },
+      {
+        skip: !source,
+      }
+    );
 
   useEffect(() => {
     dispatch(changeAwsAccountId(sourceDetails?.aws?.account_id));
@@ -55,7 +52,7 @@ export const AWSSourcesSelect = () => {
     _event: React.MouseEvent<Element, MouseEvent>,
     value: string
   ) => {
-    const source = sources.find((source) => source.name === value);
+    const source = sources?.find((source) => source.name === value);
     setSource(source);
     setIsOpen(false);
   };
@@ -89,7 +86,7 @@ export const AWSSourcesSelect = () => {
           typeAheadAriaLabel="Select source"
           isDisabled={!isSuccess}
         >
-          {sources.map((source) => (
+          {sources?.map((source) => (
             <SelectOption key={source.id} value={source.name} />
           ))}
           {/*isFetching && (

--- a/src/Components/CreateImageWizardV2/validators.ts
+++ b/src/Components/CreateImageWizardV2/validators.ts
@@ -1,0 +1,10 @@
+export const isAwsAccountIdValid = (awsAccountId: string | undefined) => {
+  if (
+    awsAccountId !== undefined &&
+    /^\d+$/.test(awsAccountId) &&
+    awsAccountId.length === 12
+  ) {
+    return true;
+  }
+  return false;
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,8 +5,17 @@ import promiseMiddleware from 'redux-promise-middleware';
 import { contentSourcesApi } from './contentSourcesApi';
 import { edgeApi } from './edgeApi';
 import { imageBuilderApi } from './enhancedImageBuilderApi';
+import { listenerMiddleware, startAppListening } from './listenerMiddleware';
 import { provisioningApi } from './provisioningApi';
 import { rhsmApi } from './rhsmApi';
+import wizardSlice, {
+  changeArchitecture,
+  changeDistribution,
+  changeImageTypes,
+  selectArchitecture,
+  selectDistribution,
+  selectImageTypes,
+} from './wizardSlice';
 
 export const reducer = {
   [contentSourcesApi.reducerPath]: contentSourcesApi.reducer,
@@ -15,16 +24,75 @@ export const reducer = {
   [rhsmApi.reducerPath]: rhsmApi.reducer,
   [provisioningApi.reducerPath]: provisioningApi.reducer,
   notifications: notificationsReducer,
+  wizard: wizardSlice,
 };
 
+startAppListening({
+  actionCreator: changeArchitecture,
+  effect: (action, listenerApi) => {
+    const state = listenerApi.getState();
+
+    const distribution = selectDistribution(state);
+    const imageTypes = selectImageTypes(state);
+    const architecture = action.payload;
+
+    // The response from the RTKQ getArchitectures hook
+    const architecturesResponse =
+      imageBuilderApi.endpoints.getArchitectures.select({
+        distribution: distribution,
+      })(state);
+
+    const allowedImageTypes = architecturesResponse?.data?.find(
+      (elem) => elem.arch === architecture
+    )?.image_types;
+
+    const filteredImageTypes = imageTypes.filter((imageType) =>
+      allowedImageTypes?.includes(imageType)
+    );
+
+    listenerApi.dispatch(changeImageTypes(filteredImageTypes));
+  },
+});
+
+startAppListening({
+  actionCreator: changeDistribution,
+  effect: (action, listenerApi) => {
+    const state = listenerApi.getState();
+
+    const distribution = action.payload;
+    const imageTypes = selectImageTypes(state);
+    const architecture = selectArchitecture(state);
+
+    // The response from the RTKQ getArchitectures hook
+    const architecturesResponse =
+      imageBuilderApi.endpoints.getArchitectures.select({
+        distribution: distribution,
+      })(state);
+
+    const allowedImageTypes = architecturesResponse?.data?.find(
+      (elem) => elem.arch === architecture
+    )?.image_types;
+
+    const filteredImageTypes = imageTypes.filter((imageType) =>
+      allowedImageTypes?.includes(imageType)
+    );
+
+    listenerApi.dispatch(changeImageTypes(filteredImageTypes));
+  },
+});
+
+// Listener middleware must be prepended according to RTK docs:
+// https://redux-toolkit.js.org/api/createListenerMiddleware#basic-usage
 export const middleware = (getDefaultMiddleware: Function) =>
-  getDefaultMiddleware().concat(
-    promiseMiddleware,
-    contentSourcesApi.middleware,
-    imageBuilderApi.middleware,
-    rhsmApi.middleware,
-    provisioningApi.middleware
-  );
+  getDefaultMiddleware()
+    .prepend(listenerMiddleware.middleware)
+    .concat(
+      promiseMiddleware,
+      contentSourcesApi.middleware,
+      imageBuilderApi.middleware,
+      rhsmApi.middleware,
+      provisioningApi.middleware
+    );
 
 export const store = configureStore({ reducer, middleware });
 

--- a/src/store/listenerMiddleware.ts
+++ b/src/store/listenerMiddleware.ts
@@ -1,0 +1,18 @@
+// listenerMiddleware.ts
+// https://redux-toolkit.js.org/api/createListenerMiddleware#typescript-usage
+import { createListenerMiddleware, addListener } from '@reduxjs/toolkit';
+import type { TypedStartListening, TypedAddListener } from '@reduxjs/toolkit';
+
+import type { RootState, AppDispatch } from './index';
+
+export const listenerMiddleware = createListenerMiddleware();
+
+export type AppStartListening = TypedStartListening<RootState, AppDispatch>;
+
+export const startAppListening =
+  listenerMiddleware.startListening as AppStartListening;
+
+export const addAppListener = addListener as TypedAddListener<
+  RootState,
+  AppDispatch
+>;

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -10,12 +10,14 @@ type wizardState = {
   architecture: ImageRequest['architecture'];
   distribution: Distributions;
   imageTypes: ImageTypes[];
+  awsAccountId: string | undefined;
 };
 
 const initialState: wizardState = {
   architecture: X86_64,
   distribution: RHEL_9,
   imageTypes: [],
+  awsAccountId: undefined,
 };
 
 export const selectArchitecture = (state: RootState) => {
@@ -28,6 +30,10 @@ export const selectDistribution = (state: RootState) => {
 
 export const selectImageTypes = (state: RootState) => {
   return state.wizard.imageTypes;
+};
+
+export const selectAwsAccountId = (state: RootState) => {
+  return state.wizard.awsAccountId;
 };
 
 export const wizardSlice = createSlice({
@@ -58,6 +64,9 @@ export const wizardSlice = createSlice({
     changeImageTypes: (state, action: PayloadAction<ImageTypes[]>) => {
       state.imageTypes = action.payload;
     },
+    changeAwsAccountId: (state, action: PayloadAction<string | undefined>) => {
+      state.awsAccountId = action.payload;
+    },
     initializeWizard: () => initialState,
   },
 });
@@ -68,6 +77,7 @@ export const {
   addImageType,
   removeImageType,
   changeImageTypes,
+  changeAwsAccountId,
   initializeWizard,
 } = wizardSlice.actions;
 export default wizardSlice.reducer;

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -1,0 +1,73 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+import { Distributions, ImageRequest, ImageTypes } from './imageBuilderApi';
+
+import { RHEL_9, X86_64 } from '../constants';
+
+import { RootState } from '.';
+
+type wizardState = {
+  architecture: ImageRequest['architecture'];
+  distribution: Distributions;
+  imageTypes: ImageTypes[];
+};
+
+const initialState: wizardState = {
+  architecture: X86_64,
+  distribution: RHEL_9,
+  imageTypes: [],
+};
+
+export const selectArchitecture = (state: RootState) => {
+  return state.wizard.architecture;
+};
+
+export const selectDistribution = (state: RootState) => {
+  return state.wizard.distribution;
+};
+
+export const selectImageTypes = (state: RootState) => {
+  return state.wizard.imageTypes;
+};
+
+export const wizardSlice = createSlice({
+  name: 'wizard',
+  initialState,
+  reducers: {
+    changeArchitecture: (
+      state,
+      action: PayloadAction<ImageRequest['architecture']>
+    ) => {
+      state.architecture = action.payload;
+    },
+    changeDistribution: (state, action: PayloadAction<Distributions>) => {
+      state.distribution = action.payload;
+    },
+    addImageType: (state, action: PayloadAction<ImageTypes>) => {
+      // Remove (if present) before adding to avoid duplicates
+      state.imageTypes = state.imageTypes.filter(
+        (imageType) => imageType !== action.payload
+      );
+      state.imageTypes.push(action.payload);
+    },
+    removeImageType: (state, action: PayloadAction<ImageTypes>) => {
+      state.imageTypes = state.imageTypes.filter(
+        (imageType) => imageType !== action.payload
+      );
+    },
+    changeImageTypes: (state, action: PayloadAction<ImageTypes[]>) => {
+      state.imageTypes = action.payload;
+    },
+    initializeWizard: () => initialState,
+  },
+});
+
+export const {
+  changeArchitecture,
+  changeDistribution,
+  addImageType,
+  removeImageType,
+  changeImageTypes,
+  initializeWizard,
+} = wizardSlice.actions;
+export default wizardSlice.reducer;

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -85,8 +85,13 @@ describe('Step Image output', () => {
     await screen.findByRole('heading', { name: 'Image output' });
 
     await clickNext();
+    await screen.findByRole('heading', {
+      name: 'Target environment - Amazon Web Services',
+    });
 
+    await clickNext();
     await screen.findByRole('heading', { name: 'Review' });
+
     const view = screen.getByTestId('image-output-expandable');
     await user.click(await within(view).findByText(/image output/i));
     expect(await screen.findByText(/x86_64/i)).not.toBeNaN();
@@ -121,7 +126,8 @@ describe('Step Image output', () => {
     // select aws as upload destination
     await user.click(await screen.findByTestId('upload-aws'));
 
-    await clickNext();
+    await user.click(await screen.findByRole('button', { name: /Next/ }));
+    await user.click(await screen.findByRole('button', { name: /Next/ }));
 
     await screen.findByRole('heading', { name: 'Review' });
     const view = screen.getByTestId('image-output-expandable');


### PR DESCRIPTION
*This is currently a WIP, there are a few bugs and some clean-up/refactoring is necessary*

So far we have considered (thanks to the work of @lavocatt) two possible options for managing the wizard state: storing state in the highest level component via useState() hooks, and storing state via a useContext() hook.

However, there is a 3rd option - we can use Redux (with RTK).

One big advantage is we can take advantage of the Redux dev tools and use them to inspect the state of the wizard during development:
![image](https://github.com/RedHatInsights/image-builder-frontend/assets/95542540/5e880267-6c7f-4aa0-a8c8-e69022db928b)