### PR TITLE
dependabot: Bump open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     rebase-strategy: "auto"


### PR DESCRIPTION
This bumps a maximum number of opened dependabot PRs as there are currently three open PRs in need of manual revision. Those are blocking any other bumps from being even opened.

The bump should be temporary.