### PR TITLE
Blueprints: add blueprint feature

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -12,7 +12,7 @@ const App = (props) => {
   const { hideGlobalFilter, updateDocumentTitle } = useChrome();
 
   useEffect(() => {
-    updateDocumentTitle('Image Builder | Red Hat Insights');
+    updateDocumentTitle('Images | Red Hat Insights');
     hideGlobalFilter();
   }, [hideGlobalFilter, updateDocumentTitle]);
 

--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -66,7 +66,7 @@ const BlueprintCard = (props: {
   );
 
   return (
-    <Card>
+    <Card className="pf-v5-u-mb-md">
       <CardHeader actions={{ actions: headerActions }}>
         <CardTitle>{props.blueprint.name}</CardTitle>
       </CardHeader>

--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
-import { Blueprint } from '../../store/imageBuilderApi';
+import { Blueprint } from '../../store/imageBuilderApiExperimental';
 
 const BlueprintCard = (props: {
   blueprint: Blueprint;

--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardBody,
+  Radio,
+  Dropdown,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+  DropdownItem,
+} from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons';
+
+import { Blueprint } from '../../store/imageBuilderApi';
+
+const BlueprintCard = (props: {
+  blueprint: Blueprint;
+  setSelectedBlueprint: React.Dispatch<React.SetStateAction<string>>;
+  selectedBlueprint: string;
+}) => {
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+  const isChecked = props.blueprint.id === props.selectedBlueprint;
+  const onSelect = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleChange = () => {
+    props.setSelectedBlueprint(props.blueprint.id);
+  };
+
+  const headerActions = (
+    <>
+      <Dropdown
+        onSelect={onSelect}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            ref={toggleRef}
+            isExpanded={isOpen}
+            onClick={() => setIsOpen(!isOpen)}
+            variant="plain"
+            aria-label="Card expandable toggle"
+          >
+            <EllipsisVIcon aria-hidden="true" />
+          </MenuToggle>
+        )}
+        isOpen={isOpen}
+        onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+      >
+        <DropdownList>
+          <DropdownItem key="disabled action" isDisabled>
+            Delete
+          </DropdownItem>
+        </DropdownList>
+      </Dropdown>
+      <Radio
+        isChecked={isChecked}
+        onChange={handleChange}
+        aria-label="blueprint checkbox"
+        id={props.blueprint.id}
+        name={props.blueprint.id}
+      />
+    </>
+  );
+
+  return (
+    <Card>
+      <CardHeader actions={{ actions: headerActions }}>
+        <CardTitle>{props.blueprint.name}</CardTitle>
+      </CardHeader>
+      <CardBody>{props.blueprint.description}</CardBody>
+    </Card>
+  );
+};
+
+export default BlueprintCard;

--- a/src/Components/Blueprints/BlueprintsSidebar.tsx
+++ b/src/Components/Blueprints/BlueprintsSidebar.tsx
@@ -67,14 +67,12 @@ const BlueprintsSidebar = (props: blueprintProps) => {
         className="pf-v5-u-mb-md"
       />
       {filteredBlueprints?.map((blueprint: Blueprint) => (
-        <>
-          <BlueprintCard
-            key={blueprint.id}
-            blueprint={blueprint}
-            selectedBlueprint={props.selectedBlueprint}
-            setSelectedBlueprint={props.setSelectedBlueprint}
-          />
-        </>
+        <BlueprintCard
+          key={blueprint.id}
+          blueprint={blueprint}
+          selectedBlueprint={props.selectedBlueprint}
+          setSelectedBlueprint={props.setSelectedBlueprint}
+        />
       ))}
     </>
   ) : (

--- a/src/Components/Blueprints/BlueprintsSidebar.tsx
+++ b/src/Components/Blueprints/BlueprintsSidebar.tsx
@@ -1,10 +1,22 @@
 import React, { useState, Dispatch, SetStateAction } from 'react';
 
-import { SearchInput } from '@patternfly/react-core';
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateHeader,
+  EmptyStateIcon,
+  SearchInput,
+} from '@patternfly/react-core';
+import { CubesIcon } from '@patternfly/react-icons';
 
 import BlueprintCard from './BlueprintCard';
 
 import { Blueprint } from '../../store/imageBuilderApiExperimental';
+import { Link } from 'react-router-dom';
+import { resolveRelPath } from '../../Utilities/path';
 
 interface blueprintProps {
   blueprints: Blueprint[];
@@ -26,7 +38,28 @@ const BlueprintsSidebar = (props: blueprintProps) => {
     }
   );
 
-  return (
+  const blueprintsEmpty = (
+    <EmptyState>
+      <EmptyStateHeader
+        titleText="Create a blueprint"
+        headingLevel="h4"
+        icon={<EmptyStateIcon icon={CubesIcon} />}
+      />
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Link
+            to={resolveRelPath('blueprintwizard')}
+            className="pf-c-button pf-m-primary pf-u-mr-md"
+            data-testid="create-blueprint-action"
+          >
+            Create
+          </Link>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+
+  return props.blueprints?.length ? (
     <>
       <SearchInput
         placeholder="Search by blueprint name"
@@ -47,6 +80,8 @@ const BlueprintsSidebar = (props: blueprintProps) => {
         </>
       ))}
     </>
+  ) : (
+    blueprintsEmpty
   );
 };
 

--- a/src/Components/Blueprints/BlueprintsSidebar.tsx
+++ b/src/Components/Blueprints/BlueprintsSidebar.tsx
@@ -1,21 +1,19 @@
 import React, { useState, Dispatch, SetStateAction } from 'react';
 
 import {
-  Button,
   EmptyState,
   EmptyStateActions,
-  EmptyStateBody,
   EmptyStateFooter,
   EmptyStateHeader,
   EmptyStateIcon,
   SearchInput,
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
+import { Link } from 'react-router-dom';
 
 import BlueprintCard from './BlueprintCard';
 
 import { Blueprint } from '../../store/imageBuilderApiExperimental';
-import { Link } from 'react-router-dom';
 import { resolveRelPath } from '../../Utilities/path';
 
 interface blueprintProps {

--- a/src/Components/Blueprints/BlueprintsSidebar.tsx
+++ b/src/Components/Blueprints/BlueprintsSidebar.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+import React, { useState } from 'react';
+
+import { SearchInput } from '@patternfly/react-core';
+
+import BlueprintCard from './BlueprintCard';
+
+import { useGetBlueprintsQuery } from '../../store/imageBuilderApi';
+import { Blueprint } from '../../store/imageBuilderApi';
+
+const BlueprintsSidebar: React.FunctionComponent = () => {
+  const { data: blueprints } = useGetBlueprintsQuery('');
+  const [blueprintFilter, setBlueprintFilter] = useState('');
+  const [selectedBlueprint, setSelectedBlueprint] = useState('');
+
+  const onChange = (value: string) => {
+    setBlueprintFilter(value);
+  };
+
+  const filteredBlueprints = blueprints?.filter((blueprint: Blueprint) => {
+    return blueprint.name.toLowerCase().includes(blueprintFilter.toLowerCase());
+  });
+
+  return (
+    <>
+      <SearchInput
+        placeholder="Search by blueprint name"
+        value={blueprintFilter}
+        onChange={(_event, value) => onChange(value)}
+        onClear={() => onChange('')}
+        className="pf-v5-u-mb-md"
+      />
+      {filteredBlueprints?.map((blueprint: Blueprint) => (
+        <>
+          <BlueprintCard
+            key={blueprint.id}
+            blueprint={blueprint}
+            selectedBlueprint={selectedBlueprint}
+            setSelectedBlueprint={setSelectedBlueprint}
+          />
+          <br />
+        </>
+      ))}
+    </>
+  );
+};
+
+export default BlueprintsSidebar;

--- a/src/Components/Blueprints/BlueprintsSidebar.tsx
+++ b/src/Components/Blueprints/BlueprintsSidebar.tsx
@@ -76,7 +76,6 @@ const BlueprintsSidebar = (props: blueprintProps) => {
             selectedBlueprint={props.selectedBlueprint}
             setSelectedBlueprint={props.setSelectedBlueprint}
           />
-          <br />
         </>
       ))}
     </>

--- a/src/Components/Blueprints/BlueprintsSidebar.tsx
+++ b/src/Components/Blueprints/BlueprintsSidebar.tsx
@@ -1,25 +1,30 @@
-/* eslint-disable no-console */
-import React, { useState } from 'react';
+import React, { useState, Dispatch, SetStateAction } from 'react';
 
 import { SearchInput } from '@patternfly/react-core';
 
 import BlueprintCard from './BlueprintCard';
 
-import { useGetBlueprintsQuery } from '../../store/imageBuilderApiExperimental';
 import { Blueprint } from '../../store/imageBuilderApiExperimental';
 
-const BlueprintsSidebar: React.FunctionComponent = () => {
-  const { data: blueprints } = useGetBlueprintsQuery('');
+interface blueprintProps {
+  blueprints: Blueprint[];
+  selectedBlueprint: string;
+  setSelectedBlueprint: Dispatch<SetStateAction<string>>;
+}
+const BlueprintsSidebar = (props: blueprintProps) => {
   const [blueprintFilter, setBlueprintFilter] = useState('');
-  const [selectedBlueprint, setSelectedBlueprint] = useState('');
 
   const onChange = (value: string) => {
     setBlueprintFilter(value);
   };
 
-  const filteredBlueprints = blueprints?.filter((blueprint: Blueprint) => {
-    return blueprint.name.toLowerCase().includes(blueprintFilter.toLowerCase());
-  });
+  const filteredBlueprints = props.blueprints?.filter(
+    (blueprint: Blueprint) => {
+      return blueprint.name
+        .toLowerCase()
+        .includes(blueprintFilter.toLowerCase());
+    }
+  );
 
   return (
     <>
@@ -35,8 +40,8 @@ const BlueprintsSidebar: React.FunctionComponent = () => {
           <BlueprintCard
             key={blueprint.id}
             blueprint={blueprint}
-            selectedBlueprint={selectedBlueprint}
-            setSelectedBlueprint={setSelectedBlueprint}
+            selectedBlueprint={props.selectedBlueprint}
+            setSelectedBlueprint={props.setSelectedBlueprint}
           />
           <br />
         </>

--- a/src/Components/Blueprints/BlueprintsSidebar.tsx
+++ b/src/Components/Blueprints/BlueprintsSidebar.tsx
@@ -5,8 +5,8 @@ import { SearchInput } from '@patternfly/react-core';
 
 import BlueprintCard from './BlueprintCard';
 
-import { useGetBlueprintsQuery } from '../../store/imageBuilderApi';
-import { Blueprint } from '../../store/imageBuilderApi';
+import { useGetBlueprintsQuery } from '../../store/imageBuilderApiExperimental';
+import { Blueprint } from '../../store/imageBuilderApiExperimental';
 
 const BlueprintsSidebar: React.FunctionComponent = () => {
   const { data: blueprints } = useGetBlueprintsQuery('');

--- a/src/Components/CreateImageWizard/CreateBlueprintWizard.js
+++ b/src/Components/CreateImageWizard/CreateBlueprintWizard.js
@@ -612,7 +612,7 @@ const CreateBlueprintWizard = () => {
 
   return (
     <>
-      <ImageBuilderHeader />
+      <ImageBuilderHeader noButtons={true} />
       <section className="pf-l-page__main-section pf-c-page__main-section">
         <ImageCreator
           onClose={handleClose}

--- a/src/Components/CreateImageWizard/CreateBlueprintWizard.js
+++ b/src/Components/CreateImageWizard/CreateBlueprintWizard.js
@@ -1,0 +1,686 @@
+import React from 'react';
+
+import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
+import { useFlag } from '@unleash/proxy-client-react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import ImageCreator from './ImageCreator';
+import {
+  awsTarget,
+  fileSystemConfiguration,
+  googleCloudTarget,
+  imageOutput,
+  msAzureTarget,
+  packages,
+  packagesContentSources,
+  registration,
+  repositories,
+  review,
+  oscap,
+  blueprintName,
+} from './steps';
+import {
+  fileSystemConfigurationValidator,
+  targetEnvironmentValidator,
+} from './validators';
+
+import './CreateImageWizard.scss';
+import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../constants';
+import {
+  useCreateBlueprintMutation,
+  useGetArchitecturesQuery,
+} from '../../store/imageBuilderApi';
+import isRhel from '../../Utilities/isRhel';
+import { resolveRelPath } from '../../Utilities/path';
+import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
+import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
+
+const handleKeyDown = (e, handleClose) => {
+  if (e.key === 'Escape') {
+    handleClose();
+  }
+};
+
+const onSave = (values) => {
+  const customizations = {
+    packages: values['selected-packages']?.map((p) => p.name),
+  };
+
+  if (values['payload-repositories']?.length > 0) {
+    customizations['payload_repositories'] = [
+      ...values['payload-repositories'],
+    ];
+  }
+
+  if (values['custom-repositories']?.length > 0) {
+    customizations['custom_repositories'] = [...values['custom-repositories']];
+  }
+
+  if (values['register-system'] === 'register-now-rhc') {
+    customizations.subscription = {
+      'activation-key': values['subscription-activation-key'],
+      insights: true,
+      rhc: true,
+      organization: Number(values['subscription-organization-id']),
+      'server-url': values['subscription-server-url'],
+      'base-url': values['subscription-base-url'],
+    };
+  } else if (values['register-system'] === 'register-now-insights') {
+    customizations.subscription = {
+      'activation-key': values['subscription-activation-key'],
+      insights: true,
+      organization: Number(values['subscription-organization-id']),
+      'server-url': values['subscription-server-url'],
+      'base-url': values['subscription-base-url'],
+    };
+  } else if (values['register-system'] === 'register-now') {
+    customizations.subscription = {
+      'activation-key': values['subscription-activation-key'],
+      insights: false,
+      organization: Number(values['subscription-organization-id']),
+      'server-url': values['subscription-server-url'],
+      'base-url': values['subscription-base-url'],
+    };
+  }
+
+  if (values['file-system-config-radio'] === 'manual') {
+    customizations.filesystem = [];
+    for (const fsc of values['file-system-configuration']) {
+      customizations.filesystem.push({
+        mountpoint: fsc.mountpoint,
+        min_size: fsc.size * fsc.unit,
+      });
+    }
+  }
+
+  if (values['oscap-profile']) {
+    customizations.openscap = {
+      profile_id: values['oscap-profile'],
+    };
+  }
+
+  const requests = [];
+  if (values['target-environment']?.aws) {
+    const options =
+      values['aws-target-type'] === 'aws-target-type-source'
+        ? { share_with_sources: [values['aws-sources-select']] }
+        : { share_with_accounts: [values['aws-account-id']] };
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: values['arch'],
+          image_type: 'aws',
+          upload_request: {
+            type: 'aws',
+            options,
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
+  if (values['target-environment']?.gcp) {
+    let share = '';
+    if (values['image_sharing'] === 'gcp-account') {
+      switch (values['google-account-type']) {
+        case 'googleAccount':
+          share = `user:${values['google-email']}`;
+          break;
+        case 'serviceAccount':
+          share = `serviceAccount:${values['google-email']}`;
+          break;
+        case 'googleGroup':
+          share = `group:${values['google-email']}`;
+          break;
+        case 'domain':
+          share = `domain:${values['google-domain']}`;
+          break;
+        // no default
+      }
+    }
+
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: values['arch'],
+          image_type: 'gcp',
+          upload_request: {
+            type: 'gcp',
+            options: {},
+          },
+        },
+      ],
+      customizations,
+    };
+
+    if (share !== '') {
+      request.options = [share];
+    }
+    requests.push(request);
+  }
+
+  if (values['target-environment']?.azure) {
+    const upload_options =
+      values['azure-type'] === 'azure-type-source'
+        ? { source_id: values['azure-sources-select'] }
+        : {
+            tenant_id: values['azure-tenant-id'],
+            subscription_id: values['azure-subscription-id'],
+          };
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: values['arch'],
+          image_type: 'azure',
+          upload_request: {
+            type: 'azure',
+            options: {
+              ...upload_options,
+              resource_group: values['azure-resource-group'],
+            },
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
+  if (values['target-environment']?.oci) {
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'oci',
+          upload_request: {
+            type: 'oci.objectstorage',
+            options: {},
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
+  if (values['target-environment']?.vsphere) {
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: values['arch'],
+          image_type: 'vsphere',
+          upload_request: {
+            type: 'aws.s3',
+            options: {},
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
+  if (values['target-environment']?.['vsphere-ova']) {
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: values['arch'],
+          image_type: 'vsphere-ova',
+          upload_request: {
+            type: 'aws.s3',
+            options: {},
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
+  if (values['target-environment']?.['guest-image']) {
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: values['arch'],
+          image_type: 'guest-image',
+          upload_request: {
+            type: 'aws.s3',
+            options: {},
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
+  if (values['target-environment']?.['image-installer']) {
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: values['arch'],
+          image_type: 'image-installer',
+          upload_request: {
+            type: 'aws.s3',
+            options: {},
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
+  if (values['target-environment']?.wsl) {
+    const request = {
+      distribution: values.release,
+      name: values?.['blueprint-name'],
+      description: values?.['blueprint-description'],
+      image_requests: [
+        {
+          architecture: values['arch'],
+          image_type: 'wsl',
+          upload_request: {
+            type: 'aws.s3',
+            options: {},
+          },
+        },
+      ],
+      customizations,
+    };
+    requests.push(request);
+  }
+
+  return requests;
+};
+
+const parseSizeUnit = (bytesize) => {
+  let size;
+  let unit;
+
+  if (bytesize % UNIT_GIB === 0) {
+    size = bytesize / UNIT_GIB;
+    unit = UNIT_GIB;
+  } else if (bytesize % UNIT_MIB === 0) {
+    size = bytesize / UNIT_MIB;
+    unit = UNIT_MIB;
+  } else if (bytesize % UNIT_KIB === 0) {
+    size = bytesize / UNIT_KIB;
+    unit = UNIT_KIB;
+  }
+
+  return [size, unit];
+};
+
+// map the blueprint request object to the expected form state
+const requestToState = (blueprintRequest, distroInfo, isProd, enableOscap) => {
+  if (blueprintRequest) {
+    const imageRequest = blueprintRequest.image_requests[0];
+    const uploadRequest = imageRequest.upload_request;
+    const formState = {};
+
+    formState['blueprint-name'] = blueprintRequest.image_name;
+    formState['blueprint-description'] = blueprintRequest.image_description;
+
+    formState.release = blueprintRequest?.distribution;
+    formState.arch = imageRequest.architecture;
+    // set defaults for target environment first
+    formState['target-environment'] = {
+      aws: false,
+      azure: false,
+      gcp: false,
+      oci: false,
+      'guest-image': false,
+    };
+    // then select the one from the request
+    // if the image type is to a cloud provider we use the upload_request.type
+    // or if the image is intended for download we use the image_type
+    let targetEnvironment;
+    if (
+      uploadRequest.type === 'aws.s3' ||
+      uploadRequest.type === 'oci.objectstorage'
+    ) {
+      targetEnvironment = imageRequest.image_type;
+    } else {
+      targetEnvironment = uploadRequest.type;
+    }
+
+    formState['target-environment'][targetEnvironment] = true;
+
+    if (targetEnvironment === 'aws') {
+      const shareWithSource = uploadRequest?.options?.share_with_sources?.[0];
+      const shareWithAccount = uploadRequest?.options?.share_with_accounts?.[0];
+      formState['aws-sources-select'] = shareWithSource;
+      formState['aws-account-id'] = shareWithAccount;
+      if (shareWithAccount && !shareWithSource) {
+        formState['aws-target-type'] = 'aws-target-type-account-id';
+      } else {
+        // if both shareWithAccount & shareWithSource are present, set radio
+        // to sources - this is essentially an arbitrary decision
+        // additionally, note that the source is not validated against the actual
+        // sources
+        formState['aws-target-type'] = 'aws-target-type-source';
+      }
+    } else if (targetEnvironment === 'azure') {
+      if (uploadRequest?.options?.source_id) {
+        formState['azure-type'] = 'azure-type-source';
+        formState['azure-sources-select'] = uploadRequest?.options?.source_id;
+      } else {
+        formState['azure-type'] = 'azure-type-manual';
+        formState['azure-tenant-id'] = uploadRequest?.options?.tenant_id;
+        formState['azure-subscription-id'] =
+          uploadRequest?.options?.subscription_id;
+      }
+      formState['azure-resource-group'] =
+        uploadRequest?.options?.resource_group;
+    } else if (targetEnvironment === 'gcp') {
+      // parse google account info
+      // roughly in the format `accountType:accountEmail`
+      const accountInfo = uploadRequest?.options?.share_with_accounts[0];
+      const [accountTypePrefix, account] = accountInfo.split(':');
+
+      switch (accountTypePrefix) {
+        case 'user':
+          formState['google-account-type'] = 'googleAccount';
+          formState['google-email'] = account;
+          break;
+        case 'serviceAccount':
+          formState['google-account-type'] = 'serviceAccount';
+          formState['google-email'] = account;
+          break;
+        case 'group':
+          formState['google-account-type'] = 'googleGroup';
+          formState['google-email'] = account;
+          break;
+        case 'domain':
+          formState['google-account-type'] = 'domain';
+          formState['google-domain'] = account;
+          break;
+        // no default
+      }
+    }
+
+    // customizations
+    // packages
+    const packages = blueprintRequest?.customizations?.packages?.map((name) => {
+      return {
+        name: name,
+        summary: undefined,
+      };
+    });
+    formState['selected-packages'] = packages;
+
+    // repositories
+    // 'original-payload-repositories' is treated as read-only and is used to populate
+    // the table in the repositories step
+    // This is necessary because there may be repositories present in the request's
+    // json blob that are not managed using the content sources API. In that case,
+    // they are still displayed in the table of repositories but without any information
+    // from the content sources API (in other words, only the URL of the repository is
+    // displayed). This information needs to persist throughout the lifetime of the
+    // Wizard as it is needed every time the repositories step is visited.
+    formState['original-payload-repositories'] =
+      blueprintRequest?.customizations?.payload_repositories;
+    // 'payload-repositories' is mutable and is used to generate the request
+    // sent to image-builder
+    formState['payload-repositories'] =
+      blueprintRequest?.customizations?.payload_repositories;
+
+    // these will be overwritten by the repositories step if revisited, and generated from the payload repositories added there
+    formState['custom-repositories'] =
+      blueprintRequest?.customizations?.custom_repositories;
+
+    // filesystem
+    const fs = blueprintRequest?.customizations?.filesystem;
+    if (fs) {
+      formState['file-system-config-radio'] = 'manual';
+      const fileSystemConfiguration = [];
+      for (const fsc of fs) {
+        const [size, unit] = parseSizeUnit(fsc.min_size);
+        fileSystemConfiguration.push({
+          mountpoint: fsc.mountpoint,
+          size,
+          unit,
+        });
+      }
+
+      formState['file-system-configuration'] = fileSystemConfiguration;
+    }
+
+    // subscription
+    const subscription = blueprintRequest?.customizations?.subscription;
+    if (subscription) {
+      if (subscription.rhc) {
+        formState['register-system'] = 'register-now-rhc';
+      } else if (subscription.insights) {
+        formState['register-system'] = 'register-now-insights';
+      } else {
+        formState['register-system'] = 'register-now';
+      }
+
+      formState['subscription-activation-key'] = subscription['activation-key'];
+      formState['subscription-organization-id'] = subscription.organization;
+
+      if (isProd) {
+        formState['subscription-server-url'] = 'subscription.rhsm.redhat.com';
+        formState['subscription-base-url'] = 'https://cdn.redhat.com/';
+      } else {
+        formState['subscription-server-url'] =
+          'subscription.rhsm.stage.redhat.com';
+        formState['subscription-base-url'] = 'https://cdn.stage.redhat.com/';
+      }
+    } else {
+      formState['register-system'] = 'register-later';
+    }
+
+    if (enableOscap) {
+      formState['oscap-profile'] =
+        blueprintRequest?.customizations?.openscap?.profile_id;
+    }
+
+    return formState;
+  } else {
+    return;
+  }
+};
+
+const formStepHistory = (
+  blueprintRequest,
+  contentSourcesEnabled,
+  enableOscap
+) => {
+  if (blueprintRequest) {
+    const imageRequest = blueprintRequest.image_requests[0];
+    const uploadRequest = imageRequest.upload_request;
+    // the order of steps must match the order of the steps in the Wizard
+    const steps = ['image-output'];
+
+    if (uploadRequest.type === 'aws') {
+      steps.push('aws-target-env');
+    } else if (uploadRequest.type === 'azure') {
+      steps.push('ms-azure-target-env');
+    } else if (uploadRequest.type === 'gcp') {
+      steps.push('google-cloud-target-env');
+    }
+
+    if (isRhel(blueprintRequest?.distribution)) {
+      steps.push('registration');
+    }
+
+    if (enableOscap) {
+      steps.push('Compliance');
+    }
+
+    if (contentSourcesEnabled) {
+      steps.push('File system configuration', 'packages', 'repositories');
+
+      const customRepositories =
+        blueprintRequest.customizations?.payload_repositories;
+      if (customRepositories) {
+        steps.push('packages-content-sources');
+      }
+    } else {
+      steps.push('File system configuration', 'packages');
+    }
+    steps.push('details');
+
+    return steps;
+  } else {
+    return [];
+  }
+};
+
+const CreateBlueprintWizard = () => {
+  const [createBlueprint] = useCreateBlueprintMutation();
+  const navigate = useNavigate();
+  const { blueprintId } = useParams();
+  // there is currently no way to get a specific blueprint by id
+  const data = undefined;
+  const blueprintRequest = blueprintId ? data?.request : undefined;
+  const contentSourcesEnabled = useFlag('image-builder.enable-content-sources');
+
+  // TODO: This causes an annoying re-render when using Recreate image
+  const { data: distroInfo } = useGetArchitecturesQuery({
+    distribution: blueprintRequest?.distribution,
+  });
+
+  // Assume that if a request is available that we should start on review step
+  // This will occur if 'Recreate image' is clicked
+  const initialStep = blueprintRequest ? 'review' : undefined;
+
+  const { isBeta, isProd } = useGetEnvironment();
+
+  // Only allow oscap to be used in Beta even if the flag says the feature is
+  // activated.
+  const oscapFeatureFlag =
+    useFlag('image-builder.wizard.oscap.enabled') && isBeta();
+  let initialState = requestToState(
+    blueprintRequest,
+    distroInfo,
+    isProd(),
+    oscapFeatureFlag
+  );
+  const stepHistory = formStepHistory(
+    blueprintRequest,
+    contentSourcesEnabled,
+    oscapFeatureFlag
+  );
+
+  if (initialState) {
+    initialState.isBeta = isBeta();
+    initialState.contentSourcesEnabled = contentSourcesEnabled;
+    initialState.enableOscap = oscapFeatureFlag;
+  } else {
+    initialState = {
+      isBeta: isBeta(),
+      enableOscap: oscapFeatureFlag,
+      contentSourcesEnabled,
+    };
+  }
+
+  const handleClose = () => navigate(resolveRelPath(''));
+
+  // In case the `created_at` date is undefined when creating an image
+  // a temporary value with current date is added
+  const currentDate = new Date();
+
+  return (
+    <>
+      <ImageBuilderHeader />
+      <section className="pf-l-page__main-section pf-c-page__main-section">
+        <ImageCreator
+          onClose={handleClose}
+          onSubmit={async ({ values, setIsSaving }) => {
+            setIsSaving(true);
+            const requests = onSave(values);
+            await Promise.allSettled(
+              requests.map((blueprintRequest) =>
+                createBlueprint({ blueprintRequest })
+              )
+            );
+            navigate(resolveRelPath(''));
+          }}
+          defaultArch="x86_64"
+          customValidatorMapper={{
+            fileSystemConfigurationValidator,
+            targetEnvironmentValidator,
+          }}
+          schema={{
+            fields: [
+              {
+                component: componentTypes.WIZARD,
+                name: 'blueprint-builder-wizard',
+                className: 'blueprintBuilder',
+                isDynamic: true,
+                inModal: false,
+                onKeyDown: (e) => {
+                  handleKeyDown(e, handleClose);
+                },
+                buttonLabels: {
+                  submit: 'Create blueprint',
+                },
+                showTitles: true,
+                crossroads: [
+                  'target-environment',
+                  'release',
+                  'payload-repositories',
+                ],
+                // order in this array does not reflect order in wizard nav, this order is managed inside
+                // of each step by `nextStep` property!
+                fields: [
+                  imageOutput,
+                  awsTarget,
+                  googleCloudTarget,
+                  msAzureTarget,
+                  registration,
+                  packages,
+                  packagesContentSources,
+                  repositories,
+                  fileSystemConfiguration,
+                  blueprintName,
+                  review,
+                  oscap,
+                ],
+                initialState: {
+                  activeStep: initialStep || 'image-output', // name of the active step
+                  activeStepIndex: stepHistory.length, // active index
+                  maxStepIndex: stepHistory.length, // max achieved index
+                  prevSteps: stepHistory, // array with names of previously visited steps
+                },
+              },
+            ],
+          }}
+          initialValues={initialState}
+        />
+      </section>
+    </>
+  );
+};
+
+export default CreateBlueprintWizard;

--- a/src/Components/CreateImageWizard/CreateBlueprintWizard.js
+++ b/src/Components/CreateImageWizard/CreateBlueprintWizard.js
@@ -606,10 +606,6 @@ const CreateBlueprintWizard = () => {
 
   const handleClose = () => navigate(resolveRelPath(''));
 
-  // In case the `created_at` date is undefined when creating an image
-  // a temporary value with current date is added
-  const currentDate = new Date();
-
   return (
     <>
       <ImageBuilderHeader noButtons={true} />

--- a/src/Components/CreateImageWizard/CreateBlueprintWizard.js
+++ b/src/Components/CreateImageWizard/CreateBlueprintWizard.js
@@ -643,7 +643,7 @@ const CreateBlueprintWizard = () => {
                   handleKeyDown(e, handleClose);
                 },
                 buttonLabels: {
-                  submit: 'Create blueprint',
+                  submit: 'Create',
                 },
                 showTitles: true,
                 crossroads: [

--- a/src/Components/CreateImageWizard/steps/blueprintName.js
+++ b/src/Components/CreateImageWizard/steps/blueprintName.js
@@ -36,6 +36,7 @@ const blueprintNameStep = {
     {
       component: componentTypes.TEXT_FIELD,
       name: 'blueprint-name',
+      isRequired: true,
       type: 'text',
       label: 'Blueprint Name',
       placeholder: 'Blueprint Name',

--- a/src/Components/CreateImageWizard/steps/blueprintName.js
+++ b/src/Components/CreateImageWizard/steps/blueprintName.js
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import componentTypes from '@data-driven-forms/react-form-renderer/component-types';
+import validatorTypes from '@data-driven-forms/react-form-renderer/validator-types';
+import { Flex, FlexItem, Text } from '@patternfly/react-core';
+
+import StepTemplate from './stepTemplate';
+
+import CustomButtons from '../formComponents/CustomButtons';
+
+const CharacterCount = () => {
+  const { getState } = useFormApi();
+  const description = getState().values?.['blueprint-description'];
+  return <h1>{description?.length || 0}/250</h1>;
+};
+
+const blueprintNameStep = {
+  StepTemplate,
+  id: 'wizard-details',
+  name: 'details',
+  title: 'Details',
+  nextStep: 'review',
+  buttons: CustomButtons,
+  fields: [
+    {
+      component: componentTypes.PLAIN_TEXT,
+      name: 'plain-text-component',
+      label: (
+        <p>
+          Enter a name to identify your blueprint later quickly. If you do not
+          provide one, the UUID will be used as the name.
+        </p>
+      ),
+    },
+    {
+      component: componentTypes.TEXT_FIELD,
+      name: 'blueprint-name',
+      type: 'text',
+      label: 'Blueprint Name',
+      placeholder: 'Blueprint Name',
+      helperText:
+        'The blueprint name can be 3-63 characters long. It can contain lowercase letters, digits and hyphens, has to start with a letter and cannot end with a hyphen.',
+      autoFocus: true,
+      validate: [
+        {
+          type: validatorTypes.PATTERN,
+          pattern: /^[a-z][-a-z0-9]{1,61}[a-z0-9]$/,
+          message:
+            'The blueprint name can be 3-63 characters long. It can contain lowercase letters, digits and hyphens, has to start with a letter and cannot end with a hyphen.',
+        },
+      ],
+    },
+    {
+      component: componentTypes.TEXTAREA,
+      name: 'blueprint-description',
+      type: 'text',
+      label: (
+        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+          <FlexItem>
+            <Text component={'b'}>Description</Text>
+          </FlexItem>
+          <FlexItem>
+            <CharacterCount />
+          </FlexItem>
+        </Flex>
+      ),
+      placeholder: 'Add Description',
+      resizeOrientation: 'vertical',
+      validate: [{ type: validatorTypes.MAX_LENGTH, threshold: 250 }],
+    },
+  ],
+};
+
+export default blueprintNameStep;

--- a/src/Components/CreateImageWizard/steps/index.js
+++ b/src/Components/CreateImageWizard/steps/index.js
@@ -11,3 +11,4 @@ export { default as imageOutput } from './imageOutput';
 export { default as nextStepMapper } from './imageOutputStepMapper';
 export { default as fileSystemConfiguration } from './fileSystemConfiguration';
 export { default as imageName } from './imageName';
+export { default as blueprintName } from './blueprintName';

--- a/src/Components/ImagesTable/ImagesTable.scss
+++ b/src/Components/ImagesTable/ImagesTable.scss
@@ -11,3 +11,7 @@
         text-decoration: none;
     }
 }
+
+.pf-v5-c-toolbar {
+    padding-top: 0;
+}

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -36,6 +36,7 @@ import {
   Thead,
   Tr,
 } from '@patternfly/react-table';
+import { useFlag } from '@unleash/proxy-client-react';
 import { Link, NavigateFunction, useNavigate } from 'react-router-dom';
 
 import './ImagesTable.scss';
@@ -87,7 +88,8 @@ const ImagesTable = (props: imagesTableProps) => {
     version: [],
   });
 
-  const experimentalFlag = process.env.EXPERIMENTAL;
+  const experimentalFlag =
+    useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL;
 
   const selectedBlueprintName = props.blueprints?.find(
     (blueprint: Blueprint) => blueprint.id === props.selectedBlueprint

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -78,13 +78,15 @@ const ImagesTable = (props: imagesTableProps) => {
   const [perPage, setPerPage] = useState(10);
   const [isTypeSelectOpen, setIsTypeSelectOpen] = useState(false);
   const [isVersionSelectOpen, setIsVersionSelectOpen] = useState(false);
-  const [filters, setFilters] = useState<{
+  interface filterProps {
     imageType: string[];
     version: string[];
-  }>({
+  }
+  const [filters, setFilters] = useState<filterProps>({
     imageType: [],
     version: [],
   });
+
   const experimentalFlag = process.env.EXPERIMENTAL;
 
   const selectedBlueprintName = props.blueprints?.find(
@@ -93,12 +95,12 @@ const ImagesTable = (props: imagesTableProps) => {
 
   const onSelect = (
     selectType: string,
-    event: React.MouseEvent | React.ChangeEvent | any,
+    event: React.MouseEvent | React.ChangeEvent | undefined,
     selection: string
   ) => {
-    const checked = (event.target as HTMLInputElement).checked;
-    setFilters((prev: any) => {
-      const prevSelections = prev[selectType];
+    const checked = (event?.target as HTMLInputElement).checked;
+    setFilters((prev: filterProps) => {
+      const prevSelections = prev[selectType as keyof filterProps];
       return {
         ...prev,
         [selectType]: checked
@@ -109,14 +111,14 @@ const ImagesTable = (props: imagesTableProps) => {
   };
 
   const onTypeSelect = (
-    event: React.MouseEvent | React.ChangeEvent | any,
+    event: React.MouseEvent | React.ChangeEvent | undefined,
     selection: string
   ) => {
     onSelect('imageType', event, selection);
   };
 
   const onVersionSelect = (
-    event: React.MouseEvent | React.ChangeEvent | any,
+    event: React.MouseEvent | React.ChangeEvent | undefined,
     selection: string
   ) => {
     onSelect('version', event, selection);

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -10,6 +10,11 @@ import {
   Text,
   TextContent,
   TabAction,
+  PageSection,
+  PageSectionVariants,
+  Sidebar,
+  SidebarContent,
+  SidebarPanel,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons';
 import { useFlag } from '@unleash/proxy-client-react';
@@ -21,6 +26,7 @@ import Quickstarts from './Quickstarts';
 
 import { manageEdgeImagesUrlName } from '../../Utilities/edge';
 import { resolveRelPath } from '../../Utilities/path';
+import BlueprintsSidebar from '../Blueprints/BlueprintsSidebar';
 import EdgeImagesTable from '../edge/ImagesTable';
 import ImagesTable from '../ImagesTable/ImagesTable';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
@@ -47,13 +53,41 @@ export const LandingPage = () => {
   };
 
   const edgeParityFlag = useFlag('edgeParity.image-list');
-  const traditionalImageList = (
-    <section className="pf-l-page__main-section pf-c-page__main-section">
-      <Quickstarts />
+  const experimentalFlag = process.env.EXPERIMENTAL;
 
-      <ImagesTable />
-    </section>
+  const traditionalImageList = (
+    <>
+      <PageSection>
+        <Quickstarts />
+      </PageSection>
+      <PageSection>
+        <ImagesTable />
+      </PageSection>
+    </>
   );
+
+  const experimentalImageList = (
+    <>
+      <PageSection>
+        <Quickstarts />
+      </PageSection>
+      <PageSection variant={PageSectionVariants.light}>
+        <Sidebar hasBorder hasGutter>
+          <SidebarPanel>
+            <BlueprintsSidebar />
+          </SidebarPanel>
+          <SidebarContent>
+            <ImagesTable />
+          </SidebarContent>
+        </Sidebar>
+      </PageSection>
+    </>
+  );
+
+  const imageList = experimentalFlag
+    ? experimentalImageList
+    : traditionalImageList;
+
   return (
     <>
       <ImageBuilderHeader />
@@ -99,7 +133,7 @@ export const LandingPage = () => {
               />
             }
           >
-            {traditionalImageList}
+            {imageList}
           </Tab>
           <Tab
             eventKey={1}
@@ -147,7 +181,7 @@ export const LandingPage = () => {
           </Tab>
         </Tabs>
       ) : (
-        traditionalImageList
+        imageList
       )}
       <Outlet />
     </>

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -71,8 +71,12 @@ export const LandingPage = () => {
       <PageSection>
         <Quickstarts />
       </PageSection>
-      <PageSection variant={PageSectionVariants.light}>
-        <Sidebar hasBorder hasGutter>
+      <PageSection>
+        <Sidebar
+          hasBorder
+          hasGutter
+          className="pf-v5-u-background-color-100 pf-v5-u-p-lg"
+        >
           <SidebarPanel>
             <BlueprintsSidebar />
           </SidebarPanel>

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -55,7 +55,8 @@ export const LandingPage = () => {
   const [selectedBlueprint, setSelectedBlueprint] = useState<string>('');
 
   const edgeParityFlag = useFlag('edgeParity.image-list');
-  const experimentalFlag = process.env.EXPERIMENTAL;
+  const experimentalFlag =
+    useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL;
 
   const traditionalImageList = (
     <>

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -11,7 +11,6 @@ import {
   TextContent,
   TabAction,
   PageSection,
-  PageSectionVariants,
   Sidebar,
   SidebarContent,
   SidebarPanel,

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -24,6 +24,7 @@ import './LandingPage.scss';
 
 import Quickstarts from './Quickstarts';
 
+import { useGetBlueprintsQuery } from '../../store/imageBuilderApiExperimental';
 import { manageEdgeImagesUrlName } from '../../Utilities/edge';
 import { resolveRelPath } from '../../Utilities/path';
 import BlueprintsSidebar from '../Blueprints/BlueprintsSidebar';
@@ -51,6 +52,8 @@ export const LandingPage = () => {
     }
     setActiveTabKey(tabIndex);
   };
+  const { data: blueprints } = useGetBlueprintsQuery('');
+  const [selectedBlueprint, setSelectedBlueprint] = useState<string>('');
 
   const edgeParityFlag = useFlag('edgeParity.image-list');
   const experimentalFlag = process.env.EXPERIMENTAL;
@@ -78,10 +81,18 @@ export const LandingPage = () => {
           className="pf-v5-u-background-color-100 pf-v5-u-p-lg"
         >
           <SidebarPanel>
-            <BlueprintsSidebar />
+            <BlueprintsSidebar
+              blueprints={blueprints}
+              selectedBlueprint={selectedBlueprint}
+              setSelectedBlueprint={setSelectedBlueprint}
+            />
           </SidebarPanel>
           <SidebarContent>
-            <ImagesTable />
+            <ImagesTable
+              blueprints={blueprints}
+              selectedBlueprint={selectedBlueprint}
+              setSelectedBlueprint={setSelectedBlueprint}
+            />
           </SidebarContent>
         </Sidebar>
       </PageSection>

--- a/src/Components/LandingPage/Quickstarts.tsx
+++ b/src/Components/LandingPage/Quickstarts.tsx
@@ -13,7 +13,7 @@ export const Quickstarts = () => {
 
   return (
     <ExpandableSection
-      className="pf-m-light pf-u-mb-xl expand-section"
+      className="pf-m-light expand-section"
       toggleText="Help get started with new features"
       onToggle={(_event, val) => setShowHint(val)}
       isExpanded={showHint}

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -92,7 +92,7 @@ export const ImageBuilderHeader = () => {
                 className="pf-c-button pf-m-primary pf-u-mr-md"
                 data-testid="create-blueprint-action"
               >
-                Create blueprint
+                Create
               </Link>
             )}
             <Link
@@ -100,7 +100,7 @@ export const ImageBuilderHeader = () => {
               className="pf-c-button pf-m-primary"
               data-testid="create-image-action"
             >
-              Create image
+              Build images
             </Link>
           </FlexItem>
         </Flex>

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -15,13 +15,15 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
+import { useFlag } from '@unleash/proxy-client-react';
 import { Link } from 'react-router-dom';
 
 import './ImageBuilderHeader.scss';
 import { resolveRelPath } from '../../Utilities/path';
 
 export const ImageBuilderHeader = (props: { noButtons?: boolean }) => {
-  const experimentalFlag = process.env.EXPERIMENTAL;
+  const experimentalFlag =
+    useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL;
   return (
     <>
       {/*@ts-ignore*/}

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 
-import { Button, Popover, Text, TextContent } from '@patternfly/react-core';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Popover,
+  Text,
+  TextContent,
+} from '@patternfly/react-core';
 import { ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons';
 // eslint-disable-next-line rulesdir/disallow-fec-relative-imports
 import {
@@ -8,70 +15,95 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
+import { Link } from 'react-router-dom';
 
 import './ImageBuilderHeader.scss';
+import { resolveRelPath } from '../../Utilities/path';
 
 export const ImageBuilderHeader = () => {
+  const experimentalFlag = process.env.EXPERIMENTAL;
   return (
     <>
       {/*@ts-ignore*/}
       <PageHeader>
-        <PageHeaderTitle className="title" title="Image Builder" />
-        <Popover
-          minWidth="35rem"
-          headerContent={'About image builder'}
-          bodyContent={
-            <TextContent>
-              <Text>
-                Image builder is a tool for creating deployment-ready customized
-                system images: installation disks, virtual machines, cloud
-                vendor-specific images, and others. By using image builder, you
-                can make these images faster than manual procedures because it
-                eliminates the specific configurations required for each output
-                type.
-              </Text>
-              <Text>
-                <Button
-                  component="a"
-                  target="_blank"
-                  variant="link"
-                  icon={<ExternalLinkAltIcon />}
-                  iconPosition="right"
-                  isInline
-                  href={
-                    'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_rhel_images_using_the_image_builder_service'
-                  }
-                >
-                  Image builder for RPM-DNF documentation
-                </Button>
-              </Text>
-              <Text>
-                <Button
-                  component="a"
-                  target="_blank"
-                  variant="link"
-                  icon={<ExternalLinkAltIcon />}
-                  iconPosition="right"
-                  isInline
-                  href={
-                    'https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/index'
-                  }
-                >
-                  Image builder for OSTree documentation
-                </Button>
-              </Text>
-            </TextContent>
-          }
-        >
-          <Button
-            variant="plain"
-            aria-label="About image builder"
-            className="pf-u-pl-sm header-button"
-          >
-            <HelpIcon />
-          </Button>
-        </Popover>
-        <OpenSourceBadge repositoriesURL="https://www.osbuild.org/guides/image-builder-service/architecture.html" />
+        <Flex>
+          <FlexItem>
+            <PageHeaderTitle className="title" title="Images" />
+            <Popover
+              minWidth="35rem"
+              headerContent={'About image builder'}
+              bodyContent={
+                <TextContent>
+                  <Text>
+                    Image builder is a tool for creating deployment-ready
+                    customized system images: installation disks, virtual
+                    machines, cloud vendor-specific images, and others. By using
+                    image builder, you can make these images faster than manual
+                    procedures because it eliminates the specific configurations
+                    required for each output type.
+                  </Text>
+                  <Text>
+                    <Button
+                      component="a"
+                      target="_blank"
+                      variant="link"
+                      icon={<ExternalLinkAltIcon />}
+                      iconPosition="right"
+                      isInline
+                      href={
+                        'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_rhel_images_using_the_image_builder_service'
+                      }
+                    >
+                      Image builder for RPM-DNF documentation
+                    </Button>
+                  </Text>
+                  <Text>
+                    <Button
+                      component="a"
+                      target="_blank"
+                      variant="link"
+                      icon={<ExternalLinkAltIcon />}
+                      iconPosition="right"
+                      isInline
+                      href={
+                        'https://access.redhat.com/documentation/en-us/edge_management/2022/html/create_rhel_for_edge_images_and_configure_automated_management/index'
+                      }
+                    >
+                      Image builder for OSTree documentation
+                    </Button>
+                  </Text>
+                </TextContent>
+              }
+            >
+              <Button
+                variant="plain"
+                aria-label="About image builder"
+                className="pf-u-pl-sm header-button"
+              >
+                <HelpIcon />
+              </Button>
+            </Popover>
+            <OpenSourceBadge repositoriesURL="https://www.osbuild.org/guides/image-builder-service/architecture.html" />
+          </FlexItem>
+          <FlexItem align={{ default: 'alignRight' }}>
+            {experimentalFlag && (
+              <Link
+                to={resolveRelPath('blueprintwizard')}
+                className="pf-c-button pf-m-primary pf-u-mr-md"
+                data-testid="create-blueprint-action"
+              >
+                Create blueprint
+              </Link>
+            )}
+            <Link
+              to={resolveRelPath('imagewizard')}
+              className="pf-c-button pf-m-primary"
+              data-testid="create-image-action"
+            >
+              Create image
+            </Link>
+          </FlexItem>
+        </Flex>
       </PageHeader>
     </>
   );

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -20,7 +20,7 @@ import { Link } from 'react-router-dom';
 import './ImageBuilderHeader.scss';
 import { resolveRelPath } from '../../Utilities/path';
 
-export const ImageBuilderHeader = () => {
+export const ImageBuilderHeader = (props: { noButtons?: boolean }) => {
   const experimentalFlag = process.env.EXPERIMENTAL;
   return (
     <>
@@ -85,24 +85,26 @@ export const ImageBuilderHeader = () => {
             </Popover>
             <OpenSourceBadge repositoriesURL="https://www.osbuild.org/guides/image-builder-service/architecture.html" />
           </FlexItem>
-          <FlexItem align={{ default: 'alignRight' }}>
-            {experimentalFlag && (
+          {!props.noButtons && (
+            <FlexItem align={{ default: 'alignRight' }}>
+              {experimentalFlag && (
+                <Link
+                  to={resolveRelPath('blueprintwizard')}
+                  className="pf-c-button pf-m-primary pf-u-mr-md"
+                  data-testid="create-blueprint-action"
+                >
+                  Create
+                </Link>
+              )}
               <Link
-                to={resolveRelPath('blueprintwizard')}
-                className="pf-c-button pf-m-primary pf-u-mr-md"
-                data-testid="create-blueprint-action"
+                to={resolveRelPath('imagewizard')}
+                className="pf-c-button pf-m-primary"
+                data-testid="create-image-action"
               >
-                Create
+                Build images
               </Link>
-            )}
-            <Link
-              to={resolveRelPath('imagewizard')}
-              className="pf-c-button pf-m-primary"
-              data-testid="create-image-action"
-            >
-              Build images
-            </Link>
-          </FlexItem>
+            </FlexItem>
+          )}
         </Flex>
       </PageHeader>
     </>

--- a/src/Router.js
+++ b/src/Router.js
@@ -3,13 +3,15 @@ import React, { lazy, Suspense } from 'react';
 import { useFlag } from '@unleash/proxy-client-react';
 import { Route, Routes } from 'react-router-dom';
 
-import EdgeImageDetail from './Components/edge/ImageDetails';
 import ShareImageModal from './Components/ShareImageModal/ShareImageModal';
 import { manageEdgeImagesUrlName } from './Utilities/edge';
 
 const LandingPage = lazy(() => import('./Components/LandingPage/LandingPage'));
 const CreateImageWizard = lazy(() =>
   import('./Components/CreateImageWizard/CreateImageWizard')
+);
+const CreateBlueprintWizard = lazy(() =>
+  import('./Components/CreateImageWizard/CreateBlueprintWizard')
 );
 const CreateImageWizardV2 = lazy(() =>
   import('./Components/CreateImageWizardV2/CreateImageWizard')
@@ -18,7 +20,7 @@ const CreateImageWizardV2 = lazy(() =>
 export const Router = () => {
   const edgeParityFlag = useFlag('edgeParity.image-list');
 
-  const experimentalWizard =
+  const experimental =
     useFlag('image-builder.new-wizard.enabled') ||
     process.env.EXPERIMENTAL === true;
   return (
@@ -33,30 +35,23 @@ export const Router = () => {
       >
         <Route path="share/:composeId" element={<ShareImageModal />} />
       </Route>
-
       <Route
         path="imagewizard/:composeId?"
         element={
           <Suspense>
-            {experimentalWizard ? (
-              <CreateImageWizardV2 />
-            ) : (
-              <CreateImageWizard />
-            )}
+            {experimental ? <CreateImageWizardV2 /> : <CreateImageWizard />}
           </Suspense>
         }
       />
-      {edgeParityFlag && (
+      {experimental && (
         <Route
-          path={`/${manageEdgeImagesUrlName}/:imageId`}
-          element={<EdgeImageDetail />}
-        >
-          <Route path="*" element={<EdgeImageDetail />} />
-          <Route
-            path={`versions/:imageVersionId/*`}
-            element={<EdgeImageDetail />}
-          />
-        </Route>
+          path="blueprintwizard/:blueprintId?"
+          element={
+            <Suspense>
+              <CreateBlueprintWizard />
+            </Suspense>
+          }
+        />
       )}
     </Routes>
   );

--- a/src/Router.js
+++ b/src/Router.js
@@ -4,7 +4,6 @@ import { useFlag } from '@unleash/proxy-client-react';
 import { Route, Routes } from 'react-router-dom';
 
 import ShareImageModal from './Components/ShareImageModal/ShareImageModal';
-import { manageEdgeImagesUrlName } from './Utilities/edge';
 
 const LandingPage = lazy(() => import('./Components/LandingPage/LandingPage'));
 const CreateImageWizard = lazy(() =>
@@ -18,8 +17,6 @@ const CreateImageWizardV2 = lazy(() =>
 );
 
 export const Router = () => {
-  const edgeParityFlag = useFlag('edgeParity.image-list');
-
   const experimental =
     useFlag('image-builder.new-wizard.enabled') ||
     process.env.EXPERIMENTAL === true;

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <title>Image Builder</title>
+        <title>Images</title>
         <esi:include src="/@@env/chrome/snippets/head.html"/>
     </head>
     <body>

--- a/src/store/emptyImageBuilderApiExperimental.ts
+++ b/src/store/emptyImageBuilderApiExperimental.ts
@@ -1,0 +1,39 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+import { IMAGE_BUILDER_API } from '../constants';
+
+// initialize an empty api service that we'll inject endpoints into later as needed
+export const emptyImageBuilderApiExperimental = createApi({
+  reducerPath: 'imageBuilderApiExperimental',
+  baseQuery: fetchBaseQuery({
+    baseUrl: IMAGE_BUILDER_API,
+    paramsSerializer: (params) => {
+      /*
+       * Image builder backend requires the arrays in get requests to be
+       * exploded, see the default behavior for swagger in the documentation:
+       * https://swagger.io/docs/specification/serialization/
+       *
+       * To accommodate to that, make sure that when the request is sent with
+       * an array we do explode properly unlike the default behavior of
+       * URLSearchParams.
+       */
+      const searchParams = new URLSearchParams();
+      for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) {
+          // avoid sending undefined parameters
+          continue;
+        }
+        if (Array.isArray(value)) {
+          for (const v of value) {
+            searchParams.append(key, v);
+          }
+        } else {
+          searchParams.append(key, value);
+        }
+      }
+
+      return searchParams.toString();
+    },
+  }),
+  endpoints: () => ({}),
+});

--- a/src/store/imageBuilderApiExperimental.ts
+++ b/src/store/imageBuilderApiExperimental.ts
@@ -1,0 +1,24 @@
+import { emptyImageBuilderApiExperimental as api } from './emptyImageBuilderApiExperimental';
+import { Distributions, ImageRequest, Customizations } from './imageBuilderApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getBlueprints: build.query({
+      query: () => ({
+        url: `/experimental/blueprint`,
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as imageBuilderApiExperimental };
+export type GetBlueprintsApiResponse = GetBlueprintsResponse;
+export type Blueprint = {
+  id: string;
+  name: string;
+  description: string;
+  distribution: Distributions;
+  image_requests: ImageRequest[];
+  customizations: Customizations;
+};
+export type GetBlueprintsResponse = Blueprint[];
+export const { useGetBlueprintsQuery } = injectedRtkApi;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import promiseMiddleware from 'redux-promise-middleware';
 import { contentSourcesApi } from './contentSourcesApi';
 import { edgeApi } from './edgeApi';
 import { imageBuilderApi } from './enhancedImageBuilderApi';
+import { imageBuilderApiExperimental } from './imageBuilderApiExperimental';
 import { listenerMiddleware, startAppListening } from './listenerMiddleware';
 import { provisioningApi } from './provisioningApi';
 import { rhsmApi } from './rhsmApi';
@@ -21,6 +22,8 @@ export const reducer = {
   [contentSourcesApi.reducerPath]: contentSourcesApi.reducer,
   [edgeApi.reducerPath]: edgeApi.reducer,
   [imageBuilderApi.reducerPath]: imageBuilderApi.reducer,
+  [imageBuilderApiExperimental.reducerPath]:
+    imageBuilderApiExperimental.reducer,
   [rhsmApi.reducerPath]: rhsmApi.reducer,
   [provisioningApi.reducerPath]: provisioningApi.reducer,
   notifications: notificationsReducer,
@@ -90,6 +93,7 @@ export const middleware = (getDefaultMiddleware: Function) =>
       promiseMiddleware,
       contentSourcesApi.middleware,
       imageBuilderApi.middleware,
+      imageBuilderApiExperimental.middleware,
       rhsmApi.middleware,
       provisioningApi.middleware
     );

--- a/src/test/Components/Blueprints/BlueprintsSidebar.test.js
+++ b/src/test/Components/Blueprints/BlueprintsSidebar.test.js
@@ -1,0 +1,90 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { useFlag } from '@unleash/proxy-client-react';
+
+import { renderWithReduxRouter } from '../../testUtils';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    isBeta: () => false,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
+jest.mock('@unleash/proxy-client-react', () => ({
+  useUnleashContext: () => jest.fn(),
+  useFlag: jest.fn((flag) =>
+    flag === 'image-builder.new-wizard.enabled' ? true : false
+  ),
+}));
+
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
+
+describe('mocking unleash calls', () => {
+  test('new wizard flag is set to true', () => {
+    const experimentalWizard = useFlag('image-builder.new-wizard.enabled');
+    expect(experimentalWizard).toBe(true);
+  });
+});
+
+describe('Blueprint sidebar', () => {
+  const user = userEvent.setup();
+  test('renders BlueprintsSidebar component', async () => {
+    await renderWithReduxRouter('', {});
+    await screen.findByTestId('images-table');
+
+    // Check if the search input is rendered
+    await screen.findByPlaceholderText('Search by blueprint name');
+
+    // Check if the blueprints are rendered
+    screen.getByText('blueprint1');
+    screen.getByText('blueprint2');
+  });
+
+  test('filters blueprints based on search input', async () => {
+    renderWithReduxRouter('', {});
+    await screen.findByTestId('images-table');
+
+    // Enter search query
+    const searchInput = await screen.findByPlaceholderText(
+      'Search by blueprint name'
+    );
+    await user.type(searchInput, 'blueprint1');
+
+    // Check if only the matching blueprint is rendered
+    const blueprintCard1 = screen.getByText('blueprint1');
+    expect(blueprintCard1).toBeInTheDocument();
+
+    const blueprintCard2 = screen.queryByText('blueprint2');
+    expect(blueprintCard2).not.toBeInTheDocument();
+  });
+
+  test('filters images based on selected blueprint', async () => {
+    renderWithReduxRouter('', {});
+    await screen.findByTestId('images-table');
+
+    // Select first blueprint radio button
+    const blueprintInput = screen.getAllByRole('radio')[0];
+    await user.click(blueprintInput);
+
+    // Check if the images are rendered
+    const firstImage = screen.getByText('test-image-name');
+    expect(firstImage).toBeInTheDocument();
+
+    const secondImage = screen.getByRole('cell', {
+      name: 'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa',
+    });
+    expect(secondImage).toBeInTheDocument();
+
+    // expected this image to be filtered out
+    const filteredBlueprint = screen.queryByText(
+      'edbae1c2-62bc-42c1-ae0c-3110ab718f58'
+    );
+    expect(filteredBlueprint).not.toBeInTheDocument();
+  });
+});

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -114,7 +114,7 @@ describe('Create Image Wizard', () => {
   test('renders component', async () => {
     renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
     // check heading
-    await screen.findByRole('heading', { name: /Image Builder/ });
+    await screen.findByRole('heading', { name: /Images/ });
 
     await screen.findByRole('button', { name: 'Image output' });
     await screen.findByRole('button', { name: 'Register' });

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -115,7 +115,7 @@ describe('Create Image Wizard', () => {
   test('renders component', async () => {
     renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
     // check heading
-    await screen.findByRole('heading', { name: /Image Builder/ });
+    await screen.findByRole('heading', { name: /Images/ });
 
     await screen.findByRole('button', { name: 'Image output' });
     await screen.findByRole('button', { name: 'Register' });

--- a/src/test/Components/LandingPage/LandingPage.test.js
+++ b/src/test/Components/LandingPage/LandingPage.test.js
@@ -24,7 +24,7 @@ describe('Landing Page', () => {
     renderWithReduxRouter('', {});
 
     // check heading
-    await screen.findByRole('heading', { name: /Image Builder/i });
+    await screen.findByRole('heading', { name: /Images/i });
   });
 
   test('renders EmptyState child component', async () => {

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -1,0 +1,54 @@
+import { RHEL_9 } from '../../constants';
+import {
+  CreateBlueprintResponse,
+  GetBlueprintsResponse,
+} from '../../store/imageBuilderApi';
+
+export const mockBlueprints: CreateBlueprintResponse[] = [
+  {
+    id: '677b010b-e95e-4694-9813-d11d847f1bfc',
+  },
+];
+
+export const mockGetBlueprints = (): GetBlueprintsResponse => {
+  return [
+    {
+      id: '677b010b-e95e-4694-9813-d11d847f1bfc',
+      name: 'blueprint1',
+      description: 'description1',
+      distribution: RHEL_9,
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'aws',
+          upload_request: {
+            type: 'aws',
+            options: {
+              share_with_accounts: ['123123123123'],
+            },
+          },
+        },
+      ],
+      customizations: {},
+    },
+    {
+      id: '677b010b-e95e-4694-9813-d11d847f1bfd',
+      name: 'blueprint2',
+      description: 'description2',
+      distribution: RHEL_9,
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'aws',
+          upload_request: {
+            type: 'aws',
+            options: {
+              share_with_accounts: ['123123123123'],
+            },
+          },
+        },
+      ],
+      customizations: {},
+    },
+  ];
+};

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -1,8 +1,6 @@
 import { RHEL_9 } from '../../constants';
-import {
-  CreateBlueprintResponse,
-  GetBlueprintsResponse,
-} from '../../store/imageBuilderApi';
+import { CreateBlueprintResponse } from '../../store/imageBuilderApi';
+import { GetBlueprintsResponse } from '../../store/imageBuilderApiExperimental';
 
 export const mockBlueprints: CreateBlueprintResponse[] = [
   {

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -89,7 +89,7 @@ export const mockComposes: ComposesResponseItem[] = [
         },
       ],
     },
-    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc'
+    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc',
   },
   {
     id: 'edbae1c2-62bc-42c1-ae0c-3110ab718f58',
@@ -107,7 +107,7 @@ export const mockComposes: ComposesResponseItem[] = [
         },
       ],
     },
-    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfd'
+    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfd',
   },
   {
     id: '42ad0826-30b5-4f64-a24e-957df26fd564',

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -69,6 +69,7 @@ export const mockComposes: ComposesResponseItem[] = [
         },
       ],
     },
+    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc',
   },
   {
     id: 'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa',
@@ -88,6 +89,7 @@ export const mockComposes: ComposesResponseItem[] = [
         },
       ],
     },
+    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc'
   },
   {
     id: 'edbae1c2-62bc-42c1-ae0c-3110ab718f58',
@@ -105,6 +107,7 @@ export const mockComposes: ComposesResponseItem[] = [
         },
       ],
     },
+    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfd'
   },
   {
     id: '42ad0826-30b5-4f64-a24e-957df26fd564',

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -11,10 +11,7 @@ import {
   mockActivationKeysResults,
 } from '../fixtures/activationKeys';
 import { mockArchitecturesByDistro } from '../fixtures/architectures';
-import {
-  mockGetBlueprints,
-  mockGetBlueprintsTest,
-} from '../fixtures/blueprints';
+import { mockGetBlueprints } from '../fixtures/blueprints';
 import {
   composesEndpoint,
   mockClones,

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -12,6 +12,10 @@ import {
 } from '../fixtures/activationKeys';
 import { mockArchitecturesByDistro } from '../fixtures/architectures';
 import {
+  mockGetBlueprints,
+  mockGetBlueprintsTest,
+} from '../fixtures/blueprints';
+import {
   composesEndpoint,
   mockClones,
   mockCloneStatus,
@@ -107,4 +111,7 @@ export const handlers = [
       return res(ctx.status(200), ctx.json(oscapCustomizations(profile)));
     }
   ),
+  rest.get(`${IMAGE_BUILDER_API}/experimental/blueprint`, (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(mockGetBlueprints()));
+  }),
 ];


### PR DESCRIPTION
Blueprints can now be created through the Create Blueprint wizard. This is almost identical to the Create Image wizard except for a couple blueprint specific fields.

Created blueprints are shown in the blueprints sidebar where they can be filtered or selected.

This commit also includes improvements to the general UI per the recent design updates. The header is now Images, filtering has been added to the images table, and the Create Image button is moved to the header.

Given that in image-builder blueprints are still experimental these new features can be seen when running stage-beta:msw+experimental. The fixtures mimic blueprints even though the cannot currently be fetched from the service.

<img width="1632" alt="Screenshot 2023-12-13 at 02 46 17" src="https://github.com/RedHatInsights/image-builder-frontend/assets/11712857/ff489f65-43ed-4470-8182-0527081566fa">
