### PR TITLE
API/test: Remove getVersion() Axios call

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -37,16 +37,9 @@ async function getPackagesContentSources(repoUrls, search) {
   return packages;
 }
 
-async function getVersion() {
-  const path = '/version';
-  const request = await axios.get(IMAGE_BUILDER_API.concat(path));
-  return request.data;
-}
-
 const apiCalls = {
   getPackages,
   getPackagesContentSources,
-  getVersion,
 };
 
 export default apiCalls;

--- a/src/test/Components/LandingPage/LandingPage.test.js
+++ b/src/test/Components/LandingPage/LandingPage.test.js
@@ -24,8 +24,6 @@ describe('Landing Page', () => {
   test('renders page heading', async () => {
     renderWithReduxRouter('', {});
 
-    const composeImage = jest.spyOn(api, 'getVersion');
-    composeImage.mockResolvedValue({ version: '1.0' });
     // check heading
     screen.getByRole('heading', { name: /Image Builder/i });
   });


### PR DESCRIPTION
This removes `getVersion()` API call previously used in Axios.