### PR TITLE
api/imageBuilder: fix the alert in case of failure

### DIFF
--- a/src/store/enhancedImageBuilderApi.ts
+++ b/src/store/enhancedImageBuilderApi.ts
@@ -66,16 +66,16 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
             );
           })
           .catch((err) => {
-            let msg = err.response.statusText;
-            if (err.response.data?.errors[0]?.detail) {
-              msg = err.response.data?.errors[0]?.detail;
+            let msg = err.error.statusText;
+            if (err.error.data?.errors[0]?.detail) {
+              msg = err.error.data?.errors[0]?.detail;
             }
 
             dispatch(
               addNotification({
                 variant: 'danger',
                 title: 'Your image could not be created',
-                description: 'Status code ' + err.response.status + ': ' + msg,
+                description: 'Status code ' + err.error.status + ': ' + msg,
               })
             );
           });


### PR DESCRIPTION
When a compose request was failing, the promises callback function was crashing. The reason was because of a misuse of the error object. This commit simply puts back the correct `path` to access the values within the error object to fix it.

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/86971992/d11a5303-5206-418b-a2ab-040f0ee26a21)
