### PR TITLE
Wizard: Indicate disabled packages

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Packages.js
+++ b/src/Components/CreateImageWizard/formComponents/Packages.js
@@ -405,7 +405,11 @@ const Packages = ({ getAllPackages, isSuccess }) => {
                   onOptionSelect={(e) => handleSelectAvailable(e, pkg.name)}
                 >
                   <TextContent key={`${pkg.name}`}>
-                    <span className="pf-c-dual-list-selector__item-text">
+                    <span
+                      className={
+                        chosenPackages[pkg.name] && 'pf-v5-u-color-400'
+                      }
+                    >
                       {pkg.name}
                     </span>
                     <small>{pkg.summary}</small>


### PR DESCRIPTION
When a package is added to the chosen packages it stays in the list of available packages, but gets disabled as an option.

This adds a visual indication in a form of greyed out name of the package.

Before:
![Screenshot from 2023-12-19 14-28-13](https://github.com/RedHatInsights/image-builder-frontend/assets/49452678/745217d4-2178-451a-8b6b-196f2b79960d)

After:
![Screenshot from 2023-12-19 14-28-38](https://github.com/RedHatInsights/image-builder-frontend/assets/49452678/0e132d19-ff37-419a-9e91-173ee92bff25)