### PR TITLE
app: useEffect warning fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ const App = (props) => {
   useEffect(() => {
     updateDocumentTitle('Image Builder | Red Hat Insights');
     hideGlobalFilter();
-  }, []);
+  }, [hideGlobalFilter, updateDocumentTitle]);
 
   return (
     <React.Fragment>

--- a/src/Components/CreateImageWizard/formComponents/AWSSourcesSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/AWSSourcesSelect.js
@@ -55,7 +55,12 @@ export const AWSSourcesSelect = ({
   useEffect(() => {
     if (isFetchingDetails || !isSuccessDetails) return;
     change('aws-associated-account-id', sourceDetails?.aws?.account_id);
-  }, [isFetchingDetails, isSuccessDetails]);
+  }, [
+    isFetchingDetails,
+    isSuccessDetails,
+    change,
+    sourceDetails?.aws?.account_id,
+  ]);
 
   const onFormChange = ({ values }) => {
     if (

--- a/src/Components/CreateImageWizard/formComponents/ActivationKeys.js
+++ b/src/Components/CreateImageWizard/formComponents/ActivationKeys.js
@@ -91,7 +91,7 @@ const ActivationKeys = ({ label, isRequired, ...props }) => {
       change('subscription-server-url', 'subscription.rhsm.stage.redhat.com');
       change('subscription-base-url', 'https://cdn.stage.redhat.com/');
     }
-  }, []);
+  }, [isProd, change]);
 
   const setActivationKey = (_, selection) => {
     selectActivationKey(selection);

--- a/src/Components/CreateImageWizard/formComponents/AzureSourcesSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/AzureSourcesSelect.js
@@ -49,7 +49,13 @@ const AzureSourcesSelect = ({ label, isRequired, className, ...props }) => {
     if (isFetchingDetails || !isSuccessDetails) return;
     change('azure-tenant-id', sourceDetails?.azure?.tenant_id);
     change('azure-subscription-id', sourceDetails?.azure?.subscription_id);
-  }, [isFetchingDetails, isSuccessDetails]);
+  }, [
+    isFetchingDetails,
+    isSuccessDetails,
+    sourceDetails?.azure?.subscription_id,
+    sourceDetails?.azure?.tenant_id,
+    change,
+  ]);
 
   const onFormChange = ({ values }) => {
     if (

--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfigButtons.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfigButtons.js
@@ -16,16 +16,16 @@ const FileSystemConfigButtons = ({ handleNext, handlePrev, nextStep }) => {
   );
   const [nextHasBeenClicked, setNextHasBeenClicked] = useState(false);
   const prefetchArchitectures = imageBuilderApi.usePrefetch('getArchitectures');
+  const errors = getState()?.errors?.['file-system-configuration'];
 
   useEffect(() => {
-    const errors = getState()?.errors?.['file-system-configuration'];
     errors ? setHasErrors(true) : setHasErrors(false);
 
     if (!errors) {
       setNextHasBeenClicked(false);
       change('file-system-config-show-errors', false);
     }
-  });
+  }, [errors, change]);
 
   const handleClick = () => {
     if (!hasErrors) {

--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -100,7 +100,7 @@ const FileSystemConfiguration = ({ ...props }) => {
       setItemOrder(newRows.map((row) => row.id));
       change('file-system-config-radio', 'manual');
     }
-  }, [customizations, isSuccess]);
+  }, [customizations, isSuccess, change, hasCustomizations, rows]);
 
   useEffect(() => {
     const fsc = getState()?.values?.['file-system-configuration'];
@@ -123,7 +123,7 @@ const FileSystemConfiguration = ({ ...props }) => {
     });
     setRows(newRows);
     setItemOrder(newOrder);
-  }, []);
+  }, [getState]);
 
   const showErrors = () =>
     getState()?.values?.['file-system-config-show-errors'];
@@ -144,7 +144,7 @@ const FileSystemConfiguration = ({ ...props }) => {
         return null;
       })
     );
-  }, [rows, itemOrder]);
+  }, [rows, itemOrder, change, input.name]);
 
   const addRow = () => {
     const id = uuidv4();

--- a/src/Components/CreateImageWizard/formComponents/MountPoint.js
+++ b/src/Components/CreateImageWizard/formComponents/MountPoint.js
@@ -36,7 +36,7 @@ const MountPoint = ({ ...props }) => {
         return;
       }
     }
-  }, []);
+  }, [props.mountpoint]);
 
   useEffect(() => {
     let suf = suffix;


### PR DESCRIPTION
This commit addresses warnings related to the react-hooks/exhaustive-deps rule.
It resolves these warnings by adding the missing dependencies to the useEffect hook.
This ensures that all necessary dependencies are correctly specified, aligning with the recommended usage patterns for React hooks.