### PR TITLE
fsc: fix array-callback-return linting warnings

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -110,7 +110,7 @@ const FileSystemConfiguration = ({ ...props }) => {
 
     const newRows = [];
     const newOrder = [];
-    fsc.map((r) => {
+    fsc.forEach((r) => {
       const id = uuidv4();
       newRows.push({
         id,
@@ -141,6 +141,7 @@ const FileSystemConfiguration = ({ ...props }) => {
             };
           }
         }
+        return null;
       })
     );
   }, [rows, itemOrder]);


### PR DESCRIPTION
this comit fixes the array-callback warning by changing map to foreach
and return null to the second map