### PR TITLE
deps: Bump @redhat-cloud-services/frontend-components to 4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@patternfly/patternfly": "5.1.0",
         "@patternfly/react-core": "5.1.2",
         "@patternfly/react-table": "5.0.1",
-        "@redhat-cloud-services/frontend-components": "4.0.10",
+        "@redhat-cloud-services/frontend-components": "4.2.1",
         "@redhat-cloud-services/frontend-components-notifications": "4.1.0",
         "@redhat-cloud-services/frontend-components-utilities": "4.0.2",
         "@reduxjs/toolkit": "1.9.5",
@@ -2217,14 +2217,16 @@
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.7.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
+      "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
       "dependencies": {
         "@emotion/memoize": "0.7.1"
       }
     },
     "node_modules/@emotion/memoize": {
       "version": "0.7.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
+      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3349,16 +3351,44 @@
       "license": "MIT"
     },
     "node_modules/@patternfly/react-component-groups": {
-      "version": "1.0.17",
-      "license": "MIT",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.0.0.tgz",
+      "integrity": "sha512-ON4h4SKOCgLRgZLd/FOj44wU19ytvFPjflxPSYU0KfCWlVgb6F62+l316/Va/tzDo/AwZypnUxOEksXDv+C2+A==",
       "dependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "react-jss": "^10.9.2"
+        "@patternfly/react-core": "^5.1.1",
+        "@patternfly/react-icons": "^5.1.1",
+        "@patternfly/react-table": "^5.1.1",
+        "clsx": "^2.0.0",
+        "react-jss": "^10.10.0"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@patternfly/react-component-groups/node_modules/@patternfly/react-table": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.1.2.tgz",
+      "integrity": "sha512-C+ctkW6oWmdVhGv1rawVlo54baSu5G3ja3ZDtBjVsgMmpsGD0GIBXpvwtFO+OJVeY7T6qXHInMyuW3QNz/0rog==",
+      "dependencies": {
+        "@patternfly/react-core": "^5.1.2",
+        "@patternfly/react-icons": "^5.1.2",
+        "@patternfly/react-styles": "^5.1.2",
+        "@patternfly/react-tokens": "^5.1.2",
+        "lodash": "^4.17.19",
+        "tslib": "^2.5.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@patternfly/react-component-groups/node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@patternfly/react-core": {
@@ -3485,14 +3515,15 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.0.10",
-      "license": "Apache-2.0",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.1.tgz",
+      "integrity": "sha512-XLaCaG+wfu6dSiLMt+tlj6kVn6WVaJgsPV3rXEdg4afFPmjaA55OBm2AxrjpfXNj+YOgRVvXPKI8/FPbPMOOYA==",
       "dependencies": {
-        "@patternfly/react-component-groups": "^1.0.17",
+        "@patternfly/react-component-groups": "^5.0.0-prerelease.7",
         "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
         "@redhat-cloud-services/types": "^0.0.24",
-        "@scalprum/core": "^0.5.1",
-        "@scalprum/react-core": "^0.5.1",
+        "@scalprum/core": "^0.6.5",
+        "@scalprum/react-core": "^0.6.5",
         "sanitize-html": "^2.7.2"
       },
       "peerDependencies": {
@@ -3838,6 +3869,81 @@
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@openshift/dynamic-plugin-sdk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-4.0.0.tgz",
+      "integrity": "sha512-OQsRqpRFz8IO6dZP6oKqdS7fLpdK25jxteevhussWFDd6RETNaLAG9GaSfvN0oigrzNIUTwH59kJx8PP8PrMug==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "semver": "^7.3.7",
+        "uuid": "^8.3.2",
+        "yup": "^0.32.11"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@scalprum/core": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.6.5.tgz",
+      "integrity": "sha512-Q9xQKmcmqKyzDev4hKyJ7Emu3uqI8rWbwezC47dffcafDLn5F9ZOTS+cNpRJcvt0Yulcb11xYDj4tBDk49B7aA==",
+      "dependencies": {
+        "@openshift/dynamic-plugin-sdk": "^4.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@scalprum/react-core": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.6.5.tgz",
+      "integrity": "sha512-ntBRJHbVFthHIxjlRYDnnqlvXXomf+QInwtCLLv2VQYRC4SOeGW6egr9jsoxImIhEBQ7BF4xnzdkqy1nAlOuvw==",
+      "dependencies": {
+        "@openshift/dynamic-plugin-sdk": "^4.0.0",
+        "@scalprum/core": "^0.6.5",
+        "lodash": "^4.17.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || >=17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8.0 || >=17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@redhat-cloud-services/frontend-components/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/@redhat-cloud-services/rbac-client": {
       "version": "1.2.8",
       "license": "Apache-2.0",
@@ -3936,11 +4042,64 @@
       "license": "ISC"
     },
     "node_modules/@scalprum/core": {
-      "version": "0.5.2",
-      "license": "Apache-2.0",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.5.4.tgz",
+      "integrity": "sha512-Z6/u1J8aRopYEfg5YzmPx+jFEjoeEQCHJPmEABLn44Dr1CmZJJStS4+jANRJXZCcGQhTH3Wsn/hu02hGxMVuCQ==",
       "dependencies": {
-        "@openshift/dynamic-plugin-sdk": "^3.0.0"
+        "@openshift/dynamic-plugin-sdk": "^4.0.0"
       }
+    },
+    "node_modules/@scalprum/core/node_modules/@openshift/dynamic-plugin-sdk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-4.0.0.tgz",
+      "integrity": "sha512-OQsRqpRFz8IO6dZP6oKqdS7fLpdK25jxteevhussWFDd6RETNaLAG9GaSfvN0oigrzNIUTwH59kJx8PP8PrMug==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "semver": "^7.3.7",
+        "uuid": "^8.3.2",
+        "yup": "^0.32.11"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18"
+      }
+    },
+    "node_modules/@scalprum/core/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@scalprum/core/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@scalprum/core/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@scalprum/core/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/@scalprum/react-core": {
       "version": "0.5.1",
@@ -7633,7 +7792,8 @@
     },
     "node_modules/css-jss": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/css-jss/-/css-jss-10.10.0.tgz",
+      "integrity": "sha512-YyMIS/LsSKEGXEaVJdjonWe18p4vXLo8CMA4FrW/kcaEyqdIGKCFXao31gbJddXEdIxSXFFURWrenBJPlKTgAA==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "^10.10.0",
@@ -7724,7 +7884,8 @@
     },
     "node_modules/css-vendor": {
       "version": "2.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
       "dependencies": {
         "@babel/runtime": "^7.8.3",
         "is-in-browser": "^1.0.2"
@@ -11097,7 +11258,8 @@
     },
     "node_modules/hyphenate-style-name": {
       "version": "1.0.4",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -11579,7 +11741,8 @@
     },
     "node_modules/is-in-browser": {
       "version": "1.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
     },
     "node_modules/is-installed-globally": {
       "version": "0.4.0",
@@ -14032,7 +14195,8 @@
     },
     "node_modules/jss": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
+      "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "csstype": "^3.0.2",
@@ -14046,7 +14210,8 @@
     },
     "node_modules/jss-plugin-camel-case": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
+      "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
@@ -14055,7 +14220,8 @@
     },
     "node_modules/jss-plugin-compose": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-compose/-/jss-plugin-compose-10.10.0.tgz",
+      "integrity": "sha512-F5kgtWpI2XfZ3Z8eP78tZEYFdgTIbpA/TMuX3a8vwrNolYtN1N4qJR/Ob0LAsqIwCMLojtxN7c7Oo/+Vz6THow==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -14064,7 +14230,8 @@
     },
     "node_modules/jss-plugin-default-unit": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
+      "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0"
@@ -14072,7 +14239,8 @@
     },
     "node_modules/jss-plugin-expand": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-expand/-/jss-plugin-expand-10.10.0.tgz",
+      "integrity": "sha512-ymT62W2OyDxBxr7A6JR87vVX9vTq2ep5jZLIdUSusfBIEENLdkkc0lL/Xaq8W9s3opUq7R0sZQpzRWELrfVYzA==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0"
@@ -14080,7 +14248,8 @@
     },
     "node_modules/jss-plugin-extend": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-extend/-/jss-plugin-extend-10.10.0.tgz",
+      "integrity": "sha512-sKYrcMfr4xxigmIwqTjxNcHwXJIfvhvjTNxF+Tbc1NmNdyspGW47Ey6sGH8BcQ4FFQhLXctpWCQSpDwdNmXSwg==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -14089,7 +14258,8 @@
     },
     "node_modules/jss-plugin-global": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
+      "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0"
@@ -14097,7 +14267,8 @@
     },
     "node_modules/jss-plugin-nested": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
+      "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -14106,7 +14277,8 @@
     },
     "node_modules/jss-plugin-props-sort": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
+      "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0"
@@ -14114,7 +14286,8 @@
     },
     "node_modules/jss-plugin-rule-value-function": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
+      "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -14123,7 +14296,8 @@
     },
     "node_modules/jss-plugin-rule-value-observable": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-observable/-/jss-plugin-rule-value-observable-10.10.0.tgz",
+      "integrity": "sha512-ZLMaYrR3QE+vD7nl3oNXuj79VZl9Kp8/u6A1IbTPDcuOu8b56cFdWRZNZ0vNr8jHewooEeq2doy8Oxtymr2ZPA==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -14132,7 +14306,8 @@
     },
     "node_modules/jss-plugin-template": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-template/-/jss-plugin-template-10.10.0.tgz",
+      "integrity": "sha512-ocXZBIOJOA+jISPdsgkTs8wwpK6UbsvtZK5JI7VUggTD6LWKbtoxUzadd2TpfF+lEtlhUmMsCkTRNkITdPKa6w==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -14141,7 +14316,8 @@
     },
     "node_modules/jss-plugin-vendor-prefixer": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
+      "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "css-vendor": "^2.0.8",
@@ -14150,7 +14326,8 @@
     },
     "node_modules/jss-preset-default": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-10.10.0.tgz",
+      "integrity": "sha512-GL175Wt2FGhjE+f+Y3aWh+JioL06/QWFgZp53CbNNq6ZkVU0TDplD8Bxm9KnkotAYn3FlplNqoW5CjyLXcoJ7Q==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -16732,7 +16909,8 @@
     },
     "node_modules/react-display-name": {
       "version": "0.2.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
+      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
     },
     "node_modules/react-dom": {
       "version": "18.2.0",
@@ -16794,7 +16972,8 @@
     },
     "node_modules/react-jss": {
       "version": "10.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-10.10.0.tgz",
+      "integrity": "sha512-WLiq84UYWqNBF6579/uprcIUnM1TSywYq6AIjKTTTG5ziJl9Uy+pwuvpN3apuyVwflMbD60PraeTKT7uWH9XEQ==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "@emotion/is-prop-valid": "^0.7.3",
@@ -17828,7 +18007,8 @@
     },
     "node_modules/shallow-equal": {
       "version": "1.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -18641,7 +18821,8 @@
     },
     "node_modules/symbol-observable": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18846,7 +19027,8 @@
     },
     "node_modules/theming": {
       "version": "3.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/theming/-/theming-3.3.0.tgz",
+      "integrity": "sha512-u6l4qTJRDaWZsqa8JugaNt7Xd8PPl9+gonZaIe28vAhqgHMIG/DOyFPqiKN/gQLQYj05tHv+YQdNILL4zoiAVA==",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.0",
         "prop-types": "^15.5.8",
@@ -18882,7 +19064,8 @@
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@patternfly/patternfly": "5.1.0",
     "@patternfly/react-core": "5.1.2",
     "@patternfly/react-table": "5.0.1",
-    "@redhat-cloud-services/frontend-components": "4.0.10",
+    "@redhat-cloud-services/frontend-components": "4.2.1",
     "@redhat-cloud-services/frontend-components-notifications": "4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "4.0.2",
     "@reduxjs/toolkit": "1.9.5",
@@ -43,7 +43,7 @@
       "\\.(css|scss)$": "identity-obj-proxy"
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(@scalprum|@openshift|lodash-es|uuid)/)"
+      "node_modules/(?!(@scalprum|@openshift|@redhat-cloud-services|lodash-es|uuid)/)"
     ],
     "setupFiles": [
       "jest-canvas-mock"


### PR DESCRIPTION
This bumps @redhat-cloud-services/frontend-components from 4.0.10 to version 4.2.1 and also adds @redhat-cloud-services module to "transformIgnorePatterns" to eliminate problems with transpiling.