### PR TITLE
ImagesTable: fix grey box under AMI when image build is in progress

### DIFF
--- a/src/Components/ImagesTable/ClonesTable.tsx
+++ b/src/Components/ImagesTable/ClonesTable.tsx
@@ -37,11 +37,8 @@ const Ami = ({ status }: AmiPropTypes) => {
         </ClipboardCopy>
       );
 
-    case 'failure':
-      return undefined;
-
     default:
-      return <Skeleton width="12rem" />;
+      return undefined;
   }
 };
 


### PR DESCRIPTION
this commit fix the fix grey box under AMI when image build is in progress
FIXES # https://github.com/RedHatInsights/image-builder-frontend/issues/1362
