### PR TITLE
ESLint: Remove temporary rule overrides and fix a lint problem

### DIFF
--- a/.eslintrc-typescript.yml
+++ b/.eslintrc-typescript.yml
@@ -5,6 +5,3 @@ extends: [
 rules:
   "@typescript-eslint/ban-ts-comment": off
   "@typescript-eslint/ban-types": off
-  "@typescript-eslint/no-explicit-any": warn
-  "@typescript-eslint/no-unused-vars": warn
-  explicit-module-boundary-types: off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,7 +13,6 @@ globals:
 plugins:
   - import
 rules:
-  no-unused-vars: warn
   import/order:
     - error
     - groups:

--- a/src/Components/ImagesTable/ClonesTable.tsx
+++ b/src/Components/ImagesTable/ClonesTable.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import { ClipboardCopy, Skeleton } from '@patternfly/react-core';
+import { ClipboardCopy } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { StatusClone, AwsDetailsStatus } from './Status';


### PR DESCRIPTION
This removes some of the temporary rule overrides and fixes one occurrence of no-unused-vars.