### PR TITLE
Travis: Disable npm cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ notifications:
   email: false
 node_js:
   - '16'
+cache:
+  npm: false
 install:
   - npm ci
 before_script: |


### PR DESCRIPTION
This disables npm caching for all Travis runs. The effect on the duration of the run is not significant and it should prevent problems with dirty cache in the future.