### PR TITLE
V2 Wizard - Image Output

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -9,13 +9,13 @@ import {
 } from '@patternfly/react-core';
 import { useNavigate } from 'react-router-dom';
 
-import { useAppDispatch } from '../../store/hooks';
+import ImageOutputStep from './steps/ImageOutput';
+
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import './CreateImageWizard.scss';
-import { initializeWizard } from '../../store/wizardSlice';
+import { initializeWizard, selectImageTypes } from '../../store/wizardSlice';
 import { resolveRelPath } from '../../Utilities/path';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
-
-import ImageOutputStep from './steps/ImageOutput';
 
 type CustomWizardFooterPropType = {
   disableNext: boolean;
@@ -55,7 +55,14 @@ const CreateImageWizard = () => {
           <WizardStep
             name="Image output"
             id="step-image-output"
-            footer={<CustomWizardFooter disableNext={false} />}
+            footer={
+              <CustomWizardFooter
+                disableNext={
+                  useAppSelector((state) => selectImageTypes(state)).length ===
+                  0
+                }
+              />
+            }
           >
             <ImageOutputStep />
           </WizardStep>

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -15,6 +15,8 @@ import { initializeWizard } from '../../store/wizardSlice';
 import { resolveRelPath } from '../../Utilities/path';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
+import ImageOutputStep from './steps/ImageOutput';
+
 type CustomWizardFooterPropType = {
   disableNext: boolean;
 };
@@ -54,7 +56,9 @@ const CreateImageWizard = () => {
             name="Image output"
             id="step-image-output"
             footer={<CustomWizardFooter disableNext={false} />}
-          ></WizardStep>
+          >
+            <ImageOutputStep />
+          </WizardStep>
           <WizardStep
             name="Review"
             id="step-review"

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ArchSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ArchSelect.tsx
@@ -1,30 +1,35 @@
-import React, { useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
-import { FormSpy } from '@data-driven-forms/react-form-renderer';
-import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
-import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import { FormGroup } from '@patternfly/react-core';
 import {
   Select,
   SelectOption,
   SelectVariant,
 } from '@patternfly/react-core/deprecated';
-import PropTypes from 'prop-types';
 
-import { ARCHS } from '../../../constants';
+import { ARCHS } from '../../../../constants';
+import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { ImageRequest } from '../../../../store/imageBuilderApi';
+import {
+  changeArchitecture,
+  selectArchitecture,
+} from '../../../../store/wizardSlice';
 
-const ArchSelect = ({ label, isRequired, ...props }) => {
-  const { change, getState } = useFormApi();
-  const { input } = useFieldApi(props);
+const ArchSelect = () => {
+  const arch = useAppSelector((state) => selectArchitecture(state));
+  const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
 
-  const setArch = (_, selection) => {
-    change(input.name, selection);
+  const setArch = (
+    _event: React.MouseEvent,
+    selection: ImageRequest['architecture']
+  ) => {
+    dispatch(changeArchitecture(selection));
     setIsOpen(false);
   };
 
   const setSelectOptions = () => {
-    var options = [];
+    const options: ReactElement[] = [];
     ARCHS.forEach((arch) => {
       options.push(
         <SelectOption key={arch} value={arch}>
@@ -37,28 +42,19 @@ const ArchSelect = ({ label, isRequired, ...props }) => {
   };
 
   return (
-    <FormSpy>
-      {() => (
-        <FormGroup isRequired={isRequired} label={label}>
-          <Select
-            ouiaId="arch_select"
-            variant={SelectVariant.single}
-            onToggle={() => setIsOpen(!isOpen)}
-            onSelect={setArch}
-            selections={getState()?.values?.[input.name]}
-            isOpen={isOpen}
-          >
-            {setSelectOptions()}
-          </Select>
-        </FormGroup>
-      )}
-    </FormSpy>
+    <FormGroup isRequired={true} label="Architecture">
+      <Select
+        ouiaId="arch_select"
+        variant={SelectVariant.single}
+        onToggle={() => setIsOpen(!isOpen)}
+        onSelect={setArch}
+        selections={arch}
+        isOpen={isOpen}
+      >
+        {setSelectOptions()}
+      </Select>
+    </FormGroup>
   );
-};
-
-ArchSelect.propTypes = {
-  label: PropTypes.node,
-  isRequired: PropTypes.bool,
 };
 
 export default ArchSelect;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ArchSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ArchSelect.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+
+import { FormSpy } from '@data-driven-forms/react-form-renderer';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import { FormGroup } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
+import PropTypes from 'prop-types';
+
+import { ARCHS } from '../../../constants';
+
+const ArchSelect = ({ label, isRequired, ...props }) => {
+  const { change, getState } = useFormApi();
+  const { input } = useFieldApi(props);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const setArch = (_, selection) => {
+    change(input.name, selection);
+    setIsOpen(false);
+  };
+
+  const setSelectOptions = () => {
+    var options = [];
+    ARCHS.forEach((arch) => {
+      options.push(
+        <SelectOption key={arch} value={arch}>
+          {arch}
+        </SelectOption>
+      );
+    });
+
+    return options;
+  };
+
+  return (
+    <FormSpy>
+      {() => (
+        <FormGroup isRequired={isRequired} label={label}>
+          <Select
+            ouiaId="arch_select"
+            variant={SelectVariant.single}
+            onToggle={() => setIsOpen(!isOpen)}
+            onSelect={setArch}
+            selections={getState()?.values?.[input.name]}
+            isOpen={isOpen}
+          >
+            {setSelectOptions()}
+          </Select>
+        </FormGroup>
+      )}
+    </FormSpy>
+  );
+};
+
+ArchSelect.propTypes = {
+  label: PropTypes.node,
+  isRequired: PropTypes.bool,
+};
+
+export default ArchSelect;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/CentOSAcknowledgement.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/CentOSAcknowledgement.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { Alert, Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const DeveloperProgramButton = () => {
+  return (
+    <Button
+      component="a"
+      target="_blank"
+      variant="link"
+      icon={<ExternalLinkAltIcon />}
+      iconPosition="right"
+      isInline
+      href={'https://developers.redhat.com/about'}
+    >
+      Red Hat Developer Program
+    </Button>
+  );
+};
+
+const CentOSAcknowledgement = () => {
+  return (
+    <Alert
+      variant="info"
+      isPlain
+      isInline
+      title={
+        <>
+          CentOS Stream builds are intended for the development of future
+          versions of RHEL and are not supported for production workloads or
+          other use cases.
+        </>
+      }
+    >
+      <p>
+        Join the <DeveloperProgramButton /> to learn about paid and no-cost RHEL
+        subscription options.
+      </p>
+    </Alert>
+  );
+};
+
+export default CentOSAcknowledgement;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseLifecycle.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseLifecycle.tsx
@@ -1,0 +1,184 @@
+import React, { useContext } from 'react';
+
+import { useFormApi } from '@data-driven-forms/react-form-renderer';
+import WizardContext from '@data-driven-forms/react-form-renderer/wizard-context';
+import {
+  Button,
+  ExpandableSection,
+  FormGroup,
+  Panel,
+  PanelMain,
+  Text,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Chart, registerables } from 'chart.js';
+import annotationPlugin from 'chartjs-plugin-annotation';
+import { Bar } from 'react-chartjs-2';
+
+import {
+  RELEASES,
+  RHEL_8,
+  RHEL_8_FULL_SUPPORT,
+  RHEL_8_MAINTENANCE_SUPPORT,
+  RHEL_9,
+  RHEL_9_FULL_SUPPORT,
+  RHEL_9_MAINTENANCE_SUPPORT,
+} from '../../../constants';
+import 'chartjs-adapter-moment';
+import { toMonthAndYear } from '../../../Utilities/time';
+
+Chart.register(annotationPlugin);
+Chart.register(...registerables);
+
+const currentDate = new Date().toString();
+
+export const chartMajorVersionCfg = {
+  data: {
+    labels: ['RHEL 9', 'RHEL 8'],
+    datasets: [
+      {
+        label: 'Full support',
+        backgroundColor: '#0066CC',
+        data: [
+          {
+            x: RHEL_9_FULL_SUPPORT,
+            y: 'RHEL 9',
+          },
+          {
+            x: RHEL_8_FULL_SUPPORT,
+            y: 'RHEL 8',
+          },
+        ],
+      },
+      {
+        label: 'Maintenance support',
+        backgroundColor: '#8BC1F7',
+        data: [
+          {
+            x: RHEL_9_MAINTENANCE_SUPPORT,
+            y: 'RHEL 9',
+          },
+          {
+            x: RHEL_8_MAINTENANCE_SUPPORT,
+            y: 'RHEL 8',
+          },
+        ],
+      },
+    ],
+  },
+  options: {
+    indexAxis: 'y' as const,
+    scales: {
+      x: {
+        type: 'time' as const,
+        time: {
+          unit: 'year' as const,
+        },
+        min: '2019-01-01' as const,
+        max: '2033-01-01' as const,
+      },
+      y: {
+        stacked: true,
+      },
+    },
+    responsive: true,
+    maintainAspectRatio: true,
+    aspectRatio: 1 | 5,
+    plugins: {
+      tooltip: {
+        enabled: false,
+      },
+      legend: {
+        position: 'bottom' as const,
+      },
+      annotation: {
+        annotations: {
+          today: {
+            type: 'line' as const,
+            xMin: currentDate,
+            xMax: currentDate,
+            borderColor: 'black',
+            borderWidth: 2,
+            borderDash: [8, 2],
+          },
+        },
+      },
+    },
+  },
+};
+
+const MajorReleasesLifecyclesChart = () => {
+  return (
+    <Panel>
+      <PanelMain maxHeight="10rem">
+        <Bar
+          data-testid="release-lifecycle-chart"
+          options={chartMajorVersionCfg.options}
+          data={chartMajorVersionCfg.data}
+        />
+      </PanelMain>
+    </Panel>
+  );
+};
+
+const ReleaseLifecycle = () => {
+  const { getState } = useFormApi();
+  const { currentStep } = useContext(WizardContext);
+  const release = getState().values.release;
+  const [isExpanded, setIsExpanded] = React.useState(true);
+
+  const onToggle = (_event: React.MouseEvent, isExpanded: boolean) => {
+    setIsExpanded(isExpanded);
+  };
+
+  if (release === RHEL_8) {
+    if (currentStep.name === 'image-output') {
+      return (
+        <ExpandableSection
+          toggleText={
+            isExpanded
+              ? 'Hide information about release lifecycle'
+              : 'Show information about release lifecycle'
+          }
+          onToggle={onToggle}
+          isExpanded={isExpanded}
+          isIndented
+        >
+          <FormGroup label="Release lifecycle">
+            <MajorReleasesLifecyclesChart />
+          </FormGroup>
+          <br />
+          <Button
+            component="a"
+            target="_blank"
+            variant="link"
+            icon={<ExternalLinkAltIcon />}
+            iconPosition="right"
+            isInline
+            href={'https://access.redhat.com/support/policy/updates/errata'}
+          >
+            View Red Hat Enterprise Linux Life Cycle dates
+          </Button>
+        </ExpandableSection>
+      );
+    } else if (currentStep.name === 'review') {
+      return (
+        <>
+          <Text className="pf-v5-u-font-size-sm">
+            {RELEASES.get(release)} will be supported through{' '}
+            {toMonthAndYear(RHEL_8_FULL_SUPPORT[0])}, with optional ELS support
+            through {toMonthAndYear(RHEL_8_MAINTENANCE_SUPPORT[0])}. Consider
+            building an image with {RELEASES.get(RHEL_9)} to extend the support
+            period.
+          </Text>
+          <FormGroup label="Release lifecycle">
+            <MajorReleasesLifecyclesChart />
+          </FormGroup>
+          <br />
+        </>
+      );
+    }
+  }
+};
+
+export default ReleaseLifecycle;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseLifecycle.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseLifecycle.tsx
@@ -1,14 +1,11 @@
-import React, { useContext } from 'react';
+import React, { useState } from 'react';
 
-import { useFormApi } from '@data-driven-forms/react-form-renderer';
-import WizardContext from '@data-driven-forms/react-form-renderer/wizard-context';
 import {
   Button,
   ExpandableSection,
   FormGroup,
   Panel,
   PanelMain,
-  Text,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Chart, registerables } from 'chart.js';
@@ -16,16 +13,15 @@ import annotationPlugin from 'chartjs-plugin-annotation';
 import { Bar } from 'react-chartjs-2';
 
 import {
-  RELEASES,
   RHEL_8,
   RHEL_8_FULL_SUPPORT,
   RHEL_8_MAINTENANCE_SUPPORT,
-  RHEL_9,
   RHEL_9_FULL_SUPPORT,
   RHEL_9_MAINTENANCE_SUPPORT,
-} from '../../../constants';
+} from '../../../../constants';
+import { useAppSelector } from '../../../../store/hooks';
+import { selectDistribution } from '../../../../store/wizardSlice';
 import 'chartjs-adapter-moment';
-import { toMonthAndYear } from '../../../Utilities/time';
 
 Chart.register(annotationPlugin);
 Chart.register(...registerables);
@@ -122,62 +118,42 @@ const MajorReleasesLifecyclesChart = () => {
 };
 
 const ReleaseLifecycle = () => {
-  const { getState } = useFormApi();
-  const { currentStep } = useContext(WizardContext);
-  const release = getState().values.release;
-  const [isExpanded, setIsExpanded] = React.useState(true);
+  const release = useAppSelector((state) => selectDistribution(state));
+  const [isExpanded, setIsExpanded] = useState(true);
 
   const onToggle = (_event: React.MouseEvent, isExpanded: boolean) => {
     setIsExpanded(isExpanded);
   };
 
   if (release === RHEL_8) {
-    if (currentStep.name === 'image-output') {
-      return (
-        <ExpandableSection
-          toggleText={
-            isExpanded
-              ? 'Hide information about release lifecycle'
-              : 'Show information about release lifecycle'
-          }
-          onToggle={onToggle}
-          isExpanded={isExpanded}
-          isIndented
+    return (
+      <ExpandableSection
+        toggleText={
+          isExpanded
+            ? 'Hide information about release lifecycle'
+            : 'Show information about release lifecycle'
+        }
+        onToggle={onToggle}
+        isExpanded={isExpanded}
+        isIndented
+      >
+        <FormGroup label="Release lifecycle">
+          <MajorReleasesLifecyclesChart />
+        </FormGroup>
+        <br />
+        <Button
+          component="a"
+          target="_blank"
+          variant="link"
+          icon={<ExternalLinkAltIcon />}
+          iconPosition="right"
+          isInline
+          href={'https://access.redhat.com/support/policy/updates/errata'}
         >
-          <FormGroup label="Release lifecycle">
-            <MajorReleasesLifecyclesChart />
-          </FormGroup>
-          <br />
-          <Button
-            component="a"
-            target="_blank"
-            variant="link"
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="right"
-            isInline
-            href={'https://access.redhat.com/support/policy/updates/errata'}
-          >
-            View Red Hat Enterprise Linux Life Cycle dates
-          </Button>
-        </ExpandableSection>
-      );
-    } else if (currentStep.name === 'review') {
-      return (
-        <>
-          <Text className="pf-v5-u-font-size-sm">
-            {RELEASES.get(release)} will be supported through{' '}
-            {toMonthAndYear(RHEL_8_FULL_SUPPORT[0])}, with optional ELS support
-            through {toMonthAndYear(RHEL_8_MAINTENANCE_SUPPORT[0])}. Consider
-            building an image with {RELEASES.get(RHEL_9)} to extend the support
-            period.
-          </Text>
-          <FormGroup label="Release lifecycle">
-            <MajorReleasesLifecyclesChart />
-          </FormGroup>
-          <br />
-        </>
-      );
-    }
+          View Red Hat Enterprise Linux Life Cycle dates
+        </Button>
+      </ExpandableSection>
+    );
   }
 };
 

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseSelect.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+
+import { FormSpy } from '@data-driven-forms/react-form-renderer';
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import { FormGroup } from '@patternfly/react-core';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core/deprecated';
+import PropTypes from 'prop-types';
+
+import {
+  RELEASES,
+  RHEL_8,
+  RHEL_8_FULL_SUPPORT,
+  RHEL_8_MAINTENANCE_SUPPORT,
+  RHEL_9,
+  RHEL_9_FULL_SUPPORT,
+  RHEL_9_MAINTENANCE_SUPPORT,
+} from '../../../constants';
+import isRhel from '../../../Utilities/isRhel';
+import { toMonthAndYear } from '../../../Utilities/time';
+
+const ImageOutputReleaseSelect = ({ label, isRequired, ...props }) => {
+  const { change, getState } = useFormApi();
+  const { input } = useFieldApi(props);
+  const [isOpen, setIsOpen] = useState(false);
+  const [showDevelopmentOptions, setShowDevelopmentOptions] = useState(false);
+
+  const setRelease = (_, selection) => {
+    change(input.name, selection);
+    setIsOpen(false);
+  };
+
+  const handleExpand = () => {
+    setShowDevelopmentOptions(true);
+  };
+
+  const setDescription = (key) => {
+    let fullSupportEnd = '';
+    let maintenanceSupportEnd = '';
+
+    if (key === RHEL_8) {
+      fullSupportEnd = toMonthAndYear(RHEL_8_FULL_SUPPORT[1]);
+      maintenanceSupportEnd = toMonthAndYear(RHEL_8_MAINTENANCE_SUPPORT[1]);
+    }
+
+    if (key === RHEL_9) {
+      fullSupportEnd = toMonthAndYear(RHEL_9_FULL_SUPPORT[1]);
+      maintenanceSupportEnd = toMonthAndYear(RHEL_9_MAINTENANCE_SUPPORT[1]);
+    }
+
+    if (isRhel(key)) {
+      return `Full support ends: ${fullSupportEnd} | Maintenance support ends: ${maintenanceSupportEnd}`;
+    }
+  };
+
+  const setSelectOptions = () => {
+    var options = [];
+    const filteredRhel = new Map(
+      [...RELEASES].filter(([key]) => {
+        // Only show non-RHEL distros if expanded
+        if (showDevelopmentOptions) {
+          return true;
+        }
+        return isRhel(key);
+      })
+    );
+
+    filteredRhel.forEach((value, key) => {
+      options.push(
+        <SelectOption key={value} value={key} description={setDescription(key)}>
+          {RELEASES.get(key)}
+        </SelectOption>
+      );
+    });
+
+    return options;
+  };
+
+  return (
+    <FormSpy>
+      {() => (
+        <FormGroup isRequired={isRequired} label={label}>
+          <Select
+            ouiaId="release_select"
+            variant={SelectVariant.single}
+            onToggle={() => setIsOpen(!isOpen)}
+            onSelect={setRelease}
+            selections={RELEASES.get(getState()?.values?.[input.name])}
+            isOpen={isOpen}
+            {...(!showDevelopmentOptions && {
+              loadingVariant: {
+                text: 'Show options for further development of RHEL',
+                onClick: handleExpand,
+              },
+            })}
+          >
+            {setSelectOptions()}
+          </Select>
+        </FormGroup>
+      )}
+    </FormSpy>
+  );
+};
+
+ImageOutputReleaseSelect.propTypes = {
+  label: PropTypes.node,
+  isRequired: PropTypes.bool,
+};
+
+export default ImageOutputReleaseSelect;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
@@ -1,0 +1,390 @@
+import React, { useEffect, useState } from 'react';
+
+import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import {
+  Alert,
+  Bullseye,
+  Checkbox,
+  FormGroup,
+  Popover,
+  Radio,
+  Spinner,
+  Text,
+  TextContent,
+  TextVariants,
+  Tile,
+} from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import PropTypes from 'prop-types';
+import { useField } from 'react-final-form';
+
+import { useGetArchitecturesQuery } from '../../../store/imageBuilderApi';
+import { provisioningApi } from '../../../store/provisioningApi';
+import { useGetEnvironment } from '../../../Utilities/useGetEnvironment';
+
+const useGetAllowedTargets = ({ architecture, release }) => {
+  const { data, isFetching, isSuccess, isError } = useGetArchitecturesQuery({
+    distribution: release,
+  });
+
+  let image_types = [];
+  if (isSuccess && data) {
+    data.forEach((elem) => {
+      if (elem.arch === architecture) {
+        image_types = elem.image_types;
+      }
+    });
+  }
+
+  return {
+    data: image_types,
+    isFetching: isFetching,
+    isSuccess: isSuccess,
+    isError: isError,
+  };
+};
+
+const TargetEnvironment = ({ label, isRequired, ...props }) => {
+  const { getState, change } = useFormApi();
+  const { input } = useFieldApi({ label, isRequired, ...props });
+  const [environment, setEnvironment] = useState({
+    aws: false,
+    azure: false,
+    gcp: false,
+    oci: false,
+    'vsphere-ova': false,
+    vsphere: false,
+    'guest-image': false,
+    'image-installer': false,
+    wsl: false,
+  });
+  const prefetchSources = provisioningApi.usePrefetch('getSourceList');
+  const { isBeta } = useGetEnvironment();
+  const release = getState()?.values?.release;
+
+  useEffect(() => {
+    if (getState()?.values?.[input.name]) {
+      setEnvironment(getState().values[input.name]);
+    }
+  }, [getState, input.name]);
+
+  const handleSetEnvironment = (env, checked) =>
+    setEnvironment((prevEnv) => {
+      const newEnv = {
+        ...prevEnv,
+        [env]: checked,
+      };
+      change(input.name, newEnv);
+      return newEnv;
+    });
+
+  const handleKeyDown = (e, env, checked) => {
+    if (e.key === ' ') {
+      handleSetEnvironment(env, checked);
+    }
+  };
+
+  // Load all the allowed targets from the backend
+  const architecture = useField('arch').input.value;
+
+  const {
+    data: allowedTargets,
+    isFetching,
+    isSuccess,
+    isError,
+  } = useGetAllowedTargets({
+    architecture: architecture,
+    release: release,
+  });
+
+  if (isFetching) {
+    return (
+      <Bullseye>
+        <Spinner size="lg" />
+      </Bullseye>
+    );
+  }
+
+  if (isError || !isSuccess) {
+    return (
+      <Alert
+        variant={'danger'}
+        isPlain
+        isInline
+        title={'Allowed targets unavailable'}
+      >
+        Allowed targets cannot be reached, try again later.
+      </Alert>
+    );
+  }
+
+  // If the user already made a choice for some targets but then changes their
+  // architecture or distribution, only keep the target choices that are still
+  // compatible.
+  const allTargets = [
+    'aws',
+    'gcp',
+    'azure',
+    'vsphere',
+    'vsphere-ova',
+    'guest-image',
+    'image-installer',
+    'wsl',
+  ];
+  allTargets.forEach((target) => {
+    if (environment[target] && !allowedTargets.includes(target)) {
+      handleSetEnvironment(target, false);
+    }
+  });
+
+  // each item the user can select is depending on what's compatible with the
+  // architecture and the distribution they previously selected
+  return (
+    <FormGroup
+      isRequired={isRequired}
+      label={label}
+      data-testid="target-select"
+    >
+      <FormGroup
+        label={<Text component={TextVariants.small}>Public cloud</Text>}
+        data-testid="target-public"
+      >
+        <div className="tiles">
+          {allowedTargets.includes('aws') && (
+            <Tile
+              className="tile pf-u-mr-sm"
+              data-testid="upload-aws"
+              title="Amazon Web Services"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={'/apps/frontend-assets/partners-icons/aws.svg'}
+                  alt="Amazon Web Services logo"
+                />
+              }
+              onClick={() => handleSetEnvironment('aws', !environment.aws)}
+              onKeyDown={(e) => handleKeyDown(e, 'aws', !environment.aws)}
+              onMouseEnter={() => prefetchSources({ provider: 'aws' })}
+              isSelected={environment.aws}
+              isStacked
+              isDisplayLarge
+            />
+          )}
+          {allowedTargets.includes('gcp') && (
+            <Tile
+              className="tile pf-u-mr-sm"
+              data-testid="upload-google"
+              title="Google Cloud Platform"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={
+                    '/apps/frontend-assets/partners-icons/google-cloud-short.svg'
+                  }
+                  alt="Google Cloud Platform logo"
+                />
+              }
+              onClick={() => handleSetEnvironment('gcp', !environment.gcp)}
+              isSelected={environment.gcp}
+              onKeyDown={(e) => handleKeyDown(e, 'gcp', !environment.gcp)}
+              onMouseEnter={() => prefetchSources({ provider: 'gcp' })}
+              isStacked
+              isDisplayLarge
+            />
+          )}
+          {allowedTargets.includes('azure') && (
+            <Tile
+              className="tile pf-u-mr-sm"
+              data-testid="upload-azure"
+              title="Microsoft Azure"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={
+                    '/apps/frontend-assets/partners-icons/microsoft-azure-short.svg'
+                  }
+                  alt="Microsoft Azure logo"
+                />
+              }
+              onClick={() => handleSetEnvironment('azure', !environment.azure)}
+              onKeyDown={(e) => handleKeyDown(e, 'azure', !environment.azure)}
+              onMouseEnter={() => prefetchSources({ provider: 'azure' })}
+              isSelected={environment.azure}
+              isStacked
+              isDisplayLarge
+            />
+          )}
+          {allowedTargets.includes('oci') && (
+            <Tile
+              className="tile pf-u-mr-sm"
+              data-testid="upload-oci"
+              title="Oracle Cloud Infrastructure"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={'/apps/frontend-assets/partners-icons/oracle-short.svg'}
+                  alt="Oracle Cloud Infrastructure logo"
+                />
+              }
+              onClick={() => handleSetEnvironment('oci', !environment.oci)}
+              onKeyDown={(e) => handleKeyDown(e, 'oci', !environment.oci)}
+              isSelected={environment.oci}
+              isStacked
+              isDisplayLarge
+            />
+          )}
+        </div>
+      </FormGroup>
+      {allowedTargets.includes('vsphere') && (
+        <FormGroup
+          label={<Text component={TextVariants.small}>Private cloud</Text>}
+          className="pf-u-mt-sm"
+          data-testid="target-private"
+        >
+          <Checkbox
+            label="VMware vSphere"
+            isChecked={environment.vsphere || environment['vsphere-ova']}
+            onChange={(_event, checked) => {
+              handleSetEnvironment('vsphere-ova', checked);
+              handleSetEnvironment('vsphere', false);
+            }}
+            aria-label="VMware checkbox"
+            id="checkbox-vmware"
+            name="VMware"
+            data-testid="checkbox-vmware"
+          />
+        </FormGroup>
+      )}
+      {allowedTargets.includes('vsphere') && (
+        <FormGroup
+          className="pf-u-mt-sm pf-u-mb-sm pf-u-ml-xl"
+          data-testid="target-private-vsphere-radio"
+        >
+          {allowedTargets.includes('vsphere-ova') && (
+            <Radio
+              name="vsphere-radio"
+              aria-label="VMware vSphere radio button OVA"
+              id="vsphere-radio-ova"
+              label={
+                <>
+                  Open virtualization format (.ova)
+                  <Popover
+                    maxWidth="30rem"
+                    position="right"
+                    bodyContent={
+                      <TextContent>
+                        <Text>
+                          An OVA file is a virtual appliance used by
+                          virtualization platforms such as VMware vSphere. It is
+                          a package that contains files used to describe a
+                          virtual machine, which includes a VMDK image, OVF
+                          descriptor file and a manifest file.
+                        </Text>
+                      </TextContent>
+                    }
+                  >
+                    <HelpIcon className="pf-u-ml-sm" />
+                  </Popover>
+                </>
+              }
+              onChange={(_event, checked) => {
+                handleSetEnvironment('vsphere-ova', checked);
+                handleSetEnvironment('vsphere', !checked);
+              }}
+              isChecked={environment['vsphere-ova']}
+              isDisabled={!(environment.vsphere || environment['vsphere-ova'])}
+            />
+          )}
+          <Radio
+            className="pf-u-mt-sm"
+            name="vsphere-radio"
+            aria-label="VMware vSphere radio button VMDK"
+            id="vsphere-radio-vmdk"
+            label={
+              <>
+                Virtual disk (.vmdk)
+                <Popover
+                  maxWidth="30rem"
+                  position="right"
+                  bodyContent={
+                    <TextContent>
+                      <Text>
+                        A VMDK file is a virtual disk that stores the contents
+                        of a virtual machine. This disk has to be imported into
+                        vSphere using govc import.vmdk, use the OVA version when
+                        using the vSphere UI.
+                      </Text>
+                    </TextContent>
+                  }
+                >
+                  <HelpIcon className="pf-u-ml-sm" />
+                </Popover>
+              </>
+            }
+            onChange={(_event, checked) => {
+              handleSetEnvironment('vsphere-ova', !checked);
+              handleSetEnvironment('vsphere', checked);
+            }}
+            isChecked={environment.vsphere}
+            isDisabled={!(environment.vsphere || environment['vsphere-ova'])}
+          />
+        </FormGroup>
+      )}
+      <FormGroup
+        label={<Text component={TextVariants.small}>Other</Text>}
+        data-testid="target-other"
+      >
+        {allowedTargets.includes('guest-image') && (
+          <Checkbox
+            label="Virtualization - Guest image (.qcow2)"
+            isChecked={environment['guest-image']}
+            onChange={(_event, checked) =>
+              handleSetEnvironment('guest-image', checked)
+            }
+            aria-label="Virtualization guest image checkbox"
+            id="checkbox-guest-image"
+            name="Virtualization guest image"
+            data-testid="checkbox-guest-image"
+          />
+        )}
+        {allowedTargets.includes('image-installer') && (
+          <Checkbox
+            label="Bare metal - Installer (.iso)"
+            isChecked={environment['image-installer']}
+            onChange={(_event, checked) =>
+              handleSetEnvironment('image-installer', checked)
+            }
+            aria-label="Bare metal installer checkbox"
+            id="checkbox-image-installer"
+            name="Bare metal installer"
+            data-testid="checkbox-image-installer"
+          />
+        )}
+        {allowedTargets.includes('wsl') && isBeta() && (
+          <Checkbox
+            label="WSL - Windows Subsystem for Linux (.tar.gz)"
+            isChecked={environment['wsl']}
+            onChange={(_event, checked) => handleSetEnvironment('wsl', checked)}
+            aria-label="windows subsystem for linux checkbox"
+            id="checkbox-wsl"
+            name="WSL"
+            data-testid="checkbox-wsl"
+          />
+        )}
+      </FormGroup>
+    </FormGroup>
+  );
+};
+
+TargetEnvironment.propTypes = {
+  label: PropTypes.node,
+  isRequired: PropTypes.bool,
+};
+
+TargetEnvironment.defaultProps = {
+  label: '',
+  isRequired: false,
+};
+
+export default TargetEnvironment;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
@@ -1,149 +1,64 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
-import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
-import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import {
-  Alert,
-  Bullseye,
   Checkbox,
   FormGroup,
   Popover,
   Radio,
-  Spinner,
   Text,
   TextContent,
   TextVariants,
   Tile,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
-import PropTypes from 'prop-types';
-import { useField } from 'react-final-form';
 
-import { useGetArchitecturesQuery } from '../../../store/imageBuilderApi';
-import { provisioningApi } from '../../../store/provisioningApi';
-import { useGetEnvironment } from '../../../Utilities/useGetEnvironment';
+import { useAppSelector, useAppDispatch } from '../../../../store/hooks';
+import {
+  ImageTypes,
+  useGetArchitecturesQuery,
+} from '../../../../store/imageBuilderApi';
+import { provisioningApi } from '../../../../store/provisioningApi';
+import {
+  addImageType,
+  removeImageType,
+  selectArchitecture,
+  selectDistribution,
+  selectImageTypes,
+} from '../../../../store/wizardSlice';
+import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
 
-const useGetAllowedTargets = ({ architecture, release }) => {
-  const { data, isFetching, isSuccess, isError } = useGetArchitecturesQuery({
-    distribution: release,
+const TargetEnvironment = () => {
+  const arch = useAppSelector((state) => selectArchitecture(state));
+  const environments = useAppSelector((state) => selectImageTypes(state));
+  const distribution = useAppSelector((state) => selectDistribution(state));
+  const { data } = useGetArchitecturesQuery({
+    distribution: distribution,
   });
+  // TODO: Handle isFetching state (add skeletons)
+  // TODO: Handle isError state (very unlikely...)
 
-  let image_types = [];
-  if (isSuccess && data) {
-    data.forEach((elem) => {
-      if (elem.arch === architecture) {
-        image_types = elem.image_types;
-      }
-    });
-  }
+  const [hasVSphere, setHasVSphere] = useState(false);
 
-  return {
-    data: image_types,
-    isFetching: isFetching,
-    isSuccess: isSuccess,
-    isError: isError,
-  };
-};
-
-const TargetEnvironment = ({ label, isRequired, ...props }) => {
-  const { getState, change } = useFormApi();
-  const { input } = useFieldApi({ label, isRequired, ...props });
-  const [environment, setEnvironment] = useState({
-    aws: false,
-    azure: false,
-    gcp: false,
-    oci: false,
-    'vsphere-ova': false,
-    vsphere: false,
-    'guest-image': false,
-    'image-installer': false,
-    wsl: false,
-  });
+  const dispatch = useAppDispatch();
   const prefetchSources = provisioningApi.usePrefetch('getSourceList');
   const { isBeta } = useGetEnvironment();
-  const release = getState()?.values?.release;
 
-  useEffect(() => {
-    if (getState()?.values?.[input.name]) {
-      setEnvironment(getState().values[input.name]);
-    }
-  }, [getState, input.name]);
+  const supportedEnvironments = data?.find(
+    (elem) => elem.arch === arch
+  )?.image_types;
 
-  const handleSetEnvironment = (env, checked) =>
-    setEnvironment((prevEnv) => {
-      const newEnv = {
-        ...prevEnv,
-        [env]: checked,
-      };
-      change(input.name, newEnv);
-      return newEnv;
-    });
-
-  const handleKeyDown = (e, env, checked) => {
-    if (e.key === ' ') {
-      handleSetEnvironment(env, checked);
+  const handleToggleEnvironment = (environment: ImageTypes) => {
+    if (environments.includes(environment)) {
+      dispatch(removeImageType(environment));
+    } else {
+      dispatch(addImageType(environment));
     }
   };
 
-  // Load all the allowed targets from the backend
-  const architecture = useField('arch').input.value;
-
-  const {
-    data: allowedTargets,
-    isFetching,
-    isSuccess,
-    isError,
-  } = useGetAllowedTargets({
-    architecture: architecture,
-    release: release,
-  });
-
-  if (isFetching) {
-    return (
-      <Bullseye>
-        <Spinner size="lg" />
-      </Bullseye>
-    );
-  }
-
-  if (isError || !isSuccess) {
-    return (
-      <Alert
-        variant={'danger'}
-        isPlain
-        isInline
-        title={'Allowed targets unavailable'}
-      >
-        Allowed targets cannot be reached, try again later.
-      </Alert>
-    );
-  }
-
-  // If the user already made a choice for some targets but then changes their
-  // architecture or distribution, only keep the target choices that are still
-  // compatible.
-  const allTargets = [
-    'aws',
-    'gcp',
-    'azure',
-    'vsphere',
-    'vsphere-ova',
-    'guest-image',
-    'image-installer',
-    'wsl',
-  ];
-  allTargets.forEach((target) => {
-    if (environment[target] && !allowedTargets.includes(target)) {
-      handleSetEnvironment(target, false);
-    }
-  });
-
-  // each item the user can select is depending on what's compatible with the
-  // architecture and the distribution they previously selected
   return (
     <FormGroup
-      isRequired={isRequired}
-      label={label}
+      isRequired={true}
+      label="Select target environments"
       data-testid="target-select"
     >
       <FormGroup
@@ -151,7 +66,7 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
         data-testid="target-public"
       >
         <div className="tiles">
-          {allowedTargets.includes('aws') && (
+          {supportedEnvironments?.includes('aws') && (
             <Tile
               className="tile pf-u-mr-sm"
               data-testid="upload-aws"
@@ -163,15 +78,16 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
                   alt="Amazon Web Services logo"
                 />
               }
-              onClick={() => handleSetEnvironment('aws', !environment.aws)}
-              onKeyDown={(e) => handleKeyDown(e, 'aws', !environment.aws)}
+              onClick={() => {
+                handleToggleEnvironment('aws');
+              }}
               onMouseEnter={() => prefetchSources({ provider: 'aws' })}
-              isSelected={environment.aws}
+              isSelected={environments.includes('aws')}
               isStacked
               isDisplayLarge
             />
           )}
-          {allowedTargets.includes('gcp') && (
+          {supportedEnvironments?.includes('gcp') && (
             <Tile
               className="tile pf-u-mr-sm"
               data-testid="upload-google"
@@ -185,15 +101,16 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
                   alt="Google Cloud Platform logo"
                 />
               }
-              onClick={() => handleSetEnvironment('gcp', !environment.gcp)}
-              isSelected={environment.gcp}
-              onKeyDown={(e) => handleKeyDown(e, 'gcp', !environment.gcp)}
+              onClick={() => {
+                handleToggleEnvironment('gcp');
+              }}
+              isSelected={environments.includes('gcp')}
               onMouseEnter={() => prefetchSources({ provider: 'gcp' })}
               isStacked
               isDisplayLarge
             />
           )}
-          {allowedTargets.includes('azure') && (
+          {supportedEnvironments?.includes('azure') && (
             <Tile
               className="tile pf-u-mr-sm"
               data-testid="upload-azure"
@@ -207,15 +124,16 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
                   alt="Microsoft Azure logo"
                 />
               }
-              onClick={() => handleSetEnvironment('azure', !environment.azure)}
-              onKeyDown={(e) => handleKeyDown(e, 'azure', !environment.azure)}
+              onClick={() => {
+                handleToggleEnvironment('azure');
+              }}
               onMouseEnter={() => prefetchSources({ provider: 'azure' })}
-              isSelected={environment.azure}
+              isSelected={environments.includes('azure')}
               isStacked
               isDisplayLarge
             />
           )}
-          {allowedTargets.includes('oci') && (
+          {supportedEnvironments?.includes('oci') && isBeta() && (
             <Tile
               className="tile pf-u-mr-sm"
               data-testid="upload-oci"
@@ -227,59 +145,101 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
                   alt="Oracle Cloud Infrastructure logo"
                 />
               }
-              onClick={() => handleSetEnvironment('oci', !environment.oci)}
-              onKeyDown={(e) => handleKeyDown(e, 'oci', !environment.oci)}
-              isSelected={environment.oci}
+              onClick={() => {
+                handleToggleEnvironment('oci');
+              }}
+              isSelected={environments.includes('oci')}
               isStacked
               isDisplayLarge
             />
           )}
         </div>
       </FormGroup>
-      {allowedTargets.includes('vsphere') && (
-        <FormGroup
-          label={<Text component={TextVariants.small}>Private cloud</Text>}
-          className="pf-u-mt-sm"
-          data-testid="target-private"
-        >
-          <Checkbox
-            label="VMware vSphere"
-            isChecked={environment.vsphere || environment['vsphere-ova']}
-            onChange={(_event, checked) => {
-              handleSetEnvironment('vsphere-ova', checked);
-              handleSetEnvironment('vsphere', false);
-            }}
-            aria-label="VMware checkbox"
-            id="checkbox-vmware"
-            name="VMware"
-            data-testid="checkbox-vmware"
-          />
-        </FormGroup>
-      )}
-      {allowedTargets.includes('vsphere') && (
-        <FormGroup
-          className="pf-u-mt-sm pf-u-mb-sm pf-u-ml-xl"
-          data-testid="target-private-vsphere-radio"
-        >
-          {allowedTargets.includes('vsphere-ova') && (
+      {supportedEnvironments?.includes('vsphere') && (
+        <>
+          <FormGroup
+            label={<Text component={TextVariants.small}>Private cloud</Text>}
+            className="pf-u-mt-sm"
+            data-testid="target-private"
+          >
+            <Checkbox
+              label="VMWare vSphere"
+              isChecked={
+                environments.includes('vsphere') ||
+                environments.includes('vsphere-ova')
+              }
+              onChange={() => {
+                setHasVSphere(!hasVSphere);
+                handleToggleEnvironment('vsphere-ova');
+              }}
+              aria-label="VMWare checkbox"
+              id="checkbox-vmware"
+              name="VMWare"
+              data-testid="checkbox-vmware"
+            />
+          </FormGroup>
+          <FormGroup
+            className="pf-u-mt-sm pf-u-mb-sm pf-u-ml-xl"
+            data-testid="target-private-vsphere-radio"
+          >
+            {supportedEnvironments?.includes('vsphere-ova') && (
+              <Radio
+                name="vsphere-radio"
+                aria-label="VMWare vSphere radio button OVA"
+                id="vsphere-radio-ova"
+                label={
+                  <>
+                    Open virtualization format (.ova)
+                    <Popover
+                      maxWidth="30rem"
+                      position="right"
+                      bodyContent={
+                        <TextContent>
+                          <Text>
+                            An OVA file is a virtual appliance used by
+                            virtualization platforms such as VMWare vSphere. It
+                            is a package that contains files used to describe a
+                            virtual machine, which includes a VMDK image, OVF
+                            descriptor file and a manifest file.
+                          </Text>
+                        </TextContent>
+                      }
+                    >
+                      <HelpIcon className="pf-u-ml-sm" />
+                    </Popover>
+                  </>
+                }
+                onChange={() => {
+                  handleToggleEnvironment('vsphere-ova');
+                  handleToggleEnvironment('vsphere');
+                }}
+                isChecked={environments.includes('vsphere-ova')}
+                isDisabled={
+                  !(
+                    environments.includes('vsphere') ||
+                    environments.includes('vsphere-ova')
+                  )
+                }
+              />
+            )}
             <Radio
+              className="pf-u-mt-sm"
               name="vsphere-radio"
-              aria-label="VMware vSphere radio button OVA"
-              id="vsphere-radio-ova"
+              aria-label="VMWare vSphere radio button VMDK"
+              id="vsphere-radio-vmdk"
               label={
                 <>
-                  Open virtualization format (.ova)
+                  Virtual disk (.vmdk)
                   <Popover
                     maxWidth="30rem"
                     position="right"
                     bodyContent={
                       <TextContent>
                         <Text>
-                          An OVA file is a virtual appliance used by
-                          virtualization platforms such as VMware vSphere. It is
-                          a package that contains files used to describe a
-                          virtual machine, which includes a VMDK image, OVF
-                          descriptor file and a manifest file.
+                          A VMDK file is a virtual disk that stores the contents
+                          of a virtual machine. This disk has to be imported
+                          into vSphere using govc import.vmdk, use the OVA
+                          version when using the vSphere UI.
                         </Text>
                       </TextContent>
                     }
@@ -288,84 +248,58 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
                   </Popover>
                 </>
               }
-              onChange={(_event, checked) => {
-                handleSetEnvironment('vsphere-ova', checked);
-                handleSetEnvironment('vsphere', !checked);
+              onChange={() => {
+                handleToggleEnvironment('vsphere-ova');
+                handleToggleEnvironment('vsphere');
               }}
-              isChecked={environment['vsphere-ova']}
-              isDisabled={!(environment.vsphere || environment['vsphere-ova'])}
+              isChecked={environments.includes('vsphere')}
+              isDisabled={
+                !(
+                  environments.includes('vsphere') ||
+                  environments.includes('vsphere-ova')
+                )
+              }
             />
-          )}
-          <Radio
-            className="pf-u-mt-sm"
-            name="vsphere-radio"
-            aria-label="VMware vSphere radio button VMDK"
-            id="vsphere-radio-vmdk"
-            label={
-              <>
-                Virtual disk (.vmdk)
-                <Popover
-                  maxWidth="30rem"
-                  position="right"
-                  bodyContent={
-                    <TextContent>
-                      <Text>
-                        A VMDK file is a virtual disk that stores the contents
-                        of a virtual machine. This disk has to be imported into
-                        vSphere using govc import.vmdk, use the OVA version when
-                        using the vSphere UI.
-                      </Text>
-                    </TextContent>
-                  }
-                >
-                  <HelpIcon className="pf-u-ml-sm" />
-                </Popover>
-              </>
-            }
-            onChange={(_event, checked) => {
-              handleSetEnvironment('vsphere-ova', !checked);
-              handleSetEnvironment('vsphere', checked);
-            }}
-            isChecked={environment.vsphere}
-            isDisabled={!(environment.vsphere || environment['vsphere-ova'])}
-          />
-        </FormGroup>
+          </FormGroup>
+        </>
       )}
       <FormGroup
         label={<Text component={TextVariants.small}>Other</Text>}
         data-testid="target-other"
       >
-        {allowedTargets.includes('guest-image') && (
+        {supportedEnvironments?.includes('guest-image') && (
           <Checkbox
             label="Virtualization - Guest image (.qcow2)"
-            isChecked={environment['guest-image']}
-            onChange={(_event, checked) =>
-              handleSetEnvironment('guest-image', checked)
-            }
+            isChecked={environments.includes('guest-image')}
+            onChange={() => {
+              handleToggleEnvironment('guest-image');
+            }}
             aria-label="Virtualization guest image checkbox"
             id="checkbox-guest-image"
             name="Virtualization guest image"
             data-testid="checkbox-guest-image"
           />
         )}
-        {allowedTargets.includes('image-installer') && (
+        {supportedEnvironments?.includes('image-installer') && (
           <Checkbox
             label="Bare metal - Installer (.iso)"
-            isChecked={environment['image-installer']}
-            onChange={(_event, checked) =>
-              handleSetEnvironment('image-installer', checked)
-            }
+            isChecked={environments.includes('image-installer')}
+            onChange={() => {
+              handleToggleEnvironment('image-installer');
+            }}
             aria-label="Bare metal installer checkbox"
             id="checkbox-image-installer"
             name="Bare metal installer"
             data-testid="checkbox-image-installer"
           />
         )}
-        {allowedTargets.includes('wsl') && isBeta() && (
+        {supportedEnvironments?.includes('wsl') && isBeta() && (
           <Checkbox
             label="WSL - Windows Subsystem for Linux (.tar.gz)"
-            isChecked={environment['wsl']}
-            onChange={(_event, checked) => handleSetEnvironment('wsl', checked)}
+            isChecked={environments.includes('wsl')}
+            onChange={() => {
+              handleToggleEnvironment('wsl');
+            }}
             aria-label="windows subsystem for linux checkbox"
             id="checkbox-wsl"
             name="WSL"
@@ -375,16 +309,6 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
       </FormGroup>
     </FormGroup>
   );
-};
-
-TargetEnvironment.propTypes = {
-  label: PropTypes.node,
-  isRequired: PropTypes.bool,
-};
-
-TargetEnvironment.defaultProps = {
-  label: '',
-  isRequired: false,
 };
 
 export default TargetEnvironment;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Text, Form, Title } from '@patternfly/react-core';
 
+import ArchSelect from './ArchSelect';
 import ReleaseLifecycle from './ReleaseLifecycle';
 import ReleaseSelect from './ReleaseSelect';
 
@@ -19,6 +20,7 @@ const ImageOutputStep = () => {
       </Text>
       <ReleaseSelect />
       <ReleaseLifecycle />
+      <ArchSelect />
     </Form>
   );
 };

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { Text, Form, Title } from '@patternfly/react-core';
+
+import DocumentationButton from '../../../sharedComponents/DocumentationButton';
+
+const ImageOutputStep = () => {
+  return (
+    <Form>
+      <Title headingLevel="h2">Image output</Title>
+      <Text>
+        Image builder allows you to create a custom image and push it to target
+        environments.
+        <br />
+        <DocumentationButton />
+      </Text>
+    </Form>
+  );
+};
+
+export default ImageOutputStep;

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Text, Form, Title } from '@patternfly/react-core';
 
+import ReleaseSelect from './ReleaseSelect';
+
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
 
 const ImageOutputStep = () => {
@@ -14,6 +16,7 @@ const ImageOutputStep = () => {
         <br />
         <DocumentationButton />
       </Text>
+      <ReleaseSelect />
     </Form>
   );
 };

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
@@ -3,13 +3,18 @@ import React from 'react';
 import { Text, Form, Title } from '@patternfly/react-core';
 
 import ArchSelect from './ArchSelect';
+import CentOSAcknowledgement from './CentOSAcknowledgement';
 import ReleaseLifecycle from './ReleaseLifecycle';
 import ReleaseSelect from './ReleaseSelect';
 import TargetEnvironment from './TargetEnvironment';
 
+import { useAppSelector } from '../../../../store/hooks';
+import { selectDistribution } from '../../../../store/wizardSlice';
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
 
 const ImageOutputStep = () => {
+  const distribution = useAppSelector((state) => selectDistribution(state));
+
   return (
     <Form>
       <Title headingLevel="h2">Image output</Title>
@@ -20,6 +25,7 @@ const ImageOutputStep = () => {
         <DocumentationButton />
       </Text>
       <ReleaseSelect />
+      {distribution.match('centos-*') && <CentOSAcknowledgement />}
       <ReleaseLifecycle />
       <ArchSelect />
       <TargetEnvironment />

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Text, Form, Title } from '@patternfly/react-core';
 
+import ReleaseLifecycle from './ReleaseLifecycle';
 import ReleaseSelect from './ReleaseSelect';
 
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
@@ -17,6 +18,7 @@ const ImageOutputStep = () => {
         <DocumentationButton />
       </Text>
       <ReleaseSelect />
+      <ReleaseLifecycle />
     </Form>
   );
 };

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/index.tsx
@@ -5,6 +5,7 @@ import { Text, Form, Title } from '@patternfly/react-core';
 import ArchSelect from './ArchSelect';
 import ReleaseLifecycle from './ReleaseLifecycle';
 import ReleaseSelect from './ReleaseSelect';
+import TargetEnvironment from './TargetEnvironment';
 
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
 
@@ -21,6 +22,7 @@ const ImageOutputStep = () => {
       <ReleaseSelect />
       <ReleaseLifecycle />
       <ArchSelect />
+      <TargetEnvironment />
     </Form>
   );
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,6 +14,7 @@ export const UNIT_KIB = 1024 ** 1;
 export const UNIT_MIB = 1024 ** 2;
 export const UNIT_GIB = 1024 ** 3;
 
+// Use a Map() to ensure order is preserved (order is not gauranteed by an Object())
 export const RELEASES = new Map([
   [RHEL_9, 'Red Hat Enterprise Linux (RHEL) 9'],
   [RHEL_8, 'Red Hat Enterprise Linux (RHEL) 8'],

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,9 +5,10 @@ import promiseMiddleware from 'redux-promise-middleware';
 import { contentSourcesApi } from './contentSourcesApi';
 import { edgeApi } from './edgeApi';
 import { imageBuilderApi } from './enhancedImageBuilderApi';
+import { listenerMiddleware, startAppListening } from './listenerMiddleware';
 import { provisioningApi } from './provisioningApi';
 import { rhsmApi } from './rhsmApi';
-import wizardSlice from './wizardSlice';
+import wizardSlice, {changeArchitecture, changeDistribution, changeImageTypes, selectArchitecture, selectDistribution, selectImageTypes} from './wizardSlice';
 
 export const reducer = {
   [contentSourcesApi.reducerPath]: contentSourcesApi.reducer,
@@ -19,14 +20,72 @@ export const reducer = {
   wizard: wizardSlice,
 };
 
+startAppListening({
+  actionCreator: changeArchitecture,
+  effect: (action, listenerApi) => {
+    const state = listenerApi.getState();
+
+    const distribution = selectDistribution(state);
+    const imageTypes = selectImageTypes(state);
+    const architecture = action.payload;
+
+    // The response from the RTKQ getArchitectures hook
+    const architecturesResponse =
+      imageBuilderApi.endpoints.getArchitectures.select({
+        distribution: distribution,
+      })(state);
+
+    const allowedImageTypes = architecturesResponse?.data?.find(
+      (elem) => elem.arch === architecture
+    )?.image_types;
+
+    const filteredImageTypes = imageTypes.filter((imageType) =>
+      allowedImageTypes?.includes(imageType)
+    );
+
+    listenerApi.dispatch(changeImageTypes(filteredImageTypes));
+  },
+});
+
+startAppListening({
+  actionCreator: changeDistribution,
+  effect: (action, listenerApi) => {
+    const state = listenerApi.getState();
+
+    const distribution = action.payload;
+    const imageTypes = selectImageTypes(state);
+    const architecture = selectArchitecture(state);
+
+    // The response from the RTKQ getArchitectures hook
+    const architecturesResponse =
+      imageBuilderApi.endpoints.getArchitectures.select({
+        distribution: distribution,
+      })(state);
+
+    const allowedImageTypes = architecturesResponse?.data?.find(
+      (elem) => elem.arch === architecture
+    )?.image_types;
+
+    const filteredImageTypes = imageTypes.filter((imageType) =>
+      allowedImageTypes?.includes(imageType)
+    );
+
+    listenerApi.dispatch(changeImageTypes(filteredImageTypes));
+  },
+});
+
+// Listener middleware must be prepended according to RTK docs:
+// https://redux-toolkit.js.org/api/createListenerMiddleware#basic-usage
 export const middleware = (getDefaultMiddleware: Function) =>
-  getDefaultMiddleware().concat(
-    promiseMiddleware,
-    contentSourcesApi.middleware,
-    imageBuilderApi.middleware,
-    rhsmApi.middleware,
-    provisioningApi.middleware
-  );
+  getDefaultMiddleware()
+    .prepend(listenerMiddleware.middleware)
+    .concat(
+      promiseMiddleware,
+      contentSourcesApi.middleware,
+      imageBuilderApi.middleware,
+      rhsmApi.middleware,
+      provisioningApi.middleware
+    );
 
 export const store = configureStore({ reducer, middleware });
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,7 +8,14 @@ import { imageBuilderApi } from './enhancedImageBuilderApi';
 import { listenerMiddleware, startAppListening } from './listenerMiddleware';
 import { provisioningApi } from './provisioningApi';
 import { rhsmApi } from './rhsmApi';
-import wizardSlice, {changeArchitecture, changeDistribution, changeImageTypes, selectArchitecture, selectDistribution, selectImageTypes} from './wizardSlice';
+import wizardSlice, {
+  changeArchitecture,
+  changeDistribution,
+  changeImageTypes,
+  selectArchitecture,
+  selectDistribution,
+  selectImageTypes,
+} from './wizardSlice';
 
 export const reducer = {
   [contentSourcesApi.reducerPath]: contentSourcesApi.reducer,

--- a/src/store/listenerMiddleware.ts
+++ b/src/store/listenerMiddleware.ts
@@ -1,0 +1,18 @@
+// listenerMiddleware.ts
+// https://redux-toolkit.js.org/api/createListenerMiddleware#typescript-usage
+import { createListenerMiddleware, addListener } from '@reduxjs/toolkit';
+import type { TypedStartListening, TypedAddListener } from '@reduxjs/toolkit';
+
+import type { RootState, AppDispatch } from './index';
+
+export const listenerMiddleware = createListenerMiddleware();
+
+export type AppStartListening = TypedStartListening<RootState, AppDispatch>;
+
+export const startAppListening =
+  listenerMiddleware.startListening as AppStartListening;
+
+export const addAppListener = addListener as TypedAddListener<
+  RootState,
+  AppDispatch
+>;

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -1,17 +1,23 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { Distributions } from './imageBuilderApi';
+import { Distributions, ImageRequest } from './imageBuilderApi';
 
-import { RHEL_9 } from '../constants';
+import { RHEL_9, X86_64 } from '../constants';
 
 import { RootState } from '.';
 
 type wizardState = {
+  architecture: ImageRequest['architecture'];
   distribution: Distributions;
 };
 
 const initialState: wizardState = {
+  architecture: X86_64,
   distribution: RHEL_9,
+};
+
+export const selectArchitecture = (state: RootState) => {
+  return state.wizard.architecture;
 };
 
 export const selectDistribution = (state: RootState) => {
@@ -23,11 +29,18 @@ export const wizardSlice = createSlice({
   initialState,
   reducers: {
     initializeWizard: () => initialState,
+    changeArchitecture: (
+      state,
+      action: PayloadAction<ImageRequest['architecture']>
+    ) => {
+      state.architecture = action.payload;
+    },
     changeDistribution: (state, action: PayloadAction<Distributions>) => {
       state.distribution = action.payload;
     },
   },
 });
 
-export const { initializeWizard, changeDistribution } = wizardSlice.actions;
+export const { initializeWizard, changeArchitecture, changeDistribution } =
+  wizardSlice.actions;
 export default wizardSlice.reducer;

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -1,16 +1,33 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-type wizardState = {};
+import { Distributions } from './imageBuilderApi';
 
-const initialState: wizardState = {};
+import { RHEL_9 } from '../constants';
+
+import { RootState } from '.';
+
+type wizardState = {
+  distribution: Distributions;
+};
+
+const initialState: wizardState = {
+  distribution: RHEL_9,
+};
+
+export const selectDistribution = (state: RootState) => {
+  return state.wizard.distribution;
+};
 
 export const wizardSlice = createSlice({
   name: 'wizard',
   initialState,
   reducers: {
     initializeWizard: () => initialState,
+    changeDistribution: (state, action: PayloadAction<Distributions>) => {
+      state.distribution = action.payload;
+    },
   },
 });
 
-export const { initializeWizard } = wizardSlice.actions;
+export const { initializeWizard, changeDistribution } = wizardSlice.actions;
 export default wizardSlice.reducer;

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -1,6 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 
-import { Distributions, ImageRequest } from './imageBuilderApi';
+import { Distributions, ImageRequest, ImageTypes } from './imageBuilderApi';
 
 import { RHEL_9, X86_64 } from '../constants';
 
@@ -9,11 +9,13 @@ import { RootState } from '.';
 type wizardState = {
   architecture: ImageRequest['architecture'];
   distribution: Distributions;
+  imageTypes: ImageTypes[];
 };
 
 const initialState: wizardState = {
   architecture: X86_64,
   distribution: RHEL_9,
+  imageTypes: [],
 };
 
 export const selectArchitecture = (state: RootState) => {
@@ -22,6 +24,10 @@ export const selectArchitecture = (state: RootState) => {
 
 export const selectDistribution = (state: RootState) => {
   return state.wizard.distribution;
+};
+
+export const selectImageTypes = (state: RootState) => {
+  return state.wizard.imageTypes;
 };
 
 export const wizardSlice = createSlice({
@@ -38,9 +44,30 @@ export const wizardSlice = createSlice({
     changeDistribution: (state, action: PayloadAction<Distributions>) => {
       state.distribution = action.payload;
     },
+    addImageType: (state, action: PayloadAction<ImageTypes>) => {
+      // Remove (if present) before adding to avoid duplicates
+      state.imageTypes = state.imageTypes.filter(
+        (imageType) => imageType !== action.payload
+      );
+      state.imageTypes.push(action.payload);
+    },
+    removeImageType: (state, action: PayloadAction<ImageTypes>) => {
+      state.imageTypes = state.imageTypes.filter(
+        (imageType) => imageType !== action.payload
+      );
+    },
+    changeImageTypes: (state, action: PayloadAction<ImageTypes[]>) => {
+      state.imageTypes = action.payload;
+    },
   },
 });
 
-export const { initializeWizard, changeArchitecture, changeDistribution } =
-  wizardSlice.actions;
+export const {
+  initializeWizard,
+  changeArchitecture,
+  changeDistribution,
+  addImageType,
+  removeImageType,
+  changeImageTypes,
+} = wizardSlice.actions;
 export default wizardSlice.reducer;

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -116,7 +116,7 @@ describe('Create Image Wizard', () => {
     // check heading
     screen.getByRole('heading', { name: /Image Builder/ });
 
-    // screen.getByRole('button', { name: 'Image output' });
+    screen.getByRole('button', { name: 'Image output' });
     // screen.getByRole('button', { name: 'Register' });
     // screen.getByRole('button', { name: 'File system configuration' });
     // screen.getByRole('button', { name: 'Content' });

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 
-// import '@testing-library/jest-dom';
+import '@testing-library/jest-dom';
 
+import type { Router as RemixRouter } from '@remix-run/router';
 import {
   screen,
-  //   waitFor,
+  waitFor,
   //   waitForElementToBeRemoved,
-  //   within,
+  within,
 } from '@testing-library/react';
-// import userEvent from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 // import { rest } from 'msw';
 
 import CreateImageWizard from '../../../Components/CreateImageWizardV2/CreateImageWizard';
@@ -19,13 +20,13 @@ import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal
 //   RHEL_8,
 //   RHSM_API,
 // } from '../../../constants.js';
-// import { server } from '../../mocks/server.js';
+import { server } from '../../mocks/server.js';
 import {
   //   clickBack,
-  //   clickNext,
-  //   getNextButton,
+  clickNext,
+  getNextButton,
   renderCustomRoutesWithReduxRouter,
-  //   verifyCancelButton,
+  verifyCancelButton,
 } from '../../testUtils';
 
 const routes = [
@@ -43,26 +44,26 @@ const routes = [
   },
 ];
 
-// let router = undefined;
+let router: RemixRouter | undefined = undefined;
 
-// jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
-//   useChrome: () => ({
-//     auth: {
-//       getUser: () => {
-//         return {
-//           identity: {
-//             internal: {
-//               org_id: 5,
-//             },
-//           },
-//         };
-//       },
-//     },
-//     isBeta: () => false,
-//     isProd: () => true,
-//     getEnvironment: () => 'prod',
-//   }),
-// }));
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => false,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
 
 // jest.mock('@unleash/proxy-client-react', () => ({
 //   useUnleashContext: () => jest.fn(),
@@ -99,16 +100,16 @@ const routes = [
 //   return sourceDropdown;
 // };
 
-// beforeAll(() => {
-//   // scrollTo is not defined in jsdom
-//   window.HTMLElement.prototype.scrollTo = function () {};
-// });
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
 
-// afterEach(() => {
-//   jest.clearAllMocks();
-//   router = undefined;
-//   server.resetHandlers();
-// });
+afterEach(() => {
+  jest.clearAllMocks();
+  router = undefined;
+  server.resetHandlers();
+});
 
 describe('Create Image Wizard', () => {
   test('renders component', () => {
@@ -127,169 +128,169 @@ describe('Create Image Wizard', () => {
   });
 });
 
-// describe('Step Image output', () => {
-//   const user = userEvent.setup();
-//   const setUp = async () => {
-//     ({ router } = await renderCustomRoutesWithReduxRouter(
-//       'imagewizard',
-//       {},
-//       routes
-//     ));
+describe('Step Image output', () => {
+  const user = userEvent.setup();
+  const setUp = async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
 
-//     // select aws as upload destination
-//     await user.click(await screen.findByTestId('upload-aws'));
+    // select aws as upload destination
+    await user.click(await screen.findByTestId('upload-aws'));
 
-//     await screen.findByRole('heading', { name: 'Image output' });
-//   };
+    await screen.findByRole('heading', { name: 'Image output' });
+  };
 
-//   test('clicking Next loads Upload to AWS', async () => {
-//     await setUp();
+  // test('clicking Next loads Upload to AWS', async () => {
+  //   await setUp();
 
-//     await clickNext();
+  //   await clickNext();
 
-//     await switchToAWSManual();
-//     await screen.findByText('AWS account ID');
-//   });
+  //   await switchToAWSManual();
+  //   await screen.findByText('AWS account ID');
+  // });
 
-//   test('clicking Cancel loads landing page', async () => {
-//     await setUp();
-//     await clickNext();
+  test('clicking Cancel loads landing page', async () => {
+    await setUp();
+    await clickNext();
 
-//     await verifyCancelButton(router);
-//   });
+    await verifyCancelButton(router);
+  });
 
-//   test('target environment is required', async () => {
-//     await setUp();
+  test('target environment is required', async () => {
+    await setUp();
 
-//     const destination = screen.getByTestId('target-select');
-//     const required = within(destination).getByText('*');
-//     expect(destination).toBeEnabled();
-//     expect(destination).toContainElement(required);
-//   });
+    const destination = await screen.findByTestId('target-select');
+    const required = await within(destination).findByText('*');
+    expect(destination).toBeEnabled();
+    expect(destination).toContainElement(required);
+  });
 
-//   test('selecting and deselecting a tile disables the next button', async () => {
-//     await setUp();
-//     const nextButton = await getNextButton();
+  test('selecting and deselecting a tile disables the next button', async () => {
+    await setUp();
+    const nextButton = await getNextButton();
 
-//     const awsTile = screen.getByTestId('upload-aws');
-//     // this has already been clicked once in the setup function
-//     await user.click(awsTile); // deselect
+    const awsTile = screen.getByTestId('upload-aws');
+    // this has already been clicked once in the setup function
+    await user.click(awsTile); // deselect
 
-//     const googleTile = screen.getByTestId('upload-google');
-//     await user.click(googleTile); // select
-//     await user.click(googleTile); // deselect
+    const googleTile = screen.getByTestId('upload-google');
+    await user.click(googleTile); // select
+    await user.click(googleTile); // deselect
 
-//     const azureTile = screen.getByTestId('upload-azure');
-//     await user.click(azureTile); // select
-//     await user.click(azureTile); // deselect
+    const azureTile = screen.getByTestId('upload-azure');
+    await user.click(azureTile); // select
+    await user.click(azureTile); // deselect
 
-//     await waitFor(() => expect(nextButton).toBeDisabled());
-//   });
+    await waitFor(() => expect(nextButton).toBeDisabled());
+  });
 
-//   test('expect only RHEL releases before expansion', async () => {
-//     await setUp();
+  test('expect only RHEL releases before expansion', async () => {
+    await setUp();
 
-//     const releaseMenu = screen.getAllByRole('button', {
-//       name: /options menu/i,
-//     })[0];
-//     await user.click(releaseMenu);
+    const releaseMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[0];
+    await user.click(releaseMenu);
 
-//     await screen.findByRole('option', {
-//       name: /Red Hat Enterprise Linux \(RHEL\) 8/,
-//     });
-//     await screen.findByRole('option', {
-//       name: /Red Hat Enterprise Linux \(RHEL\) 9/,
-//     });
-//     await screen.findByRole('button', {
-//       name: 'Show options for further development of RHEL',
-//     });
+    await screen.findByRole('option', {
+      name: /Red Hat Enterprise Linux \(RHEL\) 8/,
+    });
+    await screen.findByRole('option', {
+      name: /Red Hat Enterprise Linux \(RHEL\) 9/,
+    });
+    await screen.findByRole('button', {
+      name: 'Show options for further development of RHEL',
+    });
 
-//     await user.click(releaseMenu);
-//   });
+    await user.click(releaseMenu);
+  });
 
-//   test('expect all releases after expansion', async () => {
-//     await setUp();
+  test('expect all releases after expansion', async () => {
+    await setUp();
 
-//     const releaseMenu = screen.getAllByRole('button', {
-//       name: /options menu/i,
-//     })[0];
-//     await user.click(releaseMenu);
+    const releaseMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[0];
+    await user.click(releaseMenu);
 
-//     const showOptionsButton = screen.getByRole('button', {
-//       name: 'Show options for further development of RHEL',
-//     });
-//     await user.click(showOptionsButton);
+    const showOptionsButton = screen.getByRole('button', {
+      name: 'Show options for further development of RHEL',
+    });
+    await user.click(showOptionsButton);
 
-//     await screen.findByRole('option', {
-//       name: /Red Hat Enterprise Linux \(RHEL\) 8/,
-//     });
-//     await screen.findByRole('option', {
-//       name: /Red Hat Enterprise Linux \(RHEL\) 9/,
-//     });
-//     await screen.findByRole('option', {
-//       name: 'CentOS Stream 8',
-//     });
-//     await screen.findByRole('option', {
-//       name: 'CentOS Stream 9',
-//     });
+    await screen.findByRole('option', {
+      name: /Red Hat Enterprise Linux \(RHEL\) 8/,
+    });
+    await screen.findByRole('option', {
+      name: /Red Hat Enterprise Linux \(RHEL\) 9/,
+    });
+    await screen.findByRole('option', {
+      name: 'CentOS Stream 8',
+    });
+    await screen.findByRole('option', {
+      name: 'CentOS Stream 9',
+    });
 
-//     expect(showOptionsButton).not.toBeInTheDocument();
+    expect(showOptionsButton).not.toBeInTheDocument();
 
-//     await user.click(releaseMenu);
-//   });
+    await user.click(releaseMenu);
+  });
 
-//   test('release lifecycle chart appears only when RHEL 8 is chosen', async () => {
-//     await setUp();
+  test('release lifecycle chart appears only when RHEL 8 is chosen', async () => {
+    await setUp();
 
-//     const releaseMenu = screen.getAllByRole('button', {
-//       name: /options menu/i,
-//     })[0];
-//     await user.click(releaseMenu);
+    const releaseMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[0];
+    await user.click(releaseMenu);
 
-//     await user.click(
-//       await screen.findByRole('option', {
-//         name: /Red Hat Enterprise Linux \(RHEL\) 9/,
-//       })
-//     );
-//     expect(
-//       screen.queryByTestId('release-lifecycle-chart')
-//     ).not.toBeInTheDocument();
+    await user.click(
+      await screen.findByRole('option', {
+        name: /Red Hat Enterprise Linux \(RHEL\) 9/,
+      })
+    );
+    expect(
+      screen.queryByTestId('release-lifecycle-chart')
+    ).not.toBeInTheDocument();
 
-//     await user.click(releaseMenu);
+    await user.click(releaseMenu);
 
-//     await user.click(
-//       await screen.findByRole('option', {
-//         name: /Red Hat Enterprise Linux \(RHEL\) 8/,
-//       })
-//     );
-//     expect(
-//       await screen.findByTestId('release-lifecycle-chart')
-//     ).toBeInTheDocument();
-//   });
+    await user.click(
+      await screen.findByRole('option', {
+        name: /Red Hat Enterprise Linux \(RHEL\) 8/,
+      })
+    );
+    expect(
+      await screen.findByTestId('release-lifecycle-chart')
+    ).toBeInTheDocument();
+  });
 
-//   test('CentOS acknowledgement appears', async () => {
-//     await setUp();
+  test('CentOS acknowledgement appears', async () => {
+    await setUp();
 
-//     const releaseMenu = screen.getAllByRole('button', {
-//       name: /options menu/i,
-//     })[0];
-//     await user.click(releaseMenu);
+    const releaseMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[0];
+    await user.click(releaseMenu);
 
-//     const showOptionsButton = screen.getByRole('button', {
-//       name: 'Show options for further development of RHEL',
-//     });
-//     await user.click(showOptionsButton);
+    const showOptionsButton = screen.getByRole('button', {
+      name: 'Show options for further development of RHEL',
+    });
+    await user.click(showOptionsButton);
 
-//     const centOSButton = screen.getByRole('option', {
-//       name: 'CentOS Stream 9',
-//     });
-//     await user.click(centOSButton);
+    const centOSButton = screen.getByRole('option', {
+      name: 'CentOS Stream 9',
+    });
+    await user.click(centOSButton);
 
-//     await screen.findByText(
-//       'CentOS Stream builds are intended for the development of future versions of RHEL and are not supported for production workloads or other use cases.'
-//     );
-//   });
-// });
+    await screen.findByText(
+      'CentOS Stream builds are intended for the development of future versions of RHEL and are not supported for production workloads or other use cases.'
+    );
+  });
+});
 
 // describe('Step Upload to AWS', () => {
 //   const user = userEvent.setup();

--- a/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -4,11 +4,11 @@ import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import CreateImageWizard from '../../../../Components/CreateImageWizard/CreateImageWizard';
-import { AARCH64, RHEL_8, RHEL_9, X86_64 } from '../../../../constants';
-import { mockArchitecturesByDistro } from '../../../fixtures/architectures';
-import { server } from '../../../mocks/server';
-import { renderCustomRoutesWithReduxRouter } from '../../../testUtils';
+import CreateImageWizard from '../../../../../Components/CreateImageWizardV2/CreateImageWizard';
+import { AARCH64, RHEL_8, RHEL_9, X86_64 } from '../../../../../constants';
+import { mockArchitecturesByDistro } from '../../../../fixtures/architectures';
+import { server } from '../../../../mocks/server';
+import { renderCustomRoutesWithReduxRouter } from '../../../../testUtils';
 
 const routes = [
   {
@@ -58,7 +58,7 @@ describe('Check that the target filtering is in accordance to mock content', () 
     await user.click(await screen.findByRole('option', { name: 'x86_64' }));
 
     // make sure this test is in SYNC with the mocks
-    let images_types = [];
+    let images_types: string[] = []; // type is `string[]` and not `ImageType[]` because in imageBuilderAPI ArchitectureItem['image_types'] is type string
     mockArchitecturesByDistro(RHEL_9).forEach((elem) => {
       if (elem.arch === X86_64) {
         images_types = elem.image_types;
@@ -108,7 +108,7 @@ describe('Check that the target filtering is in accordance to mock content', () 
     await user.click(await screen.findByRole('option', { name: 'x86_64' }));
 
     // make sure this test is in SYNC with the mocks
-    let images_types = [];
+    let images_types: string[] = [];
     mockArchitecturesByDistro(RHEL_8).forEach((elem) => {
       if (elem.arch === X86_64) {
         images_types = elem.image_types;
@@ -145,7 +145,7 @@ describe('Check that the target filtering is in accordance to mock content', () 
     await user.click(await screen.findByRole('option', { name: 'aarch64' }));
 
     // make sure this test is in SYNC with the mocks
-    let images_types = [];
+    let images_types: string[] = [];
     mockArchitecturesByDistro(RHEL_9).forEach((elem) => {
       if (elem.arch === AARCH64) {
         images_types = elem.image_types;
@@ -197,7 +197,7 @@ describe('Check that the target filtering is in accordance to mock content', () 
     await user.click(await screen.findByRole('option', { name: 'aarch64' }));
 
     // make sure this test is in SYNC with the mocks
-    let images_types = [];
+    let images_types: string[] = [];
     mockArchitecturesByDistro(RHEL_8).forEach((elem) => {
       if (elem.arch === AARCH64) {
         images_types = elem.image_types;

--- a/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import CreateImageWizard from '../../../../Components/CreateImageWizard/CreateImageWizard';
+import { AARCH64, RHEL_8, RHEL_9, X86_64 } from '../../../../constants';
+import { mockArchitecturesByDistro } from '../../../fixtures/architectures';
+import { server } from '../../../mocks/server';
+import { renderCustomRoutesWithReduxRouter } from '../../../testUtils';
+
+const routes = [
+  {
+    path: 'insights/image-builder/imagewizard/:composeId?',
+    element: <CreateImageWizard />,
+  },
+];
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
+beforeAll(() => {
+  // scrollTo is not defined in jsdom
+  window.HTMLElement.prototype.scrollTo = function () {};
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+  server.resetHandlers();
+});
+
+describe('Check that the target filtering is in accordance to mock content', () => {
+  test('rhel9 x86_64', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+
+    // select x86_64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'x86_64' }));
+
+    // make sure this test is in SYNC with the mocks
+    let images_types = [];
+    mockArchitecturesByDistro(RHEL_9).forEach((elem) => {
+      if (elem.arch === X86_64) {
+        images_types = elem.image_types;
+      }
+    });
+    expect(images_types).toContain('aws');
+    expect(images_types).toContain('gcp');
+    expect(images_types).toContain('azure');
+    expect(images_types).toContain('guest-image');
+    expect(images_types).toContain('image-installer');
+    expect(images_types).toContain('vsphere');
+    expect(images_types).toContain('vsphere-ova');
+    expect(images_types).not.toContain('wsl');
+    // make sure the UX conforms to the mocks
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    await screen.findByTestId('upload-google');
+    await screen.findByTestId('upload-azure');
+    await screen.findByTestId('checkbox-guest-image');
+    await screen.findByTestId('checkbox-image-installer');
+    await screen.findByText(/vmware vsphere/i);
+    await screen.findByText(/open virtualization format \(\.ova\)/i);
+    expect(
+      screen.queryByText(/wsl - windows subsystem for linux \(\.tar\.gz\)/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('rhel8 x86_64', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+
+    // select rhel8
+    const releaseMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[0];
+    await user.click(releaseMenu);
+    await user.click(
+      screen.getByRole('option', {
+        name: /Red Hat Enterprise Linux \(RHEL\) 8/,
+      })
+    );
+
+    // select x86_64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'x86_64' }));
+
+    // make sure this test is in SYNC with the mocks
+    let images_types = [];
+    mockArchitecturesByDistro(RHEL_8).forEach((elem) => {
+      if (elem.arch === X86_64) {
+        images_types = elem.image_types;
+      }
+    });
+    expect(images_types).toContain('aws');
+    expect(images_types).toContain('gcp');
+    expect(images_types).toContain('azure');
+    expect(images_types).toContain('guest-image');
+    expect(images_types).toContain('image-installer');
+    expect(images_types).toContain('vsphere');
+    expect(images_types).toContain('vsphere-ova');
+    expect(images_types).toContain('wsl');
+    // make sure the UX conforms to the mocks
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    await screen.findByTestId('upload-google');
+    await screen.findByTestId('upload-azure');
+    await screen.findByTestId('checkbox-guest-image');
+    await screen.findByTestId('checkbox-image-installer');
+    await screen.findByText(/vmware vsphere/i);
+    await screen.findByText(/open virtualization format \(\.ova\)/i);
+    await screen.findByText(/wsl - windows subsystem for linux \(\.tar\.gz\)/i);
+  });
+
+  test('rhel9 aarch64', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+
+    // select aarch64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'aarch64' }));
+
+    // make sure this test is in SYNC with the mocks
+    let images_types = [];
+    mockArchitecturesByDistro(RHEL_9).forEach((elem) => {
+      if (elem.arch === AARCH64) {
+        images_types = elem.image_types;
+      }
+    });
+    expect(images_types).toContain('aws');
+    expect(images_types).not.toContain('gcp');
+    expect(images_types).not.toContain('azure');
+    expect(images_types).toContain('guest-image');
+    expect(images_types).toContain('image-installer');
+    expect(images_types).not.toContain('vsphere');
+    expect(images_types).not.toContain('vsphere-ova');
+    expect(images_types).not.toContain('wsl');
+    // make sure the UX conforms to the mocks
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    expect(screen.queryByTestId('upload-google')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('upload-azure')).not.toBeInTheDocument();
+    await screen.findByTestId('checkbox-guest-image');
+    await screen.findByTestId('checkbox-image-installer');
+    expect(screen.queryByText(/vmware vsphere/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/open virtualization format \(\.ova\)/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/wsl - windows subsystem for linux \(\.tar\.gz\)/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('rhel8 aarch64', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+
+    // select rhel8
+    const releaseMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[0];
+    await user.click(releaseMenu);
+    await user.click(
+      screen.getByRole('option', {
+        name: /Red Hat Enterprise Linux \(RHEL\) 8/,
+      })
+    );
+
+    // select x86_64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'aarch64' }));
+
+    // make sure this test is in SYNC with the mocks
+    let images_types = [];
+    mockArchitecturesByDistro(RHEL_8).forEach((elem) => {
+      if (elem.arch === AARCH64) {
+        images_types = elem.image_types;
+      }
+    });
+    expect(images_types).toContain('aws');
+    expect(images_types).not.toContain('gcp');
+    expect(images_types).not.toContain('azure');
+    expect(images_types).toContain('guest-image');
+    expect(images_types).toContain('image-installer');
+    expect(images_types).not.toContain('vsphere');
+    expect(images_types).not.toContain('vsphere-ova');
+    expect(images_types).not.toContain('wsl');
+    // make sure the UX conforms to the mocks
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    expect(screen.queryByTestId('upload-google')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('upload-azure')).not.toBeInTheDocument();
+    await screen.findByTestId('checkbox-guest-image');
+    await screen.findByTestId('checkbox-image-installer');
+    expect(screen.queryByText(/vmware vsphere/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/open virtualization format \(\.ova\)/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/wsl - windows subsystem for linux \(\.tar\.gz\)/i)
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('Check step consistency', () => {
+  test('going back and forth with selected options only keeps the one compatible', async () => {
+    const user = userEvent.setup();
+    await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+
+    // select x86_64
+    const archMenu = screen.getAllByRole('button', {
+      name: /options menu/i,
+    })[1];
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'x86_64' }));
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    // select GCP, it's available for x86_64
+    await user.click(screen.getByTestId('upload-google'));
+    const next = await screen.findByRole('button', { name: /Next/ });
+    await waitFor(() => expect(next).toBeEnabled());
+    // Change to aarch
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'aarch64' }));
+    await waitFor(async () => await screen.findByTestId('upload-aws'));
+    // GCP not being compatible with arch, the next button is disabled
+    await waitFor(() => expect(next).toBeDisabled());
+    // clicking on AWS the user can go next
+    await user.click(screen.getByTestId('upload-aws'));
+    await waitFor(() => expect(next).toBeEnabled());
+    // and going back to x86_64 the user should keep the next button visible
+    await user.click(archMenu);
+    await user.click(await screen.findByRole('option', { name: 'x86_64' }));
+    await waitFor(() => expect(next).toBeEnabled());
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "noImplicitAny": true,
     "module": "es6",
     "target": "es5",
+    "downlevelIteration": true, // Needed to allow iteration over some objects like Map() while target is es5
     "jsx": "react-jsx",
     "allowJs": true,
     "moduleResolution": "node",


### PR DESCRIPTION
This PR adds the Image Output step to the V2 wizard.

All relevant tests are passing.

The wizard's state is now managed using RTK query and is visible using the Redux devtools.

Note that for the most part, our existing components can easily be converted from using DDF to RTK. Calls to `change()` in DDF are updated to calls to `dispatch()`, and calls to `getState()` are update to calls to the relevant Redux selector.

RTK's listeners are used to ensure that the wizard's state is always "correct" (i.e., "infeasible" states are automatically corrected by the listeners):

![rtk listeners](https://github.com/RedHatInsights/image-builder-frontend/assets/95542540/e0c43b71-c3db-4335-9ece-2480f1d678e2)

