### PR TITLE
V2Wizard: Fix wizard reset action

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import {
   Button,
@@ -56,7 +56,12 @@ const CreateImageWizard = () => {
   const dispatch = useAppDispatch();
 
   // IMPORTANT: Ensure the wizard starts with a fresh initial state
-  dispatch(initializeWizard);
+  useEffect(() => {
+    dispatch(initializeWizard());
+    // This useEffect hook should run *only* on mount and therefore has an empty
+    // dependency array. eslint's exhaustive-deps rule does not support this use.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   /*           *
    * Selectors *


### PR DESCRIPTION
Fixes #1552.

The wizardSlice's reset wizard action was not working because when it was passed to `dispatch()` as an argument it was missing the `()`... oops!

It also needs to be dispatched inside of a useEffect hook with an empty dependency array so that it is only dispatched once, when the wizard opens.