### PR TITLE
wizardv2: fix the reinitialisation bug

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   Button,
@@ -56,7 +56,12 @@ const CreateImageWizard = () => {
   const dispatch = useAppDispatch();
 
   // IMPORTANT: Ensure the wizard starts with a fresh initial state
-  dispatch(initializeWizard);
+  // Perform the action only once per render of the wizard.
+  const [needsReinit, setNeedsReinit] = useState(true);
+  if (needsReinit) {
+    dispatch(initializeWizard());
+    setNeedsReinit(false);
+  }
 
   /*           *
    * Selectors *


### PR DESCRIPTION
The V2 wizard was not reinitializing itself when the user was opting out of the form and back again. Which meant that the old data from a previous compose was still set.

This commit fixes this issue by:
* Making sure the initializing function is actually called
* Making sure the initialization happens only once per rendering of the wizard

Fixes #1552