### PR TITLE
deps: Manual bump redux from 4.2.1 to 5.0.1 and @reduxjs/toolkit from 1.9.5 to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@redhat-cloud-services/frontend-components": "4.2.1",
         "@redhat-cloud-services/frontend-components-notifications": "4.1.0",
         "@redhat-cloud-services/frontend-components-utilities": "4.0.2",
-        "@reduxjs/toolkit": "1.9.5",
+        "@reduxjs/toolkit": "2.0.1",
         "@scalprum/react-core": "0.6.6",
         "@unleash/proxy-client-react": "4.1.1",
         "classnames": "2.5.1",
@@ -25,7 +25,7 @@
         "react-dom": "18.2.0",
         "react-redux": "8.1.3",
         "react-router-dom": "6.19.0",
-        "redux": "4.2.1",
+        "redux": "5.0.1",
         "redux-promise-middleware": "6.2.0"
       },
       "devDependencies": {
@@ -3896,17 +3896,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "1.9.5",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.0.1.tgz",
+      "integrity": "sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==",
       "dependencies": {
-        "immer": "^9.0.21",
-        "redux": "^4.2.1",
-        "redux-thunk": "^2.4.2",
-        "reselect": "^4.1.8"
+        "immer": "^10.0.3",
+        "redux": "^5.0.0",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",
-        "react-redux": "^7.2.1 || ^8.0.2"
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -4704,6 +4705,15 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-redux/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/retry": {
@@ -11249,8 +11259,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "9.0.21",
-      "license": "MIT",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.0.3.tgz",
+      "integrity": "sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -17178,11 +17189,9 @@
       }
     },
     "node_modules/redux": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
-      }
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-mock-store": {
       "version": "1.5.4",
@@ -17201,10 +17210,11 @@
       }
     },
     "node_modules/redux-thunk": {
-      "version": "2.4.2",
-      "license": "MIT",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
       "peerDependencies": {
-        "redux": "^4"
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -17370,8 +17380,9 @@
       "license": "MIT"
     },
     "node_modules/reselect": {
-      "version": "4.1.8",
-      "license": "MIT"
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
       "version": "1.22.6",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@redhat-cloud-services/frontend-components": "4.2.1",
     "@redhat-cloud-services/frontend-components-notifications": "4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "4.0.2",
-    "@reduxjs/toolkit": "1.9.5",
+    "@reduxjs/toolkit": "2.0.1",
     "@scalprum/react-core": "0.6.6",
     "@unleash/proxy-client-react": "4.1.1",
     "classnames": "2.5.1",
@@ -24,7 +24,7 @@
     "react-dom": "18.2.0",
     "react-redux": "8.1.3",
     "react-router-dom": "6.19.0",
-    "redux": "4.2.1",
+    "redux": "5.0.1",
     "redux-promise-middleware": "6.2.0"
   },
   "jest": {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
 import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { configureStore } from '@reduxjs/toolkit';
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import promiseMiddleware from 'redux-promise-middleware';
 
 import { contentSourcesApi } from './contentSourcesApi';
@@ -17,7 +17,7 @@ import wizardSlice, {
   selectImageTypes,
 } from './wizardSlice';
 
-export const reducer = {
+export const reducer = combineReducers({
   [contentSourcesApi.reducerPath]: contentSourcesApi.reducer,
   [edgeApi.reducerPath]: edgeApi.reducer,
   [imageBuilderApi.reducerPath]: imageBuilderApi.reducer,
@@ -25,7 +25,7 @@ export const reducer = {
   [provisioningApi.reducerPath]: provisioningApi.reducer,
   notifications: notificationsReducer,
   wizard: wizardSlice,
-};
+});
 
 startAppListening({
   actionCreator: changeArchitecture,

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.js
@@ -183,8 +183,8 @@ describe('Step Upload to Azure', () => {
       })
     );
     // wait for fetching the upload info
-    expect(await screen.findByTestId('azure-tenant-id-source')).not.toHaveValue(
-      ''
+    await waitFor(() =>
+      expect(screen.getByTestId('azure-tenant-id-source')).not.toHaveValue('')
     );
 
     await user.click(
@@ -212,8 +212,8 @@ describe('Step Upload to Azure', () => {
         name: /azureSource1/i,
       })
     );
-    expect(await screen.findByTestId('azure-tenant-id-source')).not.toHaveValue(
-      ''
+    await waitFor(() =>
+      expect(screen.getByTestId('azure-tenant-id-source')).not.toHaveValue('')
     );
 
     await user.click(sourceDropdown);

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
@@ -866,13 +866,13 @@ describe('Step Custom repositories', () => {
 
     expect(firstRepoCheckbox.checked).toEqual(false);
     await user.click(firstRepoCheckbox);
-    expect(firstRepoCheckbox.checked).toEqual(true);
+    await waitFor(() => expect(firstRepoCheckbox.checked).toEqual(true));
 
     await clickNext();
-    clickBack();
+    await clickBack();
 
     firstRepoCheckbox = await getFirstRepoCheckbox();
-    expect(firstRepoCheckbox.checked).toEqual(true);
+    await waitFor(() => expect(firstRepoCheckbox.checked).toEqual(true));
   });
 
   test('correct number of repositories is fetched', async () => {
@@ -1079,7 +1079,7 @@ describe('On Recreate', () => {
     const availableRepoCheckbox = await screen.findByRole('checkbox', {
       name: /select row 0/i,
     });
-    expect(availableRepoCheckbox).toBeEnabled();
+    await waitFor(() => expect(availableRepoCheckbox).toBeEnabled());
   });
 
   test('with repositories that are no longer available', async () => {


### PR DESCRIPTION
This bumps:
- redux from 4.2.1 to 5.0.1
- @reduxjs/toolkit from 1.9.5 to 2.0.1

Test started to fail so some logic was moved to async.