### PR TITLE
test: Replace `.getBy` queries by awaited `.findBy`

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.js
@@ -96,15 +96,15 @@ describe('Step Upload to Azure', () => {
     await user.click(await screen.findByTestId('azure-radio-manual'));
     // Randomly generated GUID
     await user.type(
-      screen.getByTestId('azure-tenant-id-manual'),
+      await screen.findByTestId('azure-tenant-id-manual'),
       'b8f86d22-4371-46ce-95e7-65c415f3b1e2'
     );
     await user.type(
-      screen.getByTestId('azure-subscription-id-manual'),
+      await screen.findByTestId('azure-subscription-id-manual'),
       '60631143-a7dc-4d15-988b-ba83f3c99711'
     );
     await user.type(
-      screen.getByTestId('azure-resource-group-manual'),
+      await screen.findByTestId('azure-resource-group-manual'),
       'testResourceGroup'
     );
     await clickNext();
@@ -123,7 +123,7 @@ describe('Step Upload to Azure', () => {
 
     await clickBack();
 
-    screen.getByTestId('upload-azure');
+    await screen.findByTestId('upload-azure');
   });
 
   test('clicking Cancel loads landing page', async () => {
@@ -137,37 +137,43 @@ describe('Step Upload to Azure', () => {
     const nextButton = await getNextButton();
 
     expect(nextButton).toHaveClass('pf-m-disabled');
-    expect(screen.getByTestId('azure-radio-source')).toBeChecked();
+    expect(await screen.findByTestId('azure-radio-source')).toBeChecked();
 
-    await user.click(screen.getByTestId('azure-radio-manual'));
-    expect(screen.getByTestId('azure-radio-manual')).toBeChecked();
+    await user.click(await screen.findByTestId('azure-radio-manual'));
+    expect(await screen.findByTestId('azure-radio-manual')).toBeChecked();
 
     expect(nextButton).toHaveClass('pf-m-disabled');
 
-    const tenantId = screen.getByTestId('azure-tenant-id-manual');
+    const tenantId = await screen.findByTestId('azure-tenant-id-manual');
     expect(tenantId).toHaveValue('');
     expect(tenantId).toBeEnabled();
     await user.type(tenantId, 'c983c2cd-94d7-44e1-9c6e-9cfa3a40995f');
-    const subscription = screen.getByTestId('azure-subscription-id-manual');
+    const subscription = await screen.findByTestId(
+      'azure-subscription-id-manual'
+    );
     expect(subscription).toHaveValue('');
     expect(subscription).toBeEnabled();
     await user.type(subscription, 'f8f200aa-6234-4bfb-86c2-163d33dffc0c');
-    const resourceGroup = screen.getByTestId('azure-resource-group-manual');
+    const resourceGroup = await screen.findByTestId(
+      'azure-resource-group-manual'
+    );
     expect(resourceGroup).toHaveValue('');
     expect(resourceGroup).toBeEnabled();
     await user.type(resourceGroup, 'testGroup');
 
     expect(nextButton).not.toHaveClass('pf-m-disabled');
 
-    await user.click(screen.getByTestId('azure-radio-source'));
+    await user.click(await screen.findByTestId('azure-radio-source'));
 
     await waitFor(() => expect(nextButton).toHaveClass('pf-m-disabled'));
 
     const sourceDropdown = await getSourceDropdown();
 
     // manual values should be cleared out
-    expect(screen.getByTestId('azure-tenant-id-source')).toHaveValue('');
-    expect(screen.getByTestId('azure-subscription-id-source')).toHaveValue('');
+    expect(await screen.findByTestId('azure-tenant-id-source')).toHaveValue('');
+    expect(
+      await screen.findByTestId('azure-subscription-id-source')
+    ).toHaveValue('');
 
     await user.click(sourceDropdown);
 
@@ -177,18 +183,20 @@ describe('Step Upload to Azure', () => {
       })
     );
     // wait for fetching the upload info
-    await waitFor(() =>
-      expect(screen.getByTestId('azure-tenant-id-source')).not.toHaveValue('')
+    expect(await screen.findByTestId('azure-tenant-id-source')).not.toHaveValue(
+      ''
     );
 
     await user.click(
-      screen.getByRole('textbox', {
+      await screen.findByRole('textbox', {
         name: /select resource group/i,
       })
     );
     const groups = screen.getAllByLabelText(/^Resource group/);
     expect(groups).toHaveLength(2);
-    await user.click(screen.getByLabelText('Resource group myResourceGroup1'));
+    await user.click(
+      await screen.findByLabelText('Resource group myResourceGroup1')
+    );
 
     expect(nextButton).not.toHaveClass('pf-m-disabled');
   }, 10000);
@@ -204,8 +212,8 @@ describe('Step Upload to Azure', () => {
         name: /azureSource1/i,
       })
     );
-    await waitFor(() =>
-      expect(screen.getByTestId('azure-tenant-id-source')).not.toHaveValue('')
+    expect(await screen.findByTestId('azure-tenant-id-source')).not.toHaveValue(
+      ''
     );
 
     await user.click(sourceDropdown);
@@ -214,20 +222,22 @@ describe('Step Upload to Azure', () => {
         name: /azureSource2/i,
       })
     );
-    await waitFor(() =>
+    await waitFor(() => {
       expect(screen.getByTestId('azure-tenant-id-source')).toHaveValue(
         '73d5694c-7a28-417e-9fca-55840084f508'
-      )
-    );
+      );
+    });
 
     await user.click(
-      screen.getByRole('textbox', {
+      await screen.findByRole('textbox', {
         name: /select resource group/i,
       })
     );
-    const groups = screen.getByLabelText(/^Resource group/);
+    const groups = await screen.findByLabelText(/^Resource group/);
     expect(groups).toBeInTheDocument();
-    expect(screen.getByLabelText('Resource group theirGroup2')).toBeVisible();
+    expect(
+      await screen.findByLabelText('Resource group theirGroup2')
+    ).toBeVisible();
   });
 
   test('component renders error state correctly', async () => {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
@@ -77,22 +77,27 @@ describe('Step Compliance', () => {
 
     // aws step
     await user.click(
-      screen.getByRole('radio', { name: /manually enter an account id\./i })
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
     );
-    await user.type(screen.getByTestId('aws-account-id'), '012345678901');
+    await user.type(
+      await screen.findByTestId('aws-account-id'),
+      '012345678901'
+    );
 
     await clickNext();
     // skip registration
-    await user.click(screen.getByLabelText('Register later'));
+    await user.click(await screen.findByLabelText('Register later'));
     await clickNext();
 
     // Now we should be in the Compliance step
     await screen.findByRole('heading', { name: /OpenSCAP/i });
 
     await user.click(
-      screen.getByRole('textbox', { name: /select a profile/i })
+      await screen.findByRole('textbox', { name: /select a profile/i })
     );
-    await user.click(screen.getByText(/none/i));
+    await user.click(await screen.findByText(/none/i));
 
     // check that the FSC does not contain a /tmp partition
     await clickNext();
@@ -108,7 +113,7 @@ describe('Step Compliance', () => {
     await screen.findByRole('heading', {
       name: /Additional Red Hat packages/i,
     });
-    screen.getByText(/no packages added/i);
+    await screen.findByText(/no packages added/i);
   });
 
   test('create an image with an oscap profile', async () => {
@@ -120,20 +125,25 @@ describe('Step Compliance', () => {
 
     // aws step
     await user.click(
-      screen.getByRole('radio', { name: /manually enter an account id\./i })
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
     );
-    await user.type(screen.getByTestId('aws-account-id'), '012345678901');
+    await user.type(
+      await screen.findByTestId('aws-account-id'),
+      '012345678901'
+    );
 
     await clickNext();
     // skip registration
-    await user.click(screen.getByLabelText('Register later'));
+    await user.click(await screen.findByLabelText('Register later'));
     await clickNext();
 
     // Now we should be at the OpenSCAP step
     await screen.findByRole('heading', { name: /OpenSCAP/i });
 
     await user.click(
-      screen.getByRole('textbox', {
+      await screen.findByRole('textbox', {
         name: /select a profile/i,
       })
     );

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
@@ -116,7 +116,7 @@ describe('Step Packages', () => {
 
       // aws step
       await user.click(
-        screen.getByRole('radio', {
+        await screen.findByRole('radio', {
           name: /manually enter an account id\./i,
         })
       );
@@ -151,7 +151,9 @@ describe('Step Packages', () => {
 
       await clickBack();
 
-      screen.getByRole('heading', { name: /file system configuration/i });
+      await screen.findByRole('heading', {
+        name: /file system configuration/i,
+      });
     });
 
     test('clicking Cancel loads landing page', async () => {
@@ -176,8 +178,10 @@ describe('Step Packages', () => {
     test('should display default state', async () => {
       await setUp();
 
-      screen.getByText('Search above to add additionalpackages to your image');
-      screen.getByText('No packages added');
+      await screen.findByText(
+        'Search above to add additionalpackages to your image'
+      );
+      await screen.findByText('No packages added');
     });
 
     test('search results should be sorted with most relevant results first', async () => {
@@ -190,7 +194,9 @@ describe('Step Packages', () => {
 
       await searchForAvailablePackages(searchbox, 'test');
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = await within(
         availablePackagesList
       ).findAllByRole('option');
@@ -212,12 +218,18 @@ describe('Step Packages', () => {
       await searchForAvailablePackages(searchbox, 'test');
 
       await user.click(await screen.findByTestId('available-pkgs-testPkg'));
-      await user.click(screen.getByRole('button', { name: /Add selected/ }));
+      await user.click(
+        await screen.findByRole('button', { name: /Add selected/ })
+      );
 
-      await user.click(screen.getByTestId('selected-pkgs-testPkg'));
-      await user.click(screen.getByRole('button', { name: /Remove selected/ }));
+      await user.click(await screen.findByTestId('selected-pkgs-testPkg'));
+      await user.click(
+        await screen.findByRole('button', { name: /Remove selected/ })
+      );
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = within(availablePackagesList).getAllByRole(
         'option'
       );
@@ -238,10 +250,14 @@ describe('Step Packages', () => {
 
       await searchForAvailablePackages(searchbox, 'test');
 
-      await user.click(screen.getByRole('button', { name: /Add all/ }));
-      await user.click(screen.getByRole('button', { name: /Remove all/ }));
+      await user.click(await screen.findByRole('button', { name: /Add all/ }));
+      await user.click(
+        await screen.findByRole('button', { name: /Remove all/ })
+      );
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = within(availablePackagesList).getAllByRole(
         'option'
       );
@@ -261,11 +277,13 @@ describe('Step Packages', () => {
       await user.click(searchbox);
 
       await searchForAvailablePackages(searchbox, 'test');
-      await user.click(screen.getByRole('button', { name: /Add all/ }));
+      await user.click(await screen.findByRole('button', { name: /Add all/ }));
 
       // remove a single package
       await user.click(await screen.findByTestId('selected-pkgs-lib-test'));
-      await user.click(screen.getByRole('button', { name: /Remove selected/ }));
+      await user.click(
+        await screen.findByRole('button', { name: /Remove selected/ })
+      );
 
       // skip name page
       clickNext();
@@ -281,11 +299,13 @@ describe('Step Packages', () => {
       clickBack();
       await screen.findByTestId('search-available-pkgs-input');
       await user.click(
-        screen.getByRole('option', {
+        await screen.findByRole('option', {
           name: /summary for test package/,
         })
       );
-      await user.click(screen.getByRole('button', { name: /Remove selected/ }));
+      await user.click(
+        await screen.findByRole('button', { name: /Remove selected/ })
+      );
 
       // review page
       clickNext();
@@ -343,7 +363,7 @@ describe('Step Packages', () => {
       await user.click(searchboxChosen);
       await user.type(searchboxChosen, 'asdf');
 
-      expect(screen.getByText('No packages found')).toBeInTheDocument();
+      expect(await screen.findByText('No packages found')).toBeInTheDocument();
       // We need to clear this input in order to not have sideeffects on other tests
       await searchForChosenPackages(searchboxChosen, '');
     });
@@ -367,8 +387,8 @@ describe('Step Packages', () => {
       await searchForAvailablePackages(searchbox, 'testPkg');
       await waitFor(() => expect(getPackages).toHaveBeenCalledTimes(2));
 
-      screen.getByText('Over 100 results found. Refine your search.');
-      screen.getByText('Too many results to display');
+      await screen.findByText('Over 100 results found. Refine your search.');
+      await screen.findByText('Too many results to display');
     });
 
     test('should display an exact match if found regardless of too many results', async () => {
@@ -390,14 +410,16 @@ describe('Step Packages', () => {
       await searchForAvailablePackages(searchbox, 'testPkg-128');
       await waitFor(() => expect(getPackages).toHaveBeenCalledTimes(2));
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
-      const availablePackagesItems = within(availablePackagesList).getByRole(
-        'option'
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
       );
+      const availablePackagesItems = await within(
+        availablePackagesList
+      ).findByRole('option');
       expect(availablePackagesItems).toBeInTheDocument();
-      screen.getByText('Exact match');
-      screen.getByText('testPkg-128');
-      screen.getByText('Too many results to display');
+      await screen.findByText('Exact match');
+      await screen.findByText('testPkg-128');
+      await screen.findByText('Too many results to display');
     });
 
     test('search results should be sorted alphabetically', async () => {
@@ -415,7 +437,9 @@ describe('Step Packages', () => {
       await searchForAvailablePackages(searchbox, 'test');
       await waitFor(() => expect(getPackages).toHaveBeenCalledTimes(1));
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = within(availablePackagesList).getAllByRole(
         'option'
       );
@@ -437,7 +461,9 @@ describe('Step Packages', () => {
 
       await searchForAvailablePackages(searchbox, 'test');
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = await within(
         availablePackagesList
       ).findAllByRole('option');
@@ -464,7 +490,9 @@ describe('Step Packages', () => {
 
       await searchForAvailablePackages(availableSearchbox, 'test');
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = await within(
         availablePackagesList
       ).findAllByRole('option');
@@ -472,7 +500,7 @@ describe('Step Packages', () => {
 
       await user.click(await screen.findByRole('button', { name: /Add all/ }));
 
-      const chosenPackagesList = screen.getByTestId('chosen-pkgs-list');
+      const chosenPackagesList = await screen.findByTestId('chosen-pkgs-list');
       let chosenPackagesItems = await within(chosenPackagesList).findAllByRole(
         'option'
       );
@@ -515,16 +543,23 @@ describe('Step Packages', () => {
 
       // aws step
       await user.click(
-        screen.getByRole('radio', { name: /manually enter an account id\./i })
+        await screen.findByRole('radio', {
+          name: /manually enter an account id\./i,
+        })
       );
-      await user.type(screen.getByTestId('aws-account-id'), '012345678901');
+      await user.type(
+        await screen.findByTestId('aws-account-id'),
+        '012345678901'
+      );
       await clickNext();
       // skip registration
       await screen.findByRole('textbox', {
         name: 'Select activation key',
       });
 
-      const registerLaterRadio = screen.getByTestId('registration-radio-later');
+      const registerLaterRadio = await screen.findByTestId(
+        'registration-radio-later'
+      );
       await user.click(registerLaterRadio);
       await clickNext();
       // skip fsc
@@ -536,7 +571,7 @@ describe('Step Packages', () => {
 
       const view = await screen.findByTestId('search-available-pkgs-input');
 
-      const searchbox = within(view).getByRole('textbox', {
+      const searchbox = await within(view).findByRole('textbox', {
         name: /search input/i,
       });
 
@@ -569,12 +604,18 @@ describe('Step Packages', () => {
       await searchForAvailablePackages(searchbox, 'test');
 
       await user.click(await screen.findByTestId('available-pkgs-testPkg'));
-      await user.click(screen.getByRole('button', { name: /Add selected/ }));
+      await user.click(
+        await screen.findByRole('button', { name: /Add selected/ })
+      );
 
       await user.click(await screen.findByTestId('selected-pkgs-testPkg'));
-      await user.click(screen.getByRole('button', { name: /Remove selected/ }));
+      await user.click(
+        await screen.findByRole('button', { name: /Remove selected/ })
+      );
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = within(availablePackagesList).getAllByRole(
         'option'
       );
@@ -595,10 +636,14 @@ describe('Step Packages', () => {
 
       await searchForAvailablePackages(searchbox, 'test');
 
-      await user.click(screen.getByRole('button', { name: /Add all/ }));
-      await user.click(screen.getByRole('button', { name: /Remove all/ }));
+      await user.click(await screen.findByRole('button', { name: /Add all/ }));
+      await user.click(
+        await screen.findByRole('button', { name: /Remove all/ })
+      );
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = await within(
         availablePackagesList
       ).findAllByRole('option');
@@ -618,11 +663,13 @@ describe('Step Packages', () => {
       await user.click(searchbox);
 
       await searchForAvailablePackages(searchbox, 'test');
-      await user.click(screen.getByRole('button', { name: /Add all/ }));
+      await user.click(await screen.findByRole('button', { name: /Add all/ }));
 
       // remove a single package
       await user.click(await screen.findByTestId('selected-pkgs-lib-test'));
-      await user.click(screen.getByRole('button', { name: /Remove selected/ }));
+      await user.click(
+        await screen.findByRole('button', { name: /Remove selected/ })
+      );
       // skip Custom repositories page
       clickNext();
 
@@ -659,12 +706,12 @@ describe('Step Packages', () => {
       await user.click(searchboxAvailable);
       await searchForAvailablePackages(searchboxAvailable, 'test');
 
-      await user.click(screen.getByRole('button', { name: /Add all/ }));
+      await user.click(await screen.findByRole('button', { name: /Add all/ }));
 
       await user.click(searchboxChosen);
       await user.type(searchboxChosen, 'asdf');
 
-      expect(screen.getByText('No packages found')).toBeInTheDocument();
+      expect(await screen.findByText('No packages found')).toBeInTheDocument();
       // We need to clear this input in order to not have sideeffects on other tests
       await searchForChosenPackages(searchboxChosen, '');
     });
@@ -686,7 +733,9 @@ describe('Step Packages', () => {
       await searchForAvailablePackages(searchbox, 'test');
       await waitFor(() => expect(getPackages).toHaveBeenCalledTimes(1));
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = within(availablePackagesList).getAllByRole(
         'option'
       );
@@ -708,14 +757,18 @@ describe('Step Packages', () => {
 
       await searchForAvailablePackages(searchbox, 'test');
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = await within(
         availablePackagesList
       ).findAllByRole('option');
       expect(availablePackagesItems).toHaveLength(3);
 
       await user.click(
-        screen.getByRole('button', { name: /clear available packages search/i })
+        await screen.findByRole('button', {
+          name: /clear available packages search/i,
+        })
       );
 
       await screen.findByText(
@@ -733,15 +786,17 @@ describe('Step Packages', () => {
 
       await searchForAvailablePackages(availableSearchbox, 'test');
 
-      const availablePackagesList = screen.getByTestId('available-pkgs-list');
+      const availablePackagesList = await screen.findByTestId(
+        'available-pkgs-list'
+      );
       const availablePackagesItems = await within(
         availablePackagesList
       ).findAllByRole('option');
       expect(availablePackagesItems).toHaveLength(3);
 
-      await user.click(screen.getByRole('button', { name: /Add all/ }));
+      await user.click(await screen.findByRole('button', { name: /Add all/ }));
 
-      const chosenPackagesList = screen.getByTestId('chosen-pkgs-list');
+      const chosenPackagesList = await screen.findByTestId('chosen-pkgs-list');
       let chosenPackagesItems = await within(chosenPackagesList).findAllByRole(
         'option'
       );
@@ -777,9 +832,14 @@ describe('Step Custom repositories', () => {
 
     // aws step
     await user.click(
-      screen.getByRole('radio', { name: /manually enter an account id\./i })
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
     );
-    await user.type(screen.getByTestId('aws-account-id'), '012345678901');
+    await user.type(
+      await screen.findByTestId('aws-account-id'),
+      '012345678901'
+    );
 
     await clickNext();
     // skip registration
@@ -787,7 +847,7 @@ describe('Step Custom repositories', () => {
       name: 'Select activation key',
     });
 
-    await user.click(screen.getByLabelText('Register later'));
+    await user.click(await screen.findByLabelText('Register later'));
     await clickNext();
     // skip fsc
     await clickNext();
@@ -819,12 +879,12 @@ describe('Step Custom repositories', () => {
     await setUp();
 
     await user.click(
-      screen.getByRole('button', {
+      await screen.findByRole('button', {
         name: /^select$/i,
       })
     );
 
-    screen.getByText(/select all \(1015 items\)/i);
+    await screen.findByText(/select all \(1015 items\)/i);
   });
 
   test('filter works', async () => {
@@ -933,7 +993,7 @@ describe('Step Custom repositories', () => {
     const firstRepoCheckbox = await getFirstRepoCheckbox();
 
     const getNextPageButton = async () =>
-      screen.getByRole('button', {
+      await screen.findByRole('button', {
         name: /go to next page/i,
       });
 

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -83,7 +83,7 @@ const searchForAvailablePackages = async (searchbox, searchTerm) => {
 
 const switchToAWSManual = async () => {
   const user = userEvent.setup();
-  const manualRadio = screen.getByRole('radio', {
+  const manualRadio = await screen.findByRole('radio', {
     name: /manually enter an account id\./i,
   });
   await user.click(manualRadio);
@@ -91,7 +91,7 @@ const switchToAWSManual = async () => {
 };
 
 const getSourceDropdown = async () => {
-  const sourceDropdown = screen.getByRole('textbox', {
+  const sourceDropdown = await screen.findByRole('textbox', {
     name: /select source/i,
   });
   await waitFor(() => expect(sourceDropdown).toBeEnabled());
@@ -111,19 +111,19 @@ afterEach(() => {
 });
 
 describe('Create Image Wizard', () => {
-  test('renders component', () => {
+  test('renders component', async () => {
     renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
     // check heading
-    screen.getByRole('heading', { name: /Image Builder/ });
+    await screen.findByRole('heading', { name: /Image Builder/ });
 
-    screen.getByRole('button', { name: 'Image output' });
-    screen.getByRole('button', { name: 'Register' });
-    screen.getByRole('button', { name: 'File system configuration' });
-    screen.getByRole('button', { name: 'Content' });
-    screen.getByRole('button', { name: 'Additional Red Hat packages' });
-    screen.getByRole('button', { name: 'Custom repositories' });
-    screen.getByRole('button', { name: 'Details' });
-    screen.getByRole('button', { name: 'Review' });
+    await screen.findByRole('button', { name: 'Image output' });
+    await screen.findByRole('button', { name: 'Register' });
+    await screen.findByRole('button', { name: 'File system configuration' });
+    await screen.findByRole('button', { name: 'Content' });
+    await screen.findByRole('button', { name: 'Additional Red Hat packages' });
+    await screen.findByRole('button', { name: 'Custom repositories' });
+    await screen.findByRole('button', { name: 'Details' });
+    await screen.findByRole('button', { name: 'Review' });
   });
 });
 
@@ -161,8 +161,8 @@ describe('Step Image output', () => {
   test('target environment is required', async () => {
     await setUp();
 
-    const destination = screen.getByTestId('target-select');
-    const required = within(destination).getByText('*');
+    const destination = await screen.findByTestId('target-select');
+    const required = await within(destination).findByText('*');
     expect(destination).toBeEnabled();
     expect(destination).toContainElement(required);
   });
@@ -171,15 +171,15 @@ describe('Step Image output', () => {
     await setUp();
     const nextButton = await getNextButton();
 
-    const awsTile = screen.getByTestId('upload-aws');
+    const awsTile = await screen.findByTestId('upload-aws');
     // this has already been clicked once in the setup function
     await user.click(awsTile); // deselect
 
-    const googleTile = screen.getByTestId('upload-google');
+    const googleTile = await screen.findByTestId('upload-google');
     await user.click(googleTile); // select
     await user.click(googleTile); // deselect
 
-    const azureTile = screen.getByTestId('upload-azure');
+    const azureTile = await screen.findByTestId('upload-azure');
     await user.click(azureTile); // select
     await user.click(azureTile); // deselect
 
@@ -215,7 +215,7 @@ describe('Step Image output', () => {
     })[0];
     await user.click(releaseMenu);
 
-    const showOptionsButton = screen.getByRole('button', {
+    const showOptionsButton = await screen.findByRole('button', {
       name: 'Show options for further development of RHEL',
     });
     await user.click(showOptionsButton);
@@ -275,12 +275,12 @@ describe('Step Image output', () => {
     })[0];
     await user.click(releaseMenu);
 
-    const showOptionsButton = screen.getByRole('button', {
+    const showOptionsButton = await screen.findByRole('button', {
       name: 'Show options for further development of RHEL',
     });
     await user.click(showOptionsButton);
 
-    const centOSButton = screen.getByRole('option', {
+    const centOSButton = await screen.findByRole('option', {
       name: 'CentOS Stream 9',
     });
     await user.click(centOSButton);
@@ -326,7 +326,9 @@ describe('Step Upload to AWS', () => {
       name: 'Select activation key',
     });
 
-    screen.getByText('Automatically register and enable advanced capabilities');
+    await screen.findByText(
+      'Automatically register and enable advanced capabilities'
+    );
   });
 
   test('clicking Back loads Release', async () => {
@@ -334,7 +336,7 @@ describe('Step Upload to AWS', () => {
 
     await clickBack();
 
-    screen.getByTestId('upload-aws');
+    await screen.findByTestId('upload-aws');
   });
 
   test('clicking Cancel loads landing page', async () => {
@@ -362,12 +364,14 @@ describe('Step Upload to AWS', () => {
     expect(nextButton).toHaveClass('pf-m-disabled');
 
     await user.click(
-      screen.getByRole('radio', { name: /manually enter an account id\./i })
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
     );
 
     expect(nextButton).toHaveClass('pf-m-disabled');
 
-    const awsAccId = screen.getByTestId('aws-account-id');
+    const awsAccId = await screen.findByTestId('aws-account-id');
     expect(awsAccId).toHaveValue('');
     expect(awsAccId).toBeEnabled();
     await user.type(awsAccId, '012345678901');
@@ -375,7 +379,7 @@ describe('Step Upload to AWS', () => {
     expect(nextButton).not.toHaveClass('pf-m-disabled');
 
     await user.click(
-      screen.getByRole('radio', {
+      await screen.findByRole('radio', {
         name: /use an account configured from sources\./i,
       })
     );
@@ -411,7 +415,7 @@ describe('Step Upload to AWS', () => {
       name: 'Select activation key',
     });
 
-    const registerLaterRadio = screen.getByLabelText('Register later');
+    const registerLaterRadio = await screen.findByLabelText('Register later');
     await user.click(registerLaterRadio);
 
     // click through to review step
@@ -421,7 +425,7 @@ describe('Step Upload to AWS', () => {
     await clickNext();
     await clickNext();
 
-    await user.click(screen.getByRole('button', { name: /Create/ }));
+    await user.click(await screen.findByRole('button', { name: /Create/ }));
 
     // returns back to the landing page
     await waitFor(() =>
@@ -469,7 +473,9 @@ describe('Step Upload to Google', () => {
       name: 'Select activation key',
     });
 
-    screen.getByText('Automatically register and enable advanced capabilities');
+    await screen.findByText(
+      'Automatically register and enable advanced capabilities'
+    );
   });
 
   test('clicking Back loads Release', async () => {
@@ -477,7 +483,7 @@ describe('Step Upload to Google', () => {
 
     await clickBack();
 
-    screen.getByTestId('upload-google');
+    await screen.findByTestId('upload-google');
   });
 
   test('clicking Cancel loads landing page', async () => {
@@ -489,11 +495,9 @@ describe('Step Upload to Google', () => {
   test('the google account id field is shown and required', async () => {
     await setUp();
 
-    await waitFor(() => {
-      screen.getByTestId('account-sharing');
-    });
+    await screen.findByTestId('account-sharing');
 
-    await user.click(screen.getByTestId('account-sharing'));
+    await user.click(await screen.findByTestId('account-sharing'));
     const accessKeyId = await screen.findByTestId('input-google-email');
     expect(accessKeyId).toHaveValue('');
     expect(accessKeyId).toBeEnabled();
@@ -502,11 +506,14 @@ describe('Step Upload to Google', () => {
   test('the google email field must be a valid email', async () => {
     await setUp();
 
-    await user.click(screen.getByTestId('account-sharing'));
-    await user.type(screen.getByTestId('input-google-email'), 'a');
+    await user.click(await screen.findByTestId('account-sharing'));
+    await user.type(await screen.findByTestId('input-google-email'), 'a');
     expect(await getNextButton()).toHaveClass('pf-m-disabled');
     expect(await getNextButton()).toBeDisabled();
-    await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
+    await user.type(
+      await screen.findByTestId('input-google-email'),
+      'test@test.com'
+    );
     expect(await getNextButton()).not.toHaveClass('pf-m-disabled');
     expect(await getNextButton()).toBeEnabled();
   });
@@ -528,9 +535,14 @@ describe('Step Registration', () => {
 
     await clickNext();
     await user.click(
-      screen.getByRole('radio', { name: /manually enter an account id\./i })
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
     );
-    await user.type(screen.getByTestId('aws-account-id'), '012345678901');
+    await user.type(
+      await screen.findByTestId('aws-account-id'),
+      '012345678901'
+    );
     await clickNext();
 
     await screen.findByRole('textbox', {
@@ -541,7 +553,9 @@ describe('Step Registration', () => {
   test('clicking Next loads file system configuration', async () => {
     await setUp();
 
-    const registerLaterRadio = screen.getByTestId('registration-radio-later');
+    const registerLaterRadio = await screen.findByTestId(
+      'registration-radio-later'
+    );
     await user.click(registerLaterRadio);
 
     await clickNext();
@@ -557,9 +571,11 @@ describe('Step Registration', () => {
     await clickBack();
 
     await user.click(
-      screen.getByRole('radio', { name: /manually enter an account id\./i })
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
     );
-    screen.getByText('AWS account ID');
+    await screen.findByText('AWS account ID');
   });
 
   test('clicking Cancel loads landing page', async () => {
@@ -593,14 +609,14 @@ describe('Step Registration', () => {
       name: 'name0',
     });
     await user.click(activationKey);
-    screen.getByDisplayValue('name0');
+    await screen.findByDisplayValue('name0');
 
     await clickNext();
     await clickNext();
     await clickNext();
     await clickNext();
     await clickNext();
-    const review = screen.getByTestId('review-registration');
+    const review = await screen.findByTestId('review-registration');
     expect(review).toHaveTextContent(
       'Register with Red Hat Subscription Manager (RHSM)'
     );
@@ -614,15 +630,17 @@ describe('Step Registration', () => {
   test('should allow registering without rhc', async () => {
     await setUp();
 
-    await user.click(screen.getByTestId('registration-additional-options'));
-    await user.click(screen.getByTestId('registration-checkbox-rhc'));
+    await user.click(
+      await screen.findByTestId('registration-additional-options')
+    );
+    await user.click(await screen.findByTestId('registration-checkbox-rhc'));
 
     // going back and forward when rhc isn't selected should keep additional options shown
     await clickBack();
     await screen.findByTestId('aws-account-id');
     await clickNext();
-    screen.getByTestId('registration-checkbox-insights');
-    screen.getByTestId('registration-checkbox-rhc');
+    await screen.findByTestId('registration-checkbox-insights');
+    await screen.findByTestId('registration-checkbox-rhc');
 
     const activationKeyDropdown = await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -632,14 +650,14 @@ describe('Step Registration', () => {
       name: 'name0',
     });
     await user.click(activationKey);
-    screen.getByDisplayValue('name0');
+    await screen.findByDisplayValue('name0');
 
     await clickNext();
     await clickNext();
     await clickNext();
     await clickNext();
     await clickNext();
-    const review = screen.getByTestId('review-registration');
+    const review = await screen.findByTestId('review-registration');
     expect(review).toHaveTextContent(
       'Register with Red Hat Subscription Manager (RHSM)'
     );
@@ -653,15 +671,19 @@ describe('Step Registration', () => {
   test('should allow registering without insights or rhc', async () => {
     await setUp();
 
-    await user.click(screen.getByTestId('registration-additional-options'));
-    await user.click(screen.getByTestId('registration-checkbox-insights'));
+    await user.click(
+      await screen.findByTestId('registration-additional-options')
+    );
+    await user.click(
+      await screen.findByTestId('registration-checkbox-insights')
+    );
 
     // going back and forward when neither rhc or insights is selected should keep additional options shown
     await clickBack();
     await screen.findByTestId('aws-account-id');
     await clickNext();
-    screen.getByTestId('registration-checkbox-insights');
-    screen.getByTestId('registration-checkbox-rhc');
+    await screen.findByTestId('registration-checkbox-insights');
+    await screen.findByTestId('registration-checkbox-rhc');
 
     const activationKeyDropdown = await screen.findByRole('textbox', {
       name: 'Select activation key',
@@ -671,14 +693,14 @@ describe('Step Registration', () => {
       name: 'name0',
     });
     await user.click(activationKey);
-    screen.getByDisplayValue('name0');
+    await screen.findByDisplayValue('name0');
 
     await clickNext();
     await clickNext();
     await clickNext();
     await clickNext();
     await clickNext();
-    const review = screen.getByTestId('review-registration');
+    const review = await screen.findByTestId('review-registration');
     expect(review).toHaveTextContent(
       'Register with Red Hat Subscription Manager (RHSM)'
     );
@@ -696,7 +718,7 @@ describe('Step Registration', () => {
     ]);
 
     // click the later radio button which should remove any input fields
-    await user.click(screen.getByTestId('registration-radio-later'));
+    await user.click(await screen.findByTestId('registration-radio-later'));
 
     await removeKeyInformation;
 
@@ -705,18 +727,26 @@ describe('Step Registration', () => {
     await clickNext();
     await clickNext();
     await clickNext();
-    screen.getByText('Register the system later');
+    await screen.findByText('Register the system later');
   });
 
   test('registering with rhc implies registering with insights', async () => {
     await setUp();
-    await user.click(screen.getByTestId('registration-additional-options'));
+    await user.click(
+      await screen.findByTestId('registration-additional-options')
+    );
 
-    await user.click(screen.getByTestId('registration-checkbox-insights'));
-    expect(screen.getByTestId('registration-checkbox-rhc')).not.toBeChecked();
+    await user.click(
+      await screen.findByTestId('registration-checkbox-insights')
+    );
+    expect(
+      await screen.findByTestId('registration-checkbox-rhc')
+    ).not.toBeChecked();
 
-    await user.click(screen.getByTestId('registration-checkbox-rhc'));
-    expect(screen.getByTestId('registration-checkbox-insights')).toBeChecked();
+    await user.click(await screen.findByTestId('registration-checkbox-rhc'));
+    expect(
+      await screen.findByTestId('registration-checkbox-insights')
+    ).toBeChecked();
   });
 });
 
@@ -747,7 +777,9 @@ describe('Step File system configuration', () => {
       name: 'Select activation key',
     });
 
-    const registerLaterRadio = screen.getByTestId('registration-radio-later');
+    const registerLaterRadio = await screen.findByTestId(
+      'registration-radio-later'
+    );
     await user.click(registerLaterRadio);
     await clickNext();
   };
@@ -755,7 +787,7 @@ describe('Step File system configuration', () => {
   test('Error validation occurs upon clicking next button', async () => {
     await setUp();
 
-    const manuallyConfigurePartitions = screen.getByText(
+    const manuallyConfigurePartitions = await screen.findByText(
       /manually configure partitions/i
     );
     await user.click(manuallyConfigurePartitions);
@@ -771,7 +803,7 @@ describe('Step File system configuration', () => {
     // Clicking next causes errors to appear
     await clickNext();
 
-    const mountPointWarning = screen.getByRole('heading', {
+    const mountPointWarning = await screen.findByRole('heading', {
       name: /danger alert: duplicate mount points: all mount points must be unique\. remove the duplicate or choose a new mount point\./i,
       hidden: true,
     });
@@ -780,7 +812,7 @@ describe('Step File system configuration', () => {
       name: /danger alert: duplicate mount point\./i,
     });
 
-    const tbody = screen.getByTestId('file-system-configuration-tbody');
+    const tbody = await screen.findByTestId('file-system-configuration-tbody');
     const rows = within(tbody).getAllByRole('row');
     expect(rows).toHaveLength(3);
 
@@ -828,7 +860,9 @@ describe('Step Details', () => {
       name: 'Select activation key',
     });
 
-    const registerLaterRadio = screen.getByTestId('registration-radio-later');
+    const registerLaterRadio = await screen.findByTestId(
+      'registration-radio-later'
+    );
     await user.click(registerLaterRadio);
     await clickNext();
 
@@ -844,7 +878,7 @@ describe('Step Details', () => {
     await setUp();
 
     // Enter image name
-    const nameInput = screen.getByRole('textbox', {
+    const nameInput = await screen.findByRole('textbox', {
       name: 'Image Name',
     });
     // 64 character name
@@ -859,7 +893,7 @@ describe('Step Details', () => {
     expect(await getNextButton()).toBeEnabled();
 
     // Enter description image
-    const descriptionInput = screen.getByRole('textbox', {
+    const descriptionInput = await screen.findByRole('textbox', {
       name: /description/i,
     });
 
@@ -904,7 +938,9 @@ describe('Step Review', () => {
     });
 
     // skip registration
-    const registerLaterRadio = screen.getByTestId('registration-radio-later');
+    const registerLaterRadio = await screen.findByTestId(
+      'registration-radio-later'
+    );
     await user.click(registerLaterRadio);
 
     await clickNext();
@@ -926,12 +962,12 @@ describe('Step Review', () => {
     })[0];
     await user.click(releaseMenu);
 
-    const showOptionsButton = screen.getByRole('button', {
+    const showOptionsButton = await screen.findByRole('button', {
       name: 'Show options for further development of RHEL',
     });
     await user.click(showOptionsButton);
 
-    const centos = screen.getByRole('option', {
+    const centos = await screen.findByRole('option', {
       name: 'CentOS Stream 8',
     });
     await user.click(centos);
@@ -962,9 +998,9 @@ describe('Step Review', () => {
   test('has 3 buttons', async () => {
     await setUp();
 
-    screen.getByRole('button', { name: /Create/ });
-    screen.getByRole('button', { name: /Back/ });
-    screen.getByRole('button', { name: /Cancel/ });
+    await screen.findByRole('button', { name: /Create/ });
+    await screen.findByRole('button', { name: /Back/ });
+    await screen.findByRole('button', { name: /Cancel/ });
   });
 
   test('clicking Back loads Image name', async () => {
@@ -972,7 +1008,7 @@ describe('Step Review', () => {
 
     await clickBack();
 
-    screen.getByRole('heading', {
+    await screen.findByRole('heading', {
       name: 'Details',
     });
   });
@@ -986,25 +1022,25 @@ describe('Step Review', () => {
   test('has Registration expandable section for rhel', async () => {
     await setUp();
 
-    const targetExpandable = screen.getByTestId(
+    const targetExpandable = await screen.findByTestId(
       'target-environments-expandable'
     );
-    const registrationExpandable = screen.getByTestId(
+    const registrationExpandable = await screen.findByTestId(
       'registration-expandable'
     );
-    const contentExpandable = screen.getByTestId('content-expandable');
-    const fscExpandable = screen.getByTestId(
+    const contentExpandable = await screen.findByTestId('content-expandable');
+    const fscExpandable = await screen.findByTestId(
       'file-system-configuration-expandable'
     );
 
     await user.click(targetExpandable);
-    screen.getByText('AWS');
+    await screen.findByText('AWS');
     await user.click(registrationExpandable);
-    screen.getByText('Register the system later');
+    await screen.findByText('Register the system later');
     await user.click(contentExpandable);
-    screen.getByText('Additional Red Hatand 3rd party packages');
+    await screen.findByText('Additional Red Hatand 3rd party packages');
     await user.click(fscExpandable);
-    screen.getByText('Configuration type');
+    await screen.findByText('Configuration type');
   });
 
   test('has no Registration expandable for centos', async () => {
@@ -1022,11 +1058,11 @@ describe('Step Review', () => {
     ).not.toBeInTheDocument();
 
     await user.click(targetExpandable);
-    screen.getByText('AWS');
+    await screen.findByText('AWS');
     await user.click(contentExpandable);
-    screen.getByText('Additional Red Hatand 3rd party packages');
+    await screen.findByText('Additional Red Hatand 3rd party packages');
     await user.click(fscExpandable);
-    screen.getByText('Configuration type');
+    await screen.findByText('Configuration type');
   });
 });
 
@@ -1051,44 +1087,52 @@ describe('Click through all steps', () => {
       name: /options menu/i,
     })[0];
     await user.click(releaseMenu);
-    const releaseOption = screen.getByRole('option', {
+    const releaseOption = await screen.findByRole('option', {
       name: /Red Hat Enterprise Linux \(RHEL\) 8/,
     });
     await user.click(releaseOption);
 
     await waitFor(() => screen.findByTestId('upload-aws'));
-    await user.click(screen.getByTestId('upload-azure'));
-    await user.click(screen.getByTestId('upload-google'));
-    await user.click(screen.getByTestId('checkbox-vmware'));
-    await user.click(screen.getByTestId('checkbox-guest-image'));
-    await user.click(screen.getByTestId('checkbox-image-installer'));
+    await user.click(await screen.findByTestId('upload-azure'));
+    await user.click(await screen.findByTestId('upload-google'));
+    await user.click(await screen.findByTestId('checkbox-vmware'));
+    await user.click(await screen.findByTestId('checkbox-guest-image'));
+    await user.click(await screen.findByTestId('checkbox-image-installer'));
 
     await clickNext();
     await user.click(
-      screen.getByRole('radio', { name: /manually enter an account id\./i })
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
     );
-    await user.type(screen.getByTestId('aws-account-id'), '012345678901');
+    await user.type(
+      await screen.findByTestId('aws-account-id'),
+      '012345678901'
+    );
     await clickNext();
 
-    await user.click(screen.getByTestId('account-sharing'));
+    await user.click(await screen.findByTestId('account-sharing'));
 
-    await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
+    await user.type(
+      await screen.findByTestId('input-google-email'),
+      'test@test.com'
+    );
 
     await user.click(await screen.findByTestId('account-sharing'));
     await clickNext();
 
-    await user.click(screen.getByTestId('azure-radio-manual'));
+    await user.click(await screen.findByTestId('azure-radio-manual'));
     // Randomly generated GUID
     await user.type(
-      screen.getByTestId('azure-tenant-id-manual'),
+      await screen.findByTestId('azure-tenant-id-manual'),
       'b8f86d22-4371-46ce-95e7-65c415f3b1e2'
     );
     await user.type(
-      screen.getByTestId('azure-subscription-id-manual'),
+      await screen.findByTestId('azure-subscription-id-manual'),
       '60631143-a7dc-4d15-988b-ba83f3c99711'
     );
     await user.type(
-      screen.getByTestId('azure-resource-group-manual'),
+      await screen.findByTestId('azure-resource-group-manual'),
       'testResourceGroup'
     );
     await clickNext();
@@ -1102,7 +1146,7 @@ describe('Click through all steps', () => {
       name: 'name0',
     });
     await user.click(activationKey);
-    screen.getByDisplayValue('name0');
+    await screen.findByDisplayValue('name0');
 
     await clickNext();
 
@@ -1115,7 +1159,7 @@ describe('Click through all steps', () => {
     await user.click(addPartition);
     await user.click(addPartition);
 
-    const tbody = screen.getByTestId('file-system-configuration-tbody');
+    const tbody = await screen.findByTestId('file-system-configuration-tbody');
     const rows = within(tbody).getAllByRole('row');
     await waitFor(() => expect(rows).toHaveLength(3));
     await clickNext();
@@ -1136,7 +1180,7 @@ describe('Click through all steps', () => {
       })
     ).not.toBeInTheDocument();
     await user.type(
-      within(rows[2]).getByRole('textbox', {
+      await within(rows[2]).findByRole('textbox', {
         name: 'Mount point suffix text input',
       }),
       '/tmp'
@@ -1144,7 +1188,7 @@ describe('Click through all steps', () => {
 
     // set size of the final row to 100 MiB
     await user.type(
-      within(rows[2]).getByRole('textbox', { name: 'Size text input' }),
+      await within(rows[2]).findByRole('textbox', { name: 'Size text input' }),
       '{backspace}100'
     );
     const unitMenu = within(rows[2]).getAllByRole('button', {
@@ -1158,7 +1202,7 @@ describe('Click through all steps', () => {
     await user.click(mibButton);
     await clickNext();
 
-    screen.getByText(
+    await screen.findByText(
       /Images built with Image Builder include all required packages/i
     );
 
@@ -1172,7 +1216,9 @@ describe('Click through all steps', () => {
         name: /test summary for test package/,
       })
     );
-    await user.click(screen.getByRole('button', { name: /Add selected/ }));
+    await user.click(
+      await screen.findByRole('button', { name: /Add selected/ })
+    );
     await clickNext();
 
     // Custom repositories
@@ -1188,14 +1234,14 @@ describe('Click through all steps', () => {
     await clickNext();
 
     // Enter image name
-    const nameInput = screen.getByRole('textbox', {
+    const nameInput = await screen.findByRole('textbox', {
       name: 'Image Name',
     });
 
     await user.type(nameInput, 'my-image-name');
 
     // Enter description for image
-    const descriptionInput = screen.getByRole('textbox', {
+    const descriptionInput = await screen.findByRole('textbox', {
       name: /Description/,
     });
     await user.type(
@@ -1219,7 +1265,7 @@ describe('Click through all steps', () => {
       'registration-expandable'
     );
     await user.click(registrationExpandable);
-    const review = screen.getByTestId('review-registration');
+    const review = await screen.findByTestId('review-registration');
     expect(review).toHaveTextContent(
       'Use remote host configuration (rhc) utility'
     );
@@ -1235,13 +1281,15 @@ describe('Click through all steps', () => {
     await screen.findByText('Self-Support');
     await screen.findByText('Production');
 
-    await user.click(screen.getByTestId('repositories-popover-button'));
+    await user.click(await screen.findByTestId('repositories-popover-button'));
     const repotbody = await screen.findByTestId(
       'additional-repositories-table'
     );
     expect(within(repotbody).getAllByRole('row')).toHaveLength(3);
 
-    await user.click(screen.getByTestId('file-system-configuration-popover'));
+    await user.click(
+      await screen.findByTestId('file-system-configuration-popover')
+    );
     const revtbody = await screen.findByTestId(
       'file-system-configuration-tbody-review'
     );
@@ -1442,7 +1490,7 @@ describe('Click through all steps', () => {
         );
       })
     );
-    await user.click(screen.getByRole('button', { name: /Create/ }));
+    await user.click(await screen.findByRole('button', { name: /Create/ }));
 
     expect(receivedComposeReqs).toEqual(expectedComposeReqs);
     expect(timesCalled).toEqual(6);
@@ -1471,10 +1519,10 @@ describe('Keyboard accessibility', () => {
     await waitFor(
       async () => await user.click(await screen.findByTestId('upload-aws'))
     );
-    await user.click(screen.getByTestId('upload-google'));
-    await user.click(screen.getByTestId('upload-azure'));
+    await user.click(await screen.findByTestId('upload-google'));
+    await user.click(await screen.findByTestId('upload-azure'));
     await user.click(
-      screen.getByRole('checkbox', {
+      await screen.findByRole('checkbox', {
         name: /virtualization guest image checkbox/i,
       })
     );
@@ -1488,7 +1536,7 @@ describe('Keyboard accessibility', () => {
     await clickNext();
 
     // Target environment aws
-    expect(screen.getByTestId('aws-radio-source')).toHaveFocus();
+    expect(await screen.findByTestId('aws-radio-source')).toHaveFocus();
     const awsSourceDropdown = await getSourceDropdown();
     await user.click(awsSourceDropdown);
     const awsSource = await screen.findByRole('option', {
@@ -1508,7 +1556,7 @@ describe('Keyboard accessibility', () => {
     await clickNext();
 
     // Target environment azure
-    expect(screen.getByTestId('azure-radio-source')).toHaveFocus();
+    expect(await screen.findByTestId('azure-radio-source')).toHaveFocus();
     const azureSourceDropdown = await getSourceDropdown();
     await user.click(azureSourceDropdown);
     const azureSource = await screen.findByRole('option', {
@@ -1520,20 +1568,24 @@ describe('Keyboard accessibility', () => {
       name: /select resource group/i,
     });
     await user.click(resourceGroupDropdown);
-    await user.click(screen.getByLabelText('Resource group myResourceGroup1'));
+    await user.click(
+      await screen.findByLabelText('Resource group myResourceGroup1')
+    );
     await clickNext();
 
     // Registration
     await screen.findByText(
       'Automatically register and enable advanced capabilities'
     );
-    const registerRadio = screen.getByTestId('registration-radio-now');
+    const registerRadio = await screen.findByTestId('registration-radio-now');
     expect(registerRadio).toHaveFocus();
     await screen.findByRole('textbox', {
       name: 'Select activation key',
     });
     // skip registration
-    const registerLaterRadio = screen.getByTestId('registration-radio-later');
+    const registerLaterRadio = await screen.findByTestId(
+      'registration-radio-later'
+    );
     await user.click(registerLaterRadio);
 
     await clickNext();
@@ -1542,9 +1594,9 @@ describe('Keyboard accessibility', () => {
     await clickNext();
 
     // Packages
-    const view = screen.getByTestId('search-available-pkgs-input');
+    const view = await screen.findByTestId('search-available-pkgs-input');
 
-    const availablePackagesInput = within(view).getByRole('textbox', {
+    const availablePackagesInput = await within(view).findByRole('textbox', {
       name: /search input/i,
     });
     await waitFor(() => expect(availablePackagesInput).toBeEnabled());
@@ -1555,7 +1607,9 @@ describe('Keyboard accessibility', () => {
     await clickNext();
 
     // Name
-    const nameInput = screen.getByRole('textbox', { name: /image name/i });
+    const nameInput = await screen.findByRole('textbox', {
+      name: /image name/i,
+    });
     expect(nameInput).toHaveFocus();
     await clickNext();
   });
@@ -1576,7 +1630,7 @@ describe('Keyboard accessibility', () => {
       async () => await user.click(await screen.findByTestId('upload-aws'))
     );
     await user.keyboard('{enter}');
-    screen.getByRole('heading', {
+    await screen.findByRole('heading', {
       name: /image output/i,
     });
   });
@@ -1594,8 +1648,8 @@ describe('Keyboard accessibility', () => {
     await clickNext();
 
     await waitFor(() => screen.findByTestId('upload-aws'));
-    testTile(screen.getByTestId('upload-aws'));
-    testTile(screen.getByTestId('upload-google'));
-    testTile(screen.getByTestId('upload-azure'));
+    testTile(await screen.findByTestId('upload-aws'));
+    testTile(await screen.findByTestId('upload-google'));
+    testTile(await screen.findByTestId('upload-azure'));
   });
 });

--- a/src/test/Components/CreateImageWizard/formComponents/TargetEnvironment.test.js
+++ b/src/test/Components/CreateImageWizard/formComponents/TargetEnvironment.test.js
@@ -95,7 +95,7 @@ describe('Check that the target filtering is in accordance to mock content', () 
     })[0];
     await user.click(releaseMenu);
     await user.click(
-      screen.getByRole('option', {
+      await screen.findByRole('option', {
         name: /Red Hat Enterprise Linux \(RHEL\) 8/,
       })
     );
@@ -184,7 +184,7 @@ describe('Check that the target filtering is in accordance to mock content', () 
     })[0];
     await user.click(releaseMenu);
     await user.click(
-      screen.getByRole('option', {
+      await screen.findByRole('option', {
         name: /Red Hat Enterprise Linux \(RHEL\) 8/,
       })
     );
@@ -240,7 +240,7 @@ describe('Check step consistency', () => {
     await user.click(await screen.findByRole('option', { name: 'x86_64' }));
     await waitFor(async () => await screen.findByTestId('upload-aws'));
     // select GCP, it's available for x86_64
-    await user.click(screen.getByTestId('upload-google'));
+    await user.click(await screen.findByTestId('upload-google'));
     const next = await screen.findByRole('button', { name: /Next/ });
     await waitFor(() => expect(next).toBeEnabled());
     // Change to aarch
@@ -250,7 +250,7 @@ describe('Check step consistency', () => {
     // GCP not being compatible with arch, the next button is disabled
     await waitFor(() => expect(next).toBeDisabled());
     // clicking on AWS the user can go next
-    await user.click(screen.getByTestId('upload-aws'));
+    await user.click(await screen.findByTestId('upload-aws'));
     await waitFor(() => expect(next).toBeEnabled());
     // and going back to x86_64 the user should keep the next button visible
     await user.click(archMenu);

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -84,7 +84,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 const switchToAWSManual = async () => {
   const user = userEvent.setup();
-  const manualRadio = screen.getByRole('radio', {
+  const manualRadio = await screen.findByRole('radio', {
     name: /manually enter an account id\./i,
   });
   await user.click(manualRadio);
@@ -92,7 +92,7 @@ const switchToAWSManual = async () => {
 };
 
 const getSourceDropdown = async () => {
-  const sourceDropdown = screen.getByRole('textbox', {
+  const sourceDropdown = await screen.findByRole('textbox', {
     name: /select source/i,
   });
   await waitFor(() => expect(sourceDropdown).toBeEnabled());
@@ -112,19 +112,19 @@ afterEach(() => {
 });
 
 describe('Create Image Wizard', () => {
-  test('renders component', () => {
+  test('renders component', async () => {
     renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
     // check heading
-    screen.getByRole('heading', { name: /Image Builder/ });
+    await screen.findByRole('heading', { name: /Image Builder/ });
 
-    screen.getByRole('button', { name: 'Image output' });
-    screen.getByRole('button', { name: 'Register' });
-    // screen.getByRole('button', { name: 'File system configuration' });
-    // screen.getByRole('button', { name: 'Content' });
-    // screen.getByRole('button', { name: 'Additional Red Hat packages' });
-    // screen.getByRole('button', { name: 'Custom repositories' });
-    // screen.getByRole('button', { name: 'Details' });
-    // screen.getByRole('button', { name: 'Review' });
+    await screen.findByRole('button', { name: 'Image output' });
+    await screen.findByRole('button', { name: 'Register' });
+    // await screen.findByRole('button', { name: 'File system configuration' });
+    // await screen.findByRole('button', { name: 'Content' });
+    // await screen.findByRole('button', { name: 'Additional Red Hat packages' });
+    // await screen.findByRole('button', { name: 'Custom repositories' });
+    // await screen.findByRole('button', { name: 'Details' });
+    // await screen.findByRole('button', { name: 'Review' });
   });
 });
 
@@ -172,15 +172,15 @@ describe('Step Image output', () => {
     await setUp();
     const nextButton = await getNextButton();
 
-    const awsTile = screen.getByTestId('upload-aws');
+    const awsTile = await screen.findByTestId('upload-aws');
     // this has already been clicked once in the setup function
     await user.click(awsTile); // deselect
 
-    const googleTile = screen.getByTestId('upload-google');
+    const googleTile = await screen.findByTestId('upload-google');
     await user.click(googleTile); // select
     await user.click(googleTile); // deselect
 
-    const azureTile = screen.getByTestId('upload-azure');
+    const azureTile = await screen.findByTestId('upload-azure');
     await user.click(azureTile); // select
     await user.click(azureTile); // deselect
 
@@ -216,7 +216,7 @@ describe('Step Image output', () => {
     })[0];
     await user.click(releaseMenu);
 
-    const showOptionsButton = screen.getByRole('button', {
+    const showOptionsButton = await screen.findByRole('button', {
       name: 'Show options for further development of RHEL',
     });
     await user.click(showOptionsButton);
@@ -276,12 +276,12 @@ describe('Step Image output', () => {
     })[0];
     await user.click(releaseMenu);
 
-    const showOptionsButton = screen.getByRole('button', {
+    const showOptionsButton = await screen.findByRole('button', {
       name: 'Show options for further development of RHEL',
     });
     await user.click(showOptionsButton);
 
-    const centOSButton = screen.getByRole('option', {
+    const centOSButton = await screen.findByRole('option', {
       name: 'CentOS Stream 9',
     });
     await user.click(centOSButton);
@@ -329,7 +329,9 @@ describe('Step Upload to AWS', () => {
       name: 'Select activation key',
     });
 
-    screen.getByText('Automatically register and enable advanced capabilities');
+    await screen.findByText(
+      'Automatically register and enable advanced capabilities'
+    );
   });
 
   test('clicking Back loads Release', async () => {
@@ -337,7 +339,7 @@ describe('Step Upload to AWS', () => {
 
     await clickBack();
 
-    screen.getByTestId('upload-aws');
+    await screen.findByTestId('upload-aws');
   });
 
   test('clicking Cancel loads landing page', async () => {
@@ -365,7 +367,9 @@ describe('Step Upload to AWS', () => {
     expect(nextButton).toHaveClass('pf-m-disabled');
 
     await user.click(
-      screen.getByRole('radio', { name: /manually enter an account id\./i })
+      await screen.findByRole('radio', {
+        name: /manually enter an account id\./i,
+      })
     );
 
     expect(nextButton).toHaveClass('pf-m-disabled');
@@ -380,7 +384,7 @@ describe('Step Upload to AWS', () => {
     expect(nextButton).not.toHaveClass('pf-m-disabled');
 
     await user.click(
-      screen.getByRole('radio', {
+      await screen.findByRole('radio', {
         name: /use an account configured from sources\./i,
       })
     );
@@ -416,7 +420,7 @@ describe('Step Upload to AWS', () => {
       name: 'Select activation key',
     });
 
-    const registerLaterRadio = screen.getByLabelText('Register later');
+    const registerLaterRadio = await screen.findByLabelText('Register later');
     await user.click(registerLaterRadio);
 
     //   // click through to review step
@@ -426,7 +430,7 @@ describe('Step Upload to AWS', () => {
     //   await clickNext();
     //   await clickNext();
 
-    //   await user.click(screen.getByRole('button', { name: /Create/ }));
+    //   await user.click(await screen.findByRole('button', { name: /Create/ }));
 
     //   // returns back to the landing page
     //   await waitFor(() =>
@@ -474,7 +478,7 @@ describe('Step Upload to AWS', () => {
         name: 'Select activation key',
       });
 
-      screen.getByText(
+      await screen.findByText(
         'Automatically register and enable advanced capabilities'
       );
     });
@@ -484,7 +488,7 @@ describe('Step Upload to AWS', () => {
 
       await clickBack();
 
-      screen.getByTestId('upload-google');
+      await screen.findByTestId('upload-google');
     });
 
     test('clicking Cancel loads landing page', async () => {
@@ -529,7 +533,9 @@ describe('Step Upload to AWS', () => {
 
       await clickNext();
       await user.click(
-        screen.getByRole('radio', { name: /manually enter an account id\./i })
+        await screen.findByRole('radio', {
+          name: /manually enter an account id\./i,
+        })
       );
       await user.type(
         await screen.findByRole('textbox', {
@@ -547,7 +553,7 @@ describe('Step Upload to AWS', () => {
     // test('clicking Next loads file system configuration', async () => {
     //   await setUp();
 
-    //   const registerLaterRadio = screen.getByTestId('registration-radio-later');
+    //   const registerLaterRadio = await screen.findByTestId('registration-radio-later');
     //   await user.click(registerLaterRadio);
 
     //   await clickNext();
@@ -563,9 +569,11 @@ describe('Step Upload to AWS', () => {
       await clickBack();
 
       await user.click(
-        screen.getByRole('radio', { name: /manually enter an account id\./i })
+        await screen.findByRole('radio', {
+          name: /manually enter an account id\./i,
+        })
       );
-      screen.getByText('AWS account ID');
+      await screen.findByText('AWS account ID');
     });
 
     test('clicking Cancel loads landing page', async () => {
@@ -599,14 +607,14 @@ describe('Step Upload to AWS', () => {
         name: 'name0',
       });
       await user.click(activationKey);
-      screen.getByDisplayValue('name0');
+      await screen.findByDisplayValue('name0');
 
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
-      //     const review = screen.getByTestId('review-registration');
+      //     const review = await screen.findByTestId('review-registration');
       //     expect(review).toHaveTextContent(
       //       'Register with Red Hat Subscription Manager (RHSM)'
       //     );
@@ -620,8 +628,10 @@ describe('Step Upload to AWS', () => {
     test('should allow registering without rhc', async () => {
       await setUp();
 
-      await user.click(screen.getByTestId('registration-additional-options'));
-      await user.click(screen.getByTestId('registration-checkbox-rhc'));
+      await user.click(
+        await screen.findByTestId('registration-additional-options')
+      );
+      await user.click(await screen.findByTestId('registration-checkbox-rhc'));
 
       // going back and forward when rhc isn't selected should keep additional options shown
       await clickBack();
@@ -629,8 +639,8 @@ describe('Step Upload to AWS', () => {
         name: 'aws account id',
       });
       await clickNext();
-      screen.getByTestId('registration-checkbox-insights');
-      screen.getByTestId('registration-checkbox-rhc');
+      await screen.findByTestId('registration-checkbox-insights');
+      await screen.findByTestId('registration-checkbox-rhc');
 
       const activationKeyDropdown = await screen.findByRole('textbox', {
         name: 'Select activation key',
@@ -640,14 +650,14 @@ describe('Step Upload to AWS', () => {
         name: 'name0',
       });
       await user.click(activationKey);
-      screen.getByDisplayValue('name0');
+      await screen.findByDisplayValue('name0');
 
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
-      //     const review = screen.getByTestId('review-registration');
+      //     const review = await screen.findByTestId('review-registration');
       //     expect(review).toHaveTextContent(
       //       'Register with Red Hat Subscription Manager (RHSM)'
       //     );
@@ -661,8 +671,12 @@ describe('Step Upload to AWS', () => {
     test('should allow registering without insights or rhc', async () => {
       await setUp();
 
-      await user.click(screen.getByTestId('registration-additional-options'));
-      await user.click(screen.getByTestId('registration-checkbox-insights'));
+      await user.click(
+        await screen.findByTestId('registration-additional-options')
+      );
+      await user.click(
+        await screen.findByTestId('registration-checkbox-insights')
+      );
 
       // going back and forward when neither rhc or insights is selected should keep additional options shown
       await clickBack();
@@ -670,8 +684,8 @@ describe('Step Upload to AWS', () => {
         name: 'aws account id',
       });
       await clickNext();
-      screen.getByTestId('registration-checkbox-insights');
-      screen.getByTestId('registration-checkbox-rhc');
+      await screen.findByTestId('registration-checkbox-insights');
+      await screen.findByTestId('registration-checkbox-rhc');
 
       const activationKeyDropdown = await screen.findByRole('textbox', {
         name: 'Select activation key',
@@ -681,14 +695,14 @@ describe('Step Upload to AWS', () => {
         name: 'name0',
       });
       await user.click(activationKey);
-      screen.getByDisplayValue('name0');
+      await screen.findByDisplayValue('name0');
 
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
-      //     const review = screen.getByTestId('review-registration');
+      //     const review = await screen.findByTestId('review-registration');
       //     expect(review).toHaveTextContent(
       //       'Register with Red Hat Subscription Manager (RHSM)'
       //     );
@@ -706,7 +720,7 @@ describe('Step Upload to AWS', () => {
       ]);
 
       // click the later radio button which should remove any input fields
-      await user.click(screen.getByTestId('registration-radio-later'));
+      await user.click(await screen.findByTestId('registration-radio-later'));
 
       await removeKeyInformation;
 
@@ -715,19 +729,25 @@ describe('Step Upload to AWS', () => {
       //     await clickNext();
       //     await clickNext();
       //     await clickNext();
-      //     screen.getByText('Register the system later');
+      //     await screen.findByText('Register the system later');
     });
 
     test('registering with rhc implies registering with insights', async () => {
       await setUp();
-      await user.click(screen.getByTestId('registration-additional-options'));
+      await user.click(
+        await screen.findByTestId('registration-additional-options')
+      );
 
-      await user.click(screen.getByTestId('registration-checkbox-insights'));
-      expect(screen.getByTestId('registration-checkbox-rhc')).not.toBeChecked();
-
-      await user.click(screen.getByTestId('registration-checkbox-rhc'));
+      await user.click(
+        await screen.findByTestId('registration-checkbox-insights')
+      );
       expect(
-        screen.getByTestId('registration-checkbox-insights')
+        await screen.findByTestId('registration-checkbox-rhc')
+      ).not.toBeChecked();
+
+      await user.click(await screen.findByTestId('registration-checkbox-rhc'));
+      expect(
+        await screen.findByTestId('registration-checkbox-insights')
       ).toBeChecked();
     });
   });
@@ -759,7 +779,7 @@ describe('Step Upload to AWS', () => {
   //       name: 'Select activation key',
   //     });
 
-  //     const registerLaterRadio = screen.getByTestId('registration-radio-later');
+  //     const registerLaterRadio = await screen.findByTestId('registration-radio-later');
   //     await user.click(registerLaterRadio);
   //     await clickNext();
   //   };
@@ -767,7 +787,7 @@ describe('Step Upload to AWS', () => {
   //   test('Error validation occurs upon clicking next button', async () => {
   //     await setUp();
 
-  //     const manuallyConfigurePartitions = screen.getByText(
+  //     const manuallyConfigurePartitions = await screen.findByText(
   //       /manually configure partitions/i
   //     );
   //     await user.click(manuallyConfigurePartitions);
@@ -783,7 +803,7 @@ describe('Step Upload to AWS', () => {
   //     // Clicking next causes errors to appear
   //     await clickNext();
 
-  //     const mountPointWarning = screen.getByRole('heading', {
+  //     const mountPointWarning = await screen.findByRole('heading', {
   //       name: /danger alert: duplicate mount points: all mount points must be unique\. remove the duplicate or choose a new mount point\./i,
   //       hidden: true,
   //     });
@@ -792,7 +812,7 @@ describe('Step Upload to AWS', () => {
   //       name: /danger alert: duplicate mount point\./i,
   //     });
 
-  //     const tbody = screen.getByTestId('file-system-configuration-tbody');
+  //     const tbody = await screen.findByTestId('file-system-configuration-tbody');
   //     const rows = within(tbody).getAllByRole('row');
   //     expect(rows).toHaveLength(3);
 
@@ -840,7 +860,7 @@ describe('Step Upload to AWS', () => {
   //       name: 'Select activation key',
   //     });
 
-  //     const registerLaterRadio = screen.getByTestId('registration-radio-later');
+  //     const registerLaterRadio = await screen.findByTestId('registration-radio-later');
   //     await user.click(registerLaterRadio);
   //     await clickNext();
 
@@ -856,7 +876,7 @@ describe('Step Upload to AWS', () => {
   //     await setUp();
 
   //     // Enter image name
-  //     const nameInput = screen.getByRole('textbox', {
+  //     const nameInput = await screen.findByRole('textbox', {
   //       name: 'Image Name',
   //     });
   //     // 64 character name
@@ -871,7 +891,7 @@ describe('Step Upload to AWS', () => {
   //     expect(await getNextButton()).toBeEnabled();
 
   //     // Enter description image
-  //     const descriptionInput = screen.getByRole('textbox', {
+  //     const descriptionInput = await screen.findByRole('textbox', {
   //       name: /description/i,
   //     });
 
@@ -916,7 +936,7 @@ describe('Step Upload to AWS', () => {
   //     });
 
   //     // skip registration
-  //     const registerLaterRadio = screen.getByTestId('registration-radio-later');
+  //     const registerLaterRadio = await screen.findByTestId('registration-radio-later');
   //     await user.click(registerLaterRadio);
 
   //     await clickNext();
@@ -938,12 +958,12 @@ describe('Step Upload to AWS', () => {
   //     })[0];
   //     await user.click(releaseMenu);
 
-  //     const showOptionsButton = screen.getByRole('button', {
+  //     const showOptionsButton = await screen.findByRole('button', {
   //       name: 'Show options for further development of RHEL',
   //     });
   //     await user.click(showOptionsButton);
 
-  //     const centos = screen.getByRole('option', {
+  //     const centos = await screen.findByRole('option', {
   //       name: 'CentOS Stream 8',
   //     });
   //     await user.click(centos);
@@ -974,9 +994,9 @@ describe('Step Upload to AWS', () => {
   //   test('has 3 buttons', async () => {
   //     await setUp();
 
-  //     screen.getByRole('button', { name: /Create/ });
-  //     screen.getByRole('button', { name: /Back/ });
-  //     screen.getByRole('button', { name: /Cancel/ });
+  //     await screen.findByRole('button', { name: /Create/ });
+  //     await screen.findByRole('button', { name: /Back/ });
+  //     await screen.findByRole('button', { name: /Cancel/ });
   //   });
 
   //   test('clicking Back loads Image name', async () => {
@@ -984,7 +1004,7 @@ describe('Step Upload to AWS', () => {
 
   //     await clickBack();
 
-  //     screen.getByRole('heading', {
+  //     await screen.findByRole('heading', {
   //       name: 'Details',
   //     });
   //   });
@@ -998,25 +1018,25 @@ describe('Step Upload to AWS', () => {
   //   test('has Registration expandable section for rhel', async () => {
   //     await setUp();
 
-  //     const targetExpandable = screen.getByTestId(
+  //     const targetExpandable = await screen.findByTestId(
   //       'target-environments-expandable'
   //     );
-  //     const registrationExpandable = screen.getByTestId(
+  //     const registrationExpandable = await screen.findByTestId(
   //       'registration-expandable'
   //     );
-  //     const contentExpandable = screen.getByTestId('content-expandable');
-  //     const fscExpandable = screen.getByTestId(
+  //     const contentExpandable = await screen.findByTestId('content-expandable');
+  //     const fscExpandable = await screen.findByTestId(
   //       'file-system-configuration-expandable'
   //     );
 
   //     await user.click(targetExpandable);
-  //     screen.getByText('AWS');
+  //     await screen.findByText('AWS');
   //     await user.click(registrationExpandable);
-  //     screen.getByText('Register the system later');
+  //     await screen.findByText('Register the system later');
   //     await user.click(contentExpandable);
-  //     screen.getByText('Additional Red Hatand 3rd party packages');
+  //     await screen.findByText('Additional Red Hatand 3rd party packages');
   //     await user.click(fscExpandable);
-  //     screen.getByText('Configuration type');
+  //     await screen.findByText('Configuration type');
   //   });
 
   //   test('has no Registration expandable for centos', async () => {
@@ -1034,11 +1054,11 @@ describe('Step Upload to AWS', () => {
   //     ).not.toBeInTheDocument();
 
   //     await user.click(targetExpandable);
-  //     screen.getByText('AWS');
+  //     await screen.findByText('AWS');
   //     await user.click(contentExpandable);
-  //     screen.getByText('Additional Red Hatand 3rd party packages');
+  //     await screen.findByText('Additional Red Hatand 3rd party packages');
   //     await user.click(fscExpandable);
-  //     screen.getByText('Configuration type');
+  //     await screen.findByText('Configuration type');
   //   });
   // });
 
@@ -1063,44 +1083,44 @@ describe('Step Upload to AWS', () => {
   //       name: /options menu/i,
   //     })[0];
   //     await user.click(releaseMenu);
-  //     const releaseOption = screen.getByRole('option', {
+  //     const releaseOption = await screen.findByRole('option', {
   //       name: /Red Hat Enterprise Linux \(RHEL\) 8/,
   //     });
   //     await user.click(releaseOption);
 
   //     await waitFor(() => screen.findByTestId('upload-aws'));
-  //     await user.click(screen.getByTestId('upload-azure'));
-  //     await user.click(screen.getByTestId('upload-google'));
-  //     await user.click(screen.getByTestId('checkbox-vmware'));
-  //     await user.click(screen.getByTestId('checkbox-guest-image'));
-  //     await user.click(screen.getByTestId('checkbox-image-installer'));
+  //     await user.click(await screen.findByTestId('upload-azure'));
+  //     await user.click(await screen.findByTestId('upload-google'));
+  //     await user.click(await screen.findByTestId('checkbox-vmware'));
+  //     await user.click(await screen.findByTestId('checkbox-guest-image'));
+  //     await user.click(await screen.findByTestId('checkbox-image-installer'));
 
   //     await clickNext();
   //     await user.click(
-  //       screen.getByRole('radio', { name: /manually enter an account id\./i })
+  //       await screen.findByRole('radio', { name: /manually enter an account id\./i })
   //     );
-  //     await user.type(screen.getByTestId('aws-account-id'), '012345678901');
+  //     await user.type(await screen.findByTestId('aws-account-id'), '012345678901');
   //     await clickNext();
 
-  //     await user.click(screen.getByTestId('account-sharing'));
+  //     await user.click(await screen.findByTestId('account-sharing'));
 
-  //     await user.type(screen.getByTestId('input-google-email'), 'test@test.com');
+  //     await user.type(await screen.findByTestId('input-google-email'), 'test@test.com');
 
   //     await user.click(await screen.findByTestId('account-sharing'));
   //     await clickNext();
 
-  //     await user.click(screen.getByTestId('azure-radio-manual'));
+  //     await user.click(await screen.findByTestId('azure-radio-manual'));
   //     // Randomly generated GUID
   //     await user.type(
-  //       screen.getByTestId('azure-tenant-id-manual'),
+  //       await screen.findByTestId('azure-tenant-id-manual'),
   //       'b8f86d22-4371-46ce-95e7-65c415f3b1e2'
   //     );
   //     await user.type(
-  //       screen.getByTestId('azure-subscription-id-manual'),
+  //       await screen.findByTestId('azure-subscription-id-manual'),
   //       '60631143-a7dc-4d15-988b-ba83f3c99711'
   //     );
   //     await user.type(
-  //       screen.getByTestId('azure-resource-group-manual'),
+  //       await screen.findByTestId('azure-resource-group-manual'),
   //       'testResourceGroup'
   //     );
   //     await clickNext();
@@ -1114,7 +1134,7 @@ describe('Step Upload to AWS', () => {
   //       name: 'name0',
   //     });
   //     await user.click(activationKey);
-  //     screen.getByDisplayValue('name0');
+  //     await screen.findByDisplayValue('name0');
 
   //     await clickNext();
 
@@ -1127,7 +1147,7 @@ describe('Step Upload to AWS', () => {
   //     await user.click(addPartition);
   //     await user.click(addPartition);
 
-  //     const tbody = screen.getByTestId('file-system-configuration-tbody');
+  //     const tbody = await screen.findByTestId('file-system-configuration-tbody');
   //     const rows = within(tbody).getAllByRole('row');
   //     await waitFor(() => expect(rows).toHaveLength(3));
   //     await clickNext();
@@ -1170,7 +1190,7 @@ describe('Step Upload to AWS', () => {
   //     await user.click(mibButton);
   //     await clickNext();
 
-  //     screen.getByText(
+  //     await screen.findByText(
   //       /Images built with Image Builder include all required packages/i
   //     );
 
@@ -1184,7 +1204,7 @@ describe('Step Upload to AWS', () => {
   //         name: /test summary for test package/,
   //       })
   //     );
-  //     await user.click(screen.getByRole('button', { name: /Add selected/ }));
+  //     await user.click(await screen.findByRole('button', { name: /Add selected/ }));
   //     await clickNext();
 
   //     // Custom repositories
@@ -1200,14 +1220,14 @@ describe('Step Upload to AWS', () => {
   //     await clickNext();
 
   //     // Enter image name
-  //     const nameInput = screen.getByRole('textbox', {
+  //     const nameInput = await screen.findByRole('textbox', {
   //       name: 'Image Name',
   //     });
 
   //     await user.type(nameInput, 'my-image-name');
 
   //     // Enter description for image
-  //     const descriptionInput = screen.getByRole('textbox', {
+  //     const descriptionInput = await screen.findByRole('textbox', {
   //       name: /Description/,
   //     });
   //     await user.type(
@@ -1231,7 +1251,7 @@ describe('Step Upload to AWS', () => {
   //       'registration-expandable'
   //     );
   //     await user.click(registrationExpandable);
-  //     const review = screen.getByTestId('review-registration');
+  //     const review = await screen.findByTestId('review-registration');
   //     expect(review).toHaveTextContent(
   //       'Use remote host configuration (rhc) utility'
   //     );
@@ -1247,13 +1267,13 @@ describe('Step Upload to AWS', () => {
   //     await screen.findByText('Self-Support');
   //     await screen.findByText('Production');
 
-  //     await user.click(screen.getByTestId('repositories-popover-button'));
+  //     await user.click(await screen.findByTestId('repositories-popover-button'));
   //     const repotbody = await screen.findByTestId(
   //       'additional-repositories-table'
   //     );
   //     expect(within(repotbody).getAllByRole('row')).toHaveLength(3);
 
-  //     await user.click(screen.getByTestId('file-system-configuration-popover'));
+  //     await user.click(await screen.findByTestId('file-system-configuration-popover'));
   //     const revtbody = await screen.findByTestId(
   //       'file-system-configuration-tbody-review'
   //     );
@@ -1454,7 +1474,7 @@ describe('Step Upload to AWS', () => {
   //         );
   //       })
   //     );
-  //     await user.click(screen.getByRole('button', { name: /Create/ }));
+  //     await user.click(await screen.findByRole('button', { name: /Create/ }));
 
   //     expect(receivedComposeReqs).toEqual(expectedComposeReqs);
   //     expect(timesCalled).toEqual(6);
@@ -1483,10 +1503,10 @@ describe('Step Upload to AWS', () => {
   //     await waitFor(
   //       async () => await user.click(await screen.findByTestId('upload-aws'))
   //     );
-  //     await user.click(screen.getByTestId('upload-google'));
-  //     await user.click(screen.getByTestId('upload-azure'));
+  //     await user.click(await screen.findByTestId('upload-google'));
+  //     await user.click(await screen.findByTestId('upload-azure'));
   //     await user.click(
-  //       screen.getByRole('checkbox', {
+  //       await screen.findByRole('checkbox', {
   //         name: /virtualization guest image checkbox/i,
   //       })
   //     );
@@ -1500,7 +1520,7 @@ describe('Step Upload to AWS', () => {
   //     await clickNext();
 
   //     // Target environment aws
-  //     expect(screen.getByTestId('aws-radio-source')).toHaveFocus();
+  //     expect(await screen.findByTestId('aws-radio-source')).toHaveFocus();
   //     const awsSourceDropdown = await getSourceDropdown();
   //     await user.click(awsSourceDropdown);
   //     const awsSource = await screen.findByRole('option', {
@@ -1520,7 +1540,7 @@ describe('Step Upload to AWS', () => {
   //     await clickNext();
 
   //     // Target environment azure
-  //     expect(screen.getByTestId('azure-radio-source')).toHaveFocus();
+  //     expect(await screen.findByTestId('azure-radio-source')).toHaveFocus();
   //     const azureSourceDropdown = await getSourceDropdown();
   //     await user.click(azureSourceDropdown);
   //     const azureSource = await screen.findByRole('option', {
@@ -1532,20 +1552,20 @@ describe('Step Upload to AWS', () => {
   //       name: /select resource group/i,
   //     });
   //     await user.click(resourceGroupDropdown);
-  //     await user.click(screen.getByLabelText('Resource group myResourceGroup1'));
+  //     await user.click(await screen.findByLabelText('Resource group myResourceGroup1'));
   //     await clickNext();
 
   //     // Registration
   //     await screen.findByText(
   //       'Automatically register and enable advanced capabilities'
   //     );
-  //     const registerRadio = screen.getByTestId('registration-radio-now');
+  //     const registerRadio = await screen.findByTestId('registration-radio-now');
   //     expect(registerRadio).toHaveFocus();
   //     await screen.findByRole('textbox', {
   //       name: 'Select activation key',
   //     });
   //     // skip registration
-  //     const registerLaterRadio = screen.getByTestId('registration-radio-later');
+  //     const registerLaterRadio = await screen.findByTestId('registration-radio-later');
   //     await user.click(registerLaterRadio);
 
   //     await clickNext();
@@ -1554,7 +1574,7 @@ describe('Step Upload to AWS', () => {
   //     await clickNext();
 
   //     // Packages
-  //     const view = screen.getByTestId('search-available-pkgs-input');
+  //     const view = await screen.findByTestId('search-available-pkgs-input');
 
   //     const availablePackagesInput = within(view).getByRole('textbox', {
   //       name: /search input/i,
@@ -1567,7 +1587,7 @@ describe('Step Upload to AWS', () => {
   //     await clickNext();
 
   //     // Name
-  //     const nameInput = screen.getByRole('textbox', { name: /image name/i });
+  //     const nameInput = await screen.findByRole('textbox', { name: /image name/i });
   //     expect(nameInput).toHaveFocus();
   //     await clickNext();
   //   });
@@ -1588,7 +1608,7 @@ describe('Step Upload to AWS', () => {
   //       async () => await user.click(await screen.findByTestId('upload-aws'))
   //     );
   //     await user.keyboard('{enter}');
-  //     screen.getByRole('heading', {
+  //     await screen.findByRole('heading', {
   //       name: /image output/i,
   //     });
   //   });
@@ -1606,8 +1626,8 @@ describe('Step Upload to AWS', () => {
   //     await clickNext();
 
   //     await waitFor(() => screen.findByTestId('upload-aws'));
-  //     testTile(screen.getByTestId('upload-aws'));
-  //     testTile(screen.getByTestId('upload-google'));
-  //     testTile(screen.getByTestId('upload-azure'));
+  //     testTile(await screen.findByTestId('upload-aws'));
+  //     testTile(await screen.findByTestId('upload-google'));
+  //     testTile(await screen.findByTestId('upload-azure'));
   //   });
 });

--- a/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -95,7 +95,7 @@ describe('Check that the target filtering is in accordance to mock content', () 
     })[0];
     await user.click(releaseMenu);
     await user.click(
-      screen.getByRole('option', {
+      await screen.findByRole('option', {
         name: /Red Hat Enterprise Linux \(RHEL\) 8/,
       })
     );
@@ -184,7 +184,7 @@ describe('Check that the target filtering is in accordance to mock content', () 
     })[0];
     await user.click(releaseMenu);
     await user.click(
-      screen.getByRole('option', {
+      await screen.findByRole('option', {
         name: /Red Hat Enterprise Linux \(RHEL\) 8/,
       })
     );
@@ -240,7 +240,7 @@ describe('Check step consistency', () => {
     await user.click(await screen.findByRole('option', { name: 'x86_64' }));
     await waitFor(async () => await screen.findByTestId('upload-aws'));
     // select GCP, it's available for x86_64
-    await user.click(screen.getByTestId('upload-google'));
+    await user.click(await screen.findByTestId('upload-google'));
     const next = await screen.findByRole('button', { name: /Next/ });
     await waitFor(() => expect(next).toBeEnabled());
     // Change to aarch
@@ -250,7 +250,7 @@ describe('Check step consistency', () => {
     // GCP not being compatible with arch, the next button is disabled
     await waitFor(() => expect(next).toBeDisabled());
     // clicking on AWS the user can go next
-    await user.click(screen.getByTestId('upload-aws'));
+    await user.click(await screen.findByTestId('upload-aws'));
     await waitFor(() => expect(next).toBeEnabled());
     // and going back to x86_64 the user should keep the next button visible
     await user.click(archMenu);

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -233,11 +233,11 @@ describe('Images Table Toolbar', () => {
     await screen.findByTestId('images-table');
 
     // check create image button
-    screen.getByTestId('create-image-action');
+    await screen.findByTestId('create-image-action');
 
     // check pagination renders
-    screen.getByTestId('images-pagination-top');
-    screen.getByTestId('images-pagination-bottom');
+    await screen.findByTestId('images-pagination-top');
+    await screen.findByTestId('images-pagination-bottom');
   });
 });
 
@@ -257,7 +257,7 @@ describe('Clones table', () => {
     const rows = getAllByRole('row');
 
     // first row is header so look at index 1
-    const detailsButton = within(rows[1]).getByRole('button', {
+    const detailsButton = await within(rows[1]).findByRole('button', {
       name: /details/i,
     });
     await user.click(detailsButton);

--- a/src/test/Components/LandingPage/LandingPage.test.js
+++ b/src/test/Components/LandingPage/LandingPage.test.js
@@ -24,7 +24,7 @@ describe('Landing Page', () => {
     renderWithReduxRouter('', {});
 
     // check heading
-    screen.getByRole('heading', { name: /Image Builder/i });
+    await screen.findByRole('heading', { name: /Image Builder/i });
   });
 
   test('renders EmptyState child component', async () => {

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.js
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.js
@@ -40,7 +40,9 @@ describe('Create Share To Regions Modal', () => {
     const shareButton = await screen.findByRole('button', { name: /share/i });
     expect(shareButton).toBeDisabled();
 
-    const selectToggle = screen.getByRole('button', { name: /menu toggle/i });
+    const selectToggle = await screen.findByRole('button', {
+      name: /menu toggle/i,
+    });
     await user.click(selectToggle);
 
     const usEast2 = await screen.findByRole('option', {
@@ -50,13 +52,13 @@ describe('Create Share To Regions Modal', () => {
     await user.click(usEast2);
     await waitFor(() => expect(shareButton).toBeEnabled());
 
-    const clearAllButton = screen.getByRole('button', {
+    const clearAllButton = await screen.findByRole('button', {
       name: /clear input value/i,
     });
     await user.click(clearAllButton);
     await waitFor(() => expect(shareButton).toBeDisabled());
 
-    const invalidAlert = screen.getByText(
+    const invalidAlert = await screen.findByText(
       /select at least one region to share to\./i
     );
     expect(invalidAlert).toBeInTheDocument();


### PR DESCRIPTION
Components sometimes render slower than tests run which causes failures when the test suite expects elements that did not finish their rendering yet.

This should help to prevent most of possible problems with the rendering speed.