### PR TITLE
LandingPage: Hotfix to remove exposed blueprint buttons

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -107,7 +107,7 @@ export const LandingPage = () => {
 
   return (
     <>
-      <ImageBuilderHeader />
+      <ImageBuilderHeader experimentalFlag={experimentalFlag} />
       {edgeParityFlag ? (
         <Tabs
           className="pf-c-tabs pf-c-page-header pf-c-table"

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -18,7 +18,13 @@ import {
 
 import './ImageBuilderHeader.scss';
 
-export const ImageBuilderHeader = () => {
+type ImageBuilderHeaderPropTypes = {
+  experimentalFlag?: string | true | undefined;
+};
+
+export const ImageBuilderHeader = ({
+  experimentalFlag,
+}: ImageBuilderHeaderPropTypes) => {
   return (
     <>
       {/*@ts-ignore*/}
@@ -82,12 +88,16 @@ export const ImageBuilderHeader = () => {
             </Popover>
             <OpenSourceBadge repositoriesURL="https://www.osbuild.org/guides/image-builder-service/architecture.html" />
           </FlexItem>
-          <FlexItem align={{ default: 'alignRight' }}>
-            <Button>New blueprint</Button>
-          </FlexItem>
-          <FlexItem>
-            <Button isDisabled>Build images</Button>
-          </FlexItem>
+          {experimentalFlag && (
+            <>
+              <FlexItem align={{ default: 'alignRight' }}>
+                <Button>New blueprint</Button>
+              </FlexItem>
+              <FlexItem>
+                <Button isDisabled>Build images</Button>
+              </FlexItem>{' '}
+            </>
+          )}
         </Flex>
       </PageHeader>
     </>


### PR DESCRIPTION
Commit bae6435fd92797e1879ff6f2798c11819e1dbff0 adds scaffolding for the blueprint table. Blueprint features should be hidden behind experimental flags. The new buttons related to creating blueprints and rebuilding images in the header were not hidden behind the experimental flag, this commit fixes that and does so.

bae6435fd92797e1879ff6f2798c11819e1dbff0 also changed the header title from "Image Builder" to "Images". This change has been a long time coming - it is being left in for now. We may want to revisit the copy in the popovers to align it as the term "Image Builder" is still being used in those.