### PR TITLE
api: split pulling API changes and regenerating new API

### DIFF
--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: npm ci
     - name: Check for manual changes to API
-      run: npm run api && [ -z "$(git status --porcelain=v1 2>/dev/null)" ] && echo "✓ No manual API changes." || echo "✗ API manually changed, please refer to the README for the procedure to follow for programmatically generated API endpoints." && [ -z "$(git status --porcelain=v1 2>/dev/null)" ]
+      run: npm run api:generate && [ -z "$(git status --porcelain=v1 2>/dev/null)" ] && echo "✓ No manual API changes." || echo "✗ API manually changed, please refer to the README for the procedure to follow for programmatically generated API endpoints." && [ -z "$(git status --porcelain=v1 2>/dev/null)" ]
     - name: Run build
       run: npm run build
     - name: Run lint check

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,19 @@
+# API
+
+This folder contains generated code for API endpoints needed by this repo.
+
+## Updating API changes
+
+To pull new API changes and regenerating the code run
+
+```shell
+npm run api
+```
+
+## Regenerating the code only
+
+To regenerate the code only, run
+
+```shell
+npm run api:generate
+```

--- a/api/codegen.sh
+++ b/api/codegen.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Download the most up-to-date imageBuilder.yaml file and overwrite the existing one
-curl https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml -o ./api/schema/imageBuilder.yaml
-
 # Run commands in the background using & operator
 npx @rtk-query/codegen-openapi ./api/config/imageBuilder.ts &
 npx @rtk-query/codegen-openapi ./api/config/rhsm.ts &

--- a/api/pull.sh
+++ b/api/pull.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Download the most up-to-date imageBuilder.yaml file and overwrite the existing one
+curl https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml -o ./api/schema/imageBuilder.yaml

--- a/package.json
+++ b/package.json
@@ -129,7 +129,9 @@
     "test": "TZ=UTC jest --verbose --no-cache",
     "test:single": "jest --verbose -w 1",
     "build": "webpack --config config/prod.webpack.config.js",
-    "api": "bash api.sh",
+    "api": "npm-run-all api:*",
+    "api:generate": "bash api/codegen.sh",
+    "api:pull": "bash api/pull.sh",
     "verify": "npm-run-all build lint test"
   },
   "insights": {


### PR DESCRIPTION
For checking wether the api was tempered with, we need separate action, that just checks the code against the currently pulled spec.

This introduces two subactions for `npx api`.
These are `npx api:generate` and `npx api:pull`.