### PR TITLE
node: Bump NODE_BUILD_VERSION

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -9,7 +9,7 @@ export COMPONENT="image-builder"
 export IMAGE="quay.io/cloudservices/image-builder-frontend"
 export APP_ROOT=$(pwd)
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=18
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 set -exv

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -10,7 +10,7 @@ export IMAGE="quay.io/cloudservices/image-builder-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 #16 is the default Node version. Change this to override it.
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=18
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------


### PR DESCRIPTION
This bumps NODE_BUILD_VERSION in `build_deploy` and `pr_check` scripts from the default 16 to version 18.