### PR TITLE
ImagesTable: Add error state

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -16,6 +16,9 @@ import {
   EmptyStateActions,
   EmptyStateHeader,
   EmptyStateFooter,
+  Alert,
+  Spinner,
+  Bullseye,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import {
@@ -71,7 +74,7 @@ const ImagesTable = () => {
     setPerPage(perPage);
   };
 
-  const { data, isSuccess } = useGetComposesQuery({
+  const { data, isError, isSuccess } = useGetComposesQuery({
     limit: perPage,
     offset: perPage * (page - 1),
     ignoreImageTypes: [
@@ -83,7 +86,21 @@ const ImagesTable = () => {
   });
 
   if (!isSuccess) {
-    return undefined;
+    if (isError) {
+      return (
+        <Alert variant="warning" title="Service unavailable">
+          <p>
+            The Images service is unavailable right now. We&apos;re working on
+            it... please check back later.
+          </p>
+        </Alert>
+      );
+    }
+    return (
+      <Bullseye>
+        <Spinner />
+      </Bullseye>
+    );
   }
 
   const composes = data.data;


### PR DESCRIPTION
It is important we have an error state for times that we may need to bring the image builder service down for whatever reason.

![image](https://github.com/RedHatInsights/image-builder-frontend/assets/95542540/22601b2f-b109-4c73-a214-67069e2c907d)
