### PR TITLE
Wizard: Temporarily disable Recreate for images with custom repositories

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/CustomButtons.js
+++ b/src/Components/CreateImageWizard/formComponents/CustomButtons.js
@@ -68,7 +68,10 @@ const CustomButtons = ({
               !formOptions.valid ||
               formOptions.getState().validating ||
               isSaving ||
-              hasUnavailableRepo
+              hasUnavailableRepo ||
+              // Temporarily disable when there are custom repositories
+              getState().values?.['payload-repositories'] ||
+              getState().values?.['custom-repositories']
             }
             isLoading={currentStep.id === 'wizard-review' ? isSaving : null}
             onClick={onNextOrSubmit}

--- a/src/Components/CreateImageWizard/formComponents/ReviewStep.js
+++ b/src/Components/CreateImageWizard/formComponents/ReviewStep.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
 import {
+  Alert,
   ExpandableSection,
   Text,
   TextContent,
@@ -9,7 +10,8 @@ import {
 } from '@patternfly/react-core';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
-import RepositoryUnavailable from './RepositoryUnavailable';
+// Temporarily disable
+//import RepositoryUnavailable from './RepositoryUnavailable';
 import {
   ContentList,
   FSCList,
@@ -66,7 +68,20 @@ const ReviewStep = () => {
 
   return (
     <>
-      <RepositoryUnavailable />
+      {
+        // Temporarily disable
+        //<RepositoryUnavailable />
+
+        // vv REMOVE WHEN CONTENT REACHABLE AGAIN
+        (getState()?.values?.['payload-repositories'] ||
+          getState()?.values?.['custom-repositories']) && (
+          <Alert title="Repositories unavailable" variant="warning" isInline>
+            The Content service cannot be reached, please check back later.
+          </Alert>
+        )
+        // ^^ REMOVE WHEN CONTENT REACHABLE AGAIN
+      }
+
       {getState()?.values?.['file-system-configuration']?.find((mp) =>
         mp.mountpoint.includes('/usr')
       ) && <UsrSubDirectoriesDisabled />}


### PR DESCRIPTION
This temporarily disables recreating images containing custom repos.

Changes were marked with "Temporarily disable" and "REMOVE" comments to make the revert easier.