### PR TITLE
test: Remove debugging statement and change `getBy` query to `findBy`

### DIFF
--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -891,9 +891,8 @@ describe('Step Upload to AWS', () => {
       //     expect(await getNextButton()).toBeDisabled();
       //     await user.clear(nameInput);
       //     // Enter image name
-      screen.logTestingPlaygroundURL();
 
-      const nameInput = screen.getByRole('textbox', {
+      const nameInput = await screen.findByRole('textbox', {
         name: /blueprint name/i,
       });
       const invalidName = 'a'.repeat(64);


### PR DESCRIPTION
This removes a leftover debugging statement and changes `getBy` query to an awaited async `findBy` as this was causing problems in the test when the checked component wasn't immediately available.