### PR TITLE
ESLint: Add no-debugging-utils rule

### DIFF
--- a/src/test/.eslintrc
+++ b/src/test/.eslintrc
@@ -9,7 +9,8 @@
   ],
   "rules": {
     "react/display-name": "off",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "testing-library/no-debugging-utils": "error"
   },
   "extends": [
     "plugin:testing-library/react",


### PR DESCRIPTION
This adds `testing-library/no-debugging-utils` rule to output an error when a debugging statement was left over in the code.

https://github.com/RedHatInsights/image-builder-frontend/pull/1596 needs to be merged first.

Can be tested by adding `screen.logTestingPlaygroundURL();` to a test file.