### PR TITLE
cockpit/spec: fix source url

### DIFF
--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -5,7 +5,7 @@ Summary:        Image builder plugin for Cockpit
 
 License:        Apache-2.0
 URL:            http://osbuild.org/
-Source0:        https://github.com/osbuild/image-builder-frontend/releases/download/%{version}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/osbuild/image-builder-frontend/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
 # Drop obsoletes until functional enough compared to cockpit-composer
 # Obsoletes:      cockpit-composer < 54


### PR DESCRIPTION
Downstream the "v" got dropped from the version by #2831, but then the source url is wrong. The path has got a "v" in it, and the artefact doesn't.

The workflow already got fixed in #2860.