### PR TITLE
packit.yaml: release into fedora-42

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -48,9 +48,11 @@ jobs:
   - job: propose_downstream
     trigger: release
     dist_git_branches:
+      - fedora-42
       - fedora-rawhide
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
+      - fedora-42
       - fedora-rawhide


### PR DESCRIPTION
Fedora was forked and we're now in rawhide and f42.