### PR TITLE
Wizard/Oscap: Add analytics (HMS-5990)

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -40,6 +40,7 @@ vi.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
     analytics: {
       track: () => 'test',
       group: () => 'test',
+      screen: () => 'test',
     },
     isBeta: () => true,
   }),


### PR DESCRIPTION
The Intercom team has some ideas about helping new users determine which security profile is right for them. Tracking differentiates between "vanilla" OpenSCAP and Compliance so that any messages from Intercom can be targeted.