### PR TITLE
analytics: Update name of a tracking event

### DIFF
--- a/src/Components/ImagesTable/ImageDetails.tsx
+++ b/src/Components/ImagesTable/ImageDetails.tsx
@@ -163,7 +163,7 @@ export const AwsDetails = ({ compose }: AwsDetailsPropTypes) => {
               clickTip="Copied"
               variant="inline-compact"
               onClick={() => {
-                analytics.track(`${AMPLITUDE_MODULE_NAME} - Button Clicked`, {
+                analytics.track(`${AMPLITUDE_MODULE_NAME} - Copy UUID`, {
                   module: AMPLITUDE_MODULE_NAME,
                   link_name: compose.id,
                   current_path: window.location.pathname,


### PR DESCRIPTION
This updates the name of `- Button Clicked` tracking event to more descriptive `- Copy UUID`.