### PR TITLE
Revert "Wizard: temporarily disable OCI" (HMS-8592)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
@@ -10,7 +10,6 @@ import {
   TextContent,
   TextVariants,
   Tile,
-  Tooltip,
 } from '@patternfly/react-core';
 import { HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
@@ -30,10 +29,7 @@ import {
   selectImageTypes,
 } from '../../../../store/wizardSlice';
 import isRhel from '../../../../Utilities/isRhel';
-import {
-  useFlag,
-  useGetEnvironment,
-} from '../../../../Utilities/useGetEnvironment';
+import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
 
 const TargetEnvironment = () => {
   const arch = useAppSelector(selectArchitecture);
@@ -56,10 +52,6 @@ const TargetEnvironment = () => {
   const dispatch = useAppDispatch();
   const prefetchSources = provisioningApi.usePrefetch('getSourceList');
   const prefetchActivationKeys = rhsmApi.usePrefetch('listActivationKeys');
-
-  const showOracleUnavailableWarning = useFlag(
-    'image-builder.oci.unavailable-warning.enabled'
-  );
 
   useEffect(() => {
     if (!isFedoraEnv) prefetchActivationKeys();
@@ -93,28 +85,6 @@ const TargetEnvironment = () => {
       handleToggleEnvironment(env);
     }
   };
-
-  const ociTile = (
-    <Tile
-      className="tile pf-v5-u-mr-sm"
-      title="Oracle Cloud Infrastructure"
-      icon={
-        <img
-          className="provider-icon"
-          src={'/apps/frontend-assets/partners-icons/oracle-short.svg'}
-          alt="Oracle Cloud Infrastructure logo"
-        />
-      }
-      onClick={() => {
-        handleToggleEnvironment('oci');
-      }}
-      onKeyDown={(e) => handleKeyDown(e, 'oci')}
-      isSelected={environments.includes('oci')}
-      isStacked
-      isDisplayLarge
-      isDisabled={showOracleUnavailableWarning}
-    />
-  );
 
   return (
     <FormGroup
@@ -196,19 +166,26 @@ const TargetEnvironment = () => {
               isDisplayLarge
             />
           )}
-          {supportedEnvironments?.includes('oci') &&
-            showOracleUnavailableWarning && (
-              <Tooltip
-                content={
-                  <div>Oracle Cloud support is temporarily unavailable</div>
-                }
-              >
-                <div>{ociTile}</div>
-              </Tooltip>
-            )}
-          {supportedEnvironments?.includes('oci') &&
-            !showOracleUnavailableWarning &&
-            ociTile}
+          {supportedEnvironments?.includes('oci') && (
+            <Tile
+              className="tile pf-v5-u-mr-sm"
+              title="Oracle Cloud Infrastructure"
+              icon={
+                <img
+                  className="provider-icon"
+                  src={'/apps/frontend-assets/partners-icons/oracle-short.svg'}
+                  alt="Oracle Cloud Infrastructure logo"
+                />
+              }
+              onClick={() => {
+                handleToggleEnvironment('oci');
+              }}
+              onKeyDown={(e) => handleKeyDown(e, 'oci')}
+              isSelected={environments.includes('oci')}
+              isStacked
+              isDisplayLarge
+            />
+          )}
         </div>
       </FormGroup>
       {supportedEnvironments?.includes('vsphere') && (


### PR DESCRIPTION
Once everything is back to 'normal' with Oracle Cloud, we should revert the temporary patch that allowed us to disable this specific image type in the frontend.

This reverts commit efed39dd9da8de903705e61faaa1bed6aad64be6.