### PR TITLE
Wizard: fix blueprints showing incorrect template versions

### DIFF
--- a/src/Utilities/releaseToVersion.ts
+++ b/src/Utilities/releaseToVersion.ts
@@ -1,7 +1,9 @@
-import { CENTOS_9, RHEL_8, RHEL_9 } from '../constants';
+import { CENTOS_9, RHEL_8, RHEL_9, RHEL_10 } from '../constants';
 
 export const releaseToVersion = (release: string) => {
   switch (release) {
+    case RHEL_10:
+      return '10';
     case RHEL_9:
       return '9';
     case RHEL_8:


### PR DESCRIPTION
This fixes an issue where RHEL9 and RHEL10 templates would be shown when creating a RHEL10 image. Required just a small change to map '10' as a possible version from the given releases.