### PR TITLE
.gitlab-ci: Disable fedora-42 runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ test:
     matrix:
       - RUNNER:
           - aws/fedora-41-x86_64
-          - aws/fedora-42-x86_64
+          # - aws/fedora-42-x86_64
           - aws/rhel-9.6-nightly-x86_64
           - aws/rhel-10.0-nightly-x86_64
         INTERNAL_NETWORK: ["true"]


### PR DESCRIPTION
The Fedora 42 runner is timing out while running after script, making the runs take over 70 minutes instead of original 20-30 minutes. We should revisit this and address why are the time outs happening before re-eneblaing the runner again.