### PR TITLE
Wizard: Fix release dropdown's `maxWidth` (HMS-8683)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/ReleaseSelect.tsx
@@ -158,7 +158,7 @@ const ReleaseSelect = () => {
       data-testid="release_select"
       style={
         {
-          'max-width': '100%',
+          maxWidth: '100%',
         } as React.CSSProperties
       }
     >


### PR DESCRIPTION
This applies the styling and removes `Warning: Unsupported style property max-width. Did you mean maxWidth?` from the test output.

JIRA: [HMS-8683](https://issues.redhat.com/browse/HMS-8683)