### PR TITLE
Wizard: hide other repos for on-prem (HMS-6135)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -475,12 +475,14 @@ const Packages = () => {
                   </EmptyStateBody>
                   <EmptyStateFooter>
                     <EmptyStateActions>
-                      <Button
-                        variant="primary"
-                        onClick={() => setActiveTabKey(Repos.OTHER)}
-                      >
-                        Search other repositories
-                      </Button>
+                      {!process.env.IS_ON_PREMISE && (
+                        <Button
+                          variant="primary"
+                          onClick={() => setActiveTabKey(Repos.OTHER)}
+                        >
+                          Search other repositories
+                        </Button>
+                      )}
                     </EmptyStateActions>
                     <EmptyStateActions>
                       <Button
@@ -1512,12 +1514,14 @@ const Packages = () => {
           actions={<IncludedReposPopover />}
           aria-label="Included repositories"
         />
-        <Tab
-          eventKey="other-repos"
-          title={<TabTitleText>Other repos</TabTitleText>}
-          actions={<OtherReposPopover />}
-          aria-label="Other repositories"
-        />
+        {!process.env.IS_ON_PREMISE && (
+          <Tab
+            eventKey="other-repos"
+            title={<TabTitleText>Other repos</TabTitleText>}
+            actions={<OtherReposPopover />}
+            aria-label="Other repositories"
+          />
+        )}
       </Tabs>
       <PackagesTable />
       <Pagination


### PR DESCRIPTION
There is no way of configuring 3rd party repos for on-prem as of yet, we should hide this tab from the users.

Fixes: HMS-6135