### PR TITLE
Wizard: organize steps components into the "components" folders

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -17,7 +17,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import DetailsStep from './steps/Details';
 import FileSystemStep from './steps/FileSystem';
-import { FileSystemContext } from './steps/FileSystem/FileSystemTable';
+import { FileSystemContext } from './steps/FileSystem/components/FileSystemTable';
 import FirewallStep from './steps/Firewall';
 import FirstBootStep from './steps/FirstBoot';
 import HostnameStep from './steps/Hostname';

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemAutomaticPartitionInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemAutomaticPartitionInformation.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Button, Content, ContentVariants } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { FILE_SYSTEM_CUSTOMIZATION_URL } from '../../../../constants';
+import { FILE_SYSTEM_CUSTOMIZATION_URL } from '../../../../../constants';
 
 const FileSystemAutomaticPartition = () => {
   return (

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
@@ -12,14 +12,14 @@ import { v4 as uuidv4 } from 'uuid';
 
 import FileSystemTable from './FileSystemTable';
 
-import { FILE_SYSTEM_CUSTOMIZATION_URL } from '../../../../constants';
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { FILE_SYSTEM_CUSTOMIZATION_URL } from '../../../../../constants';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   addPartition,
   selectImageTypes,
   selectPartitions,
-} from '../../../../store/wizardSlice';
-import UsrSubDirectoriesDisabled from '../../UsrSubDirectoriesDisabled';
+} from '../../../../../store/wizardSlice';
+import UsrSubDirectoriesDisabled from '../../../UsrSubDirectoriesDisabled';
 
 const FileSystemConfiguration = () => {
   const partitions = useAppSelector(selectPartitions);

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemPartition.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemPartition.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import { FormGroup, Label, Radio } from '@patternfly/react-core';
 
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   changeFileSystemConfigurationType,
   selectFileSystemConfigurationType,
   selectComplianceProfileID,
-} from '../../../../store/wizardSlice';
+} from '../../../../../store/wizardSlice';
 
 const FileSystemPartition = () => {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
@@ -25,8 +25,8 @@ import {
   Td,
 } from '@patternfly/react-table';
 
-import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../../../constants';
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../../../../constants';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   changePartitionMinSize,
   changePartitionMountpoint,
@@ -34,9 +34,9 @@ import {
   changePartitionUnit,
   removePartition,
   selectPartitions,
-} from '../../../../store/wizardSlice';
-import { useFilesystemValidation } from '../../utilities/useValidation';
-import { ValidatedInputAndTextArea } from '../../ValidatedInput';
+} from '../../../../../store/wizardSlice';
+import { useFilesystemValidation } from '../../../utilities/useValidation';
+import { ValidatedInputAndTextArea } from '../../../ValidatedInput';
 
 export const FileSystemContext = React.createContext<boolean>(true);
 

--- a/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { Content, Form, Title } from '@patternfly/react-core';
 
-import FileSystemAutomaticPartition from './FileSystemAutomaticPartitionInformation';
-import FileSystemConfiguration from './FileSystemConfiguration';
-import FileSystemPartition from './FileSystemPartition';
+import FileSystemAutomaticPartition from './components/FileSystemAutomaticPartitionInformation';
+import FileSystemConfiguration from './components/FileSystemConfiguration';
+import FileSystemPartition from './components/FileSystemPartition';
 
 import { useAppSelector } from '../../../../store/hooks';
 import { selectFileSystemConfigurationType } from '../../../../store/wizardSlice';

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ArchSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ArchSelect.tsx
@@ -9,13 +9,13 @@ import {
   SelectOption,
 } from '@patternfly/react-core';
 
-import { ARCHES } from '../../../../constants';
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
-import { ImageRequest } from '../../../../store/imageBuilderApi';
+import { ARCHES } from '../../../../../constants';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
+import { ImageRequest } from '../../../../../store/imageBuilderApi';
 import {
   changeArchitecture,
   selectArchitecture,
-} from '../../../../store/wizardSlice';
+} from '../../../../../store/wizardSlice';
 
 const ArchSelect = () => {
   const arch = useAppSelector(selectArchitecture);

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/CentOSAcknowledgement.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/CentOSAcknowledgement.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { DEVELOPERS_URL } from '../../../../constants';
+import { DEVELOPERS_URL } from '../../../../../constants';
 
 const DeveloperProgramButton = () => {
   return (

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseLifecycle.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseLifecycle.tsx
@@ -22,9 +22,9 @@ import {
   RHEL_9_MAINTENANCE_SUPPORT,
   RHEL_10_FULL_SUPPORT,
   RHEL_10_MAINTENANCE_SUPPORT,
-} from '../../../../constants';
-import { useAppSelector } from '../../../../store/hooks';
-import { selectDistribution } from '../../../../store/wizardSlice';
+} from '../../../../../constants';
+import { useAppSelector } from '../../../../../store/hooks';
+import { selectDistribution } from '../../../../../store/wizardSlice';
 import 'chartjs-adapter-moment';
 
 Chart.register(annotationPlugin);

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseSelect.tsx
@@ -24,20 +24,20 @@ import {
   RHEL_10_MAINTENANCE_SUPPORT,
   ON_PREM_RELEASES,
   FEDORA_RELEASES,
-} from '../../../../constants';
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
-import { Distributions } from '../../../../store/imageBuilderApi';
+} from '../../../../../constants';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
+import { Distributions } from '../../../../../store/imageBuilderApi';
 import {
   changeDistribution,
   changeRegistrationType,
   selectDistribution,
-} from '../../../../store/wizardSlice';
-import isRhel from '../../../../Utilities/isRhel';
-import { toMonthAndYear } from '../../../../Utilities/time';
+} from '../../../../../store/wizardSlice';
+import isRhel from '../../../../../Utilities/isRhel';
+import { toMonthAndYear } from '../../../../../Utilities/time';
 import {
   useFlag,
   useGetEnvironment,
-} from '../../../../Utilities/useGetEnvironment';
+} from '../../../../../Utilities/useGetEnvironment';
 
 const ReleaseSelect = () => {
   // What the UI refers to as the "release" is referred to as the "distribution" in the API.

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -16,11 +16,11 @@ import {
 } from '@patternfly/react-core';
 import { HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { useGetArchitecturesQuery } from '../../../../store/backendApi';
-import { useAppSelector, useAppDispatch } from '../../../../store/hooks';
-import { ImageTypes } from '../../../../store/imageBuilderApi';
-import { provisioningApi } from '../../../../store/provisioningApi';
-import { rhsmApi } from '../../../../store/rhsmApi';
+import { useGetArchitecturesQuery } from '../../../../../store/backendApi';
+import { useAppSelector, useAppDispatch } from '../../../../../store/hooks';
+import { ImageTypes } from '../../../../../store/imageBuilderApi';
+import { provisioningApi } from '../../../../../store/provisioningApi';
+import { rhsmApi } from '../../../../../store/rhsmApi';
 import {
   addImageType,
   reinitializeAws,
@@ -30,9 +30,9 @@ import {
   selectArchitecture,
   selectDistribution,
   selectImageTypes,
-} from '../../../../store/wizardSlice';
-import isRhel from '../../../../Utilities/isRhel';
-import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
+} from '../../../../../store/wizardSlice';
+import isRhel from '../../../../../Utilities/isRhel';
+import { useGetEnvironment } from '../../../../../Utilities/useGetEnvironment';
 
 type TargetEnvironmentCardProps = {
   title: string;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -2,11 +2,11 @@ import React, { useEffect } from 'react';
 
 import { Content, Form, Title } from '@patternfly/react-core';
 
-import ArchSelect from './ArchSelect';
-import CentOSAcknowledgement from './CentOSAcknowledgement';
-import ReleaseLifecycle from './ReleaseLifecycle';
-import ReleaseSelect from './ReleaseSelect';
-import TargetEnvironment from './TargetEnvironment';
+import ArchSelect from './components/ArchSelect';
+import CentOSAcknowledgement from './components/CentOSAcknowledgement';
+import ReleaseLifecycle from './components/ReleaseLifecycle';
+import ReleaseSelect from './components/ReleaseSelect';
+import TargetEnvironment from './components/TargetEnvironment';
 
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -38,7 +38,7 @@ import {
 } from '../../../../../store/wizardSlice';
 import { useHasSpecificTargetOnly } from '../../../utilities/hasSpecificTargetOnly';
 import { parseSizeUnit } from '../../../utilities/parseSizeUnit';
-import { Partition, Units } from '../../FileSystem/FileSystemTable';
+import { Partition, Units } from '../../FileSystem/components/FileSystemTable';
 import { removeBetaFromRelease } from '../removeBetaFromRelease';
 
 type ComplianceSelectOptionPropType = {

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -49,7 +49,7 @@ import {
 } from '../../../../../store/wizardSlice';
 import { useHasSpecificTargetOnly } from '../../../utilities/hasSpecificTargetOnly';
 import { parseSizeUnit } from '../../../utilities/parseSizeUnit';
-import { Partition, Units } from '../../FileSystem/FileSystemTable';
+import { Partition, Units } from '../../FileSystem/components/FileSystemTable';
 import { removeBetaFromRelease } from '../removeBetaFromRelease';
 
 type OScapSelectOptionValueType = {

--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeyInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeyInformation.tsx
@@ -10,9 +10,9 @@ import { Button, Popover } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { useAppSelector } from '../../../../store/hooks';
-import { useShowActivationKeyQuery } from '../../../../store/rhsmApi';
-import { selectActivationKey } from '../../../../store/wizardSlice';
+import { useAppSelector } from '../../../../../store/hooks';
+import { useShowActivationKeyQuery } from '../../../../../store/rhsmApi';
+import { selectActivationKey } from '../../../../../store/wizardSlice';
 
 const ActivationKeyInformation = (): JSX.Element => {
   const activationKey = useAppSelector(selectActivationKey);

--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
@@ -15,25 +15,25 @@ import {
 } from '@patternfly/react-core';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
-import ManageKeysButton from './components/ManageKeysButton';
-import PopoverActivation from './components/PopoverActivation';
+import ManageKeysButton from './ManageKeysButton';
+import PopoverActivation from './PopoverActivation';
 
-import { CDN_PROD_URL, CDN_STAGE_URL } from '../../../../constants';
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { CDN_PROD_URL, CDN_STAGE_URL } from '../../../../../constants';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   useListActivationKeysQuery,
   useCreateActivationKeysMutation,
-} from '../../../../store/rhsmApi';
+} from '../../../../../store/rhsmApi';
 import {
   changeActivationKey,
   changeBaseUrl,
   changeServerUrl,
   selectActivationKey,
   selectRegistrationType,
-} from '../../../../store/wizardSlice';
-import sortfn from '../../../../Utilities/sortfn';
-import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
-import { generateRandomId } from '../../utilities/generateRandomId';
+} from '../../../../../store/wizardSlice';
+import sortfn from '../../../../../Utilities/sortfn';
+import { useGetEnvironment } from '../../../../../Utilities/useGetEnvironment';
+import { generateRandomId } from '../../../utilities/generateRandomId';
 
 const ActivationKeysList = () => {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
@@ -11,13 +11,13 @@ import {
 import { ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons';
 import { useFlag } from '@unleash/proxy-client-react';
 
-import { INSIGHTS_URL, RHC_URL, RHEL_10_BETA } from '../../../../constants';
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { INSIGHTS_URL, RHC_URL, RHEL_10_BETA } from '../../../../../constants';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   changeRegistrationType,
   selectDistribution,
   selectRegistrationType,
-} from '../../../../store/wizardSlice';
+} from '../../../../../store/wizardSlice';
 
 const InsightsPopover = () => {
   return (

--- a/src/Components/CreateImageWizard/steps/Registration/components/SatelliteRegistration.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/SatelliteRegistration.tsx
@@ -9,14 +9,14 @@ import {
   HelperTextItem,
 } from '@patternfly/react-core';
 
-import SatelliteRegistrationCommand from './components/SatelliteRegistrationCommand';
+import SatelliteRegistrationCommand from './SatelliteRegistrationCommand';
 
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   changeSatelliteCaCertificate,
   selectSatelliteCaCertificate,
-} from '../../../../store/wizardSlice';
-import { useRegistrationValidation } from '../../utilities/useValidation';
+} from '../../../../../store/wizardSlice';
+import { useRegistrationValidation } from '../../../utilities/useValidation';
 
 const SatelliteRegistration = () => {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/Registration/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/index.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 
 import { Content, Form, Title, FormGroup } from '@patternfly/react-core';
 
-import ActivationKeyInformation from './ActivationKeyInformation';
-import ActivationKeysList from './ActivationKeysList';
-import Registration from './Registration';
-import SatelliteRegistration from './SatelliteRegistration';
+import ActivationKeyInformation from './components/ActivationKeyInformation';
+import ActivationKeysList from './components/ActivationKeysList';
+import Registration from './components/Registration';
+import SatelliteRegistration from './components/SatelliteRegistration';
 
 import { useAppSelector } from '../../../../store/hooks';
 import {

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -13,7 +13,6 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
-import ActivationKeyInformation from './../Registration/ActivationKeyInformation';
 import {
   PackagesTable,
   RepositoriesTable,
@@ -87,9 +86,10 @@ import {
   getConversionFactor,
   MinimumSizePopover,
   Partition,
-} from '../FileSystem/FileSystemTable';
-import { MajorReleasesLifecyclesChart } from '../ImageOutput/ReleaseLifecycle';
+} from '../FileSystem/components/FileSystemTable';
+import { MajorReleasesLifecyclesChart } from '../ImageOutput/components/ReleaseLifecycle';
 import OscapProfileInformation from '../Oscap/components/OscapProfileInformation';
+import ActivationKeyInformation from '../Registration/components/ActivationKeyInformation';
 import PopoverActivation from '../Registration/components/PopoverActivation';
 
 const ExpirationWarning = () => {

--- a/src/Components/CreateImageWizard/steps/Snapshot/components/Snapshot.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/components/Snapshot.tsx
@@ -11,9 +11,9 @@ import {
   Title,
 } from '@patternfly/react-core';
 
-import Templates from './components/Templates';
+import Templates from './Templates';
 
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   selectSnapshotDate,
   changeUseLatest,
@@ -21,10 +21,10 @@ import {
   changeTemplate,
   selectUseLatest,
   selectTemplate,
-} from '../../../../store/wizardSlice';
-import { yyyyMMddFormat } from '../../../../Utilities/time';
-import { useFlag } from '../../../../Utilities/useGetEnvironment';
-import { isSnapshotDateValid } from '../../validators';
+} from '../../../../../store/wizardSlice';
+import { yyyyMMddFormat } from '../../../../../Utilities/time';
+import { useFlag } from '../../../../../Utilities/useGetEnvironment';
+import { isSnapshotDateValid } from '../../../validators';
 
 export default function Snapshot() {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/Snapshot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Button, Form, Grid, Content, Title } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import Snapshot from './Snapshot';
+import Snapshot from './components/Snapshot';
 
 import { CONTENT_URL } from '../../../../constants';
 

--- a/src/Components/CreateImageWizard/utilities/parseSizeUnit.ts
+++ b/src/Components/CreateImageWizard/utilities/parseSizeUnit.ts
@@ -1,5 +1,5 @@
 import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../../constants';
-import { Units } from '../steps/FileSystem/FileSystemTable';
+import { Units } from '../steps/FileSystem/components/FileSystemTable';
 
 export const parseSizeUnit = (bytesize: string) => {
   let size;

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -102,7 +102,7 @@ import {
   getConversionFactor,
   Partition,
   Units,
-} from '../steps/FileSystem/FileSystemTable';
+} from '../steps/FileSystem/components/FileSystemTable';
 import { PackageRepository } from '../steps/Packages/Packages';
 import {
   convertSchemaToIBCustomRepo,

--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -1,4 +1,4 @@
-import type { Partition } from './steps/FileSystem/FileSystemTable';
+import type { Partition } from './steps/FileSystem/components/FileSystemTable';
 
 export const isAwsAccountIdValid = (awsAccountId: string | undefined) => {
   return (

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -19,7 +19,7 @@ import type { FileSystemConfigurationType } from '../Components/CreateImageWizar
 import type {
   Partition,
   Units,
-} from '../Components/CreateImageWizard/steps/FileSystem/FileSystemTable';
+} from '../Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable';
 import type {
   GroupWithRepositoryInfo,
   IBPackageWithRepositoryInfo,


### PR DESCRIPTION
This PR adds `components` folders to the wizard steps. I tried avoiding steps that are touched by current PRs, however @regexowl , your [test-id PR](https://github.com/osbuild/image-builder-frontend/pull/3204) is impossible to avoid :sweat_smile: 