### PR TITLE
Wizard: Deduplicate `ManageRepositoriesButton` (HMS-8747)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Repositories/components/ManageRepositoriesButton.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/ManageRepositoriesButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import { CONTENT_URL } from '../../../../../constants';
+
+const ManageRepositoriesButton = () => {
+  return (
+    <Button
+      component="a"
+      target="_blank"
+      variant="link"
+      iconPosition="right"
+      isInline
+      icon={<ExternalLinkAltIcon />}
+      href={CONTENT_URL}
+    >
+      Create and manage repositories here
+    </Button>
+  );
+};
+
+export default ManageRepositoriesButton;

--- a/src/Components/CreateImageWizard/steps/Repositories/components/UploadRepositoryLabel.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/UploadRepositoryLabel.tsx
@@ -1,29 +1,19 @@
 import React from 'react';
 
-import { Button, Label, Content, Tooltip } from '@patternfly/react-core';
-import { ExternalLinkAltIcon, UploadIcon } from '@patternfly/react-icons';
+import { Label, Tooltip } from '@patternfly/react-core';
+import { UploadIcon } from '@patternfly/react-icons';
 
-import { CONTENT_URL } from '../../../../../constants';
+import ManageRepositoriesButton from './ManageRepositoriesButton';
 
 const UploadRepositoryLabel = () => {
   return (
     <Tooltip
       content={
-        <Content>
+        <>
           Upload repository: Snapshots will only be taken when new content is
-          uploaded.&nbsp;
-          <Button
-            component="a"
-            target="_blank"
-            variant="link"
-            iconPosition="right"
-            isInline
-            icon={<ExternalLinkAltIcon />}
-            href={CONTENT_URL}
-          >
-            Create and manage repositories here.
-          </Button>
-        </Content>
+          uploaded.
+          <ManageRepositoriesButton />
+        </>
       }
     >
       <Label

--- a/src/Components/CreateImageWizard/steps/Repositories/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/index.tsx
@@ -1,32 +1,15 @@
 import React from 'react';
 
-import { Alert, Button, Form, Content, Title } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Alert, Form, Content, Title } from '@patternfly/react-core';
 
+import ManageRepositoriesButton from './components/ManageRepositoriesButton';
 import Repositories from './Repositories';
 
-import { CONTENT_URL } from '../../../../constants';
 import { useAppSelector } from '../../../../store/hooks';
 import {
   selectPackages,
   selectRecommendedRepositories,
 } from '../../../../store/wizardSlice';
-
-const ManageRepositoriesButton = () => {
-  return (
-    <Button
-      component="a"
-      target="_blank"
-      variant="link"
-      iconPosition="right"
-      isInline
-      icon={<ExternalLinkAltIcon />}
-      href={CONTENT_URL}
-    >
-      Create and manage repositories here
-    </Button>
-  );
-};
 
 const RepositoriesStep = () => {
   const packages = useAppSelector(selectPackages);
@@ -39,9 +22,10 @@ const RepositoriesStep = () => {
       </Title>
       <Content>
         Select the linked custom repositories from which you can add packages to
-        the image.
-        <br />
-        <ManageRepositoriesButton />
+        the image
+        <Content>
+          <ManageRepositoriesButton />
+        </Content>
       </Content>
       {packages.length && recommendedRepos.length ? (
         <Alert

--- a/src/Components/CreateImageWizard/steps/Snapshot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
-import { Button, Form, Grid, Content, Title } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Form, Content, Title } from '@patternfly/react-core';
 
 import Snapshot from './components/Snapshot';
 
-import { CONTENT_URL } from '../../../../constants';
+import ManageRepositoriesButton from '../Repositories/components/ManageRepositoriesButton';
 
 export default function SnapshotStep() {
   return (
@@ -13,23 +12,13 @@ export default function SnapshotStep() {
       <Title headingLevel="h1" size="xl">
         Repeatable build
       </Title>
-      <Grid>
+      <Content>
+        Control the consistency of the packages in the repository used to build
+        the image.
         <Content>
-          Control the consistency of the packages in the repository used to
-          build the image.
+          <ManageRepositoriesButton />
         </Content>
-        <Button
-          component="a"
-          target="_blank"
-          variant="link"
-          iconPosition="right"
-          isInline
-          icon={<ExternalLinkAltIcon />}
-          href={CONTENT_URL}
-        >
-          Create and manage repositories here
-        </Button>
-      </Grid>
+      </Content>
       <Snapshot />
     </Form>
   );


### PR DESCRIPTION
This moves the `ManageRepositoriesButton` component to its own file and deduplicates it in the code base.

Tooltip for Upload repositories was also fixed and is now readable again.

Before:
![image](https://github.com/user-attachments/assets/c9ede40a-8517-4009-a2d0-ab08cc74b1ad)

After:
![image](https://github.com/user-attachments/assets/2a046b93-d680-456a-b956-cc53f5d7da8c)


JIRA: [HMS-8747](https://issues.redhat.com/browse/HMS-8747)