### PR TITLE
playwright: Add check to ensure test is authenticated

### DIFF
--- a/playwright/Customizations/Filesystem.spec.ts
+++ b/playwright/Customizations/Filesystem.spec.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { FILE_SYSTEM_CUSTOMIZATION_URL } from '../../src/constants';
 import { test } from '../fixtures/cleanup';
 import { isHosted } from '../helpers/helpers';
+import { ensureAuthenticated } from '../helpers/login';
 import {
   navigateToOptionalSteps,
   ibFrame,
@@ -27,6 +28,8 @@ test('Create a blueprint with Filesystem customization', async ({
 
   // Delete the blueprint after the run fixture
   await cleanup.add(() => deleteBlueprint(page, blueprintName));
+
+  await ensureAuthenticated(page);
 
   // Login, navigate to IB and get the frame
   await navigateToLandingPage(page);

--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
+import { ensureAuthenticated } from '../helpers/login';
 import {
   navigateToOptionalSteps,
   ibFrame,
@@ -26,6 +27,8 @@ test('Create a blueprint with Firewall customization', async ({
 
   // Delete the blueprint after the run fixture
   await cleanup.add(() => deleteBlueprint(page, blueprintName));
+
+  await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);

--- a/playwright/Customizations/Hostname.spec.ts
+++ b/playwright/Customizations/Hostname.spec.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
+import { ensureAuthenticated } from '../helpers/login';
 import {
   navigateToOptionalSteps,
   ibFrame,
@@ -27,6 +28,8 @@ test('Create a blueprint with Hostname customization', async ({
 
   // Delete the blueprint after the run fixture
   await cleanup.add(() => deleteBlueprint(page, blueprintName));
+
+  await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);

--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
+import { ensureAuthenticated } from '../helpers/login';
 import {
   navigateToOptionalSteps,
   ibFrame,
@@ -26,6 +27,8 @@ test('Create a blueprint with Kernel customization', async ({
 
   // Delete the blueprint after the run fixture
   await cleanup.add(() => deleteBlueprint(page, blueprintName));
+
+  await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);

--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
+import { ensureAuthenticated } from '../helpers/login';
 import {
   navigateToOptionalSteps,
   ibFrame,
@@ -26,6 +27,8 @@ test('Create a blueprint with Locale customization', async ({
 
   // Delete the blueprint after the run fixture
   await cleanup.add(() => deleteBlueprint(page, blueprintName));
+
+  await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
+import { ensureAuthenticated } from '../helpers/login';
 import {
   navigateToOptionalSteps,
   ibFrame,
@@ -26,6 +27,8 @@ test('Create a blueprint with Systemd customization', async ({
 
   // Delete the blueprint after the run fixture
   await cleanup.add(() => deleteBlueprint(page, blueprintName));
+
+  await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);

--- a/playwright/Customizations/Timezone.spec.ts
+++ b/playwright/Customizations/Timezone.spec.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
+import { ensureAuthenticated } from '../helpers/login';
 import {
   navigateToOptionalSteps,
   ibFrame,
@@ -26,6 +27,8 @@ test('Create a blueprint with Timezone customization', async ({
 
   // Delete the blueprint after the run fixture
   await cleanup.add(() => deleteBlueprint(page, blueprintName));
+
+  await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);

--- a/playwright/test.spec.ts
+++ b/playwright/test.spec.ts
@@ -2,11 +2,13 @@ import { expect, test } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
 import { closePopupsIfExist, isHosted } from './helpers/helpers';
+import { ensureAuthenticated } from './helpers/login';
 import { ibFrame, navigateToLandingPage } from './helpers/navHelpers';
 
 test.describe.serial('test', () => {
   const blueprintName = uuidv4();
   test('create blueprint', async ({ page }) => {
+    await ensureAuthenticated(page);
     await closePopupsIfExist(page);
     // Navigate to IB landing page and get the frame
     await navigateToLandingPage(page);
@@ -85,6 +87,7 @@ test.describe.serial('test', () => {
   });
 
   test('edit blueprint', async ({ page }) => {
+    await ensureAuthenticated(page);
     await closePopupsIfExist(page);
     // package searching is really slow the first time in cockpit
     if (!isHosted()) {
@@ -123,6 +126,7 @@ test.describe.serial('test', () => {
   });
 
   test('build blueprint', async ({ page }) => {
+    await ensureAuthenticated(page);
     await closePopupsIfExist(page);
     // Navigate to IB landing page and get the frame
     await navigateToLandingPage(page);
@@ -142,6 +146,7 @@ test.describe.serial('test', () => {
   });
 
   test('delete blueprint', async ({ page }) => {
+    await ensureAuthenticated(page);
     await closePopupsIfExist(page);
     // Navigate to IB landing page and get the frame
     await navigateToLandingPage(page);


### PR DESCRIPTION
In order to fix the flakiness in cockpit plugin tests introduced by the single login, the tests need a check if they are authenticated at the start of their execution and relog in case the session expired.