### PR TITLE
PackageRecommendations: Add modelVersion to analytics tracking (HMS-8831)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
@@ -100,6 +100,7 @@ const PackageRecommendations = () => {
               shownRecommendations: response.data.packages,
               selectedPackages: packages.map((pkg) => pkg.name),
               distribution: distribution.replace('-', ''),
+              modelVersion: response.data.modelVersion,
             }
           );
         }
@@ -267,6 +268,7 @@ const PackageRecommendations = () => {
                                   ),
                                   shownRecommendations: data.packages,
                                   distribution: distribution.replace('-', ''),
+                                  modelVersion: data.modelVersion,
                                 }
                               );
                               addRecommendedPackage(pkg);


### PR DESCRIPTION
Previous commit 852d24e5 added modelVersion to the API response and mentioned adding it to analytics tracking, but only added the distribution field to the analytics events. This commit completes the implementation by adding modelVersion to both package recommendation analytics events:

- "Package Recommendations Shown" event now includes modelVersion
- "Recommended Package Added" event now includes modelVersion

This enables proper tracking of which recommendation models are being used and their effectiveness.

🤖 Generated with [Claude Code](https://claude.ai/code)

JIRA: [HMS-8831](https://issues.redhat.com/browse/HMS-8831)