### PR TITLE
dependabot: Lower limit for number of open PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     rebase-strategy: "auto"
     ignore:
       - dependency-name: "@playwright/test"


### PR DESCRIPTION
We no longer have dependency bumps "stuck" in the limbo. Let's lower the limit again as we're not overwhelmed by new dependabot PRs.