### PR TITLE
src: Fix status text color (HMS-8865)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Repositories/RepositoriesStatus.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/RepositoriesStatus.tsx
@@ -66,7 +66,7 @@ const RepositoriesStatus = ({
         <Icon status="success">
           <CheckCircleIcon />
         </Icon>{' '}
-        <span className="pf-v6-u-font-weight-bold pf-v6-u-success-color-200">
+        <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-success">
           {repoStatus}
         </span>
       </>
@@ -142,7 +142,7 @@ const RepositoriesStatus = ({
                 <Icon status="danger">
                   <ExclamationCircleIcon />
                 </Icon>{' '}
-                <span className="pf-v6-u-font-weight-bold pf-v6-u-danger-color-200 failure-button">
+                <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-danger failure-button">
                   {repoStatus}
                 </span>
               </>
@@ -152,7 +152,7 @@ const RepositoriesStatus = ({
                 <Icon status="warning">
                   <ExclamationTriangleIcon />
                 </Icon>{' '}
-                <span className="pf-v6-u-font-weight-bold pf-v6-u-warning-color-200 failure-button">
+                <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-warning failure-button">
                   {repoStatus}
                 </span>
               </>
@@ -165,7 +165,7 @@ const RepositoriesStatus = ({
     return (
       <>
         <Spinner isInline />{' '}
-        <span className="pf-v6-u-font-weight-bold pf-v6-u-info-color-200">
+        <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-info">
           {repoStatus}
         </span>
       </>

--- a/src/Components/ImagesTable/Status.tsx
+++ b/src/Components/ImagesTable/Status.tsx
@@ -238,7 +238,7 @@ export const ExpiringStatus = ({
       <Status
         icon={statuses['expiring'].icon}
         text={
-          <span className="pf-v6-u-font-weight-bold pf-v6-u-warning-color-200">
+          <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-warning">
             {text}
           </span>
         }
@@ -254,7 +254,7 @@ export const ExpiringStatus = ({
       <Status
         icon={statuses['expiring'].icon}
         text={
-          <span className="pf-v6-u-font-weight-bold pf-v6-u-warning-color-200">
+          <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-warning">
             {text}
           </span>
         }
@@ -310,7 +310,7 @@ const statuses = {
       </Icon>
     ),
     text: (
-      <span className="pf-v6-u-font-weight-bold pf-v6-u-danger-color-200">
+      <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-danger">
         Image build failed
       </span>
     ),
@@ -326,7 +326,7 @@ const statuses = {
   building: {
     icon: <Spinner isInline />,
     text: (
-      <span className="pf-v6-u-font-weight-bold pf-v6-u-info-color-200">
+      <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-info">
         Image build in progress
       </span>
     ),
@@ -335,7 +335,7 @@ const statuses = {
   uploading: {
     icon: <Spinner isInline />,
     text: (
-      <span className="pf-v6-u-font-weight-bold pf-v6-u-info-color-200">
+      <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-info">
         Image upload in progress
       </span>
     ),
@@ -344,7 +344,7 @@ const statuses = {
   registering: {
     icon: <Spinner isInline />,
     text: (
-      <span className="pf-v6-u-font-weight-bold pf-v6-u-info-color-200">
+      <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-info">
         Cloud registration in progress
       </span>
     ),
@@ -353,7 +353,7 @@ const statuses = {
   running: {
     icon: <Spinner isInline />,
     text: (
-      <span className="pf-v6-u-font-weight-bold pf-v6-u-info-color-200">
+      <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-info">
         Running
       </span>
     ),
@@ -366,7 +366,7 @@ const statuses = {
       </Icon>
     ),
     text: (
-      <span className="pf-v6-u-font-weight-bold pf-v6-u-success-color-200">
+      <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-success">
         Ready
       </span>
     ),
@@ -392,7 +392,7 @@ const statuses = {
       </Icon>
     ),
     text: (
-      <span className="pf-v6-u-font-weight-bold pf-v6-u-danger-color-200">
+      <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-danger">
         Sharing image failed
       </span>
     ),
@@ -405,7 +405,7 @@ const statuses = {
       </Icon>
     ),
     text: (
-      <span className="pf-v6-u-font-weight-bold pf-v6-u-danger-color-200">
+      <span className="pf-v6-u-font-weight-bold pf-v6-u-text-color-status-danger">
         Failure sharing
       </span>
     ),


### PR DESCRIPTION
The `className` for text color was changed in PF6, this updates it in relevant places.

JIRA: [HMS-8865](https://issues.redhat.com/browse/HMS-8865)

Before:
<img width="905" height="532" alt="image" src="https://github.com/user-attachments/assets/e7440c60-d904-42b8-a378-724cab1df5ab" />

After:
<img width="905" height="532" alt="image" src="https://github.com/user-attachments/assets/abe8f099-10a3-46c5-abe8-547b3c734945" />