### PR TITLE
src: Update Registration step based on mocks (HMS-9409)

### DIFF
--- a/playwright/test.spec.ts
+++ b/playwright/test.spec.ts
@@ -29,7 +29,7 @@ test.describe.serial('test', () => {
 
     if (isHosted()) {
       frame.getByRole('heading', {
-        name: 'Register systems using this image',
+        name: 'Register',
       });
       await page.getByRole('radio', { name: /Register later/i }).click();
       await frame.getByRole('button', { name: 'Next', exact: true }).click();

--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeyInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeyInformation.tsx
@@ -5,10 +5,13 @@ import {
   Button,
   Content,
   ContentVariants,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
   Popover,
   Spinner,
 } from '@patternfly/react-core';
-import { HelpIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { useAppSelector } from '../../../../../store/hooks';
@@ -34,51 +37,40 @@ const ActivationKeyInformation = (): JSX.Element => {
     <>
       {isFetchingActivationKeyInfo && <Spinner size='lg' />}
       {isSuccessActivationKeyInfo && (
-        <Content>
-          <Content component={ContentVariants.dl}>
-            <Content component={ContentVariants.dt}>Name:</Content>
-            <Content component={ContentVariants.dd}>{activationKey}</Content>
-            <Content component={ContentVariants.dt}>Description:</Content>
-            <Content component={ContentVariants.dd}>
+        <DescriptionList>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Name</DescriptionListTerm>
+            <DescriptionListDescription>
+              {activationKey}
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Description</DescriptionListTerm>
+            <DescriptionListDescription>
               {activationKeyInfo?.body?.description || ''}
-            </Content>
-            <Content component={ContentVariants.dt}>Role:</Content>
-            <Content component={ContentVariants.dd}>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Role</DescriptionListTerm>
+            <DescriptionListDescription>
               {activationKeyInfo?.body?.role || 'Not defined'}
-            </Content>
-            <Content component={ContentVariants.dt}>SLA:</Content>
-            <Content component={ContentVariants.dd}>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>SLA</DescriptionListTerm>
+            <DescriptionListDescription>
               {activationKeyInfo?.body?.serviceLevel || 'Not defined'}
-            </Content>
-            <Content component={ContentVariants.dt}>Usage:</Content>
-            <Content component={ContentVariants.dd}>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Usage</DescriptionListTerm>
+            <DescriptionListDescription>
               {activationKeyInfo?.body?.usage || 'Not defined'}
-            </Content>
-            <Content component={ContentVariants.dt}>
-              Additional repositories:
-              <Popover
-                bodyContent={
-                  <Content>
-                    <Content>
-                      The core repositories for your operating system version
-                      are always enabled and do not need to be explicitly added
-                      to the activation key.
-                    </Content>
-                  </Content>
-                }
-              >
-                <Button
-                  icon={<HelpIcon />}
-                  variant='plain'
-                  aria-label='About additional repositories'
-                  className='pf-v6-u-pl-sm pf-v6-u-pt-0 pf-v6-u-pb-0'
-                />
-              </Popover>
-            </Content>
-            <Content
-              component={ContentVariants.dd}
-              className='pf-v6-u-display-flex pf-v6-u-align-items-flex-end'
-            >
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Additional repositories</DescriptionListTerm>
+            <DescriptionListDescription>
               {activationKeyInfo?.body?.additionalRepositories &&
               activationKeyInfo?.body?.additionalRepositories?.length > 0 ? (
                 <Popover
@@ -123,9 +115,9 @@ const ActivationKeyInformation = (): JSX.Element => {
               ) : (
                 'None'
               )}
-            </Content>
-          </Content>
-        </Content>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
       )}
       {isErrorActivationKeyInfo && (
         <Content>

--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
@@ -2,12 +2,16 @@ import React, { useEffect, useState } from 'react';
 
 import {
   Alert,
+  Button,
+  Flex,
+  FlexItem,
   FormGroup,
   FormHelperText,
   HelperText,
   HelperTextItem,
   MenuToggle,
   MenuToggleElement,
+  Popover,
   Select,
   SelectList,
   SelectOption,
@@ -15,9 +19,11 @@ import {
   TextInputGroup,
   TextInputGroupMain,
 } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import { v4 as uuidv4 } from 'uuid';
 
+import ActivationKeyInformation from './ActivationKeyInformation';
 import ManageKeysButton from './ManageKeysButton';
 
 import { CDN_PROD_URL, CDN_STAGE_URL } from '../../../../../constants';
@@ -266,18 +272,38 @@ const ActivationKeysList = () => {
 
   return (
     <>
-      <FormGroup label='Activation key to use for this image'>
-        <Select
-          isScrollable
-          isOpen={isOpen}
-          selected={activationKey}
-          onSelect={handleSelect}
-          onOpenChange={handleToggle}
-          toggle={toggle}
-          shouldFocusFirstItemOnOpen={false}
-        >
-          <SelectList>{prepareSelectOptions()}</SelectList>
-        </Select>
+      <FormGroup label='Activation key'>
+        <Flex spaceItems={{ default: 'spaceItemsMd' }}>
+          <FlexItem>
+            <Select
+              isScrollable
+              isOpen={isOpen}
+              selected={activationKey}
+              onSelect={handleSelect}
+              onOpenChange={handleToggle}
+              toggle={toggle}
+              shouldFocusFirstItemOnOpen={false}
+            >
+              <SelectList>{prepareSelectOptions()}</SelectList>
+            </Select>
+          </FlexItem>
+          <FlexItem>
+            <Popover
+              headerContent='Details'
+              bodyContent={<ActivationKeyInformation />}
+              minWidth='30'
+            >
+              <Button
+                variant='secondary'
+                icon={<InfoCircleIcon />}
+                iconPosition='left'
+                isDisabled={!activationKey}
+              >
+                View details
+              </Button>
+            </Popover>
+          </FlexItem>
+        </Flex>
         <FormHelperText>
           <HelperText>
             <HelperTextItem>

--- a/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
@@ -1,119 +1,23 @@
-import React, { useState } from 'react';
+import React from 'react';
 
-import {
-  Button,
-  Checkbox,
-  Content,
-  FormGroup,
-  Popover,
-  Radio,
-} from '@patternfly/react-core';
-import { ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons';
-import { useFlag } from '@unleash/proxy-client-react';
+import { Content, FormGroup, Radio, Switch } from '@patternfly/react-core';
 
-import { INSIGHTS_URL, RHC_URL } from '../../../../../constants';
+import ActivationKeysList from './ActivationKeysList';
+
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   changeRegistrationType,
   selectRegistrationType,
 } from '../../../../../store/wizardSlice';
 
-const InsightsPopover = () => {
-  const lightspeedEnabled = useFlag('image-builder.lightspeed.enabled');
-
-  return (
-    <Popover
-      headerContent={`About ${lightspeedEnabled ? 'Red Hat Lightspeed' : 'Red Hat Insights'}`}
-      position='right'
-      minWidth='30rem'
-      bodyContent={
-        <Content>
-          <Content>
-            Red Hat {lightspeedEnabled ? 'Lightspeed' : 'Insights'} client
-            provides actionable intelligence about your Red Hat Enterprise Linux
-            environments, helping to identify and address operational and
-            vulnerability risks before an issue results in downtime.
-          </Content>
-          <Button
-            component='a'
-            target='_blank'
-            variant='link'
-            icon={<ExternalLinkAltIcon />}
-            iconPosition='right'
-            isInline
-            href={INSIGHTS_URL}
-          >
-            Learn more about Red Hat{' '}
-            {lightspeedEnabled ? 'Lightspeed' : 'Insights'}
-          </Button>
-        </Content>
-      }
-    >
-      <Button
-        icon={<HelpIcon />}
-        variant='plain'
-        className='pf-v6-u-pl-sm pf-v6-u-pt-0 pf-v6-u-pb-0'
-        aria-label='About remote host configuration (rhc)'
-        isInline
-      />
-    </Popover>
-  );
-};
-
-const RhcPopover = () => {
-  const lightspeedEnabled = useFlag('image-builder.lightspeed.enabled');
-
-  return (
-    <Popover
-      headerContent='About remote host configuration (rhc)'
-      position='right'
-      minWidth='30rem'
-      bodyContent={
-        <Content>
-          <Content>
-            Remote host configuration allows Red Hat Enterprise Linux hosts to
-            connect to Red Hat {lightspeedEnabled ? 'Lightspeed' : 'Insights'}.
-            Remote host configuration is required to use the Red Hat{' '}
-            {lightspeedEnabled ? 'Lightspeed' : 'Insights'} Remediations
-            service.
-          </Content>
-          <Button
-            component='a'
-            target='_blank'
-            variant='link'
-            icon={<ExternalLinkAltIcon />}
-            iconPosition='right'
-            isInline
-            href={RHC_URL}
-          >
-            Learn more about remote host configuration
-          </Button>
-        </Content>
-      }
-    >
-      <Button
-        icon={<HelpIcon />}
-        variant='plain'
-        className='pf-v6-u-pl-sm pf-v6-u-pt-0 pf-v6-u-pb-0'
-        aria-label='About remote host configuration (rhc)'
-        isInline
-      />
-    </Popover>
-  );
-};
-
 const Registration = () => {
   const dispatch = useAppDispatch();
   const registrationType = useAppSelector(selectRegistrationType);
 
-  const [showOptions, setShowOptions] = useState(
-    registrationType === 'register-later',
-  );
-
   return (
     <FormGroup label='Registration method'>
       <Radio
-        label='Automatically register and enable advanced capabilities'
+        label='Automatically register and enable advanced capabilities.'
         isChecked={
           registrationType === 'register-now' ||
           registrationType === 'register-now-insights' ||
@@ -127,63 +31,51 @@ const Registration = () => {
         id='register-system-now'
         name='register-system-now'
         autoFocus
-        description={
-          <Button
-            component='a'
-            variant='link'
-            isDisabled={!registrationType.startsWith('register-now')}
-            isInline
-            onClick={() => setShowOptions(!showOptions)}
-          >
-            {`${!showOptions ? 'Show' : 'Hide'} additional connection options`}
-          </Button>
-        }
+        className='pf-v6-u-pb-sm'
         body={
-          showOptions && (
-            <Checkbox
-              className='pf-v6-u-ml-lg'
-              label={
-                <>
-                  Enable predictive analytics and management capabilities
-                  <InsightsPopover />
-                </>
-              }
-              isChecked={
-                registrationType === 'register-now-insights' ||
-                registrationType === 'register-now-rhc'
-              }
-              onChange={(_event, checked) => {
-                if (checked) {
-                  dispatch(changeRegistrationType('register-now-insights'));
-                } else {
-                  dispatch(changeRegistrationType('register-now'));
+          <>
+            <Content component='p'>
+              <Switch
+                label='Enable predictive analytics and management capabilities'
+                isChecked={
+                  registrationType === 'register-now-insights' ||
+                  registrationType === 'register-now-rhc'
                 }
-              }}
-              id='register-system-now-insights'
-              name='register-system-insights'
-              body={
-                <Checkbox
-                  label={
-                    <>
-                      Enable remote remediations and system management with
-                      automation
-                      <RhcPopover />
-                    </>
+                onChange={(_event, checked) => {
+                  if (checked) {
+                    dispatch(changeRegistrationType('register-now-insights'));
+                  } else {
+                    dispatch(changeRegistrationType('register-now'));
                   }
-                  isChecked={registrationType === 'register-now-rhc'}
-                  onChange={(_event, checked) => {
-                    if (checked) {
-                      dispatch(changeRegistrationType('register-now-rhc'));
-                    } else {
-                      dispatch(changeRegistrationType('register-now-insights'));
-                    }
-                  }}
-                  id='register-system-now-rhc'
-                  name='register-system-rhc'
-                />
-              }
-            />
-          )
+                }}
+                id='register-system-now-insights'
+                name='register-system-insights'
+                hasCheckIcon
+              />
+            </Content>
+            <Content component='p'>
+              <Switch
+                label='Enable remote remediations and system management with automation'
+                isChecked={registrationType === 'register-now-rhc'}
+                onChange={(_event, checked) => {
+                  if (checked) {
+                    dispatch(changeRegistrationType('register-now-rhc'));
+                  } else {
+                    dispatch(changeRegistrationType('register-now-insights'));
+                  }
+                }}
+                id='register-system-now-rhc'
+                name='register-system-rhc'
+                hasCheckIcon
+              />
+            </Content>
+            {!process.env.IS_ON_PREMISE &&
+              registrationType.startsWith('register-now') && (
+                <Content component='p'>
+                  <ActivationKeysList />
+                </Content>
+              )}
+          </>
         }
       />
       <Radio
@@ -191,7 +83,6 @@ const Registration = () => {
         isChecked={registrationType === 'register-later'}
         onChange={() => {
           dispatch(changeRegistrationType('register-later'));
-          setShowOptions(false);
         }}
         id='register-later'
         name='register-later'
@@ -201,7 +92,6 @@ const Registration = () => {
         isChecked={registrationType === 'register-satellite'}
         onChange={() => {
           dispatch(changeRegistrationType('register-satellite'));
-          setShowOptions(false);
         }}
         id='register-satellite'
         name='register-satellite'

--- a/src/Components/CreateImageWizard/steps/Registration/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {
   ClipboardCopy,
+  Content,
   Form,
   FormGroup,
   FormHelperText,
@@ -11,61 +12,50 @@ import {
 } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import ActivationKeyInformation from './components/ActivationKeyInformation';
-import ActivationKeysList from './components/ActivationKeysList';
 import Registration from './components/Registration';
 import SatelliteRegistration from './components/SatelliteRegistration';
 
 import { useGetUser } from '../../../../Hooks';
 import { useAppSelector } from '../../../../store/hooks';
-import {
-  selectActivationKey,
-  selectRegistrationType,
-} from '../../../../store/wizardSlice';
+import { selectRegistrationType } from '../../../../store/wizardSlice';
 
 const RegistrationStep = () => {
   const { auth } = useChrome();
   const { orgId } = useGetUser(auth);
 
-  const activationKey = useAppSelector(selectActivationKey);
   const registrationType = useAppSelector(selectRegistrationType);
   return (
     <Form>
-      <Title headingLevel='h1' size='xl'>
-        Register systems using this image
-      </Title>
-      <FormGroup label='Organization ID'>
-        <ClipboardCopy
-          hoverTip='Copy to clipboard'
-          clickTip='Successfully copied to clipboard!'
-          variant='inline-compact'
-        >
-          {orgId || ''}
-        </ClipboardCopy>
-        <FormHelperText>
-          <HelperText>
-            <HelperTextItem>
-              If using an activation key with command line registration, you
-              must provide your organization&apos;s ID
-            </HelperTextItem>
-          </HelperText>
-        </FormHelperText>
-      </FormGroup>
-      <Registration />
-      {registrationType === 'register-satellite' && <SatelliteRegistration />}
-      {!process.env.IS_ON_PREMISE &&
-        registrationType !== 'register-satellite' && <ActivationKeysList />}
-      {!process.env.IS_ON_PREMISE &&
-        activationKey &&
-        registrationType !== 'register-later' &&
-        registrationType !== 'register-satellite' && (
-          <FormGroup
-            label={'Selected activation key'}
-            data-testid='selected-activation-key'
-          >
-            <ActivationKeyInformation />
+      <Content>
+        <Title headingLevel='h1' size='xl'>
+          Register
+        </Title>
+        <Content component='p'>
+          Configure registration settings for systems that will use this image.
+        </Content>
+        <Content component='p'>
+          <FormGroup label='Organization ID'>
+            <ClipboardCopy
+              hoverTip='Copy to clipboard'
+              clickTip='Successfully copied to clipboard!'
+              isReadOnly
+              className='pf-v6-u-w-25'
+            >
+              {orgId || ''}
+            </ClipboardCopy>
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>
+                  If you&apos;re using an activation key with command line
+                  registration, you must provide your organization&apos;s ID.
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
           </FormGroup>
-        )}
+        </Content>
+        <Registration />
+        {registrationType === 'register-satellite' && <SatelliteRegistration />}
+      </Content>
     </Form>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -89,7 +89,6 @@ import { Partition } from '../FileSystem/fscTypes';
 import { getConversionFactor } from '../FileSystem/fscUtilities';
 import { MajorReleasesLifecyclesChart } from '../ImageOutput/components/ReleaseLifecycle';
 import OscapProfileInformation from '../Oscap/components/OscapProfileInformation';
-import ActivationKeyInformation from '../Registration/components/ActivationKeyInformation';
 
 const ExpirationWarning = () => {
   return (
@@ -725,9 +724,7 @@ export const RegisterNowList = () => {
           <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
             Activation key
           </Content>
-          <Content component={ContentVariants.dd}>
-            <ActivationKeyInformation />
-          </Content>
+          <Content component={ContentVariants.dd}>{activationKey}</Content>
         </Content>
       </Content>
       {isError && (

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -159,7 +159,7 @@ describe('Import modal', () => {
 
     // Registration
     await screen.findByText(
-      'Automatically register and enable advanced capabilities',
+      'Automatically register and enable advanced capabilities.',
     );
     //const registrationCheckbox = await screen.findByRole('radio', {
     //  name: /Automatically register and enable advanced capabilities/i,

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -140,7 +140,7 @@ describe('Keyboard accessibility', () => {
 
     // Registration
     await screen.findByText(
-      'Automatically register and enable advanced capabilities',
+      'Automatically register and enable advanced capabilities.',
     );
     //const registrationCheckbox = await screen.findByRole('radio', {
     //  name: /Automatically register and enable advanced capabilities/i,

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -155,7 +155,7 @@ describe('Step Image output', () => {
     await selectGuestImageTarget();
     await clickNext();
     await screen.findByRole('heading', {
-      name: 'Register systems using this image',
+      name: 'Register',
     });
   });
 

--- a/src/test/Components/CreateImageWizard/steps/Registration/Registration.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Registration/Registration.test.tsx
@@ -57,26 +57,20 @@ Object.defineProperty(window, 'localStorage', {
 // Initiliaze the router
 const router: RemixRouter | undefined = undefined;
 
-const clickShowAdditionalConnectionOptions = async () => {
-  const user = userEvent.setup();
-  const link = await screen.findByText('Show additional connection options');
-  await waitFor(() => user.click(link));
-};
-
 const deselectEnableRemoteRemediations = async () => {
   const user = userEvent.setup();
-  const checkBox = await screen.findByRole('checkbox', {
-    name: 'Enable remote remediations and system management with automation',
+  const optionSwitch = await screen.findByRole('switch', {
+    name: /Enable remote remediations and system management with automation/,
   });
-  await waitFor(() => user.click(checkBox));
+  await waitFor(() => user.click(optionSwitch));
 };
 
 const deselectPredictiveAnalytics = async () => {
   const user = userEvent.setup();
-  const checkBox = await screen.findByRole('checkbox', {
-    name: 'Enable predictive analytics and management capabilities',
+  const optionSwitch = await screen.findByRole('switch', {
+    name: /Enable predictive analytics and management capabilities/,
   });
-  await waitFor(() => user.click(checkBox));
+  await waitFor(() => user.click(optionSwitch));
 };
 
 const openActivationKeyDropdown = async () => {
@@ -199,7 +193,7 @@ describe('Step Registration', () => {
     );
   });
 
-  test('should disable dropdown when clicking Register the system later', async () => {
+  test('should hide dropdown when clicking Register the system later', async () => {
     await renderCreateMode();
     await goToRegistrationStep();
     await clickRegisterLater();
@@ -210,9 +204,9 @@ describe('Step Registration', () => {
       ).not.toBeInTheDocument(),
     );
     await waitFor(async () =>
-      expect(await screen.findByTestId('activation-key-select')).toHaveClass(
-        'pf-m-disabled',
-      ),
+      expect(
+        screen.queryByTestId('activation-key-select'),
+      ).not.toBeInTheDocument(),
     );
     await goToReview();
     await screen.findByText('Register the system later');
@@ -226,7 +220,7 @@ describe('Step Registration', () => {
     await goToReview();
     await clickRevisitButton();
     await screen.findByRole('heading', {
-      name: /Register systems using this image/,
+      name: /Register/,
     });
   });
 });
@@ -292,7 +286,6 @@ describe('Registration request generated correctly', () => {
   test('register + insights', async () => {
     await renderCreateMode();
     await goToRegistrationStep();
-    await clickShowAdditionalConnectionOptions();
     await deselectEnableRemoteRemediations();
     await goToReview();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
@@ -324,7 +317,6 @@ describe('Registration request generated correctly', () => {
   test('register now', async () => {
     await renderCreateMode();
     await goToRegistrationStep();
-    await clickShowAdditionalConnectionOptions();
     await deselectPredictiveAnalytics();
     await goToReview();
     // informational modal pops up in the first test only as it's tied

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AwsTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AwsTarget.test.tsx
@@ -132,7 +132,7 @@ describe('Step Upload to AWS', () => {
     await enterAccountId();
     await clickNext();
     await screen.findByRole('heading', {
-      name: 'Register systems using this image',
+      name: 'Register',
     });
   });
 

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
@@ -100,7 +100,7 @@ describe('Step Upload to Azure', () => {
     await enterResourceGroup();
     await clickNext();
     await screen.findByRole('heading', {
-      name: 'Register systems using this image',
+      name: 'Register',
     });
   });
 

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -107,7 +107,7 @@ describe('Step Upload to Google', () => {
     await selectGoogleAccount('Google account');
     await clickNext();
     await screen.findByRole('heading', {
-      name: 'Register systems using this image',
+      name: 'Register',
     });
   });
 

--- a/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
@@ -183,7 +183,7 @@ export const goToRegistrationStep = async () => {
 export const clickRegisterLater = async () => {
   const user = userEvent.setup();
   await screen.findByRole('heading', {
-    name: /Register systems using this image/,
+    name: /Register/,
   });
   const registerLaterRadio = await screen.findByRole('radio', {
     name: /register later/i,
@@ -194,7 +194,7 @@ export const clickRegisterLater = async () => {
 export const clickRegisterSatellite = async () => {
   const user = userEvent.setup();
   await screen.findByRole('heading', {
-    name: /Register systems using this image/,
+    name: /Register/,
   });
   const registerLaterRadio = await screen.findByRole('radio', {
     name: /register with satellite/i,


### PR DESCRIPTION
This moves registration options outside of the "Show additional connection options" expandable, making them always visible.

It also adds back the step description and updates the organization ID clipboard copy based on recent mocks.

The "Register now" part of Registration step should reflect final mocks.

Related to [HMS-8823](https://issues.redhat.com/browse/HMS-8823)

JIRA: [HMS-9409](https://issues.redhat.com/browse/HMS-9409)