### PR TITLE
Wizard: Remove alert from OpenSCAP step (HMS-8950)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -42,18 +42,6 @@ const Oscap = ({ majorVersion }: OscapPropTypes) => {
       )}
       {complianceType === 'openscap' ? <ProfileSelector /> : <PolicySelector />}
       {oscapProfile && <OscapProfileInformation />}
-      {oscapProfile && (
-        <Alert
-          variant="info"
-          isInline
-          isPlain
-          title="Additional customizations"
-        >
-          Selecting an OpenSCAP profile will cause the appropriate packages,
-          file system configuration, kernel arguments, and services to be added
-          to your image.
-        </Alert>
-      )}
     </>
   );
 };


### PR DESCRIPTION
Information about required packages, services and kernel arguments is back on the step. Meaning we can remove the alert as per UX recommendation.

JIRA: [HMS-8950](https://issues.redhat.com/browse/HMS-8950)