### PR TITLE
Wizard: Fix registration validation for Satellite on edit (HMS-8998)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -130,7 +130,11 @@ export function useRegistrationValidation(): StepValidation {
       }
     );
 
-  if (registrationType !== 'register-later' && !activationKey) {
+  if (
+    registrationType !== 'register-later' &&
+    registrationType !== 'register-satellite' &&
+    !activationKey
+  ) {
     return {
       errors: { activationKey: 'No activation key selected' },
       disabledNext: true,
@@ -139,6 +143,7 @@ export function useRegistrationValidation(): StepValidation {
 
   if (
     registrationType !== 'register-later' &&
+    registrationType !== 'register-satellite' &&
     activationKey &&
     (isFetchingKeyInfo || isErrorKeyInfo)
   ) {


### PR DESCRIPTION
When editing a blueprint with Satellite registration the "Save changes" button was disabled due to registration validation failing with "No activation key selected". Activation key is not required for Satellite.

JIRA: [HMS-8998](https://issues.redhat.com/browse/HMS-8998)

How to reproduce the bug:
1. create a new blueprint with Satellite registration and few packages
2. click on "Edit blueprint"
3. remove any package
4. jump to review - the "Save changes" button would be now disabled

Expected behaviour:
- the "Save changes" button should be enabled after the package was removed when in Edit mode 