### PR TITLE
Wizard: add support for shared EPEL repos (HMS-5986)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
@@ -23,6 +23,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { BulkSelect } from './components/BulkSelect';
+import CommunityRepositoryLabel from './components/CommunityRepositoryLabel';
 import Empty from './components/Empty';
 import { Error } from './components/Error';
 import { Loading } from './components/Loading';
@@ -63,6 +64,7 @@ import {
 } from '../../../../store/wizardSlice';
 import { releaseToVersion } from '../../../../Utilities/releaseToVersion';
 import useDebounce from '../../../../Utilities/useDebounce';
+import { useFlag } from '../../../../Utilities/useGetEnvironment';
 
 const Repositories = () => {
   const dispatch = useAppDispatch();
@@ -88,6 +90,14 @@ const Repositories = () => {
     'toggle-group-all' | 'toggle-group-selected'
   >('toggle-group-all');
   const [isTemplateSelected, setIsTemplateSelected] = useState(false);
+
+  const isSharedEPELEnabled = useFlag('image-builder.shared-epel.enabled');
+
+  const originParam = useMemo(() => {
+    const origins = [ContentOrigin.CUSTOM];
+    if (isSharedEPELEnabled) origins.push(ContentOrigin.COMMUNITY);
+    return origins.join(',');
+  }, [isSharedEPELEnabled]);
 
   const debouncedFilterValue = useDebounce(filterValue);
 
@@ -144,7 +154,7 @@ const Repositories = () => {
     {
       availableForArch: arch,
       availableForVersion: version,
-      origin: ContentOrigin.CUSTOM,
+      origin: originParam,
       limit: 999, // O.O Oh dear, if possible this whole call should be removed
       offset: 0,
       uuid: [...initialSelectedState].join(','),
@@ -173,7 +183,7 @@ const Repositories = () => {
       availableForArch: arch,
       availableForVersion: version,
       contentType: 'rpm',
-      origin: ContentOrigin.CUSTOM,
+      origin: originParam,
       limit: perPage,
       offset: perPage * (page - 1),
       search: debouncedFilterValue,
@@ -652,6 +662,22 @@ const Repositories = () => {
                           {name}
                           {origin === ContentOrigin.UPLOAD ? (
                             <UploadRepositoryLabel />
+                          ) : origin === ContentOrigin.COMMUNITY ? (
+                            <>
+                              <CommunityRepositoryLabel />
+                              <br />
+                              <Button
+                                component='a'
+                                target='_blank'
+                                variant='link'
+                                icon={<ExternalLinkAltIcon />}
+                                iconPosition='right'
+                                isInline
+                                href={url}
+                              >
+                                {url}
+                              </Button>
+                            </>
                           ) : (
                             <>
                               <br />

--- a/src/Components/CreateImageWizard/steps/Repositories/components/CommunityRepositoryLabel.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/CommunityRepositoryLabel.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { Label, Tooltip } from '@patternfly/react-core';
+import { RepositoryIcon } from '@patternfly/react-icons';
+
+import ManageRepositoriesButton from './ManageRepositoriesButton';
+
+const CommunityRepositoryLabel = () => {
+  return (
+    <Tooltip
+      content={
+        <>
+          Community repository: This EPEL repository is shared across
+          organizations.
+          <ManageRepositoriesButton />
+        </>
+      }
+    >
+      <Label
+        variant='outline'
+        isCompact
+        icon={<RepositoryIcon />}
+        style={{ marginLeft: '8px' }}
+      >
+        Community
+      </Label>
+    </Tooltip>
+  );
+};
+
+export default CommunityRepositoryLabel;

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -35,6 +35,7 @@ export const useFlagWithEphemDefault = (
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
     case 'image-builder.templates.enabled':
+    case 'image-builder.shared-epel.enabled':
       return true;
     default:
       return false;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -295,6 +295,7 @@ export enum ContentOrigin {
   'REDHAT' = 'red_hat',
   'EXTERNAL' = 'external', // custom only
   'UPLOAD' = 'upload', // custom upload repo
+  'COMMUNITY' = 'community', // shared epel repos
   'CUSTOM' = 'external,upload',
   'ALL' = 'red_hat,external,upload',
 }


### PR DESCRIPTION
Adds the "community" origin when listing repositories to include the shared EPEL repos. This is gated by a feature flag, shared EPEL repos are only available in stage for now. 

Jira: [HMS-5986](https://issues.redhat.com/browse/HMS-5986)