### PR TITLE
Wizard: add support for shared EPEL repos (HMS-5986)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Repositories/components/CommunityRepositoryLabel.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/CommunityRepositoryLabel.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { Label, Tooltip } from '@patternfly/react-core';
+import { RepositoryIcon } from '@patternfly/react-icons';
+
+import ManageRepositoriesButton from './ManageRepositoriesButton';
+
+const CommunityRepositoryLabel = () => {
+  return (
+    <Tooltip
+      content={
+        <>
+          Community repository: This EPEL repository is shared across
+          organizations.
+          <ManageRepositoriesButton />
+        </>
+      }
+    >
+      <Label
+        variant='outline'
+        isCompact
+        icon={<RepositoryIcon />}
+        style={{ marginLeft: '8px' }}
+      >
+        Community
+      </Label>
+    </Tooltip>
+  );
+};
+
+export default CommunityRepositoryLabel;

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -35,6 +35,7 @@ export const useFlagWithEphemDefault = (
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
     case 'image-builder.templates.enabled':
+    case 'image-builder.shared-epel.enabled':
       return true;
     default:
       return false;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -295,6 +295,7 @@ export enum ContentOrigin {
   'REDHAT' = 'red_hat',
   'EXTERNAL' = 'external', // custom only
   'UPLOAD' = 'upload', // custom upload repo
+  'COMMUNITY' = 'community', // shared epel repos
   'CUSTOM' = 'external,upload',
   'ALL' = 'red_hat,external,upload',
 }


### PR DESCRIPTION
Adds the "community" origin when listing repositories to include the shared EPEL repos. This is gated by a feature flag, shared EPEL repos are only available in stage for now. 

Jira: [HMS-5986](https://issues.redhat.com/browse/HMS-5986)