### PR TITLE
Wizard: on-prem aws region in edit (HMS-9096)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -211,8 +211,9 @@ function commonRequestToState(
     snapshot_date = '';
   }
 
+  // we need to check for the region for on-prem
   const awsUploadOptions = aws?.upload_request
-    .options as AwsUploadRequestOptions;
+    .options as AwsUploadRequestOptions & { region?: string | undefined };
   const gcpUploadOptions = gcp?.upload_request
     .options as GcpUploadRequestOptions;
   const azureUploadOptions = azure?.upload_request
@@ -315,6 +316,7 @@ function commonRequestToState(
         : 'manual') as AwsShareMethod,
       source: { id: awsUploadOptions?.share_with_sources?.[0] },
       sourceId: awsUploadOptions?.share_with_sources?.[0],
+      region: awsUploadOptions?.region,
     },
     snapshotting: {
       useLatest: !snapshot_date && !request.image_requests[0]?.content_template,


### PR DESCRIPTION
The AWS region was getting reset when going into edit mode for a blueprint. This was because the request wasn't being properly mapped back to the correct state.

JIRA: [HMS-9096](https://issues.redhat.com/browse/HMS-9096)