### PR TITLE
Wizard: hide azure sources integration (HMS-9092)

### DIFF
--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/index.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/index.tsx
@@ -12,6 +12,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { useFlag } from '@unleash/proxy-client-react';
 
 import { AzureAuthButton } from './AzureAuthButton';
 import { AzureHyperVSelect } from './AzureHyperVSelect';
@@ -62,6 +63,7 @@ const Azure = () => {
   const tenantId = useAppSelector(selectAzureTenantId);
   const subscriptionId = useAppSelector(selectAzureSubscriptionId);
   const resourceGroup = useAppSelector(selectAzureResourceGroup);
+  const launchEofFlag = useFlag('image-builder.launcheof');
 
   return (
     <Form>
@@ -77,8 +79,10 @@ const Azure = () => {
         To authorize Image Builder to push images to Microsoft Azure, the
         account owner must configure Image Builder as an authorized application
         for a specific tenant ID and give it the role of &quot;Contributor&quot;
-        for the resource group you want to upload to. This applies even when
-        defining target by Source selection.
+        for the resource group you want to upload to.{' '}
+        {!launchEofFlag
+          ? 'This applies even when defining target by Source selection.'
+          : ''}
         <br />
         <Button
           component='a'
@@ -93,37 +97,39 @@ const Azure = () => {
         </Button>
       </Content>
       <AzureHyperVSelect />
-      <FormGroup label='Share method:'>
-        <Radio
-          id='radio-with-description'
-          label='Use an account configured from Sources.'
-          name='radio-7'
-          description='Use a configured source to launch environments directly from the console.'
-          isChecked={shareMethod === 'sources'}
-          onChange={() => {
-            dispatch(changeAzureSource(''));
-            dispatch(changeAzureTenantId(''));
-            dispatch(changeAzureSubscriptionId(''));
-            dispatch(changeAzureShareMethod('sources'));
-            dispatch(changeAzureResourceGroup(''));
-          }}
-          autoFocus
-        />
-        <Radio
-          id='radio'
-          label='Manually enter the account information.'
-          name='radio-8'
-          isChecked={shareMethod === 'manual'}
-          onChange={() => {
-            dispatch(changeAzureSource(''));
-            dispatch(changeAzureTenantId(''));
-            dispatch(changeAzureSubscriptionId(''));
-            dispatch(changeAzureShareMethod('manual'));
-            dispatch(changeAzureResourceGroup(''));
-          }}
-        />
-      </FormGroup>
-      {shareMethod === 'sources' && (
+      {!launchEofFlag && (
+        <FormGroup label='Share method:'>
+          <Radio
+            id='radio-with-description'
+            label='Use an account configured from Sources.'
+            name='radio-7'
+            description='Use a configured source to launch environments directly from the console.'
+            isChecked={shareMethod === 'sources'}
+            onChange={() => {
+              dispatch(changeAzureSource(''));
+              dispatch(changeAzureTenantId(''));
+              dispatch(changeAzureSubscriptionId(''));
+              dispatch(changeAzureShareMethod('sources'));
+              dispatch(changeAzureResourceGroup(''));
+            }}
+            autoFocus
+          />
+          <Radio
+            id='radio'
+            label='Manually enter the account information.'
+            name='radio-8'
+            isChecked={shareMethod === 'manual'}
+            onChange={() => {
+              dispatch(changeAzureSource(''));
+              dispatch(changeAzureTenantId(''));
+              dispatch(changeAzureSubscriptionId(''));
+              dispatch(changeAzureShareMethod('manual'));
+              dispatch(changeAzureResourceGroup(''));
+            }}
+          />
+        </FormGroup>
+      )}
+      {!launchEofFlag && shareMethod === 'sources' && (
         <>
           <AzureSourcesSelect />
           <SourcesButton />
@@ -156,7 +162,7 @@ const Azure = () => {
           <AzureResourceGroups />
         </>
       )}
-      {shareMethod === 'manual' && (
+      {(launchEofFlag || shareMethod === 'manual') && (
         <>
           <FormGroup label='Azure tenant GUID' isRequired>
             <ValidatedInput

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -209,7 +209,7 @@ export const initialState: wizardState = {
     region: 'us-east-1',
   },
   azure: {
-    shareMethod: 'sources',
+    shareMethod: 'manual',
     tenantId: '',
     subscriptionId: '',
     source: '',
@@ -617,7 +617,7 @@ export const wizardSlice = createSlice({
       state.azure.hyperVGeneration = action.payload;
     },
     reinitializeAzure: (state) => {
-      state.azure.shareMethod = 'sources';
+      state.azure.shareMethod = 'manual';
       state.azure.tenantId = '';
       state.azure.subscriptionId = '';
       state.azure.source = '';

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -10,6 +10,14 @@ const getSourceDropdown = async () => {
   return sourceDropdown;
 };
 
+const selectSourcesOption = async () => {
+  const user = userEvent.setup();
+  const sourcesOption = await screen.findByRole('radio', {
+    name: /use an account configured from sources\./i,
+  });
+  await waitFor(async () => user.click(sourcesOption));
+};
+
 const selectAllEnvironments = async () => {
   const user = userEvent.setup();
 
@@ -94,6 +102,7 @@ describe('Keyboard accessibility', () => {
     //    name: /use an account configured from sources\./i,
     //  })
     //).toHaveFocus();
+    await selectSourcesOption();
     const awsSourceDropdown = await getSourceDropdown();
     await waitFor(() => user.click(awsSourceDropdown));
     const awsSource = await screen.findByRole('option', {
@@ -123,6 +132,7 @@ describe('Keyboard accessibility', () => {
     //    name: /use an account configured from sources\./i,
     //  })
     //).toHaveFocus();
+    await selectSourcesOption();
     const azureSourceDropdown = await getSourceDropdown();
     await waitFor(() => user.click(azureSourceDropdown));
     const azureSource = await screen.findByRole('option', {

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
@@ -30,6 +30,18 @@ import {
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
+vi.mock('@unleash/proxy-client-react', () => ({
+  useUnleashContext: () => vi.fn(),
+  useFlag: vi.fn((flag) => {
+    switch (flag) {
+      case 'image-builder.launcheof':
+        return false;
+      default:
+        return false;
+    }
+  }),
+}));
+
 // The router is just initiliazed here, it's assigned a value in the tests
 let router: RemixRouter | undefined = undefined;
 
@@ -272,6 +284,7 @@ describe('Step Upload to Azure', () => {
     await renderCreateMode();
     await selectAzureTarget();
     await goToAzureStep();
+    await selectSourcesOption();
     await selectSource('azureSource1');
     await waitFor(async () => {
       expect(await getTenantGuidInput()).toHaveValue(
@@ -300,6 +313,7 @@ describe('Step Upload to Azure', () => {
     await goToAzureStep();
 
     // Select first source and verify fields are populated
+    await selectSourcesOption();
     await selectSource('azureSource1');
     await waitFor(async () => {
       expect(await getTenantGuidInput()).not.toHaveValue('');
@@ -334,6 +348,7 @@ describe('Step Upload to Azure', () => {
     await renderCreateMode();
     await selectAzureTarget();
     await goToAzureStep();
+    await selectSourcesOption();
     await screen.findByText(
       /Sources cannot be reached, try again later or enter an account info for upload manually\./i,
     );
@@ -343,6 +358,7 @@ describe('Step Upload to Azure', () => {
     await renderCreateMode();
     await selectAzureTarget();
     await goToAzureStep();
+    await selectSourcesOption();
     await selectSource('azureSource1');
     await selectResourceGroup();
     await goToReviewStep();
@@ -360,6 +376,7 @@ describe('Azure image type request generated correctly', () => {
     await renderCreateMode();
     await selectAzureTarget();
     await goToAzureStep();
+    await selectSourcesOption();
     await selectSource('azureSource1');
     await selectResourceGroup();
     await goToReviewStep();
@@ -461,6 +478,7 @@ describe('Azure image type request generated correctly', () => {
     await renderCreateMode();
     await selectAzureTarget();
     await goToAzureStep();
+    await selectSourcesOption();
     await selectSource('azureSource1');
     await clickBack();
     await deselectAzureAndSelectGuestImage();

--- a/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
@@ -22,6 +22,18 @@ import {
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
+vi.mock('@unleash/proxy-client-react', () => ({
+  useUnleashContext: () => vi.fn(),
+  useFlag: vi.fn((flag) => {
+    switch (flag) {
+      case 'image-builder.launcheof':
+        return false;
+      default:
+        return false;
+    }
+  }),
+}));
+
 let router: RemixRouter | undefined = undefined;
 
 const validUserName = 'best';
@@ -44,6 +56,10 @@ const addAzureTarget = async () => {
   );
   await clickNext();
 
+  const sourcesOption = await screen.findByRole('radio', {
+    name: /use an account configured from sources\./i,
+  });
+  await waitFor(async () => user.click(sourcesOption));
   const azureSourceDropdown =
     await screen.findByPlaceholderText(/select source/i);
   await waitFor(() => user.click(azureSourceDropdown));


### PR DESCRIPTION
This commit conditionally hides the azure sources integration. It also sets the default value of share method to 'manual' in order not to break many things. This is a very temporary state, and we'll very soon after turning the flag on, make these changes permanent and will deal with more logic in the code.