### PR TITLE
Remove MSW browser (HMS-9225)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,41 +296,6 @@ configure({
 ```
 If you'd like to see the stack printed out you can either temporarily disable the configuration or generate a [Testing Playground](https://testing-playground.com/) link by adding `screen.logTestingPlaygroundURL()` to your test.
 
-### ~~Using MSW data in development~~ - CURRENTLY NOT WORKING
-
-If you want to develop in environment with mocked data, run the command `npm run stage-beta:msw`.
-
-#### Enabling MSW
-In a case you're seeing `Error: [MSW] Failed to register the Service Worker` in console, you might also need to configure SSL certification on your computer.
-
-In order to do this install [mkcert](https://github.com/FiloSottile/mkcert)
-
-After the installation, go to the `/node_modules/.cache/webpack-dev-server` folder and run following commands:
-
-1. `mkcert -install`  to create a new certificate authority on your machine
-2. `mkcert prod.foo.redhat.com`  to create the actual signed certificate
-
-#### Mac Configuration
-Follow these steps to find and paste the certification file into the 'Keychain Access' application:
-
-1. Open the 'Keychain Access' application.
-
-2. Select 'login' on the left side.
-
-3. Navigate to the 'Certificates' tab.
-
-4. Drag the certification file (located at /image-builder-frontend/node_modules/.cache/webpack-dev-server/server.pem) to the certification list.
-
-5. Double-click on the added certificate (localhost certificate) to open the localhost window.
-
-6. Open the 'Trust' dropdown menu.
-
-7. Set all options to 'Always Trust'.
-
-8. Close the localhost screen.
-
-9. Run `npm run stage-beta:msw` and open the Firefox browser to verify that it is working as expected.
-
 ## Running hosted service Playwright tests
 
 1. Copy the [example env file](playwright_example.env) content and create a file named `.env` in the root directory of the project. Paste the example file content into it.

--- a/fec.config.js
+++ b/fec.config.js
@@ -29,28 +29,6 @@ function add_define(key, value) {
   }
 }
 
-if (process.env.MSW) {
-  // Copy mockServiceWorker.js to ./dist/ so it is served with the bundle
-  plugins.push(
-    new CopyPlugin({
-      patterns: [
-        { from: 'src/mockServiceWorker.js', to: 'mockServiceWorker.js' },
-      ],
-    })
-  );
-
-  /*
-  We would like the client to be able to determine whether or not to start
-  the service worker at run time based on the value of process.env.MSW. We can
-  add that variable to process.env via the DefinesPlugin plugin, but
-  DefinePlugin has already been added by config() to the default webpackConfig.
-
-  Therefore, we find it in the `plugins` array based on its type, then update
-  it to add our new process.env.MSW variable.
-  */
-  add_define('process.env.MSW', process.env.MSW);
-}
-
 if (process.env.NODE_ENV) {
   add_define('process.env.NODE_ENV', process.env.NODE_ENV);
 }
@@ -77,20 +55,6 @@ module.exports = {
   sassPrefix: '.imageBuilder',
   debug: true,
   useFileHash: true,
-  /*
-  mockServiceWorker.js will be served from /beta/apps/image-builder, which
-  will become its default scope. Setting the Service-Worker-Allowed header to
-  '/' allows the worker's scope to be expanded to the root route '/'.
-
-  The default webpackConfig for stage does not contain any headers.
-
-  Caution: The default webpackConfig for prod *does* contain headers, so this
-  code will need to be modified if using MSW in prod-beta or prod-stable so that
-  those headers are not overwritten.
-  */
-  devServer: process.env.MSW && {
-    headers: { 'Service-Worker-Allowed': '/' },
-  },
   devtool: 'hidden-source-map',
   appUrl: '/insights/image-builder',
   useProxy: true,

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "start": "fec dev",
     "start:stage": "fec dev --clouddotEnv=stage",
     "start:prod": "fec dev --clouddotEnv=prod",
-    "start:msw:stage": "NODE_ENV=development MSW=TRUE fec dev --clouddotEnv=stage",
     "start:federated": "fec static",
     "patch:hosts": "fec patch-etc-hosts",
     "test": "TZ=UTC vitest run",
@@ -125,8 +124,5 @@
   },
   "insights": {
     "appname": "image-builder"
-  },
-  "msw": {
-    "workerDirectory": "src"
   }
 }

--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -5,30 +5,6 @@ import { Provider } from 'react-redux';
 import App from './App';
 import { serviceStore as store } from './store';
 
-if (
-  process.env.NODE_ENV === 'development' &&
-  process.env.MSW?.toString().toLowerCase() === 'true'
-) {
-  // process.env.MSW is set in the webpack config using DefinePlugin
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { worker } = require('./test/mocks/browser');
-  worker.start({
-    serviceWorker: {
-      url: '/beta/apps/image-builder/mockServiceWorker.js',
-      options: {
-        /*
-        Service workers can only intercept requests made from within their scope.
-        mockServiceWorker.js is served from /beta/apps/image-builder/, which becomes
-        the worker's default scope. Set scope to '/' so that all requests are in scope
-        and can be intercepted. Note that the Service-Worker-Allowed header must
-        be set to '/' for this to work, and is done in the webpack config.
-        */
-        scope: '../../../',
-      },
-    },
-  });
-}
-
 const ImageBuilder = () => (
   <Provider store={store}>
     <App />

--- a/src/test/mocks/browser.ts
+++ b/src/test/mocks/browser.ts
@@ -1,7 +1,0 @@
-// src/mocks/browser.js
-import { setupWorker } from 'msw/browser';
-
-import { handlers } from './handlers';
-
-// This configures a Service Worker with the given request handlers.
-export const worker = setupWorker(...handlers);


### PR DESCRIPTION
MSW in browser hasn't been working for a long time now. Since we're slowly shifting towards playwright tests we can remove the browser integration.

JIRA: [HMS-9225](https://issues.redhat.com/browse/HMS-9225)