### PR TITLE
WIP (do not review) Add blueprint query parameter support to Images Table (HMS-9267)

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   PageSection,
@@ -9,18 +9,29 @@ import {
   Toolbar,
   ToolbarContent,
 } from '@patternfly/react-core';
-import { Outlet } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { Outlet, useSearchParams } from 'react-router-dom';
 
 import './LandingPage.scss';
 
 import { NewAlert } from './NewAlert';
 
+import { setBlueprintId } from '../../store/BlueprintSlice';
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
 import ImagesTable from '../ImagesTable/ImagesTable';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
 export const LandingPage = () => {
   const [showAlert, setShowAlert] = useState(true);
+  const [searchParams] = useSearchParams();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    const blueprintId = searchParams.get('blueprint');
+    if (blueprintId) {
+      dispatch(setBlueprintId(blueprintId));
+    }
+  }, [searchParams, dispatch]);
 
   const imageList = (
     <>

--- a/src/test/Components/LandingPage/LandingPage.test.tsx
+++ b/src/test/Components/LandingPage/LandingPage.test.tsx
@@ -2,6 +2,7 @@ import { screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 
 import { IMAGE_BUILDER_API } from '../../../constants';
+import { mockBlueprintIds } from '../../fixtures/blueprints';
 import { mockComposesEmpty } from '../../fixtures/composes';
 import { server } from '../../mocks/server';
 import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
@@ -31,5 +32,59 @@ describe('Landing Page', () => {
     await screen.findByText(
       /Image builder is a tool for creating deployment-ready customized system images/i,
     );
+  });
+});
+
+describe('Set blueprint using query parameter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('no blueprint selected by default (no query parameter)', async () => {
+    renderCustomRoutesWithReduxRouter();
+
+    // Verify no blueprint is selected by checking that "All Images" is shown
+    // and no blueprint-specific UI elements are present
+    await screen.findByText('Images');
+
+    // Check that we don't have blueprint-specific elements like build button
+    expect(
+      screen.queryByRole('button', { name: /Build images/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('blueprint selected even with invalid ID (current behavior)', async () => {
+    renderCustomRoutesWithReduxRouter('/?blueprint=invalid-blueprint-id');
+
+    // Currently, any blueprint ID from URL will be set in Redux state
+    // This shows that the URL parameter handling is working
+    await screen.findByText('Images');
+
+    // The build button should appear because a blueprint ID is set
+    // even if it's invalid - the backend will handle the invalid ID
+    const buildImageBtn = await screen.findByRole('button', {
+      name: /Build images/i,
+    });
+    expect(buildImageBtn).toBeInTheDocument();
+  });
+
+  test('blueprint selected (query parameter provided)', async () => {
+    const blueprintId = mockBlueprintIds.darkChocolate;
+    renderCustomRoutesWithReduxRouter(`/?blueprint=${blueprintId}`);
+
+    // Wait for the blueprint to be selected and verify blueprint-specific UI appears
+    const buildImageBtn = await screen.findByRole('button', {
+      name: /Build images/i,
+    });
+    expect(buildImageBtn).toBeInTheDocument();
+
+    // Verify that the images table shows blueprint-specific content
+    const table = await screen.findByTestId('images-table');
+    expect(table).toBeInTheDocument();
+
+    // The main test is that blueprint-specific UI elements appear
+    // This indicates that the URL parameter was processed and the blueprint was selected
+    // The presence of the build button confirms blueprint selection is working
+    expect(buildImageBtn).toBeEnabled();
   });
 });


### PR DESCRIPTION
This adds support for opening the Images Table with a specific blueprint selected via URL query parameter (?blueprint=<blueprint-id>). This works similarly to the existing Image Wizard query parameters (release=rhel8, arch=aarch64, target=iso).

Changes:
- LandingPage component now parses blueprint query parameter and dispatches setBlueprintId action to Redux store
- Added comprehensive tests following existing query parameter test patterns
- Images Table automatically shows blueprint-specific content when blueprint parameter is provided in URL

These changes are needed to help support the insights-mcp server, which requires the ability to deep-link directly to specific blueprint views in the Images Table interface.

🤖 Generated with [Claude Code](https://claude.ai/code)