### PR TITLE
src: Remove import flag from code base (HMS-9468)

### DIFF
--- a/src/Components/Blueprints/BlueprintActionsMenu.tsx
+++ b/src/Components/Blueprints/BlueprintActionsMenu.tsx
@@ -15,7 +15,6 @@ import {
   BlueprintExportResponse,
   useLazyExportBlueprintQuery,
 } from '../../store/imageBuilderApi';
-import { useFlagWithEphemDefault } from '../../Utilities/useGetEnvironment';
 
 interface BlueprintActionsMenuProps {
   setShowDeleteModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -29,9 +28,6 @@ export const BlueprintActionsMenu: React.FunctionComponent<
   const onSelect = () => {
     setShowBlueprintActionsMenu(!showBlueprintActionsMenu);
   };
-  const importExportFlag = useFlagWithEphemDefault(
-    'image-builder.import.enabled',
-  );
 
   const [trigger] = useLazyExportBlueprintQuery();
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
@@ -66,11 +62,9 @@ export const BlueprintActionsMenu: React.FunctionComponent<
       )}
     >
       <DropdownList>
-        {importExportFlag && (
-          <DropdownItem onClick={handleClick}>
-            Download blueprint (.json)
-          </DropdownItem>
-        )}
+        <DropdownItem onClick={handleClick}>
+          Download blueprint (.json)
+        </DropdownItem>
         <DropdownItem onClick={() => setShowDeleteModal(true)}>
           Delete blueprint
         </DropdownItem>

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -18,7 +18,6 @@ import { useAppSelector } from '../../store/hooks';
 import { selectDistribution } from '../../store/wizardSlice';
 import { resolveRelPath } from '../../Utilities/path';
 import './ImageBuilderHeader.scss';
-import { useFlagWithEphemDefault } from '../../Utilities/useGetEnvironment';
 import { ImportBlueprintModal } from '../Blueprints/ImportBlueprintModal';
 
 type ImageBuilderHeaderPropTypes = {
@@ -74,18 +73,13 @@ export const ImageBuilderHeader = ({
   const distribution = useAppSelector(selectDistribution);
   const prefetchTargets = useBackendPrefetch('getArchitectures');
 
-  const importExportFlag = useFlagWithEphemDefault(
-    'image-builder.import.enabled',
-  );
   const [showImportModal, setShowImportModal] = useState(false);
   return (
     <>
-      {importExportFlag && (
-        <ImportBlueprintModal
-          setShowImportModal={setShowImportModal}
-          isOpen={showImportModal}
-        />
-      )}
+      <ImportBlueprintModal
+        setShowImportModal={setShowImportModal}
+        isOpen={showImportModal}
+      />
       <PageHeader className='pf-m-sticky-top'>
         <PageHeaderTitle
           className='title'
@@ -113,14 +107,12 @@ export const ImageBuilderHeader = ({
                   >
                     Create image blueprint
                   </Button>
-                  {importExportFlag && (
-                    <Button
-                      variant='secondary'
-                      onClick={() => setShowImportModal(true)}
-                    >
-                      Import
-                    </Button>
-                  )}
+                  <Button
+                    variant='secondary'
+                    onClick={() => setShowImportModal(true)}
+                  >
+                    Import
+                  </Button>
                   {process.env.IS_ON_PREMISE && (
                     <Button
                       variant='secondary'

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -4,7 +4,6 @@ import { Route, Routes } from 'react-router-dom';
 
 import { CloudProviderConfig } from './Components/CloudProviderConfig/CloudProviderConfig';
 import ShareImageModal from './Components/ShareImageModal/ShareImageModal';
-import { useFlagWithEphemDefault } from './Utilities/useGetEnvironment';
 
 const LandingPage = lazy(() => import('./Components/LandingPage/LandingPage'));
 const ImportImageWizard = lazy(
@@ -13,9 +12,6 @@ const ImportImageWizard = lazy(
 const CreateImageWizard = lazy(() => import('./Components/CreateImageWizard'));
 
 export const Router = () => {
-  const importExportFlag = useFlagWithEphemDefault(
-    'image-builder.import.enabled',
-  );
   return (
     <Routes>
       <Route
@@ -28,17 +24,14 @@ export const Router = () => {
       >
         <Route path='share/:composeId' element={<ShareImageModal />} />
       </Route>
-
-      {importExportFlag && (
-        <Route
-          path='imagewizard/import'
-          element={
-            <Suspense>
-              <ImportImageWizard />
-            </Suspense>
-          }
-        />
-      )}
+      <Route
+        path='imagewizard/import'
+        element={
+          <Suspense>
+            <ImportImageWizard />
+          </Suspense>
+        }
+      />
       <Route
         path='imagewizard/:composeId?'
         element={

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -58,8 +58,6 @@ vi.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => vi.fn(),
   useFlag: vi.fn((flag) => {
     switch (flag) {
-      case 'image-builder.import.enabled':
-        return true;
       case 'image-builder.templates.enabled':
         return true;
       case 'image-builder.aap.enabled':


### PR DESCRIPTION
Import functionality was fully released, we can remove `image-builder.import.enabled` flag and gating from the code base.

JIRA: [HMS-9468](https://issues.redhat.com/browse/HMS-9468)