### PR TITLE
pr-best-practices: add new_issues_jira_epic input

### DIFF
--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -19,3 +19,4 @@ jobs:
         with:
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           jira_token: ${{ secrets.IMAGEBUILDER_BOT_JIRA_TOKEN }}
+          new_issues_jira_epic: HMS-5279


### PR DESCRIPTION
Without this input, the bot doesn't have jira epic number to put the reported issues into. This is a followup PR on my last change in this workflow, forgot about this input when I edited it last time, my apologies!