### PR TITLE
Playwright: Change AAP tests file extension, remove redundant timeout

### DIFF
--- a/playwright/BootTests/AAP/AAP.boot.ts
+++ b/playwright/BootTests/AAP/AAP.boot.ts
@@ -61,7 +61,6 @@ KVuPT3baU0/iZg==
 -----END CERTIFICATE-----`;
 
 test('AAP registration boot integration test', async ({ page, cleanup }) => {
-  test.setTimeout(120 * 60 * 1000); // 2 hours
   test.skip(
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',

--- a/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
@@ -27,7 +27,6 @@ import { OpenStackWrapper } from '../helpers/OpenStackWrapper';
 test.use({ storageState: { cookies: [], origins: [] } });
 
 test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
-  test.setTimeout(120 * 60 * 1000); // 2 hours
   test.skip(
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',


### PR DESCRIPTION
Adjust AAP test to new `.boot.ts` extension and remove redundant explicit timeout set in boot tests. Follow up to #3718 