### PR TITLE
LandingPage: Add "service unavailable" alert (HMS-9582)

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -9,11 +9,13 @@ import {
   Toolbar,
   ToolbarContent,
 } from '@patternfly/react-core';
+import { useFlag } from '@unleash/proxy-client-react';
 import { Outlet } from 'react-router-dom';
 
 import './LandingPage.scss';
 
 import { NewAlert } from './NewAlert';
+import ServiceUnavailableAlert from './ServiceUnavailableAlert';
 
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
 import ImagesTable from '../ImagesTable/ImagesTable';
@@ -21,10 +23,12 @@ import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
 export const LandingPage = () => {
   const [showAlert, setShowAlert] = useState(true);
+  const serviceUnavailable = useFlag('image-builder.service-unavailable');
 
   const imageList = (
     <>
       <PageSection hasBodyWrapper={false}>
+        {serviceUnavailable && <ServiceUnavailableAlert />}
         {showAlert && <NewAlert setShowAlert={setShowAlert} />}
         <Sidebar hasBorder className='pf-v6-u-background-color-100'>
           <SidebarPanel

--- a/src/Components/LandingPage/ServiceUnavailableAlert.tsx
+++ b/src/Components/LandingPage/ServiceUnavailableAlert.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { Alert } from '@patternfly/react-core';
+
+const ServiceUnavailableAlert = () => {
+  return (
+    <Alert
+      title='The Image Builder service is currently unavailable. Please check back later.'
+      variant='danger'
+    />
+  );
+};
+
+export default ServiceUnavailableAlert;


### PR DESCRIPTION
This adds an alert to inform users the service is currently unavailable.

The alert is gated behind `image-builder.service-unavailable` flag and can be enabled/disabled via unleash as needed.

<img width="956" height="565" alt="image" src="https://github.com/user-attachments/assets/a6a9cefe-c49f-4438-b656-e442c45e5cbe" />


JIRA: [HMS-9582](https://issues.redhat.com/browse/HMS-9582)