### PR TITLE
cockpit: move state directory to XDG_STATE_HOME

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -318,4 +318,4 @@ export const PAGINATION_LIMIT = 10;
 export const PAGINATION_COUNT = 0;
 export const SEARCH_INPUT = '';
 
-export const BLUEPRINTS_DIR = '.cache/cockpit-image-builder/';
+export const BLUEPRINTS_DIR = 'cockpit-image-builder';

--- a/src/test/mocks/cockpit/index.ts
+++ b/src/test/mocks/cockpit/index.ts
@@ -31,6 +31,14 @@ export default {
       resolve('');
     });
   },
+  script: (script: string): Promise<string | Uint8Array> => {
+    return new Promise((resolve) => {
+      if (script === 'echo -n $XDG_STATE_HOME') {
+        resolve('/default/.local/state');
+      }
+      resolve('');
+    });
+  },
   http: cockpitHTTP,
   permission: cockpitPermission,
 };


### PR DESCRIPTION
With $HOME/.local/state as a fallback.

For backwards compatibility, copy the old `.cache/cockpit-image-builder` to `$XDG_STATE_HOME/cockpit-image-builder`.