### PR TITLE
Wizard: add custom EPEL repo warning

### DIFF
--- a/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
@@ -25,6 +25,7 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import { BulkSelect } from './components/BulkSelect';
 import CommunityRepositoryLabel from './components/CommunityRepositoryLabel';
+import CustomEpelWarning from './components/CustomEpelWarning';
 import Empty from './components/Empty';
 import { Error } from './components/Error';
 import { Loading } from './components/Loading';
@@ -373,6 +374,16 @@ const Repositories = () => {
     setToggleSelected(toggleType);
   };
 
+  const isEPELUrl = (repoUrl: string) => {
+    const epelUrls = [
+      'https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/',
+      'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/',
+      'https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/',
+    ];
+
+    return epelUrls.includes(repoUrl);
+  };
+
   const isRepoDisabled = (
     repo: ApiRepositoryResponseRead,
     isSelected: boolean,
@@ -382,13 +393,10 @@ const Repositories = () => {
     }
 
     const hasSelectedEPEL = contentList.some(
-      (r) =>
-        r.uuid !== repo.uuid &&
-        r.url?.includes('epel') &&
-        selected.has(r.uuid!),
+      (r) => r.uuid !== repo.uuid && isEPELUrl(r.url!) && selected.has(r.uuid!),
     );
 
-    if (repo.url?.includes('epel') && !isSelected && hasSelectedEPEL) {
+    if (isEPELUrl(repo.url!) && !isSelected && hasSelectedEPEL) {
       return [true, 'Only one EPEL repository can be selected at a time.'];
     }
 
@@ -705,6 +713,21 @@ const Repositories = () => {
                                     );
                                   }
                                 }}
+                                href={url}
+                              >
+                                {url}
+                              </Button>
+                            </>
+                          ) : isSharedEPELEnabled && isEPELUrl(url) ? (
+                            <>
+                              <CustomEpelWarning />
+                              <Button
+                                component='a'
+                                target='_blank'
+                                variant='link'
+                                icon={<ExternalLinkAltIcon />}
+                                iconPosition='right'
+                                isInline
                                 href={url}
                               >
                                 {url}

--- a/src/Components/CreateImageWizard/steps/Repositories/components/CustomEpelWarning.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/CustomEpelWarning.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import { Icon, Tooltip } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import spacing from '@patternfly/react-styles/css/utilities/Spacing/spacing';
+
+const CustomEpelWarning = () => (
+  <Tooltip content='Custom EPEL repositories will stop being snapshotted. Please use the community EPEL repositories instead.'>
+    <Icon status='warning' isInline className={spacing.mlSm}>
+      <ExclamationTriangleIcon />
+    </Icon>
+  </Tooltip>
+);
+
+export default CustomEpelWarning;


### PR DESCRIPTION
To prepare for moving to the community (shared) EPEL repos, this PR adds a warning on existing custom EPEL repos in the wizard to make users aware that these repos will soon stop being snapshotted and to use the community EPEL repos instead.

Testing steps:

1. Custom EPEL repos in the Custom repositories step of the wizard should have a warning icon with a tooltip encouraging users to use the community EPEL repos instead
2. This behavior is gated by the shared_epel feature flag, it should only exist in stage right now