### PR TITLE
playwright: Override vitest globals (HMS-9602)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,7 @@ module.exports = defineConfig([
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
-        project: './tsconfig.json'
+        project: ['./tsconfig.json', './playwright/tsconfig.json']
       },
       globals: {
         ...globals.browser,

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["@playwright/test"]
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,6 @@
       ]
     }
   },
-  "include": ["./src", "./playwright"]
+  "include": ["./src"],
+  "exclude": ["./playwright"]
 }


### PR DESCRIPTION
Since having both vitest and playwright in one project isn't standard nor ideal it might not be the cleanest solution, but should be easy to revert once we completely migrate to PW.

JIRA: [HMS-9602](https://issues.redhat.com/browse/HMS-9602)