### PR TITLE
Update JIRA epic for automatically opened bugs (HMS-9608)

### DIFF
--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           jira_token: ${{ secrets.IMAGEBUILDER_BOT_JIRA_TOKEN }}
-          new_issues_jira_epic: HMS-5279
+          new_issues_jira_epic: HMS-9607


### PR DESCRIPTION
The previous bugs epic was closed, now we have a new one for this quarter, this updates the label so new bugs are created in the right place.

JIRA: [HMS-9608](https://issues.redhat.com/browse/HMS-9608)