### PR TITLE
package.json: replace @ltd/j-toml with smol-toml (RHEL-123840)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@ltd/j-toml": "1.38.0",
         "@patternfly/patternfly": "6.3.1",
         "@patternfly/react-code-editor": "6.4.0",
         "@patternfly/react-core": "6.3.1",
@@ -30,7 +29,8 @@
         "react-redux": "9.2.0",
         "react-router-dom": "6.27.0",
         "redux": "5.0.1",
-        "redux-promise-middleware": "6.2.0"
+        "redux-promise-middleware": "6.2.0",
+        "smol-toml": "1.4.2"
       },
       "devDependencies": {
         "@babel/core": "7.28.5",
@@ -3468,12 +3468,6 @@
       "version": "2.0.5",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@ltd/j-toml": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
-      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==",
-      "license": "LGPL-3.0"
     },
     "node_modules/@monaco-editor/loader": {
       "version": "1.4.0",
@@ -17480,6 +17474,18 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
+      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/sockjs": {
       "version": "0.3.24",
       "dev": true,
@@ -22572,11 +22578,6 @@
     "@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "dev": true
-    },
-    "@ltd/j-toml": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@ltd/j-toml/-/j-toml-1.38.0.tgz",
-      "integrity": "sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw=="
     },
     "@monaco-editor/loader": {
       "version": "1.4.0",
@@ -31407,6 +31408,11 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
+    },
+    "smol-toml": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
+      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g=="
     },
     "sockjs": {
       "version": "0.3.24",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "npm": ">=7.0.0"
   },
   "dependencies": {
-    "@ltd/j-toml": "1.38.0",
     "@patternfly/patternfly": "6.3.1",
     "@patternfly/react-code-editor": "6.4.0",
     "@patternfly/react-core": "6.3.1",
@@ -28,7 +27,8 @@
     "react-redux": "9.2.0",
     "react-router-dom": "6.27.0",
     "redux": "5.0.1",
-    "redux-promise-middleware": "6.2.0"
+    "redux-promise-middleware": "6.2.0",
+    "smol-toml": "1.4.2"
   },
   "devDependencies": {
     "@babel/core": "7.28.5",

--- a/playwright/Cockpit/cockpit.spec.ts
+++ b/playwright/Cockpit/cockpit.spec.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 
-import TOML from '@ltd/j-toml';
 import { expect } from '@playwright/test';
+import TOML from 'smol-toml';
 import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { parse } from '@ltd/j-toml';
 import {
   Button,
   Checkbox,
@@ -22,6 +21,7 @@ import { HelpIcon } from '@patternfly/react-icons';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import { useFlag } from '@unleash/proxy-client-react';
 import { useNavigate } from 'react-router-dom';
+import TOML from 'smol-toml';
 
 import { mapOnPremToHosted } from './helpers/onPremToHostedBlueprintMapper';
 
@@ -138,7 +138,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
           const isToml = filename.endsWith('.toml');
           const isJson = filename.endsWith('.json');
           if (isToml) {
-            const tomlBlueprint = parse(fileContent);
+            const tomlBlueprint = TOML.parse(fileContent);
             const blueprintFromFile = mapOnPremToHosted(
               tomlBlueprint as BlueprintItem,
             );

--- a/src/store/cockpit/cockpitApi.ts
+++ b/src/store/cockpit/cockpitApi.ts
@@ -6,9 +6,9 @@ import path from 'path';
 // the `tsconfig` to stubs of the `cockpit` and `cockpit/fsinfo`
 // modules. These stubs are in the `src/test/mocks/cockpit` directory.
 // We also needed to create an alias in vitest to make this work.
-import TOML, { Section } from '@ltd/j-toml';
 import cockpit from 'cockpit';
 import { fsinfo } from 'cockpit/fsinfo';
+import TOML from 'smol-toml';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Customizations } from './composerCloudApi';
@@ -699,27 +699,12 @@ export const cockpitApi = contentSourcesApi.injectEndpoints({
               if (!updateWorkerConfigRequest) {
                 return prev;
               }
-
               const merged = {
                 ...TOML.parse(prev),
                 ...updateWorkerConfigRequest,
               } as WorkerConfigFile;
 
-              const contents: WorkerConfigFile = {};
-              Object.keys(merged).forEach((key: string) => {
-                // this check helps prevent saving empty objects
-                // into the osbuild-worker.toml config file.
-                if (merged[key] !== undefined) {
-                  contents[key] = Section({
-                    ...merged[key],
-                  });
-                }
-              });
-
-              return TOML.stringify(contents, {
-                newline: '\n',
-                newlineAround: 'document',
-              });
+              return TOML.stringify(merged);
             });
 
             const systemServices = [


### PR DESCRIPTION
    smol-toml has a simpler stringify interface, similar to the built-in
    JSON.stringify. Its last update is also more recent (3 months vs. 3
    years).
    
    The simpler stringify interface will also help with exporting blueprints
    as toml in cockpit.

