### PR TITLE
devDeps: Bump @rtk-query/codegen-openapi (HMS-9617)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "3.0.1",
         "@redhat-cloud-services/frontend-components-config": "6.7.4",
         "@redhat-cloud-services/tsc-transform-imports": "1.0.26",
-        "@rtk-query/codegen-openapi": "2.0.0",
+        "@rtk-query/codegen-openapi": "2.1.0",
         "@testing-library/dom": "10.4.1",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.0",
@@ -126,37 +126,27 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
+      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
       },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -165,21 +155,25 @@
     },
     "node_modules/@apidevtools/swagger-methods": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@apidevtools/swagger-parser": {
-      "version": "10.1.0",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
+      "integrity": "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "9.0.6",
+        "@apidevtools/json-schema-ref-parser": "11.7.2",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "ajv": "^8.6.3",
+        "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
+        "call-me-maybe": "^1.0.2"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
@@ -3106,6 +3100,8 @@
     },
     "node_modules/@exodus/schemasafe": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3398,6 +3394,8 @@
     },
     "node_modules/@jsdevtools/ono": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3558,7 +3556,9 @@
       }
     },
     "node_modules/@oazapfts/runtime": {
-      "version": "1.0.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oazapfts/runtime/-/runtime-1.0.4.tgz",
+      "integrity": "sha512-7t6C2shug/6tZhQgkCa532oTYBLEnbASV/i1SG1rH2GB4h3aQQujYciYSPT92hvN4IwTe8S2hPkN/6iiOyTlCg==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -4644,18 +4644,20 @@
       ]
     },
     "node_modules/@rtk-query/codegen-openapi": {
-      "version": "2.0.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rtk-query/codegen-openapi/-/codegen-openapi-2.1.0.tgz",
+      "integrity": "sha512-JQ2L7fIVEo43ccVOv9Wm4kjyb4QfDA3ndTjAU+oYh0fnY4lnCQQiNDxiZlo97GbjX2lVdmlaBuWtk/gwK+50OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/swagger-parser": "^10.0.2",
+        "@apidevtools/swagger-parser": "^10.1.1",
         "commander": "^6.2.0",
         "lodash.camelcase": "^4.3.0",
-        "oazapfts": "^6.1.0",
+        "oazapfts": "^6.3.0",
         "prettier": "^3.2.5",
         "semver": "^7.3.5",
         "swagger2openapi": "^7.0.4",
-        "typescript": "^5.5.4"
+        "typescript": "^5.8.2"
       },
       "bin": {
         "rtk-query-codegen-openapi": "lib/bin/cli.mjs"
@@ -7099,6 +7101,8 @@
     },
     "node_modules/ajv-draft-04": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -8061,6 +8065,8 @@
     },
     "node_modules/call-me-maybe": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -9825,6 +9831,8 @@
     },
     "node_modules/es6-promise": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
       "dev": true,
       "license": "MIT"
     },
@@ -10876,6 +10884,8 @@
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -12162,6 +12172,8 @@
     },
     "node_modules/http2-client": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
       "dev": true,
       "license": "MIT"
     },
@@ -14448,6 +14460,8 @@
     },
     "node_modules/node-fetch-h2": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14490,6 +14504,8 @@
     },
     "node_modules/node-readfiles": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14676,6 +14692,8 @@
     },
     "node_modules/oas-kit-common": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14684,6 +14702,8 @@
     },
     "node_modules/oas-linter": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14707,6 +14727,8 @@
     },
     "node_modules/oas-resolver": {
       "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14735,6 +14757,8 @@
     },
     "node_modules/oas-schema-walker": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "funding": {
@@ -14743,6 +14767,8 @@
     },
     "node_modules/oas-validator": {
       "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14770,22 +14796,59 @@
       }
     },
     "node_modules/oazapfts": {
-      "version": "6.1.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/oazapfts/-/oazapfts-6.3.1.tgz",
+      "integrity": "sha512-iFWDzRMXOw/UwO/AcgkEVO6CECthgKN0elJt72zsTZNiYU9ZtfMEDaUuxb767hT4lvlCoohPbz6HvY3upFth8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@apidevtools/swagger-parser": "^10.1.0",
+        "@apidevtools/swagger-parser": "^12.0.0",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
         "swagger2openapi": "^7.0.8",
-        "tapable": "^2.2.1",
-        "typescript": "^5.4.5"
+        "tapable": "^2.2.2",
+        "typescript": "^5.8.3"
       },
       "bin": {
         "oazapfts": "cli.js"
       },
       "peerDependencies": {
         "@oazapfts/runtime": "*"
+      }
+    },
+    "node_modules/oazapfts/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/oazapfts/node_modules/@apidevtools/swagger-parser": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/object-assign": {
@@ -15007,6 +15070,8 @@
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -16369,6 +16434,8 @@
     },
     "node_modules/reftools": {
       "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "funding": {
@@ -17321,6 +17388,8 @@
     },
     "node_modules/should": {
       "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17333,6 +17402,8 @@
     },
     "node_modules/should-equal": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17341,6 +17412,8 @@
     },
     "node_modules/should-format": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17350,11 +17423,15 @@
     },
     "node_modules/should-type": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/should-type-adaptors": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17364,6 +17441,8 @@
     },
     "node_modules/should-util": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true,
       "license": "MIT"
     },
@@ -17620,11 +17699,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -18257,6 +18331,8 @@
     },
     "node_modules/swagger2openapi": {
       "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -18355,10 +18431,16 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tar": {
@@ -20590,50 +20672,41 @@
       }
     },
     "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
+      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
       "dev": true,
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.13.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
       }
     },
     "@apidevtools/openapi-schemas": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
       "dev": true
     },
     "@apidevtools/swagger-methods": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
       "dev": true
     },
     "@apidevtools/swagger-parser": {
-      "version": "10.1.0",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.1.1.tgz",
+      "integrity": "sha512-u/kozRnsPO/x8QtKYJOqoGtC4kH6yg1lfYkB9Au0WhYB0FNLpyFusttQtvhlwjtG3rOwiRz4D8DnnXa8iEpIKA==",
       "dev": true,
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "9.0.6",
+        "@apidevtools/json-schema-ref-parser": "11.7.2",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
-        "ajv": "^8.6.3",
+        "ajv": "^8.17.1",
         "ajv-draft-04": "^1.0.0",
-        "call-me-maybe": "^1.0.1"
+        "call-me-maybe": "^1.0.2"
       }
     },
     "@asamuzakjp/css-color": {
@@ -22365,6 +22438,8 @@
     },
     "@exodus/schemasafe": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.3.0.tgz",
+      "integrity": "sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==",
       "dev": true
     },
     "@hapi/hoek": {
@@ -22547,6 +22622,8 @@
     },
     "@jsdevtools/ono": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
     },
     "@jsonjoy.com/base64": {
@@ -22644,7 +22721,9 @@
       }
     },
     "@oazapfts/runtime": {
-      "version": "1.0.3",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oazapfts/runtime/-/runtime-1.0.4.tgz",
+      "integrity": "sha512-7t6C2shug/6tZhQgkCa532oTYBLEnbASV/i1SG1rH2GB4h3aQQujYciYSPT92hvN4IwTe8S2hPkN/6iiOyTlCg==",
       "dev": true,
       "peer": true
     },
@@ -23300,17 +23379,19 @@
       "optional": true
     },
     "@rtk-query/codegen-openapi": {
-      "version": "2.0.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rtk-query/codegen-openapi/-/codegen-openapi-2.1.0.tgz",
+      "integrity": "sha512-JQ2L7fIVEo43ccVOv9Wm4kjyb4QfDA3ndTjAU+oYh0fnY4lnCQQiNDxiZlo97GbjX2lVdmlaBuWtk/gwK+50OA==",
       "dev": true,
       "requires": {
-        "@apidevtools/swagger-parser": "^10.0.2",
+        "@apidevtools/swagger-parser": "^10.1.1",
         "commander": "^6.2.0",
         "lodash.camelcase": "^4.3.0",
-        "oazapfts": "^6.1.0",
+        "oazapfts": "^6.3.0",
         "prettier": "^3.2.5",
         "semver": "^7.3.5",
         "swagger2openapi": "^7.0.4",
-        "typescript": "^5.5.4"
+        "typescript": "^5.8.2"
       },
       "dependencies": {
         "commander": {
@@ -24860,6 +24941,8 @@
     },
     "ajv-draft-04": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "dev": true,
       "requires": {}
     },
@@ -25476,6 +25559,8 @@
     },
     "call-me-maybe": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
       "dev": true
     },
     "callsites": {
@@ -26581,6 +26666,8 @@
     },
     "es6-promise": {
       "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
       "dev": true
     },
     "esbuild": {
@@ -27276,6 +27363,8 @@
     },
     "fast-safe-stringify": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true
     },
     "fast-uri": {
@@ -28103,6 +28192,8 @@
     },
     "http2-client": {
       "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/http2-client/-/http2-client-1.3.5.tgz",
+      "integrity": "sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==",
       "dev": true
     },
     "https-proxy-agent": {
@@ -29536,6 +29627,8 @@
     },
     "node-fetch-h2": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch-h2/-/node-fetch-h2-2.3.0.tgz",
+      "integrity": "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==",
       "dev": true,
       "requires": {
         "http2-client": "^1.2.5"
@@ -29553,6 +29646,8 @@
     },
     "node-readfiles": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/node-readfiles/-/node-readfiles-0.2.0.tgz",
+      "integrity": "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==",
       "dev": true,
       "requires": {
         "es6-promise": "^3.2.1"
@@ -29667,6 +29762,8 @@
     },
     "oas-kit-common": {
       "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/oas-kit-common/-/oas-kit-common-1.0.8.tgz",
+      "integrity": "sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==",
       "dev": true,
       "requires": {
         "fast-safe-stringify": "^2.0.7"
@@ -29674,6 +29771,8 @@
     },
     "oas-linter": {
       "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/oas-linter/-/oas-linter-3.2.2.tgz",
+      "integrity": "sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==",
       "dev": true,
       "requires": {
         "@exodus/schemasafe": "^1.0.0-rc.2",
@@ -29691,6 +29790,8 @@
     },
     "oas-resolver": {
       "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/oas-resolver/-/oas-resolver-2.5.6.tgz",
+      "integrity": "sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==",
       "dev": true,
       "requires": {
         "node-fetch-h2": "^2.3.0",
@@ -29710,10 +29811,14 @@
     },
     "oas-schema-walker": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/oas-schema-walker/-/oas-schema-walker-1.1.5.tgz",
+      "integrity": "sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==",
       "dev": true
     },
     "oas-validator": {
       "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/oas-validator/-/oas-validator-5.0.8.tgz",
+      "integrity": "sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==",
       "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
@@ -29735,15 +29840,43 @@
       }
     },
     "oazapfts": {
-      "version": "6.1.0",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/oazapfts/-/oazapfts-6.3.1.tgz",
+      "integrity": "sha512-iFWDzRMXOw/UwO/AcgkEVO6CECthgKN0elJt72zsTZNiYU9ZtfMEDaUuxb767hT4lvlCoohPbz6HvY3upFth8w==",
       "dev": true,
       "requires": {
-        "@apidevtools/swagger-parser": "^10.1.0",
+        "@apidevtools/swagger-parser": "^12.0.0",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
         "swagger2openapi": "^7.0.8",
-        "tapable": "^2.2.1",
-        "typescript": "^5.4.5"
+        "tapable": "^2.2.2",
+        "typescript": "^5.8.3"
+      },
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": {
+          "version": "14.0.1",
+          "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+          "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.15",
+            "js-yaml": "^4.1.0"
+          }
+        },
+        "@apidevtools/swagger-parser": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+          "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+          "dev": true,
+          "requires": {
+            "@apidevtools/json-schema-ref-parser": "14.0.1",
+            "@apidevtools/openapi-schemas": "^2.1.0",
+            "@apidevtools/swagger-methods": "^3.0.2",
+            "ajv": "^8.17.1",
+            "ajv-draft-04": "^1.0.0",
+            "call-me-maybe": "^1.0.2"
+          }
+        }
       }
     },
     "object-assign": {
@@ -29884,6 +30017,8 @@
     },
     "openapi-types": {
       "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
       "dev": true,
       "peer": true
     },
@@ -30716,6 +30851,8 @@
     },
     "reftools": {
       "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/reftools/-/reftools-1.1.9.tgz",
+      "integrity": "sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==",
       "dev": true
     },
     "regenerate": {
@@ -31317,6 +31454,8 @@
     },
     "should": {
       "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "dev": true,
       "requires": {
         "should-equal": "^2.0.0",
@@ -31328,6 +31467,8 @@
     },
     "should-equal": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
       "dev": true,
       "requires": {
         "should-type": "^1.4.0"
@@ -31335,6 +31476,8 @@
     },
     "should-format": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==",
       "dev": true,
       "requires": {
         "should-type": "^1.3.0",
@@ -31343,10 +31486,14 @@
     },
     "should-type": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==",
       "dev": true
     },
     "should-type-adaptors": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
       "dev": true,
       "requires": {
         "should-type": "^1.3.0",
@@ -31355,6 +31502,8 @@
     },
     "should-util": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==",
       "dev": true
     },
     "side-channel": {
@@ -31521,10 +31670,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
       "dev": true
     },
     "stack-utils": {
@@ -31950,6 +32095,8 @@
     },
     "swagger2openapi": {
       "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/swagger2openapi/-/swagger2openapi-7.0.8.tgz",
+      "integrity": "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==",
       "dev": true,
       "requires": {
         "call-me-maybe": "^1.0.1",
@@ -32015,7 +32162,9 @@
       }
     },
     "tapable": {
-      "version": "2.2.1"
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="
     },
     "tar": {
       "version": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "3.0.1",
     "@redhat-cloud-services/frontend-components-config": "6.7.4",
     "@redhat-cloud-services/tsc-transform-imports": "1.0.26",
-    "@rtk-query/codegen-openapi": "2.0.0",
+    "@rtk-query/codegen-openapi": "2.1.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.0",

--- a/src/store/service/imageBuilderApi.ts
+++ b/src/store/service/imageBuilderApi.ts
@@ -1023,7 +1023,7 @@ export type ClonesResponse = {
   data: ClonesResponseItem[];
 };
 export type CloneStatusResponse = {
-  compose_id?: string | undefined;
+  compose_id: string;
 } & UploadStatus;
 export type Package = {
   name: string;


### PR DESCRIPTION
This bumps @rtk-query/codegen-openapi from 2.0.0 to 2.1.0 and runs `npm run api` to add needed changes.

JIRA: [HMS-9617](https://issues.redhat.com/browse/HMS-9617)