### PR TITLE
packit.yaml: Release into fedora-all (HMS-9619)

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -24,6 +24,7 @@ jobs:
       - centos-stream-10
       - fedora-41
       - fedora-42
+      - fedora-43
 
   - job: copr_build
     trigger: pull_request
@@ -56,11 +57,9 @@ jobs:
   - job: propose_downstream
     trigger: release
     dist_git_branches:
-      - fedora-42
-      - fedora-rawhide
+      - fedora-all
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
-      - fedora-42
-      - fedora-rawhide
+      - fedora-all


### PR DESCRIPTION
This updates targets and dist_git_branches to fedora-all

JIRA: [HMS-9619](https://issues.redhat.com/browse/HMS-9619)