### PR TITLE
dependabot: Switch from daily to weekly updates (HMS-9650)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
       time: "04:00"
     open-pull-requests-limit: 3
     rebase-strategy: "auto"
@@ -13,3 +14,7 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
This switches dependabot updates from daily to weekly (Monday morning). Updates should be also grouped into one bulk PR.

JIRA: [HMS-9650](https://issues.redhat.com/browse/HMS-9650)