### PR TITLE
Wizard: Update Lightspeed gating flag

### DIFF
--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -180,7 +180,7 @@ registrationModes.forEach(
           // Test enabling/disabling predictive analytics
           const insightsSwitch = frame.getByText('Enable predictive analytics');
           const insightsReviewStep = frame.getByText(
-            'Connect to Red Hat Insights',
+            'Connect to Red Hat Lightspeed',
           );
           // Test enabling/disabling remote remediations
           const rhcSwitch = frame.getByText('Enable remote remediations');

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -51,7 +51,7 @@ interface ImportBlueprintModalProps {
 export const ImportBlueprintModal: React.FunctionComponent<
   ImportBlueprintModalProps
 > = ({ setShowImportModal, isOpen }: ImportBlueprintModalProps) => {
-  const lightspeedEnabled = useFlag('image-builder.lightspeed.enabled');
+  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
 
   const onImportClose = () => {
     setShowImportModal(false);

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -53,7 +53,7 @@ import { useOnPremOpenSCAPAvailable } from '../../../../Utilities/useOnPremOpenS
 const OscapContent = () => {
   const dispatch = useAppDispatch();
   const complianceEnabled = useFlag('image-builder.compliance.enabled');
-  const lightspeedEnabled = useFlag('image-builder.lightspeed.enabled');
+  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
   const complianceType = useAppSelector(selectComplianceType);
   const profileID = useAppSelector(selectComplianceProfileID);
   const fips = useAppSelector(selectFips);

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -271,7 +271,7 @@ export const TargetEnvAWSList = () => {
 };
 
 export const TargetEnvGCPList = () => {
-  const lightspeedEnabled = useFlag('image-builder.lightspeed.enabled');
+  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
 
   const accountType = useAppSelector(selectGcpAccountType);
   const sharedMethod = useAppSelector(selectGcpShareMethod);
@@ -676,7 +676,7 @@ export const RegisterAapList = () => {
 };
 
 export const RegisterNowList = () => {
-  const lightspeedEnabled = useFlag('image-builder.lightspeed.enabled');
+  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
 
   const orgId = useAppSelector(selectOrgId);
   const activationKey = useAppSelector(selectActivationKey);

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Gcp/index.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Gcp/index.tsx
@@ -31,7 +31,7 @@ export type GcpAccountType =
   | undefined;
 
 const Gcp = () => {
-  const lightspeedEnabled = useFlag('image-builder.lightspeed.enabled');
+  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
 
   const dispatch = useAppDispatch();
 


### PR DESCRIPTION
This replaces `image-builder.lightspeed.enabled` flag with a platform one as per [RHINENG-19585](https://issues.redhat.com/browse/RHINENG-19585).