### PR TITLE
devDeps: Bump eslint-plugin-playwright from 2.2.2 to 2.3.0 (HMS-9654)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-jest-dom": "5.5.0",
         "eslint-plugin-jsx-a11y": "6.10.2",
-        "eslint-plugin-playwright": "2.2.2",
+        "eslint-plugin-playwright": "2.3.0",
         "eslint-plugin-prettier": "5.5.4",
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "5.2.0",
@@ -10236,44 +10236,19 @@
       }
     },
     "node_modules/eslint-plugin-playwright": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.2.2.tgz",
-      "integrity": "sha512-j0jKpndIPOXRRP9uMkwb9l/nSmModOU3452nrFdgFJoEv/435J1onk8+aITzjDW8DfypxgmVaDMdmVIa6F7I0w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.3.0.tgz",
+      "integrity": "sha512-7UeUuIb5SZrNkrUGb2F+iwHM97kn33/huajcVtAaQFCSMUYGNFvjzRPil5C0OIppslPfuOV68M/zsisXx+/ZvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globals": "^13.23.0"
+        "globals": "^16.4.0"
       },
       "engines": {
-        "node": ">=16.6.0"
+        "node": ">=16.9.0"
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
-      }
-    },
-    "node_modules/eslint-plugin-playwright/node_modules/globals": {
-      "version": "13.24.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-playwright/node_modules/type-fest": {
-      "version": "0.20.2",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -27018,25 +26993,12 @@
       }
     },
     "eslint-plugin-playwright": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.2.2.tgz",
-      "integrity": "sha512-j0jKpndIPOXRRP9uMkwb9l/nSmModOU3452nrFdgFJoEv/435J1onk8+aITzjDW8DfypxgmVaDMdmVIa6F7I0w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-2.3.0.tgz",
+      "integrity": "sha512-7UeUuIb5SZrNkrUGb2F+iwHM97kn33/huajcVtAaQFCSMUYGNFvjzRPil5C0OIppslPfuOV68M/zsisXx+/ZvQ==",
       "dev": true,
       "requires": {
-        "globals": "^13.23.0"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "13.24.0",
-          "dev": true,
-          "requires": {
-            "type-fest": "^0.20.2"
-          }
-        },
-        "type-fest": {
-          "version": "0.20.2",
-          "dev": true
-        }
+        "globals": "^16.4.0"
       }
     },
     "eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jest-dom": "5.5.0",
     "eslint-plugin-jsx-a11y": "6.10.2",
-    "eslint-plugin-playwright": "2.2.2",
+    "eslint-plugin-playwright": "2.3.0",
     "eslint-plugin-prettier": "5.5.4",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "5.2.0",

--- a/playwright/Cockpit/cockpit.spec.ts
+++ b/playwright/Cockpit/cockpit.spec.ts
@@ -88,7 +88,9 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
 
   await test.step('Cockpit cloud upload', async () => {
     await frame.getByTestId('blueprints-create-button').click();
-    frame.getByRole('heading', { name: 'Image output' });
+    await expect(
+      frame.getByRole('heading', { name: 'Image output' }),
+    ).toBeVisible();
     // the first card should be the AWS card
     await frame.locator('.pf-v6-c-card').first().click();
     await frame.getByRole('button', { name: 'Next', exact: true }).click();
@@ -96,7 +98,7 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
     await frame.getByRole('button', { name: 'Review and finish' }).click();
     await frame.getByRole('button', { name: 'Back', exact: true }).click();
 
-    frame.getByRole('heading', { name: 'Details' });
+    await expect(frame.getByRole('heading', { name: 'Details' })).toBeVisible();
     await frame.getByTestId('blueprint').fill(blueprintName);
     await expect(frame.getByTestId('blueprint')).toHaveValue(blueprintName);
     await frame.getByRole('button', { name: 'Next', exact: true }).click();
@@ -118,6 +120,6 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
       .getByTestId('images-table')
       .getByRole('button', { name: 'Details' })
       .click();
-    frame.getByText('Build Information');
+    await expect(frame.getByText('Build Information')).toBeVisible();
   });
 });


### PR DESCRIPTION
This bumps eslint-plugin-playwright from 2.2.2 to 2.3.0 and updates code to resolve "Unused locator" errors.

JIRA: [HMS-9654](https://issues.redhat.com/browse/HMS-9654)