### PR TITLE
devDeps: Bump eslint-plugin-testing-library to 7.13.3 (HMS-9657)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-redux": "4.2.2",
-        "eslint-plugin-testing-library": "7.6.8",
+        "eslint-plugin-testing-library": "7.13.3",
         "git-revision-webpack-plugin": "5.0.0",
         "globals": "16.4.0",
         "history": "5.3.0",
@@ -10429,9 +10429,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.6.8.tgz",
-      "integrity": "sha512-8qvVtc9gzYsBWJd2bMJByAlOdr/GBBH2RZygvp70OTivsJkLkYRxSZFtHq1XQK8k+zNi8DcV7aiSx3avE0rf2w==",
+      "version": "7.13.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.13.3.tgz",
+      "integrity": "sha512-STwyXN7GnHulgsfdXVd5iC8fFCJVRQj2AcKtMmQOsA8G4oMnSCOX1p3MjbrDQ9fmwVf5wZy6vboTOTFobWuxOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27138,9 +27138,9 @@
       "dev": true
     },
     "eslint-plugin-testing-library": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.6.8.tgz",
-      "integrity": "sha512-8qvVtc9gzYsBWJd2bMJByAlOdr/GBBH2RZygvp70OTivsJkLkYRxSZFtHq1XQK8k+zNi8DcV7aiSx3avE0rf2w==",
+      "version": "7.13.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.13.3.tgz",
+      "integrity": "sha512-STwyXN7GnHulgsfdXVd5iC8fFCJVRQj2AcKtMmQOsA8G4oMnSCOX1p3MjbrDQ9fmwVf5wZy6vboTOTFobWuxOA==",
       "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-redux": "4.2.2",
-    "eslint-plugin-testing-library": "7.6.8",
+    "eslint-plugin-testing-library": "7.13.3",
     "git-revision-webpack-plugin": "5.0.0",
     "globals": "16.4.0",
     "history": "5.3.0",

--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -72,7 +72,7 @@ describe('Blueprints', () => {
     });
     expect(emptyStateAction).toBeInTheDocument();
 
-    user.click(emptyStateAction);
+    await waitFor(() => user.click(emptyStateAction));
 
     const { router } = await view;
     await waitFor(() =>
@@ -118,14 +118,14 @@ describe('Blueprints', () => {
     });
     expect(buildImageBtn).toBeEnabled();
     const buildImageDropDown = screen.getByTestId('blueprint-build-image-menu');
-    user.click(buildImageDropDown);
+    await waitFor(() => user.click(buildImageDropDown));
 
     const awsCheckbox = await screen.findByRole('checkbox', {
       name: /amazon web services/i,
     });
     expect(awsCheckbox).toBeChecked();
 
-    user.click(awsCheckbox);
+    await waitFor(() => user.click(awsCheckbox));
     await waitFor(() => expect(awsCheckbox).not.toBeChecked());
 
     const buildSelectedBtn = await screen.findByRole('button', {
@@ -144,13 +144,13 @@ describe('Blueprints', () => {
     expect(buildImageBtn).toBeEnabled();
     const buildImageDropDown = screen.getByTestId('blueprint-build-image-menu');
 
-    user.click(buildImageDropDown);
+    await waitFor(() => user.click(buildImageDropDown));
     const awsCheckbox = await screen.findByRole('checkbox', {
       name: /amazon web services/i,
     });
     expect(awsCheckbox).toBeChecked();
 
-    user.click(awsCheckbox);
+    await waitFor(() => user.click(awsCheckbox));
     await waitFor(() => expect(awsCheckbox).not.toBeChecked());
     const buildSelectedBtn = await screen.findByRole('button', {
       name: /Build images/i,
@@ -203,7 +203,7 @@ describe('Blueprints', () => {
     const button = await screen.findByRole('button', {
       name: /fix errors automatically/i,
     });
-    user.click(button);
+    await waitFor(() => user.click(button));
     await waitFor(() => {
       expect(
         screen.queryByText('The selected blueprint has errors.'),
@@ -237,7 +237,7 @@ describe('Blueprints', () => {
       const blueprintDetails = await screen.findByTestId(
         'image-details-expandable',
       );
-      user.click(blueprintDetails);
+      await waitFor(() => user.click(blueprintDetails));
       await screen.findByText(editedBlueprintName);
     });
     test('redirect to index page when blueprint is invalid', async () => {
@@ -267,7 +267,7 @@ describe('Blueprints', () => {
         'Search by name or description',
       );
       searchInput.focus();
-      user.keyboard('Milk');
+      await waitFor(() => user.keyboard('Milk'));
 
       // wait for debounce
       await waitFor(
@@ -311,8 +311,8 @@ describe('Blueprints', () => {
         expect(button).toBeEnabled();
       });
 
-      user.click(button);
-      user.click(button);
+      await waitFor(() => user.click(button));
+      await waitFor(() => user.click(button));
 
       await waitFor(() => {
         expect(screen.getAllByTestId('blueprint-card')).toHaveLength(10);
@@ -339,9 +339,9 @@ describe('Blueprints', () => {
         within(screen.getByTestId('images-table')).getAllByRole('row'),
       ).toHaveLength(4);
 
-      user.click(composesVersionFilter);
+      await waitFor(() => user.click(composesVersionFilter));
       const option = await screen.findByRole('menuitem', { name: 'Newest' });
-      user.click(option);
+      await waitFor(() => user.click(option));
       await waitFor(() =>
         expect(
           within(screen.getByTestId('images-table')).getAllByRole('row'),

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -36,7 +36,7 @@ const uploadFile = async (filename: string, content: string): Promise<void> => {
 
   if (fileInput) {
     const file = new File([content], filename, { type: 'application/json' });
-    user.upload(fileInput, file);
+    await waitFor(() => user.upload(fileInput, file));
   }
 };
 
@@ -59,7 +59,7 @@ describe('Import modal', () => {
     const reviewButton = screen.getByRole('button', {
       name: /Review and finish/i,
     });
-    expect(reviewButton).toBeDisabled();
+    await waitFor(() => expect(reviewButton).toBeDisabled());
     const helperText = await screen.findByText(
       /not compatible with the blueprints format\./i,
     );
@@ -72,7 +72,7 @@ describe('Import modal', () => {
     const reviewButton = screen.getByRole('button', {
       name: /Review and finish/i,
     });
-    expect(reviewButton).toBeDisabled();
+    await waitFor(() => expect(reviewButton).toBeDisabled());
     const helperText = await screen.findByText(
       /not compatible with the blueprints format\./i,
     );
@@ -86,7 +86,7 @@ describe('Import modal', () => {
       name: /Review and finish/i,
     });
     await waitFor(() => expect(reviewButton).toBeEnabled());
-    user.click(reviewButton);
+    await waitFor(() => user.click(reviewButton));
 
     await waitFor(async () =>
       expect(
@@ -102,7 +102,7 @@ describe('Import modal', () => {
       name: /Review and finish/i,
     });
     await waitFor(() => expect(reviewButton).toBeEnabled());
-    user.click(reviewButton);
+    await waitFor(() => user.click(reviewButton));
 
     await waitFor(async () =>
       expect(
@@ -125,7 +125,7 @@ describe('Import modal', () => {
       name: /Review and finish/i,
     });
     await waitFor(() => expect(reviewButton).toBeEnabled());
-    user.click(reviewButton);
+    await waitFor(() => user.click(reviewButton));
 
     await waitFor(async () =>
       expect(
@@ -260,7 +260,7 @@ describe('Import modal', () => {
       name: /Review and finish/i,
     });
     await waitFor(() => expect(reviewButton).toBeEnabled());
-    user.click(reviewButton);
+    await waitFor(() => user.click(reviewButton));
 
     // Image output
     const guestImageCheckBox = await screen.findByRole('checkbox', {
@@ -449,7 +449,7 @@ describe('Partitioning import', () => {
       name: /Review and finish/i,
     });
     await waitFor(() => expect(reviewButton).toBeEnabled());
-    user.click(reviewButton);
+    await waitFor(() => user.click(reviewButton));
 
     // Image output
     const guestImageCheckBox = await screen.findByRole('checkbox', {
@@ -476,7 +476,7 @@ describe('Partitioning import', () => {
       name: /Review and finish/i,
     });
     await waitFor(() => expect(reviewButton).toBeEnabled());
-    user.click(reviewButton);
+    await waitFor(() => user.click(reviewButton));
 
     // Image output
     const guestImageCheckBox = await screen.findByRole('checkbox', {
@@ -502,7 +502,7 @@ describe('Partitioning import', () => {
     const reviewButton = screen.getByRole('button', {
       name: /Review and finish/i,
     });
-    expect(reviewButton).toBeDisabled();
+    await waitFor(() => expect(reviewButton).toBeDisabled());
     const helperText = await screen.findByText(
       /not compatible with the blueprints format\./i,
     );

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -167,10 +167,12 @@ describe('Keyboard accessibility', () => {
 
   test('pressing Enter does not advance the wizard', async () => {
     await renderCreateMode();
-    user.click(
-      await screen.findByRole('button', { name: /Amazon Web Services/i }),
+    await waitFor(async () =>
+      user.click(
+        await screen.findByRole('button', { name: /Amazon Web Services/i }),
+      ),
     );
-    user.keyboard('{enter}');
+    await waitFor(() => user.keyboard('{enter}'));
     await screen.findByRole('heading', {
       name: /image output/i,
     });

--- a/src/test/Components/CreateImageWizard/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
@@ -173,7 +173,7 @@ describe('Step File system configuration', () => {
     const varButton = await screen.findByRole('option', {
       name: /\/var/i,
     });
-    user.click(varButton);
+    await waitFor(() => user.click(varButton));
     await waitFor(() => expect(mountPointAlerts[0]).not.toBeInTheDocument());
     await waitFor(() => expect(mountPointAlerts[1]).not.toBeInTheDocument());
     expect(await getNextButton()).toBeEnabled();

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -182,25 +182,25 @@ describe('Step Image output', () => {
     const awsTile = await screen.findByRole('button', {
       name: /Amazon Web Services/i,
     });
-    user.click(awsTile); // select
+    await waitFor(() => user.click(awsTile)); // select
     await waitFor(() => expect(nextButton).toBeEnabled());
-    user.click(awsTile); // deselect
+    await waitFor(() => user.click(awsTile)); // deselect
     await waitFor(() => expect(nextButton).toBeDisabled());
 
     const googleTile = await screen.findByRole('button', {
       name: /Google Cloud/i,
     });
-    user.click(googleTile); // select
+    await waitFor(() => user.click(googleTile)); // select
     await waitFor(() => expect(nextButton).toBeEnabled());
-    user.click(googleTile); // deselect
+    await waitFor(() => user.click(googleTile)); // deselect
     await waitFor(() => expect(nextButton).toBeDisabled());
 
     const azureTile = await screen.findByRole('button', {
       name: /Microsoft Azure/i,
     });
-    user.click(azureTile); // select
+    await waitFor(() => user.click(azureTile)); // select
     await waitFor(() => expect(nextButton).toBeEnabled());
-    user.click(azureTile); // deselect
+    await waitFor(() => user.click(azureTile)); // deselect
     await waitFor(() => expect(nextButton).toBeDisabled());
   });
 
@@ -226,7 +226,7 @@ describe('Step Image output', () => {
     const showOptionsButton = await screen.findByRole('option', {
       name: 'Show options for further development of RHEL',
     });
-    user.click(showOptionsButton);
+    await waitFor(() => user.click(showOptionsButton));
 
     await screen.findByRole('option', {
       name: /Red Hat Enterprise Linux \(RHEL\) 8/,
@@ -634,7 +634,7 @@ describe('Check step consistency', () => {
     const uploadGcpBtn = await screen.findByRole('button', {
       name: /Google Cloud/i,
     });
-    user.click(uploadGcpBtn);
+    await waitFor(() => user.click(uploadGcpBtn));
     await waitFor(() => expect(next).toBeEnabled());
 
     // change to aarch, GCP not being compatible and gets removed from targets
@@ -645,7 +645,7 @@ describe('Check step consistency', () => {
     const uploadAwsBtn = await screen.findByRole('button', {
       name: /Amazon Web Services/i,
     });
-    user.click(uploadAwsBtn);
+    await waitFor(() => user.click(uploadAwsBtn));
     await waitFor(() => expect(next).toBeEnabled());
 
     // and going back to x86_64 the Next button stays enabled
@@ -737,7 +737,7 @@ describe('Set target using query parameter', () => {
     const targetExpandable = await screen.findByTestId(
       'target-environments-expandable',
     );
-    user.click(targetExpandable);
+    await waitFor(() => user.click(targetExpandable));
     await screen.findByText('Bare metal - Installer (.iso)');
   });
 
@@ -754,7 +754,7 @@ describe('Set target using query parameter', () => {
     const targetExpandable = await screen.findByTestId(
       'target-environments-expandable',
     );
-    user.click(targetExpandable);
+    await waitFor(() => user.click(targetExpandable));
     await screen.findByText('Virtualization - Guest image (.qcow2)');
   });
 });

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
@@ -135,21 +135,21 @@ describe('Compliance edit mode', () => {
     const fscBtns = await screen.findAllByRole('button', {
       name: /file system configuration/i,
     });
-    user.click(fscBtns[0]);
+    await waitFor(() => user.click(fscBtns[0]));
     await screen.findByRole('heading', { name: /file system configuration/i });
     await screen.findByText('/tmp');
     // check that the Packages contain neovim package
     const packagesNavBtn = await screen.findByRole('button', {
       name: /additional packages/i,
     });
-    user.click(packagesNavBtn);
+    await waitFor(() => user.click(packagesNavBtn));
     await screen.findByRole('heading', {
       name: /Additional packages/i,
     });
     const selectedBtn = await screen.findByRole('button', {
       name: /Selected/i,
     });
-    user.click(selectedBtn);
+    await waitFor(() => user.click(selectedBtn));
     await screen.findByText('emacs');
 
     expect(screen.queryByText('aide')).not.toBeInTheDocument();

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
@@ -158,7 +158,7 @@ describe('Step OpenSCAP', () => {
       name: /Additional packages/i,
     });
     const selected = await screen.findByText(/Selected/);
-    user.click(selected);
+    await waitFor(() => user.click(selected));
     await screen.findByText(/aide/i);
     await screen.findByText(/neovim/i);
   });
@@ -329,21 +329,21 @@ describe('OpenSCAP edit mode', () => {
     const fscBtns = await screen.findAllByRole('button', {
       name: /file system configuration/i,
     });
-    user.click(fscBtns[0]);
+    await waitFor(() => user.click(fscBtns[0]));
     await screen.findByRole('heading', { name: /file system configuration/i });
     await screen.findByText('/tmp');
     // check that the Packages contain neovim package
     const packagesNavBtn = await screen.findByRole('button', {
       name: /additional packages/i,
     });
-    user.click(packagesNavBtn);
+    await waitFor(() => user.click(packagesNavBtn));
     await screen.findByRole('heading', {
       name: /Additional packages/i,
     });
     const selectedBtn = await screen.findByRole('button', {
       name: /Selected/i,
     });
-    user.click(selectedBtn);
+    await waitFor(() => user.click(selectedBtn));
     await screen.findByText('neovim');
   });
 

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -273,7 +273,7 @@ describe('Step Packages', () => {
     let firstPkgCheckbox = checkboxes[0] as HTMLInputElement;
 
     expect(firstPkgCheckbox.checked).toEqual(false);
-    user.click(firstPkgCheckbox);
+    await waitFor(() => user.click(firstPkgCheckbox));
     await waitFor(() => expect(firstPkgCheckbox.checked).toEqual(true));
     await clickNext();
     await clickBack();

--- a/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
@@ -91,7 +91,7 @@ const toggleAll = async () => {
   const allButton = await screen.findByRole('button', {
     name: /all repositories/i,
   });
-  user.click(allButton);
+  await waitFor(() => user.click(allButton));
 };
 
 const searchForRepository = async (searchTerm: string) => {
@@ -116,7 +116,7 @@ describe('Step Custom repositories', () => {
     let firstRepoCheckbox = (await getFirstRepoCheckbox()) as HTMLInputElement;
 
     expect(firstRepoCheckbox.checked).toEqual(false);
-    user.click(firstRepoCheckbox);
+    await waitFor(() => user.click(firstRepoCheckbox));
     await waitFor(() => expect(firstRepoCheckbox.checked).toEqual(true));
 
     await clickNext();
@@ -130,7 +130,7 @@ describe('Step Custom repositories', () => {
     await renderCreateMode();
     await goToRepositoriesStep();
     const select = await screen.findByTestId('bulk-select-toggle');
-    user.click(select);
+    await waitFor(() => user.click(select));
     await screen.findByText(/select page \(10 items\)/i);
   });
 
@@ -142,7 +142,7 @@ describe('Step Custom repositories', () => {
       (await getFirstRepoCheckbox()) as HTMLInputElement;
 
     expect(firstRepoCheckbox.checked).toEqual(false);
-    user.click(firstRepoCheckbox);
+    await waitFor(() => user.click(firstRepoCheckbox));
     await waitFor(() => expect(firstRepoCheckbox.checked).toEqual(true));
 
     await toggleSelected();
@@ -165,7 +165,7 @@ describe('Step Custom repositories', () => {
 
     expect(firstRepoCheckbox.checked).toEqual(false);
     expect(secondRepoCheckbox.checked).toEqual(false);
-    user.click(firstRepoCheckbox);
+    await waitFor(() => user.click(firstRepoCheckbox));
     await waitFor(() => expect(firstRepoCheckbox.checked).toEqual(true));
     expect(secondRepoCheckbox.checked).toEqual(false);
 
@@ -189,7 +189,7 @@ describe('Step Custom repositories', () => {
       (await getFirstRepoCheckbox()) as HTMLInputElement;
 
     expect(firstRepoCheckbox.checked).toEqual(false);
-    user.click(firstRepoCheckbox);
+    await waitFor(() => user.click(firstRepoCheckbox));
     await waitFor(() => expect(firstRepoCheckbox.checked).toEqual(true));
 
     await toggleSelected();
@@ -200,7 +200,7 @@ describe('Step Custom repositories', () => {
     await clickNext();
     await clickBack();
     expect(firstRepoCheckbox.checked).toEqual(true);
-    user.click(firstRepoCheckbox);
+    await waitFor(() => user.click(firstRepoCheckbox));
     await waitFor(() => expect(firstRepoCheckbox.checked).toEqual(false));
   });
 
@@ -357,7 +357,7 @@ describe('Repositories edit mode', () => {
       name: /Custom repositories/,
     });
 
-    user.click(customRepositories);
+    await waitFor(() => user.click(customRepositories));
 
     await screen.findByText(
       /Removing previously added repositories may lead to issues with selected packages/i,
@@ -368,12 +368,12 @@ describe('Repositories edit mode', () => {
     const repoCheckbox = await getFirstRepoCheckbox();
     await waitFor(() => expect(repoCheckbox).toBeChecked());
 
-    user.click(repoCheckbox);
+    await waitFor(() => user.click(repoCheckbox));
     await screen.findByText(/Are you sure?/);
     const removeAnywayBtn = await screen.findByRole('button', {
       name: /Remove anyway/,
     });
-    user.click(removeAnywayBtn);
+    await waitFor(() => user.click(removeAnywayBtn));
 
     await waitFor(() =>
       expect(screen.queryByText(/Are you sure?/)).not.toBeInTheDocument(),

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AwsTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AwsTarget.test.tsx
@@ -93,7 +93,7 @@ const chooseSourcesOption = async () => {
   const sourceRadio = await screen.findByRole('radio', {
     name: /use an account configured from sources\./i,
   });
-  user.click(sourceRadio);
+  await waitFor(() => user.click(sourceRadio));
 };
 
 const getSourceDropdown = async () => {
@@ -201,7 +201,7 @@ describe('Step Upload to AWS', () => {
     const createBlueprintBtn = await screen.findByRole('button', {
       name: /Create blueprint/,
     });
-    user.click(createBlueprintBtn);
+    await waitFor(() => user.click(createBlueprintBtn));
   });
 
   test('revisit step button on Review works', async () => {

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -240,7 +240,7 @@ describe('GCP image type request generated correctly', () => {
       name: /Share image with Red Hat Insights only/i,
     });
 
-    user.click(shareWithInsightOption);
+    await waitFor(() => user.click(shareWithInsightOption));
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
     const expectedImageRequest = createGCPCloudImage('gcp', {});

--- a/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
@@ -215,7 +215,7 @@ export const selectCustomRepo = async () => {
     name: /select row 0/i,
   });
 
-  user.click(customRepoCheckbox);
+  await waitFor(() => user.click(customRepoCheckbox));
   await clickNext();
 };
 

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.tsx
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.tsx
@@ -38,19 +38,19 @@ describe('Create Share To Regions Modal', () => {
     const selectToggle = await screen.findByRole('button', {
       name: /menu toggle/i,
     });
-    user.click(selectToggle);
+    await waitFor(() => user.click(selectToggle));
 
     const usEast2 = await screen.findByRole('option', {
       name: /us east \(ohio\) us-east-2/i,
     });
     expect(usEast2).toBeEnabled();
-    user.click(usEast2);
+    await waitFor(() => user.click(usEast2));
     await waitFor(() => expect(shareButton).toBeEnabled());
 
     const clearAllButton = await screen.findByRole('button', {
       name: /clear input value/i,
     });
-    user.click(clearAllButton);
+    await waitFor(() => user.click(clearAllButton));
     await waitFor(() => expect(shareButton).toBeDisabled());
 
     const invalidAlert = await screen.findByText(
@@ -67,7 +67,7 @@ describe('Create Share To Regions Modal', () => {
     );
 
     const cancelButton = await screen.findByRole('button', { name: /cancel/i });
-    user.click(cancelButton);
+    await waitFor(() => user.click(cancelButton));
 
     // returns back to the landing page
     await waitFor(() =>
@@ -83,7 +83,7 @@ describe('Create Share To Regions Modal', () => {
     );
 
     const closeButton = await screen.findByRole('button', { name: /close/i });
-    user.click(closeButton);
+    await waitFor(() => user.click(closeButton));
 
     // returns back to the landing page
     await waitFor(() =>
@@ -97,7 +97,7 @@ describe('Create Share To Regions Modal', () => {
     const selectToggle = await screen.findByRole('button', {
       name: /menu toggle/i,
     });
-    user.click(selectToggle);
+    await waitFor(() => user.click(selectToggle));
 
     // parent region disabled
     const usEast1 = await screen.findByRole('option', {
@@ -106,7 +106,7 @@ describe('Create Share To Regions Modal', () => {
     expect(usEast1).toBeDisabled();
 
     // close the select again to avoid state update
-    user.click(selectToggle);
+    await waitFor(() => user.click(selectToggle));
   });
 
   // TODO Verify that sharing clones works once msw/data is incorporated.


### PR DESCRIPTION
This bumps eslint-plugin-testing-library from 7.6.8 to 7.13.3 and resolves new errors.

JIRA: [HMS-9657](https://issues.redhat.com/browse/HMS-9657)