### PR TITLE
src: Update and deduplicate links to documentation (HMS-9666)

### DIFF
--- a/src/Components/ImagesTable/EmptyState.tsx
+++ b/src/Components/ImagesTable/EmptyState.tsx
@@ -16,10 +16,7 @@ import {
   SearchIcon,
 } from '@patternfly/react-icons';
 
-import {
-  CREATING_IMAGES_WITH_IB_SERVICE_URL,
-  MANAGING_WITH_DNF_URL,
-} from '../../constants';
+import { IB_DOCUMENTATION_URL, MANAGING_WITH_DNF_URL } from '../../constants';
 import { BuildImagesButtonEmptyState } from '../Blueprints/BuildImagesButton';
 
 type ImagesEmptyStateProps = {
@@ -95,7 +92,7 @@ const EmptyImagesTable = () => {
                 icon={<ExternalLinkAltIcon />}
                 iconPosition='right'
                 isInline
-                href={CREATING_IMAGES_WITH_IB_SERVICE_URL}
+                href={IB_DOCUMENTATION_URL}
                 className='pf-v6-u-pt-md'
               >
                 Image builder for RPM-DNF documentation

--- a/src/Components/sharedComponents/DocumentationButton.tsx
+++ b/src/Components/sharedComponents/DocumentationButton.tsx
@@ -4,11 +4,11 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { AMPLITUDE_MODULE_NAME, DOCUMENTATION_URL } from '../../constants';
+import { AMPLITUDE_MODULE_NAME, IB_DOCUMENTATION_URL } from '../../constants';
 import { useGetUser } from '../../Hooks';
 
 const DocumentationButton = () => {
-  const documentationURL = DOCUMENTATION_URL;
+  const documentationURL = IB_DOCUMENTATION_URL;
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
 

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -10,7 +10,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 
 import {
-  CREATING_IMAGES_WITH_IB_SERVICE_URL,
+  IB_DOCUMENTATION_URL,
   OSBUILD_SERVICE_ARCHITECTURE_URL,
 } from '../../constants';
 import { useBackendPrefetch } from '../../store/backendApi';
@@ -47,7 +47,7 @@ const AboutImageBuilderPopover = () => {
               icon={<ExternalLinkAltIcon />}
               iconPosition='right'
               isInline
-              href={CREATING_IMAGES_WITH_IB_SERVICE_URL}
+              href={IB_DOCUMENTATION_URL}
             >
               Image builder for RPM-DNF documentation
             </Button>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,14 +32,10 @@ export const ACTIVATION_KEYS_URL = !process.env.IS_ON_PREMISE
   : 'https://console.redhat.com/settings/connector/activation-keys';
 export const COMPLIANCE_AND_VULN_SCANNING_URL =
   'https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/security_guide/chap-compliance_and_vulnerability_scanning';
-export const CREATING_IMAGES_WITH_IB_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/deploying_and_managing_rhel_systems_in_hybrid_clouds/index';
 export const MANAGING_WITH_DNF_URL =
   'https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_software_with_the_dnf_tool/index';
-export const CREATING_IMAGES_WITH_IB_SERVICE_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/deploying_and_managing_rhel_systems_in_hybrid_clouds/index';
-export const DOCUMENTATION_URL =
-  'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/deploying_and_managing_rhel_systems_in_hybrid_clouds/index';
+export const IB_DOCUMENTATION_URL =
+  'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/deploying_and_managing_rhel_systems_in_hybrid_clouds/index';
 export const OSBUILD_SERVICE_ARCHITECTURE_URL =
   'https://osbuild.org/docs/service/architecture/';
 export const GENERATING_SSH_KEY_PAIRS_URL =


### PR DESCRIPTION
Documentation links were re-directed due to rebrand. Also we had some duplicate links in our constants, so cleaned up those a bit.

JIRA: [HMS-9666](https://issues.redhat.com/browse/HMS-9666)