### PR TITLE
Wizard: fix interconnected ids of compliance policy & oscap profile (HMS-9596)

### DIFF
--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -37,7 +37,7 @@ test('Create a blueprint with Compliance policy selected', async ({
     await registerLater(frame);
   });
 
-  await test.step('Select Compliance and choose a policy if available', async () => {
+  await test.step('Select Compliance and choose a mock policy', async () => {
     await frame.getByRole('button', { name: 'Security' }).nth(1).click();
 
     await frame

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicyDetails.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicyDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import {
   Content,
@@ -10,61 +10,33 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 
-import { useGetComplianceCustomizationsQuery } from '../../../../../store/backendApi';
 import { PolicyRead, usePolicyQuery } from '../../../../../store/complianceApi';
-import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
-import {
-  changeCompliance,
-  selectCompliancePolicyID,
-  selectDistribution,
-} from '../../../../../store/wizardSlice';
+import { useAppSelector } from '../../../../../store/hooks';
+import { selectCompliancePolicyID } from '../../../../../store/wizardSlice';
 
 const PolicyDetails = (): JSX.Element => {
-  const dispatch = useAppDispatch();
-  const release = useAppSelector(selectDistribution);
   const compliancePolicyID = useAppSelector(selectCompliancePolicyID);
 
   const {
-    isFetching: isFetchingOscapPolicyInfo,
-    isSuccess: isSuccessOscapPolicyInfo,
+    data: policyInfo,
+    isFetching: isFetchingPolicyInfo,
+    isSuccess: isSuccessPolicyInfo,
     error: policyError,
-  } = useGetComplianceCustomizationsQuery(
+  } = usePolicyQuery(
     {
-      distribution: release,
-      policy: compliancePolicyID!,
+      policyId: compliancePolicyID || '',
     },
     {
-      skip: !compliancePolicyID || !!process.env.IS_ON_PREMISE,
+      skip: !compliancePolicyID,
     },
   );
 
-  const isPolicyDataLoading = compliancePolicyID
-    ? isFetchingOscapPolicyInfo
-    : false;
-  const isPolicyDataSuccess = compliancePolicyID
-    ? isSuccessOscapPolicyInfo
-    : true;
-  const isSuccessOscapData = isPolicyDataSuccess;
-  const hasCriticalError = compliancePolicyID && policyError;
-  const shouldShowData = isSuccessOscapData && !hasCriticalError;
+  const isPolicyDataLoading = !!compliancePolicyID && isFetchingPolicyInfo;
+  const shouldShowData =
+    !!compliancePolicyID && isSuccessPolicyInfo && !policyError;
+  const hasCriticalError = !!compliancePolicyID && !!policyError;
 
-  const { data: policyInfo, isSuccess: isSuccessPolicyInfo } = usePolicyQuery({
-    policyId: compliancePolicyID || '',
-  });
-
-  useEffect(() => {
-    if (!policyInfo || policyInfo.data === undefined) {
-      return;
-    }
-    const pol = policyInfo.data as PolicyRead;
-    dispatch(
-      changeCompliance({
-        policyID: pol.id,
-        profileID: pol.ref_id,
-        policyTitle: pol.title,
-      }),
-    );
-  }, [isSuccessPolicyInfo, dispatch, policyInfo]);
+  const policy = policyInfo?.data as PolicyRead | undefined;
 
   return (
     <>
@@ -74,25 +46,27 @@ const PolicyDetails = (): JSX.Element => {
           <DescriptionListGroup>
             <DescriptionListTerm>Policy type</DescriptionListTerm>
             <DescriptionListDescription>
-              {policyInfo?.data?.schema?.type || '—'}
+              {policy?.type ?? '—'}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Policy description</DescriptionListTerm>
             <DescriptionListDescription>
-              {policyInfo?.data?.schema?.description || '—'}
+              {policy?.description ?? '—'}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Business objective</DescriptionListTerm>
             <DescriptionListDescription>
-              {policyInfo?.data?.schema?.business_objective || '—'}
+              {policy?.business_objective ?? '—'}
             </DescriptionListDescription>
           </DescriptionListGroup>
           <DescriptionListGroup>
             <DescriptionListTerm>Compliance threshold</DescriptionListTerm>
             <DescriptionListDescription>
-              {policyInfo?.data?.schema?.compliance_threshold || '—'}
+              {policy?.compliance_threshold !== undefined
+                ? `${policy.compliance_threshold}%`
+                : '—'}
             </DescriptionListDescription>
           </DescriptionListGroup>
         </DescriptionList>

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -31,13 +31,13 @@ import {
   OpenScapProfile,
 } from '../../../../../store/imageBuilderApi';
 import {
-  changeCompliance,
   changeFips,
   changeFscMode,
   clearKernelAppend,
   selectComplianceProfileID,
   selectComplianceType,
   selectDistribution,
+  setOscapProfile,
 } from '../../../../../store/wizardSlice';
 import { useHasSpecificTargetOnly } from '../../../utilities/hasSpecificTargetOnly';
 import { removeBetaFromRelease } from '../removeBetaFromRelease';
@@ -177,13 +177,7 @@ const ProfileSelector = ({ isDisabled = false }: ProfileSelectorProps) => {
   };
 
   const handleClear = () => {
-    dispatch(
-      changeCompliance({
-        profileID: undefined,
-        policyID: undefined,
-        policyTitle: undefined,
-      }),
-    );
+    dispatch(setOscapProfile(undefined));
     clearCompliancePackages(currentProfileData?.packages || []);
     dispatch(changeFscMode('automatic'));
     handleServices(undefined);
@@ -206,13 +200,7 @@ const ProfileSelector = ({ isDisabled = false }: ProfileSelectorProps) => {
     setFilterValue(value);
 
     if (value !== profileID) {
-      dispatch(
-        changeCompliance({
-          profileID: undefined,
-          policyID: undefined,
-          policyTitle: undefined,
-        }),
-      );
+      dispatch(setOscapProfile(undefined));
     }
   };
 
@@ -262,13 +250,7 @@ const ProfileSelector = ({ isDisabled = false }: ProfileSelectorProps) => {
           );
           handleServices(response.services);
           handleKernelAppend(response.kernel?.append);
-          dispatch(
-            changeCompliance({
-              profileID: selection.profileID,
-              policyID: undefined,
-              policyTitle: undefined,
-            }),
-          );
+          dispatch(setOscapProfile(selection.profileID));
           dispatch(changeFips(response.fips?.enabled || false));
         });
     }

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -42,7 +42,6 @@ import {
 import { usePoliciesQuery } from '../../../../store/complianceApi';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
-  changeCompliance,
   changeComplianceType,
   changeDisabledServices,
   changeEnabledServices,
@@ -59,6 +58,8 @@ import {
   selectFips,
   selectImageTypes,
   selectServices,
+  setCompliancePolicy,
+  setOscapProfile,
 } from '../../../../store/wizardSlice';
 import { useFlag } from '../../../../Utilities/useGetEnvironment';
 import { useOnPremOpenSCAPAvailable } from '../../../../Utilities/useOnPremOpenSCAP';
@@ -104,12 +105,9 @@ const OscapContent = () => {
     // Avoid showing profile information when switching between types by
     // clearing the compliance data.
     dispatch(
-      changeCompliance({
-        profileID: undefined,
-        policyID: undefined,
-        policyTitle: undefined,
-      }),
+      setCompliancePolicy({ policyID: undefined, policyTitle: undefined }),
     );
+    dispatch(setOscapProfile(undefined));
 
     const pkgs = currentProfileData?.packages || [];
     for (const pkg of pkgs) {

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -15,6 +15,7 @@ import { ArrowRightIcon } from '@patternfly/react-icons';
 
 import './ReviewStep.scss';
 import {
+  CompliancePolicyDetailsList,
   ContentList,
   DetailsList,
   FirewallList,
@@ -351,6 +352,7 @@ const Review = () => {
           data-testid='compliance-detail-expandable'
         >
           <OscapList />
+          <CompliancePolicyDetailsList />
         </ExpandableSection>
       )}
       {!hasWslTargetOnly && (

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -34,6 +34,7 @@ import {
   targetOptions,
   UNIT_GIB,
 } from '../../../../constants';
+import { PolicyRead, usePolicyQuery } from '../../../../store/complianceApi';
 import {
   useGetTemplateQuery,
   useListSnapshotsByDateMutation,
@@ -57,6 +58,7 @@ import {
   selectAzureTenantId,
   selectBlueprintDescription,
   selectBlueprintName,
+  selectCompliancePolicyID,
   selectCustomRepositories,
   selectDistribution,
   selectFilesystemPartitions,
@@ -787,7 +789,58 @@ export const DetailsList = () => {
 };
 
 export const OscapList = () => {
-  return <OscapProfileInformation allowChangingCompliancePolicy={true} />;
+  return <OscapProfileInformation />;
+};
+
+export const CompliancePolicyDetailsList = () => {
+  const compliancePolicyID = useAppSelector(selectCompliancePolicyID);
+  const { data: policyInfo, isFetching } = usePolicyQuery(
+    {
+      policyId: compliancePolicyID || '',
+    },
+    { skip: !compliancePolicyID },
+  );
+
+  const policy = policyInfo?.data as PolicyRead | undefined;
+  let complianceThresholdText = '';
+  if (!isFetching) {
+    if (policy?.compliance_threshold !== undefined) {
+      complianceThresholdText = `${policy.compliance_threshold}%`;
+    } else {
+      complianceThresholdText = '—';
+    }
+  }
+
+  return (
+    <Content>
+      <Content component={ContentVariants.dl} className='review-step-dl'>
+        <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+          Policy type
+        </Content>
+        <Content component={ContentVariants.dd}>
+          {isFetching ? '' : (policy?.type ?? '—')}
+        </Content>
+        <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+          Policy description
+        </Content>
+        <Content component={ContentVariants.dd}>
+          {isFetching ? '' : (policy?.description ?? '—')}
+        </Content>
+        <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+          Business objective
+        </Content>
+        <Content component={ContentVariants.dd}>
+          {isFetching ? '' : (policy?.business_objective ?? '—')}
+        </Content>
+        <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+          Compliance threshold
+        </Content>
+        <Content component={ContentVariants.dd}>
+          {complianceThresholdText}{' '}
+        </Content>
+      </Content>
+    </Content>
+  );
 };
 
 export const TimezoneList = () => {

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -702,17 +702,18 @@ export const wizardSlice = createSlice({
     changeComplianceType: (state, action: PayloadAction<ComplianceType>) => {
       state.compliance.complianceType = action.payload;
     },
-    changeCompliance: (
+    setCompliancePolicy: (
       state,
       action: PayloadAction<{
         policyID: string | undefined;
-        profileID: string | undefined;
         policyTitle: string | undefined;
       }>,
     ) => {
       state.compliance.policyID = action.payload.policyID;
-      state.compliance.profileID = action.payload.profileID;
       state.compliance.policyTitle = action.payload.policyTitle;
+    },
+    setOscapProfile: (state, action: PayloadAction<string | undefined>) => {
+      state.compliance.profileID = action.payload;
     },
     changeFileSystemConfiguration: (
       state,
@@ -1465,7 +1466,8 @@ export const {
   changeRegistrationType,
   changeActivationKey,
   changeOrgId,
-  changeCompliance,
+  setCompliancePolicy,
+  setOscapProfile,
   changeComplianceType,
   changeFileSystemConfiguration,
   changeFscMode,


### PR DESCRIPTION
The id of compliance policy got set for oscap id as well when selecting it in the Security step. This PR splits the former `changeCompliance` action into two - one for compliance and one for oscap to be set. There's also a minor fix in the name of a test step in the Compliance PW test just to make it more precise :)