### PR TITLE
Wizard: Fix case for Red Hat Lightspeed compliance

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -295,8 +295,8 @@ const OscapContent = () => {
                 To help you get started, select one of the default policies
                 below and we will create the policy for you. However, in order
                 to modify the policy or to create a new one, you must go through{' '}
-                {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'}
-                Compliance.
+                {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'}{' '}
+                compliance.
               </p>
               <AlertActionLink
                 component='a'
@@ -317,7 +317,7 @@ const OscapContent = () => {
               >
                 Save blueprint and navigate to{' '}
                 {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'}{' '}
-                Compliance
+                compliance
               </AlertActionLink>
             </Alert>
           )}


### PR DESCRIPTION
As product names should be capitalized and features or components should be lowercase, we should go with 'compliance' over 'Compliance'. Also, there was a missing space in the alert.