### PR TITLE
playwright: Add Satellite boot tests (HMS-6024)

### DIFF
--- a/playwright/BootTests/Satellite/Satellite.boot.ts
+++ b/playwright/BootTests/Satellite/Satellite.boot.ts
@@ -1,6 +1,11 @@
 import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
+import {
+  registrationCurlCommand,
+  validCertificate,
+  validRegistrationCommand,
+} from '../../BootTests/fixtures/satelliteFixtures';
 import { test } from '../../fixtures/customizations';
 import { isHosted } from '../../helpers/helpers';
 import { ensureAuthenticated } from '../../helpers/login';
@@ -20,27 +25,6 @@ import {
   downloadImage,
 } from '../helpers/imageBuilding';
 import { OpenStackWrapper } from '../helpers/OpenStackWrapper';
-
-const validRegistrationCommand = `set -o pipefail && curl --silent --show-error 'https://localhost/register?activation_keys=my-key&download_utility=curl&location_id=2&organization_id=1&update_packages=false' --header 'Authorization: Bearer mock.eyJleHAiOjk5OTk5OTk5OTl9.mock' | bash`;
-const validCertificate = `-----BEGIN CERTIFICATE-----
-MIIDCDCCAfCgAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQKDApFeGFt
-cGxlIENBMB4XDTIwMTExODA3NTMzN1oXDTM1MTExODA3NTMzN1owFTETMBEGA1UE
-CgwKRXhhbXBsZSBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALHm
-fFYvVEtk1TIb2OHKoXiO4/1mXILBOi5mgxn49VT2YxWUO9E511iJg9j66yDlvJ0/
-AwZBc+TTEk5wG2HGviE307TShj6uSywD5/gf5Py00jITEjbyzjLdpzuh8W/C8g/0
-FQyIvpxfAwoiG1YB8a0l7Ejvx2tmSOyMDhNfBuS/OEiIMM9jiboLyEbhxKAhb3Q0
-cG2pBZmYpWRLm1G2raecR5Lcl2Bl5lMGvm1XUvmsGEF45m8T+6XxitJlfurGLYFz
-h3pUAfSAjnVp3KYAhbA2EVmSCo6OQfL9d6TbuecHMoGIXpMGBFLGvuC1UyIzkYJQ
-kCWtplODPM4P14/7lv0CAwEAAaNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8B
-Af8EBAMCAQYwHQYDVR0OBBYEFMRTOqKRV2rv/yO9L5xhP7k7IB+zMB8GA1UdIwQY
-MBaAFMRTOqKRV2rv/yO9L5xhP7k7IB+zMA0GCSqGSIb3DQEBCwUAA4IBAQAh9yku
-uDvMBT06mocBLt/mW6JvW9tHfJIU/srfOV+pYO8PFv0JVYRwwsVhGWX7gvNyNXj8
-5AjqEiyaC4ebmXCosPDCyoxA/RUtEaMJ980gMtdo2lc1uNlDYx7F6oxdqoQ66/Qm
-vY5dh8cGqql9+BYlXFELbU6K/cbXbFINzE+QwRvPgx/Ctemq5BbZFmcOTw/M9R7p
-3hh5PfM/uM71SkG8VyI6iStu8KqgBmEI43CH5KLaS6lZfnGaa1Ks10OdQuNbicuR
-EuA3qL3jj7OPwyjecA9+X6qJd8FEXM1W2zCxFaODgr6iR7mvTkTxOEVfHRVT06GQ
-LkB1TdfHQkk/525x
------END CERTIFICATE-----`;
 
 test('Satellite registration boot integration test', async ({
   page,

--- a/playwright/BootTests/fixtures/README.md
+++ b/playwright/BootTests/fixtures/README.md
@@ -1,0 +1,69 @@
+This directory includes test data and mock fixtures for boot tests.
+
+## Information about test certificates
+
+### Example certificate
+
+This certificate is used only for the purpose of running Satellite boot tests as a mock "Certificate authority (CA) for Satellite". It is externalized as `validCertificate` in [`satelliteFixtures.ts`](satelliteFixtures.ts)
+
+```text
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 1 (0x1)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: O=Example CA
+        Validity
+            Not Before: Nov 18 07:53:37 2020 GMT
+            Not After : Nov 18 07:53:37 2035 GMT
+        Subject: O=Example CA
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:b1:e6:7c:56:2f:54:4b:64:d5:32:1b:d8:e1:ca:
+                    a1:78:8e:e3:fd:66:5c:82:c1:3a:2e:66:83:19:f8:
+                    f5:54:f6:63:15:94:3b:d1:39:d7:58:89:83:d8:fa:
+                    eb:20:e5:bc:9d:3f:03:06:41:73:e4:d3:12:4e:70:
+                    1b:61:c6:be:21:37:d3:b4:d2:86:3e:ae:4b:2c:03:
+                    e7:f8:1f:e4:fc:b4:d2:32:13:12:36:f2:ce:32:dd:
+                    a7:3b:a1:f1:6f:c2:f2:0f:f4:15:0c:88:be:9c:5f:
+                    03:0a:22:1b:56:01:f1:ad:25:ec:48:ef:c7:6b:66:
+                    48:ec:8c:0e:13:5f:06:e4:bf:38:48:88:30:cf:63:
+                    89:ba:0b:c8:46:e1:c4:a0:21:6f:74:34:70:6d:a9:
+                    05:99:98:a5:64:4b:9b:51:b6:ad:a7:9c:47:92:dc:
+                    97:60:65:e6:53:06:be:6d:57:52:f9:ac:18:41:78:
+                    e6:6f:13:fb:a5:f1:8a:d2:65:7e:ea:c6:2d:81:73:
+                    87:7a:54:01:f4:80:8e:75:69:dc:a6:00:85:b0:36:
+                    11:59:92:0a:8e:8e:41:f2:fd:77:a4:db:b9:e7:07:
+                    32:81:88:5e:93:06:04:52:c6:be:e0:b5:53:22:33:
+                    91:82:50:90:25:ad:a6:53:83:3c:ce:0f:d7:8f:fb:
+                    96:fd
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Basic Constraints: critical
+                CA:TRUE
+            X509v3 Key Usage: critical
+                Certificate Sign, CRL Sign
+            X509v3 Subject Key Identifier: 
+                C4:53:3A:A2:91:57:6A:EF:FF:23:BD:2F:9C:61:3F:B9:3B:20:1F:B3
+            X509v3 Authority Key Identifier: 
+                C4:53:3A:A2:91:57:6A:EF:FF:23:BD:2F:9C:61:3F:B9:3B:20:1F:B3
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        21:f7:29:2e:b8:3b:cc:05:3d:3a:9a:87:01:2e:df:e6:5b:a2:
+        6f:5b:db:47:7c:92:14:fe:ca:df:39:5f:a9:60:ef:0f:16:fd:
+        09:55:84:70:c2:c5:61:19:65:fb:82:f3:72:35:78:fc:e4:08:
+        ea:12:2c:9a:0b:87:9b:99:70:a8:b0:f0:c2:ca:8c:40:fd:15:
+        2d:11:a3:09:f7:cd:20:32:d7:68:da:57:35:b8:d9:43:63:1e:
+        c5:ea:8c:5d:aa:84:3a:eb:f4:26:bd:8e:5d:87:c7:06:aa:a9:
+        7d:f8:16:25:5c:51:0b:6d:4e:8a:fd:c6:d7:6c:52:0d:cc:4f:
+        90:c1:1b:cf:83:1f:c2:b5:e9:aa:e4:16:d9:16:67:0e:4f:0f:
+        cc:f5:1e:e9:de:18:79:3d:f3:3f:b8:ce:f5:4a:41:bc:57:22:
+        3a:89:2b:6e:f0:aa:a0:06:61:08:e3:70:87:e4:a2:da:4b:a9:
+        59:7e:71:9a:6b:52:ac:d7:43:9d:42:e3:5b:89:cb:91:12:e0:
+        37:a8:bd:e3:8f:b3:8f:c3:28:de:70:0f:7e:5f:aa:89:77:c1:
+        44:5c:cd:56:db:30:b1:15:a3:83:82:be:a2:47:b9:af:4e:44:
+        f1:38:45:5f:1d:15:53:d3:a1:90:2e:40:75:4d:d7:c7:42:49:
+        3f:e7:6e:71
+```

--- a/playwright/BootTests/fixtures/satelliteFixtures.ts
+++ b/playwright/BootTests/fixtures/satelliteFixtures.ts
@@ -1,0 +1,23 @@
+// Command uses mock token
+export const registrationCurlCommand = `curl --silent --show-error 'https://localhost/register?activation_keys=my-key&download_utility=curl&location_id=2&organization_id=1&update_packages=false' --header 'Authorization: Bearer mock.eyJleHAiOjk5OTk5OTk5OTl9.mock'`; // not secret
+export const validRegistrationCommand = `set -o pipefail && ${registrationCurlCommand} | bash`;
+
+export const validCertificate = `-----BEGIN CERTIFICATE-----
+MIIDCDCCAfCgAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQKDApFeGFt
+cGxlIENBMB4XDTIwMTExODA3NTMzN1oXDTM1MTExODA3NTMzN1owFTETMBEGA1UE
+CgwKRXhhbXBsZSBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALHm
+fFYvVEtk1TIb2OHKoXiO4/1mXILBOi5mgxn49VT2YxWUO9E511iJg9j66yDlvJ0/
+AwZBc+TTEk5wG2HGviE307TShj6uSywD5/gf5Py00jITEjbyzjLdpzuh8W/C8g/0
+FQyIvpxfAwoiG1YB8a0l7Ejvx2tmSOyMDhNfBuS/OEiIMM9jiboLyEbhxKAhb3Q0
+cG2pBZmYpWRLm1G2raecR5Lcl2Bl5lMGvm1XUvmsGEF45m8T+6XxitJlfurGLYFz
+h3pUAfSAjnVp3KYAhbA2EVmSCo6OQfL9d6TbuecHMoGIXpMGBFLGvuC1UyIzkYJQ
+kCWtplODPM4P14/7lv0CAwEAAaNjMGEwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8B
+Af8EBAMCAQYwHQYDVR0OBBYEFMRTOqKRV2rv/yO9L5xhP7k7IB+zMB8GA1UdIwQY
+MBaAFMRTOqKRV2rv/yO9L5xhP7k7IB+zMA0GCSqGSIb3DQEBCwUAA4IBAQAh9yku
+uDvMBT06mocBLt/mW6JvW9tHfJIU/srfOV+pYO8PFv0JVYRwwsVhGWX7gvNyNXj8
+5AjqEiyaC4ebmXCosPDCyoxA/RUtEaMJ980gMtdo2lc1uNlDYx7F6oxdqoQ66/Qm
+vY5dh8cGqql9+BYlXFELbU6K/cbXbFINzE+QwRvPgx/Ctemq5BbZFmcOTw/M9R7p
+3hh5PfM/uM71SkG8VyI6iStu8KqgBmEI43CH5KLaS6lZfnGaa1Ks10OdQuNbicuR
+EuA3qL3jj7OPwyjecA9+X6qJd8FEXM1W2zCxFaODgr6iR7mvTkTxOEVfHRVT06GQ
+LkB1TdfHQkk/525x
+-----END CERTIFICATE-----`;


### PR DESCRIPTION
These tests are heavily inspired by AAP boot tests, they select Satellite registration and then check whether the registration command was ran and the certificate file exists.