### PR TITLE
Wizard: remove add and clear buttons from the LabelInput (HMS-9576)

### DIFF
--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -49,11 +49,11 @@ test('Create a blueprint with Kernel customization', async ({
     await frame.getByRole('button', { name: 'Menu toggle' }).click();
     await frame.getByRole('option', { name: 'kernel', exact: true }).click();
     await frame.getByPlaceholder('Add kernel argument').fill('rootwait');
-    await frame.getByRole('button', { name: 'Add kernel argument' }).click();
+    await frame.getByPlaceholder('Add kernel argument').press('Enter');
     await frame
       .getByPlaceholder('Add kernel argument')
       .fill('invalid$argument');
-    await frame.getByRole('button', { name: 'Add kernel argument' }).click();
+    await frame.getByPlaceholder('Add kernel argument').press('Enter');
     await expect(
       frame.getByText(
         'Expected format: <kernel-argument>. Example: console=tty0',
@@ -66,7 +66,7 @@ test('Create a blueprint with Kernel customization', async ({
     await expect(
       frame.getByRole('heading', { name: 'Warning alert: Custom kernel' }),
     ).toBeVisible();
-    await frame.getByRole('button', { name: 'Clear input' }).first().click();
+    await frame.getByPlaceholder('Select kernel package').fill('');
     await frame.getByRole('button', { name: 'Menu toggle' }).click();
     await expect(
       frame.getByRole('option', { name: 'new-package' }),
@@ -78,13 +78,13 @@ test('Create a blueprint with Kernel customization', async ({
       }),
     ).toBeVisible();
     await frame.getByPlaceholder('Add kernel argument').fill('console=tty0');
-    await frame.getByRole('button', { name: 'Add kernel argument' }).click();
+    await frame.getByPlaceholder('Add kernel argument').press('Enter');
     await frame.getByPlaceholder('Add kernel argument').fill('xxnosmp');
-    await frame.getByRole('button', { name: 'Add kernel argument' }).click();
+    await frame.getByPlaceholder('Add kernel argument').press('Enter');
     await frame
       .getByPlaceholder('Add kernel argument')
       .fill('console=ttyS0,115200n8');
-    await frame.getByRole('button', { name: 'Add kernel argument' }).click();
+    await frame.getByPlaceholder('Add kernel argument').press('Enter');
     await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 
@@ -102,7 +102,7 @@ test('Create a blueprint with Kernel customization', async ({
     await frame.getByRole('button', { name: 'Menu toggle' }).click();
     await frame.getByRole('option', { name: 'kernel', exact: true }).click();
     await frame.getByPlaceholder('Add kernel argument').fill('new=argument');
-    await frame.getByRole('button', { name: 'Add kernel argument' }).click();
+    await frame.getByPlaceholder('Add kernel argument').press('Enter');
     await frame.getByRole('button', { name: 'Close xxnosmp' }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
     await frame

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -50,37 +50,37 @@ test('Create a blueprint with Systemd customization', async ({
     await frame
       .getByPlaceholder('Add disabled service')
       .fill('systemd-dis.service');
-    await frame.getByRole('button', { name: 'Add disabled service' }).click();
+    await frame.getByPlaceholder('Add disabled service').press('Enter');
     await expect(frame.getByText('systemd-dis.service')).toBeVisible();
 
     await frame
       .getByPlaceholder('Add enabled service')
       .fill('systemd-en.service');
-    await frame.getByRole('button', { name: 'Add enabled service' }).click();
+    await frame.getByPlaceholder('Add enabled service').press('Enter');
     await expect(frame.getByText('systemd-en.service')).toBeVisible();
 
     await frame
       .getByPlaceholder('Add masked service')
       .fill('systemd-m.service');
-    await frame.getByRole('button', { name: 'Add masked service' }).click();
+    await frame.getByPlaceholder('Add masked service').press('Enter');
     await expect(frame.getByText('systemd-m.service')).toBeVisible();
   });
 
   await test.step('Select and incorrectly fill all of the service fields', async () => {
     await frame.getByPlaceholder('Add disabled service').fill('&&');
-    await frame.getByRole('button', { name: 'Add disabled service' }).click();
+    await frame.getByPlaceholder('Add disabled service').press('Enter');
     await expect(
       frame.getByText('Expected format: <service-name>. Example: sshd').nth(0),
     ).toBeVisible();
 
     await frame.getByPlaceholder('Add enabled service').fill('áá');
-    await frame.getByRole('button', { name: 'Add enabled service' }).click();
+    await frame.getByPlaceholder('Add enabled service').press('Enter');
     await expect(
       frame.getByText('Expected format: <service-name>. Example: sshd').nth(1),
     ).toBeVisible();
 
     await frame.getByPlaceholder('Add masked service').fill('78');
-    await frame.getByRole('button', { name: 'Add masked service' }).click();
+    await frame.getByPlaceholder('Add masked service').press('Enter');
     await expect(
       frame.getByText('Expected format: <service-name>. Example: sshd').nth(2),
     ).toBeVisible();
@@ -102,11 +102,11 @@ test('Create a blueprint with Systemd customization', async ({
     await frame
       .getByPlaceholder('Add disabled service')
       .fill('disabled-service');
-    await frame.getByRole('button', { name: 'Add disabled service' }).click();
+    await frame.getByPlaceholder('Add disabled service').press('Enter');
     await frame.getByPlaceholder('Add enabled service').fill('enabled-service');
-    await frame.getByRole('button', { name: 'Add enabled service' }).click();
+    await frame.getByPlaceholder('Add enabled service').press('Enter');
     await frame.getByPlaceholder('Add masked service').fill('masked-service');
-    await frame.getByRole('button', { name: 'Add masked service' }).click();
+    await frame.getByPlaceholder('Add masked service').press('Enter');
 
     await frame
       .getByRole('button', { name: 'Close systemd-m.service' })

--- a/playwright/Customizations/Timezone.spec.ts
+++ b/playwright/Customizations/Timezone.spec.ts
@@ -48,28 +48,28 @@ test('Create a blueprint with Timezone customization', async ({
     await frame.getByRole('button', { name: 'Timezone' }).click();
     await frame.getByPlaceholder('Select a timezone').fill('Canada');
     await frame.getByRole('option', { name: 'Canada/Saskatchewan' }).click();
-    await frame.getByRole('button', { name: 'Clear input' }).first().click();
+    await frame.getByPlaceholder('Select a timezone').fill('');
     await frame.getByPlaceholder('Select a timezone').fill('Europe');
     await frame.getByRole('option', { name: 'Europe/Stockholm' }).click();
 
     await frame.getByPlaceholder('Add NTP servers').fill('0.nl.pool.ntp.org');
-    await frame.getByRole('button', { name: 'Add NTP server' }).click();
+    await frame.getByPlaceholder('Add NTP servers').press('Enter');
     await expect(frame.getByText('0.nl.pool.ntp.org')).toBeVisible();
     await frame.getByPlaceholder('Add NTP servers').fill('0.nl.pool.ntp.org');
-    await frame.getByRole('button', { name: 'Add NTP server' }).click();
+    await frame.getByPlaceholder('Add NTP servers').press('Enter');
     await expect(frame.getByText('NTP server already exists.')).toBeVisible();
     await frame.getByPlaceholder('Add NTP servers').fill('xxxx');
-    await frame.getByRole('button', { name: 'Add NTP server' }).click();
+    await frame.getByPlaceholder('Add NTP servers').press('Enter');
     await expect(
       frame
         .getByText('Expected format: <ntp-server>. Example: time.redhat.com')
         .nth(0),
     ).toBeVisible();
     await frame.getByPlaceholder('Add NTP servers').fill('0.cz.pool.ntp.org');
-    await frame.getByRole('button', { name: 'Add NTP server' }).click();
+    await frame.getByPlaceholder('Add NTP servers').press('Enter');
     await expect(frame.getByText('0.cz.pool.ntp.org')).toBeVisible();
     await frame.getByPlaceholder('Add NTP servers').fill('0.de.pool.ntp.org');
-    await frame.getByRole('button', { name: 'Add NTP server' }).click();
+    await frame.getByPlaceholder('Add NTP servers').press('Enter');
     await expect(frame.getByText('0.de.pool.ntp.org')).toBeVisible();
     await frame
       .getByRole('button', { name: 'Close 0.cz.pool.ntp.org' })

--- a/playwright/Customizations/Users.spec.ts
+++ b/playwright/Customizations/Users.spec.ts
@@ -60,7 +60,7 @@ test('Create a blueprint with Users customization', async ({
       .getByRole('textbox', { name: 'blueprint user password' })
       .fill('AdminPass123');
     await frame.getByPlaceholder('Add user group').fill('wheel');
-    await frame.getByRole('button', { name: 'Add user group' }).click();
+    await frame.getByPlaceholder('Add user group').press('Enter');
 
     // Verify admin checkbox is automatically checked due to wheel group
     await expect(
@@ -321,7 +321,7 @@ test('Create a blueprint with Users customization', async ({
       .nth(2)
       .fill('AdminPass123');
     await frame.getByPlaceholder('Add user group').nth(2).fill('wheel');
-    await frame.getByRole('button', { name: 'Add user group' }).nth(2).click();
+    await frame.getByPlaceholder('Add user group').nth(2).press('Enter');
 
     // Verify admin checkbox is automatically checked due to wheel group
     await frame

--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -1,17 +1,13 @@
 import React, { useState } from 'react';
 
 import {
-  Button,
   HelperText,
   HelperTextItem,
-  Icon,
   Label,
   LabelGroup,
   TextInputGroup,
   TextInputGroupMain,
-  TextInputGroupUtilities,
 } from '@patternfly/react-core/dist/esm';
-import { PlusCircleIcon, TimesIcon } from '@patternfly/react-icons';
 import { UnknownAction } from 'redux';
 
 import { StepValidation } from './utilities/useValidation';
@@ -32,7 +28,6 @@ type LabelInputProps = {
   removeAction: (value: string) => UnknownAction;
   stepValidation: StepValidation;
   fieldName: string;
-  hideUtilities?: boolean;
 };
 
 const LabelInput = ({
@@ -47,7 +42,6 @@ const LabelInput = ({
   removeAction,
   stepValidation,
   fieldName,
-  hideUtilities,
 }: LabelInputProps) => {
   const dispatch = useAppDispatch();
 
@@ -128,17 +122,8 @@ const LabelInput = ({
     }
   };
 
-  const handleAddItem = (e: React.MouseEvent, value: string) => {
-    addItem(value);
-  };
-
   const handleRemoveItem = (e: React.MouseEvent, value: string) => {
     dispatch(removeAction(value));
-  };
-
-  const handleClear = () => {
-    setInputValue('');
-    setOnStepInputErrorText('');
   };
 
   const errors = [];
@@ -172,28 +157,6 @@ const LabelInput = ({
             </LabelGroup>
           )}
         </TextInputGroupMain>
-        {!hideUtilities && (
-          <TextInputGroupUtilities>
-            <Button
-              icon={
-                <Icon status='info'>
-                  <PlusCircleIcon />
-                </Icon>
-              }
-              variant='plain'
-              onClick={(e) => handleAddItem(e, inputValue)}
-              isDisabled={!inputValue}
-              aria-label={ariaLabel}
-            />
-            <Button
-              icon={<TimesIcon />}
-              variant='plain'
-              onClick={handleClear}
-              isDisabled={!inputValue}
-              aria-label='Clear input'
-            />
-          </TextInputGroupUtilities>
-        )}
       </TextInputGroup>
       {errors.length > 0 && (
         <HelperText>

--- a/src/Components/CreateImageWizard/steps/Firewall/components/PortsInput.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/components/PortsInput.tsx
@@ -29,7 +29,6 @@ const PortsInput = () => {
         removeAction={removePort}
         stepValidation={stepValidation}
         fieldName='ports'
-        hideUtilities
       />
     </FormGroup>
   );

--- a/src/Components/CreateImageWizard/steps/Firewall/components/Services.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/components/Services.tsx
@@ -33,7 +33,6 @@ const Services = () => {
           removeAction={removeEnabledFirewallService}
           stepValidation={stepValidation}
           fieldName='enabledServices'
-          hideUtilities
         />
       </FormGroup>
       <FormGroup label='Disabled services'>
@@ -47,7 +46,6 @@ const Services = () => {
           removeAction={removeDisabledFirewallService}
           stepValidation={stepValidation}
           fieldName='disabledServices'
-          hideUtilities
         />
       </FormGroup>
     </>

--- a/src/test/Components/CreateImageWizard/steps/Kernel/Kernel.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Kernel/Kernel.test.tsx
@@ -93,10 +93,8 @@ const selectCustomKernelName = async (kernelName: string) => {
 
 const clearKernelName = async () => {
   const user = userEvent.setup();
-  const kernelNameClearBtn = await screen.findAllByRole('button', {
-    name: /clear input/i,
-  });
-  await waitFor(() => user.click(kernelNameClearBtn[0]));
+  const kernelNameDropdown = await getKernelNameOptions();
+  await waitFor(() => user.clear(kernelNameDropdown));
 };
 
 const addKernelAppend = async (kernelArg: string) => {
@@ -104,13 +102,7 @@ const addKernelAppend = async (kernelArg: string) => {
   const kernelAppendInput = await screen.findByPlaceholderText(
     'Add kernel argument',
   );
-  await waitFor(() => user.click(kernelAppendInput));
-  await waitFor(() => user.type(kernelAppendInput, kernelArg));
-
-  const addKernelArg = await screen.findByRole('button', {
-    name: /Add kernel argument/,
-  });
-  await waitFor(() => user.click(addKernelArg));
+  await waitFor(() => user.type(kernelAppendInput, `${kernelArg}{enter}`));
 };
 
 const removeKernelArg = async (kernelArg: string) => {

--- a/src/test/Components/CreateImageWizard/steps/Services/Services.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Services/Services.test.tsx
@@ -151,9 +151,14 @@ describe('Step Services', () => {
     const user = userEvent.setup();
     await renderCreateMode();
     await goToServicesStep();
-    const clearInputButtons = await screen.findAllByRole('button', {
-      name: /clear input/i,
-    });
+    const enabledServiceInput = await screen.findByPlaceholderText(
+      'Add enabled service',
+    );
+    const disabledServiceInput = await screen.findByPlaceholderText(
+      'Add disabled service',
+    );
+    const maskedServiceInput =
+      await screen.findByPlaceholderText('Add masked service');
 
     // Enabled services input
     expect(screen.queryByText('Invalid format.')).not.toBeInTheDocument();
@@ -161,7 +166,7 @@ describe('Step Services', () => {
     expect(
       await screen.findByText('Expected format: <service-name>. Example: sshd'),
     ).toBeInTheDocument();
-    await waitFor(() => user.click(clearInputButtons[0]));
+    await waitFor(() => user.clear(enabledServiceInput));
 
     // Disabled services input
     expect(screen.queryByText('Invalid format.')).not.toBeInTheDocument();
@@ -169,7 +174,7 @@ describe('Step Services', () => {
     expect(
       await screen.findByText('Expected format: <service-name>. Example: sshd'),
     ).toBeInTheDocument();
-    await waitFor(() => user.click(clearInputButtons[1]));
+    await waitFor(() => user.clear(disabledServiceInput));
 
     // Masked services input
     expect(screen.queryByText('Invalid format.')).not.toBeInTheDocument();
@@ -177,7 +182,7 @@ describe('Step Services', () => {
     expect(
       await screen.findByText('Expected format: <service-name>. Example: sshd'),
     ).toBeInTheDocument();
-    await waitFor(() => user.click(clearInputButtons[2]));
+    await waitFor(() => user.clear(maskedServiceInput));
 
     // Enabled services input
     expect(screen.queryByText('Invalid format.')).not.toBeInTheDocument();
@@ -185,7 +190,7 @@ describe('Step Services', () => {
     expect(
       await screen.findByText('Expected format: <service-name>. Example: sshd'),
     ).toBeInTheDocument();
-    await waitFor(() => user.click(clearInputButtons[0]));
+    await waitFor(() => user.clear(enabledServiceInput));
   });
 
   test('services from OpenSCAP get added correctly and cannot be removed', async () => {

--- a/src/test/Components/CreateImageWizard/steps/Timezone/Timezone.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Timezone/Timezone.test.tsx
@@ -38,16 +38,7 @@ const selectTimezone = async () => {
   const timezoneDropdown =
     await screen.findByPlaceholderText(/select a timezone/i);
   await waitFor(() => user.click(timezoneDropdown));
-
-  const clearButtons = screen.queryAllByRole('button', {
-    name: /clear input/i,
-  });
-  if (clearButtons.length > 0) {
-    const clearBtn = clearButtons[0] as HTMLButtonElement;
-    if (!clearBtn.disabled) {
-      await waitFor(() => user.click(clearBtn));
-    }
-  }
+  await waitFor(() => user.clear(timezoneDropdown));
   await waitFor(() => user.type(timezoneDropdown, 'Europe/Am'));
   const amsterdamTimezone = await screen.findByText('Europe/Amsterdam');
   await waitFor(() => user.click(amsterdamTimezone));
@@ -72,19 +63,14 @@ const addNtpServerViaAddButton = async (ntpServer: string) => {
   const user = userEvent.setup();
   const ntpServersInput =
     await screen.findByPlaceholderText(/add ntp servers/i);
-  const addServerBtn = await screen.findByRole('button', {
-    name: /add ntp server/i,
-  });
-  await waitFor(() => user.type(ntpServersInput, ntpServer));
-  await waitFor(() => user.click(addServerBtn));
+  await waitFor(() => user.type(ntpServersInput, ntpServer + '{enter}'));
 };
 
 const clearInput = async () => {
   const user = userEvent.setup();
-  const clearInputBtns = await screen.findAllByRole('button', {
-    name: /clear input/i,
-  });
-  await waitFor(() => user.click(clearInputBtns[clearInputBtns.length - 1]));
+  const ntpServersInput =
+    await screen.findByPlaceholderText(/add ntp servers/i);
+  await waitFor(() => user.clear(ntpServersInput));
 };
 
 const clickRevisitButton = async () => {


### PR DESCRIPTION
These two buttons are no longer used anywhere in the Figma mocks, so I removed them and edited the old tests so they are not looking for them.