### PR TITLE
Wizard: list all red hat and custom repos (HMS-8853, HMS-8854)

### DIFF
--- a/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
@@ -82,7 +82,7 @@ test('Content integration test - Non repeatable build - URL source', async ({
   });
 
   await test.step('Select the repository', async () => {
-    await frame.getByRole('button', { name: 'Custom repositories' }).click();
+    await frame.getByRole('button', { name: 'Repositories' }).click();
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
@@ -223,7 +223,7 @@ test('Content integration test - Non repeatable build - Upload source', async ({
   });
 
   await test.step('Select the repository', async () => {
-    await frame.getByRole('button', { name: 'Custom repositories' }).click();
+    await frame.getByRole('button', { name: 'Repositories' }).click();
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
@@ -331,7 +331,7 @@ test('Content integration test - Non repeatable build - Community repository', a
   });
 
   await test.step('Select the repository', async () => {
-    await frame.getByRole('button', { name: 'Custom repositories' }).click();
+    await frame.getByRole('button', { name: 'Repositories' }).click();
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -565,7 +565,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 <SnapshotStep />
               </WizardStep>,
               <WizardStep
-                name='Custom repositories'
+                name='Repositories'
                 id='wizard-custom-repositories'
                 key='wizard-custom-repositories'
                 navItem={CustomStatusNavItem}

--- a/src/Components/CreateImageWizard/steps/Repositories/components/Empty.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/Empty.tsx
@@ -22,9 +22,7 @@ const Empty = ({ hasFilterValue, refetch }: EmptyProps) => {
       headingLevel='h4'
       icon={RepositoryIcon}
       titleText={
-        hasFilterValue
-          ? 'No matching repositories found'
-          : 'No custom repositories'
+        hasFilterValue ? 'No matching repositories found' : 'No repositories'
       }
       variant={EmptyStateVariant.lg}
     >

--- a/src/Components/CreateImageWizard/steps/Repositories/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/index.tsx
@@ -18,11 +18,11 @@ const RepositoriesStep = () => {
   return (
     <Form>
       <Title headingLevel='h1' size='xl'>
-        Custom repositories
+        Repositories
       </Title>
       <Content>
-        Select the linked custom repositories from which you can add packages to
-        the image
+        Select the linked repositories from which you can add packages to the
+        image
         <Content>
           <ManageRepositoriesButton />
         </Content>

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -539,14 +539,14 @@ export const ContentList = () => {
                 component={ContentVariants.dt}
                 className='pf-v6-u-min-width'
               >
-                Custom repositories
+                Repositories
               </Content>
               <Content component={ContentVariants.dd}>
                 {customRepositories.length + recommendedRepositories.length >
                 0 ? (
                   <Popover
                     position='bottom'
-                    headerContent='Custom repositories'
+                    headerContent='Repositories'
                     hasAutoWidth
                     minWidth='30rem'
                     bodyContent={<RepositoriesTable />}

--- a/src/Utilities/requiredRedHatRepos.ts
+++ b/src/Utilities/requiredRedHatRepos.ts
@@ -1,0 +1,41 @@
+export const requiredRedHatRepos = (
+  arch?: string,
+  version?: string,
+): string[] | undefined => {
+  if (!arch || !version) return;
+  switch (true) {
+    case arch === 'x86_64' && version === '8':
+      return [
+        'https://cdn.redhat.com/content/dist/rhel8/8/x86_64/appstream/os/',
+        'https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/',
+      ];
+    case arch === 'x86_64' && version === '9':
+      return [
+        'https://cdn.redhat.com/content/dist/rhel9/9/x86_64/appstream/os/',
+        'https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/',
+      ];
+    case arch === 'x86_64' && version === '10':
+      return [
+        'https://cdn.redhat.com/content/dist/rhel10/10/x86_64/appstream/os/',
+        'https://cdn.redhat.com/content/dist/rhel10/10/x86_64/baseos/os/',
+      ];
+    case arch === 'aarch64' && version === '8':
+      return [
+        'https://cdn.redhat.com/content/dist/rhel8/8/aarch64/appstream/os/',
+        'https://cdn.redhat.com/content/dist/rhel8/8/aarch64/baseos/os/',
+      ];
+    case arch === 'aarch64' && version === '9':
+      return [
+        'https://cdn.redhat.com/content/dist/rhel9/9/aarch64/appstream/os/',
+        'https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os/',
+      ];
+    case arch === 'aarch64' && version === '10':
+      return [
+        'https://cdn.redhat.com/content/dist/rhel10/10/aarch64/appstream/os/',
+        'https://cdn.redhat.com/content/dist/rhel10/10/aarch64/baseos/os/',
+      ];
+
+    default:
+      return;
+  }
+};

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -80,7 +80,7 @@ describe('Create Image Wizard', () => {
       await screen.findByRole('button', { name: /Register/ });
       await screen.findByRole('button', { name: 'Security' });
       await screen.findByRole('button', { name: 'Repeatable build' });
-      await screen.findByRole('button', { name: 'Custom repositories' });
+      await screen.findByRole('button', { name: 'Repositories' });
       await screen.findByRole('button', {
         name: 'First boot script configuration',
       });

--- a/src/test/Components/CreateImageWizard/EditImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/EditImageWizard.test.tsx
@@ -43,7 +43,7 @@ describe('EditImageWizard', () => {
       name: /repeatable build/i,
     });
     const repositoriesNavItem = within(navigation).getByRole('button', {
-      name: /custom repositories/i,
+      name: /repositories/i,
     });
     const packagesNavItem = within(navigation).getByRole('button', {
       name: /additional packages/i,

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -189,12 +189,12 @@ describe('Step Packages', () => {
     });
   });
 
-  test('clicking Back loads Custom repositories', async () => {
+  test('clicking Back loads Repositories', async () => {
     await renderCreateMode();
     await goToPackagesStep();
     await clickBack();
     await screen.findByRole('heading', {
-      name: 'Custom repositories',
+      name: 'Repositories',
     });
   });
 
@@ -400,7 +400,7 @@ describe('Step Packages', () => {
     await clickFirstPackageCheckbox();
     await goToReview();
     await clickRevisitButton();
-    await screen.findByRole('heading', { name: /Custom repositories/ });
+    await screen.findByRole('heading', { name: /Repositories/ });
   });
 
   describe('Pagination', () => {

--- a/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
@@ -36,7 +36,7 @@ const goToRepositoriesStep = async () => {
   await waitFor(() => user.click(guestImageCheckBox));
   await clickNext(); // Registration
   await clickRegisterLater();
-  await goToStep(/Custom repositories/);
+  await goToStep(/Repositories/);
 };
 
 const clickRevisitButton = async () => {
@@ -219,7 +219,7 @@ describe('Step Custom repositories', () => {
     await selectFirstRepository();
     await goToReview();
     await clickRevisitButton();
-    await screen.findByRole('heading', { name: /Custom repositories/ });
+    await screen.findByRole('heading', { name: /Repositories/ });
   });
 });
 
@@ -354,7 +354,7 @@ describe('Repositories edit mode', () => {
     await renderEditMode(id);
 
     const customRepositories = await screen.findByRole('button', {
-      name: /Custom repositories/,
+      name: /Repositories/,
     });
 
     await waitFor(() => user.click(customRepositories));

--- a/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
@@ -199,7 +199,7 @@ describe('repository snapshot tab - ', () => {
     const snapshotMethodElement = await getSnapshotMethodElement();
     // Check date was recorded correctly
     expect(snapshotMethodElement).toHaveTextContent('State as of 2024-04-22');
-    // Check that the button is clickable (has 1 repo selected)
+    // Check that the button is not clickable (has 0 repos selected)
     await waitFor(() => {
       expect(snapshotMethodElement).toBeDisabled();
     });
@@ -294,7 +294,7 @@ describe('repository snapshot tab - ', () => {
     await clickNext();
     await goToReview();
     await clickRevisitButton();
-    await screen.findByRole('heading', { name: /Custom repositories/i });
+    await screen.findByRole('heading', { name: /Repositories/i });
   });
 
   test('select use a content template', async () => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -66,6 +66,8 @@ vi.mock('@unleash/proxy-client-react', () => ({
         return true;
       case 'image-builder.compliance.enabled':
         return true;
+      case 'image-builder.layered-repos.enabled':
+        return true;
       default:
         return false;
     }


### PR DESCRIPTION
Jira: [HMS-8853](https://issues.redhat.com/browse/HMS-8853), [HMS-8854](https://issues.redhat.com/browse/HMS-8854)

- Renames the "Custom repositories" step to "Repositories"
- Based on a feature flag, includes Red Hat repositories in the Repositories step in the wizard
- BaseOS and Appstream repositories for the selected arch/OS version should be pre-selected and not able to be removed
- Packages from layered repositories are searchable on the Packages step of the wizard
- Image builds with layered repositories (like RHEL - High Availability) should succeed