### PR TITLE
ghaction/release: Pass Slack bot token instead of webhook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: osbuild/release-action@main
         with:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
-          slack_webhook_url: "${{ secrets.SLACK_WEBHOOK_URL }}"
+          slack_bot_token: "${{ secrets.SLACK_BOT_TOKEN }}"
 
       # upload release artefact
       # Source0 expands to `https://github.com/osbuild/image-builder-frontend/releases/download/v$VERSION/cockpit-image-builder-v$VERSION.tar.gz`,


### PR DESCRIPTION
We have updated our Slack integration to use a Slack bot token instead of a webhook to be able to post threaded responses or react to messages. For reference see: https://github.com/osbuild/release-action/pull/35