### PR TITLE
API: Comment out provisioning URL in codegen

### DIFF
--- a/api/codegen.sh
+++ b/api/codegen.sh
@@ -4,7 +4,7 @@
 npx @rtk-query/codegen-openapi ./api/config/imageBuilder.ts &
 npx @rtk-query/codegen-openapi ./api/config/rhsm.ts &
 npx @rtk-query/codegen-openapi ./api/config/contentSources.ts &
-npx @rtk-query/codegen-openapi ./api/config/provisioning.ts &
+# npx @rtk-query/codegen-openapi ./api/config/provisioning.ts &
 npx @rtk-query/codegen-openapi ./api/config/compliance.ts &
 npx @rtk-query/codegen-openapi ./api/config/composerCloudApi.ts &
 


### PR DESCRIPTION
This disables re-generating provisioning API schema from the original URL. The API was decommissioned and is no longer available.

A follow up PR to clean up the rest of provisioning from the codebase will be required, but this should fix an issue with failing manual changes check in the CI.