### PR TITLE
playwright: Add wait time and extra check

### DIFF
--- a/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
@@ -94,6 +94,14 @@ test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
     await frame.getByRole('button', { name: 'None' }).click();
     await frame.getByRole('option', { name: policyName }).click();
     await expect(frame.getByRole('button', { name: policyName })).toBeVisible(); // Wait for the policy to get selected
+    await page.waitForTimeout(3000); // Slow down execution to let the policy customizations load
+    await frame
+      .getByLabel('Wizard steps')
+      .getByRole('button', { name: 'Additional packages' })
+      .click();
+    await expect(
+      frame.getByRole('button', { name: /selected \(\d+\)/i }),
+    ).toBeVisible();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 


### PR DESCRIPTION
This adds a short wait time to the compliance boot test to allow space for the policy customizations to get applied to the image.

Extra check for the presence of package required by OpenSCAP was added. This shouldn't be the complete check of applied customizations as the other (kernel, services, ...) are missing. The check should be an indication of customizations not being applied timely.