### PR TITLE
Wizard: wait for changes triggered by selecting a policy (HMS-9787)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -73,6 +73,7 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
   const hasWslTargetOnly = useHasSpecificTargetOnly('wsl');
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
   const {
     clearCompliancePackages,
     handleKernelAppend,
@@ -145,12 +146,7 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
       // handle user has selected 'None' case
       handleClear();
     } else {
-      dispatch(
-        setCompliancePolicy({
-          policyID: selection.policyID,
-          policyTitle: selection.title,
-        }),
-      );
+      setIsApplying(true);
       const oldOscapPackages = currentProfileData?.packages || [];
       trigger(
         {
@@ -172,7 +168,14 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
           handleServices(response.services);
           handleKernelAppend(response.kernel?.append);
           dispatch(changeFips(response?.fips?.enabled || false));
-        });
+          dispatch(
+            setCompliancePolicy({
+              policyID: selection.policyID,
+              policyTitle: selection.title,
+            }),
+          );
+        })
+        .finally(() => setIsApplying(false));
     }
   };
 
@@ -223,11 +226,19 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
       ref={toggleRef}
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
-      isDisabled={isDisabled || isFetchingPolicies || hasWslTargetOnly}
+      isDisabled={
+        isDisabled || isFetchingPolicies || hasWslTargetOnly || isApplying
+      }
       isFullWidth
       style={{ maxWidth: 'none' }}
     >
-      {policyTitle || 'None'}
+      {isApplying ? (
+        <>
+          <Spinner size='sm' /> Applying policy...
+        </>
+      ) : (
+        policyTitle || 'None'
+      )}
     </MenuToggle>
   );
 


### PR DESCRIPTION
The buggy behavior of PolicySelector.tsx was this:
1. Show the selected policy name in the selector
2. Start async trigger to change additional packages, services, and kernel args

This made the boot tests crash, because PW is simply too fast, and the trigger didn't finish.
This PR fixes that behavior by showing the policy name as the trigger applies changes. But I'm conflicted - we are losing the point of the async trigger by waiting for it to finish to show the changes, and a user would never be that fast to achieve this problem. So for the sake of tests passing, and to make it more user friendly, I added an indicator for the user to see that changes are being applied.
But I'm thinking that maybe letting the name change in the selector before the trigger ends and forcing the tests to wait a bit could be a better option. What do you think @regexowl @tkoscieln ?