### PR TITLE
Wizard/Filesystem: Add alert for large file systems

### DIFF
--- a/src/Components/CreateImageWizard/FilesystemSizeAlert.tsx
+++ b/src/Components/CreateImageWizard/FilesystemSizeAlert.tsx
@@ -3,15 +3,24 @@ import React from 'react';
 import { Alert } from '@patternfly/react-core';
 
 import { UNIT_GIB } from '../../constants';
+import { ImageTypes } from '../../store/imageBuilderApi';
 
 type FilesystemSizeAlertProps = {
   totalSizeBytes: number;
+  imageTypes: ImageTypes[];
 };
 
-const FilesystemSizeAlert = ({ totalSizeBytes }: FilesystemSizeAlertProps) => {
+const FilesystemSizeAlert = ({
+  totalSizeBytes,
+  imageTypes,
+}: FilesystemSizeAlertProps) => {
   const threshold = 99 * UNIT_GIB;
 
-  if (totalSizeBytes <= threshold) {
+  // Only show alert for Azure and AWS targets
+  const targetTypes: ImageTypes[] = ['aws', 'ami', 'azure'];
+  const shouldShowAlert = imageTypes.some((type) => targetTypes.includes(type));
+
+  if (totalSizeBytes <= threshold || !shouldShowAlert) {
     return null;
   }
 
@@ -30,4 +39,3 @@ const FilesystemSizeAlert = ({ totalSizeBytes }: FilesystemSizeAlertProps) => {
 };
 
 export default FilesystemSizeAlert;
-

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/AdvancedPartitioning.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/AdvancedPartitioning.tsx
@@ -12,7 +12,6 @@ import { v4 as uuidv4 } from 'uuid';
 
 import FileSystemTable from './FileSystemTable';
 import VolumeGroups from './VolumeGroups';
-import { calculateTotalDiskSize } from '../fscUtilities';
 
 import { PARTITIONING_URL } from '../../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
@@ -21,13 +20,16 @@ import {
   changeDiskMinsize,
   selectDiskMinsize,
   selectDiskPartitions,
+  selectImageTypes,
 } from '../../../../../store/wizardSlice';
 import FilesystemSizeAlert from '../../../FilesystemSizeAlert';
+import { calculateTotalDiskSize } from '../fscUtilities';
 
 const AdvancedPartitioning = () => {
   const dispatch = useAppDispatch();
   const minsize = useAppSelector(selectDiskMinsize);
   const diskPartitions = useAppSelector(selectDiskPartitions);
+  const imageTypes = useAppSelector(selectImageTypes);
 
   const totalSizeBytes = useMemo(
     () => calculateTotalDiskSize(diskPartitions, minsize),
@@ -100,7 +102,10 @@ const AdvancedPartitioning = () => {
           </Button>
         </Content>
       </Content>
-      <FilesystemSizeAlert totalSizeBytes={totalSizeBytes} />
+      <FilesystemSizeAlert
+        totalSizeBytes={totalSizeBytes}
+        imageTypes={imageTypes}
+      />
       <FormGroup label='Minimum disk size'>
         <TextInput
           aria-label='Minimum disk size input'

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
@@ -10,7 +10,6 @@ import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { v4 as uuidv4 } from 'uuid';
 
 import FileSystemTable from './FileSystemTable';
-import { calculateTotalFilesystemSize } from '../fscUtilities';
 
 import {
   FILE_SYSTEM_CUSTOMIZATION_URL,
@@ -25,6 +24,7 @@ import {
 } from '../../../../../store/wizardSlice';
 import FilesystemSizeAlert from '../../../FilesystemSizeAlert';
 import UsrSubDirectoriesDisabled from '../../../UsrSubDirectoriesDisabled';
+import { calculateTotalFilesystemSize } from '../fscUtilities';
 
 const FileSystemConfiguration = () => {
   const environments = useAppSelector(selectImageTypes);
@@ -101,7 +101,10 @@ const FileSystemConfiguration = () => {
           )} images`}
         />
       )}
-      <FilesystemSizeAlert totalSizeBytes={totalSizeBytes} />
+      <FilesystemSizeAlert
+        totalSizeBytes={totalSizeBytes}
+        imageTypes={environments}
+      />
       <FileSystemTable partitions={filesystemPartitions} mode='filesystem' />
       <Content>
         <Button

--- a/src/Components/CreateImageWizard/steps/FileSystem/fscUtilities.ts
+++ b/src/Components/CreateImageWizard/steps/FileSystem/fscUtilities.ts
@@ -90,8 +90,7 @@ export const calculateTotalDiskSize = (
       // For LVM, sum up all logical volumes
       const lvTotal = partition.logical_volumes.reduce((lvSum, lv) => {
         const sizeInBytes =
-          parseInt(lv.min_size || '0') *
-          getConversionFactor(lv.unit || 'GiB');
+          parseInt(lv.min_size || '0') * getConversionFactor(lv.unit || 'GiB');
         return lvSum + sizeInBytes;
       }, 0);
       return total + lvTotal;

--- a/src/test/Components/CreateImageWizard/steps/FileSystem/fscUtilities.test.ts
+++ b/src/test/Components/CreateImageWizard/steps/FileSystem/fscUtilities.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../../../../constants';
+import {
+  DiskPartition,
+  FilesystemPartition,
+} from '../../../../../Components/CreateImageWizard/steps/FileSystem/fscTypes';
 import {
   calculateTotalDiskSize,
   calculateTotalFilesystemSize,
   parseMinDiskSize,
 } from '../../../../../Components/CreateImageWizard/steps/FileSystem/fscUtilities';
-import {
-  DiskPartition,
-  FilesystemPartition,
-} from '../../../../../Components/CreateImageWizard/steps/FileSystem/fscTypes';
+import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../../../../constants';
 
 describe('fscUtilities size calculation functions', () => {
   describe('calculateTotalFilesystemSize', () => {
@@ -94,8 +94,7 @@ describe('fscUtilities size calculation functions', () => {
         },
       ];
 
-      const expected =
-        10 * UNIT_GIB + 500 * UNIT_MIB + 1024 * UNIT_KIB + 2048;
+      const expected = 10 * UNIT_GIB + 500 * UNIT_MIB + 1024 * UNIT_KIB + 2048;
       expect(calculateTotalFilesystemSize(partitions)).toBe(expected);
     });
 
@@ -365,9 +364,7 @@ describe('fscUtilities size calculation functions', () => {
         },
       ];
 
-      expect(calculateTotalDiskSize(partitions, '10 GiB')).toBe(
-        100 * UNIT_GIB
-      );
+      expect(calculateTotalDiskSize(partitions, '10 GiB')).toBe(100 * UNIT_GIB);
     });
 
     it('should ignore minDiskSize when empty', () => {
@@ -462,9 +459,8 @@ describe('fscUtilities size calculation functions', () => {
     it('should return minDiskSize when partitions are empty', () => {
       const partitions: DiskPartition[] = [];
       expect(calculateTotalDiskSize(partitions, '100 GiB')).toBe(
-        100 * UNIT_GIB
+        100 * UNIT_GIB,
       );
     });
   });
 });
-


### PR DESCRIPTION
When users build images with large file systems we want to warn them about long build and upload times for those images. The informational alert may lead to them reconsidering or manage their expectation about the build process.
We've seen reports from users who did not make this connection and were puzzled by long build times.

<img width="2306" height="648" alt="image" src="https://github.com/user-attachments/assets/d5a574a4-3d7d-4ce1-852b-cd26beacd9e4" />

This works for both the basic and the advanced partitioning mode.

**Caveats:**
1. The current size limit for the alert is hardcoded at >99GB.
2. I'm not sure about the 'minimum size' input box in the advanced partitioning mode (currently it's simply taken into account separately).
3. I'm not sure about the position and copy of the alert.
4. This should be reviewed with UXD.