### PR TITLE
onPrem: Update FS types to fix image builds

### DIFF
--- a/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
+++ b/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
@@ -222,7 +222,7 @@ export const mapHostedToOnPrem = (
       (fs) => {
         return {
           mountpoint: fs.mountpoint,
-          minsize: fs.min_size,
+          min_size: fs.min_size,
         };
       },
     );

--- a/src/store/cockpit/composerCloudApi.ts
+++ b/src/store/cockpit/composerCloudApi.ts
@@ -774,7 +774,7 @@ export type BlueprintCustomizations = {
   firewall?: BlueprintFirewall | undefined;
   services?: Services | undefined;
   /** List of filesystem mountpoints to create */
-  filesystem?: BlueprintFilesystem[] | undefined;
+  filesystem?: Filesystem[] | undefined;
   disk?: Disk | undefined;
   dnf?: Dnf | undefined;
   /** Name of the installation device, currently only useful for the edge-simplified-installer type


### PR DESCRIPTION
Image builds were failing due to type mismatch/typo in mapper.