### PR TITLE
onPrem: Set minimum wizard height (HMS-9784)

### DIFF
--- a/src/AppCockpit.scss
+++ b/src/AppCockpit.scss
@@ -69,6 +69,10 @@
   padding-inline: 0;
 }
 
+.pf-v6-c-wizard {
+  min-height: 80vh;
+}
+
 .pf-v6-c-card {
   &.pf-m-clickable::before,
   &.pf-m-selectable::before {


### PR DESCRIPTION
This sets minimum Wizard height to '80vh'.

<img width="1261" height="1213" alt="image" src="https://github.com/user-attachments/assets/b4146c25-4ffd-41a7-9b44-e11b8a4a9550" />

It's a bit hacky, but seems to work.

JIRA: [HMS-9784](https://issues.redhat.com/browse/HMS-9784)