### PR TITLE
onPrem: Add margin to main section (HMS-9783)

### DIFF
--- a/src/AppCockpit.scss
+++ b/src/AppCockpit.scss
@@ -63,6 +63,7 @@
 .pf-v6-c-page__main-section {
   padding-inline: 0;
   padding-block-start: 0;
+  margin: 15px;
 }
 
 .pf-v6-c-page__main > section.pf-v6-c-page__main-section:not(.pf-m-padding) {


### PR DESCRIPTION
This adds margin of 15px to main section so its content is not glued to the border of the section.

<img width="1512" height="1146" alt="image" src="https://github.com/user-attachments/assets/6a633eda-d438-4686-8e2a-53cf9cb3aac9" />

Again, not the most elegant solution, but :shrug: 

JIRA: [HMS-9783](https://issues.redhat.com/browse/HMS-9783)