### PR TITLE
store/cockpit: explicitly set fs `min_size` (HMS-9781)

### DIFF
--- a/src/store/cockpit/cockpitApi.ts
+++ b/src/store/cockpit/cockpitApi.ts
@@ -169,6 +169,12 @@ const toCloudAPIComposeRequest = (
   const customizations = mapHostedToOnPrem(blueprint as CreateBlueprintRequest)
     .customizations as Customizations;
 
+  if (blueprint.customizations?.filesystem) {
+    // use the blueprint fs customization since this has the same
+    // value for `min_size`. The on-prem bp uses `minsize` instead.
+    customizations!.filesystem = blueprint.customizations.filesystem;
+  }
+
   if (blueprint.customizations?.subscription) {
     const { subscription } = blueprint.customizations;
     customizations!.subscription = {


### PR DESCRIPTION
Use the original blueprint filesystem customization since the on-prem
customization for `BlueprintFilesystem` uses `minsize` rather than
`min_size`. This change essentially ignores the filesystem customization
convertion from `mapHostedToOnPrem`.

JIRA: [HMS-9781](https://issues.redhat.com/browse/HMS-9781)