### PR TITLE
store/cockpit: correct users customization

### DIFF
--- a/src/store/cockpit/cockpitApi.ts
+++ b/src/store/cockpit/cockpitApi.ts
@@ -13,6 +13,8 @@ import { v4 as uuidv4 } from 'uuid';
 
 import type {
   Blueprint as CloudApiBlueprint,
+  ComposeRequest as CloudApiComposeRequest,
+  ImageTypes as CloudApiImageTypes,
   Customizations,
 } from './composerCloudApi';
 // We have to work around RTK query here, since it doesn't like splitting
@@ -162,7 +164,7 @@ export const toCloudAPIComposeRequest = (
   blueprint: CockpitCreateBlueprintRequest,
   distribution: string,
   image_requests: CockpitImageRequest[],
-) => {
+): CloudApiComposeRequest => {
   // subscription, users & openscap are the only options
   // that aren't compatibile with the on-prem customizations,
   // so we have to handle those separately
@@ -182,9 +184,11 @@ export const toCloudAPIComposeRequest = (
 
   if (users) {
     customizations.users = users.map((user) => {
-      const { ssh_key, ...options } = user;
+      const { ssh_key, groups, password } = user;
       return {
-        ...options,
+        name: user.name,
+        ...(groups && { groups: groups }),
+        ...(password && { password: password }),
         ...(ssh_key && { key: ssh_key }),
       };
     });
@@ -207,7 +211,7 @@ export const toCloudAPIComposeRequest = (
     customizations,
     image_requests: image_requests.map((ir) => ({
       architecture: ir.architecture,
-      image_type: ir.image_type,
+      image_type: ir.image_type as CloudApiImageTypes,
       repositories: [],
       upload_targets: [
         {

--- a/src/test/store/cockpit/cockpitApi.test.ts
+++ b/src/test/store/cockpit/cockpitApi.test.ts
@@ -68,6 +68,7 @@ describe('toCloudAPIComposeRequest', () => {
               name: 'admin',
               groups: ['wheel'],
               ssh_key: 'ssh-rsa AAAAB3...',
+              hasPassword: false,
             },
           ],
         },
@@ -111,7 +112,7 @@ describe('toCloudAPIComposeRequest', () => {
 
       const result = toCloudAPIComposeRequest(blueprint, 'rhel-9', []);
 
-      expect(result.customizations.subscription).toEqual({
+      expect(result.customizations?.subscription).toEqual({
         organization: '12345', // converted to string
         activation_key: 'my-activation-key', // underscore instead of hyphen
         server_url: 'https://subscription.rhsm.redhat.com',
@@ -142,7 +143,7 @@ describe('toCloudAPIComposeRequest', () => {
 
       const result = toCloudAPIComposeRequest(blueprint, 'rhel-9', []);
 
-      expect(result.customizations.subscription).toEqual({
+      expect(result.customizations?.subscription).toEqual({
         organization: '67890',
         activation_key: 'key123',
         server_url: 'https://server.example.com',
@@ -177,9 +178,9 @@ describe('toCloudAPIComposeRequest', () => {
       expect(result.customizations).toHaveProperty('packages');
       expect(result.customizations).toHaveProperty('hostname');
       expect(result.customizations).toHaveProperty('subscription');
-      expect(result.customizations.packages).toEqual(['nginx']);
-      expect(result.customizations.hostname).toBe('webserver');
-      expect(result.customizations.subscription?.organization).toBe('11111');
+      expect(result.customizations?.packages).toEqual(['nginx']);
+      expect(result.customizations?.hostname).toBe('webserver');
+      expect(result.customizations?.subscription?.organization).toBe('11111');
     });
   });
 
@@ -211,14 +212,14 @@ describe('toCloudAPIComposeRequest', () => {
 
       const result = toCloudAPIComposeRequest(blueprint, 'rhel-9', []);
 
-      expect(result.customizations.users).toHaveLength(2);
-      expect(result.customizations.users?.[0]).toEqual({
+      expect(result.customizations?.users).toHaveLength(2);
+      expect(result.customizations?.users?.[0]).toEqual({
         name: 'testuser',
         groups: ['wheel', 'docker'],
         key: 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ...',
         password: password,
       });
-      expect(result.customizations.users?.[1]).toEqual({
+      expect(result.customizations?.users?.[1]).toEqual({
         name: 'anotheruser',
         groups: ['users'],
       });
@@ -244,10 +245,10 @@ describe('toCloudAPIComposeRequest', () => {
 
       const result = toCloudAPIComposeRequest(blueprint, 'rhel-9', []);
 
-      expect(result.customizations.packages).toEqual(['htop']);
-      expect(result.customizations.hostname).toBe('server.example.com');
-      expect(result.customizations.users?.[0].key).toBe('ssh-rsa KEY123');
-      expect(result.customizations.users?.[0]).not.toHaveProperty('ssh_key');
+      expect(result.customizations?.packages).toEqual(['htop']);
+      expect(result.customizations?.hostname).toBe('server.example.com');
+      expect(result.customizations?.users?.[0].key).toBe('ssh-rsa KEY123');
+      expect(result.customizations?.users?.[0]).not.toHaveProperty('ssh_key');
     });
   });
 
@@ -269,7 +270,7 @@ describe('toCloudAPIComposeRequest', () => {
 
       const result = toCloudAPIComposeRequest(blueprint, 'rhel-9', []);
 
-      expect(result.customizations.openscap).toEqual({
+      expect(result.customizations?.openscap).toEqual({
         profile_id: 'xccdf_org.ssgproject.content_profile_cis',
       });
     });
@@ -291,8 +292,8 @@ describe('toCloudAPIComposeRequest', () => {
 
       const result = toCloudAPIComposeRequest(blueprint, 'rhel-9', []);
 
-      expect(result.customizations.packages).toEqual(['aide']);
-      expect(result.customizations.openscap).toEqual({
+      expect(result.customizations?.packages).toEqual(['aide']);
+      expect(result.customizations?.openscap).toEqual({
         profile_id: 'xccdf_org.ssgproject.content_profile_pci-dss',
       });
     });
@@ -328,7 +329,7 @@ describe('toCloudAPIComposeRequest', () => {
       );
 
       expect(result.image_requests).toHaveLength(1);
-      expect(result.image_requests[0]).toEqual({
+      expect(result.image_requests![0]).toEqual({
         architecture: 'x86_64',
         image_type: 'ami',
         repositories: [],
@@ -380,10 +381,10 @@ describe('toCloudAPIComposeRequest', () => {
       );
 
       expect(result.image_requests).toHaveLength(2);
-      expect(result.image_requests[0].architecture).toBe('x86_64');
-      expect(result.image_requests[1].architecture).toBe('aarch64');
-      expect(result.image_requests[0].image_type).toBe('guest-image');
-      expect(result.image_requests[1].image_type).toBe('ami');
+      expect(result.image_requests![0].architecture).toBe('x86_64');
+      expect(result.image_requests![1].architecture).toBe('aarch64');
+      expect(result.image_requests![0].image_type).toBe('guest-image');
+      expect(result.image_requests![1].image_type).toBe('ami');
     });
 
     it('should handle different upload request types', () => {
@@ -416,7 +417,7 @@ describe('toCloudAPIComposeRequest', () => {
         imageRequests,
       );
 
-      expect(result.image_requests[0].upload_targets[0]).toEqual({
+      expect(result.image_requests![0].upload_targets![0]).toEqual({
         type: 'azure',
         upload_options: {
           tenant_id: 'tenant-123',
@@ -452,7 +453,7 @@ describe('toCloudAPIComposeRequest', () => {
         imageRequests,
       );
 
-      expect(result.image_requests[0].repositories).toEqual([]);
+      expect(result.image_requests![0].repositories).toEqual([]);
     });
   });
 
@@ -547,19 +548,19 @@ describe('toCloudAPIComposeRequest', () => {
       );
 
       // Verify all customizations are present and correctly transformed
-      expect(result.customizations.packages).toEqual([
+      expect(result.customizations?.packages).toEqual([
         'firewalld',
         'aide',
         'audit',
       ]);
-      expect(result.customizations.hostname).toBe('secure.example.com');
-      expect(result.customizations.users).toHaveLength(1);
-      expect(result.customizations.users?.[0]).toEqual({
+      expect(result.customizations?.hostname).toBe('secure.example.com');
+      expect(result.customizations?.users).toHaveLength(1);
+      expect(result.customizations?.users?.[0]).toEqual({
         name: 'secadmin',
         groups: ['wheel'],
         key: 'ssh-rsa AAAAB3...', // ssh_key converted to key
       });
-      expect(result.customizations.subscription).toEqual({
+      expect(result.customizations?.subscription).toEqual({
         organization: '54321',
         activation_key: 'secure-key',
         server_url: 'https://subscription.rhsm.redhat.com',
@@ -567,7 +568,7 @@ describe('toCloudAPIComposeRequest', () => {
         insights: true,
         rhc: true,
       });
-      expect(result.customizations.openscap).toEqual({
+      expect(result.customizations?.openscap).toEqual({
         profile_id: 'xccdf_org.ssgproject.content_profile_stig',
       });
       expect(result.image_requests).toHaveLength(1);


### PR DESCRIPTION
The hosted blueprint contains `hasPassword`, this shouldn't be passed along to the cloudapi compose request.