### PR TITLE
dependabot: Update grouping of updates (HMS-9798)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "04:00"
     open-pull-requests-limit: 3
     rebase-strategy: "auto"
     ignore:
@@ -14,7 +12,16 @@ updates:
           - "version-update:semver-major"
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+      - dependency-name: "react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react-dom"
+        update-types:
+          - "version-update:semver-major"
     groups:
-      npm:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
There's been issues with how the dependabot updates are set up. This should hopefully resolve the issue.

JIRA: [HMS-9798](https://issues.redhat.com/browse/HMS-9798)