### PR TITLE
src: Fix rendering validation for `ValidatedInput` (HMS-9797)

### DIFF
--- a/src/Components/CloudProviderConfig/AWSConfig.tsx
+++ b/src/Components/CloudProviderConfig/AWSConfig.tsx
@@ -91,7 +91,9 @@ const AWSBucket = ({ value, onChange, isDisabled }: FormGroupProps<string>) => {
         value={value || ''}
         validator={isAwsBucketValid}
         onChange={(_event, value) => onChange(value)}
-        helperText='Invalid AWS bucket name'
+        helperText={
+          !value ? 'AWS bucket name is required' : 'Invalid AWS bucket name'
+        }
       />
     </FormGroup>
   );
@@ -152,7 +154,11 @@ const AWSCredsPath = ({
         value={value || ''}
         validator={isAwsCredsPathValid}
         onChange={(_event, value) => onChange(value)}
-        helperText='Invalid filepath for AWS credentials'
+        helperText={
+          !value
+            ? 'Filepath for AWS credentials is required'
+            : 'Invalid filepath for AWS credentials'
+        }
       />
     </FormGroup>
   );

--- a/src/Components/CreateImageWizard/ValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInput.tsx
@@ -75,9 +75,7 @@ export const ValidatedInputAndTextArea = ({
   };
 
   useEffect(() => {
-    if (!value) {
-      setIsPristine(true);
-    } else if (errorMessage) {
+    if (errorMessage) {
       setIsPristine(false);
     }
   }, [value, errorMessage]);

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Aws/index.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Aws/index.tsx
@@ -192,7 +192,11 @@ const Aws = () => {
                 onChange={(_event, value) =>
                   dispatch(changeAwsAccountId(value))
                 }
-                helperText='Should be 12 characters long.'
+                helperText={
+                  !shareWithAccount
+                    ? 'AWS account ID is required'
+                    : 'Should be 12 characters long'
+                }
               />
             </FormGroup>
           )}

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/index.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/index.tsx
@@ -71,7 +71,11 @@ const Azure = () => {
             value={tenantId || ''}
             validator={isAzureTenantGUIDValid}
             onChange={(_event, value) => dispatch(changeAzureTenantId(value))}
-            helperText='Please enter a valid tenant ID'
+            helperText={
+              !tenantId
+                ? 'Tenant ID is required'
+                : 'Please enter a valid tenant ID'
+            }
           />
         </FormGroup>
         <AzureAuthButton />
@@ -83,7 +87,11 @@ const Azure = () => {
             onChange={(_event, value) =>
               dispatch(changeAzureSubscriptionId(value))
             }
-            helperText='Please enter a valid subscription ID'
+            helperText={
+              !subscriptionId
+                ? 'Subscription ID is required'
+                : 'Please enter a valid subscription ID'
+            }
           />
         </FormGroup>
         <FormGroup label='Resource group' isRequired>
@@ -94,7 +102,11 @@ const Azure = () => {
             onChange={(_event, value) =>
               dispatch(changeAzureResourceGroup(value))
             }
-            helperText='Resource group names only allow alphanumeric characters, periods, underscores, hyphens, and parenthesis and cannot end in a period'
+            helperText={
+              !resourceGroup
+                ? 'Resource group is required'
+                : 'Resource group names only allow alphanumeric characters, periods, underscores, hyphens, and parenthesis and cannot end in a period'
+            }
           />
         </FormGroup>
       </>

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Gcp/index.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Gcp/index.tsx
@@ -139,7 +139,11 @@ const Gcp = () => {
               value={gcpEmail || ''}
               validator={isGcpEmailValid}
               onChange={(_event, value) => dispatch(changeGcpEmail(value))}
-              helperText='Please enter a valid e-mail address.'
+              helperText={
+                !gcpEmail
+                  ? 'E-mail address is required'
+                  : 'Please enter a valid e-mail address'
+              }
             />
           </FormGroup>
         </>

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -195,46 +195,52 @@ export function useRegistrationValidation(): StepValidation {
 
   if (registrationType === 'register-satellite') {
     const errors = {};
+
     if (caCertificate === '') {
       Object.assign(errors, {
         certificate:
-          'Valid certificate must be present if you are registering Satellite.',
+          'Valid certificate must be present if you are registering Satellite',
       });
     }
+
     if (registrationCommand === '' || !registrationCommand) {
       Object.assign(errors, {
         command: 'No registration command for Satellite registration',
       });
     }
-    try {
-      const match = registrationCommand?.match(
-        /Bearer\s+([\w-]+\.[\w-]+\.[\w-]+)/,
-      );
-      if (!match) {
-        Object.assign(errors, { command: 'Invalid or missing token' });
-      } else {
-        const token = match[1];
-        const decoded = jwtDecode(token);
-        if (decoded.exp) {
-          const currentTimeSeconds = Date.now() / 1000;
-          const dayInSeconds = 86400;
-          if (decoded.exp < currentTimeSeconds + dayInSeconds) {
-            const expirationDate = new Date(decoded.exp * 1000);
-            Object.assign(errors, {
-              expired:
-                'The token is already expired or will expire by next day. Expiration date: ' +
-                expirationDate,
-            });
-            return {
-              errors: errors,
-              disabledNext: caCertificate === undefined,
-            };
+
+    if (registrationCommand) {
+      try {
+        const match = registrationCommand?.match(
+          /Bearer\s+([\w-]+\.[\w-]+\.[\w-]+)/,
+        );
+        if (!match) {
+          Object.assign(errors, { command: 'Invalid or missing token' });
+        } else {
+          const token = match[1];
+          const decoded = jwtDecode(token);
+          if (decoded.exp) {
+            const currentTimeSeconds = Date.now() / 1000;
+            const dayInSeconds = 86400;
+            if (decoded.exp < currentTimeSeconds + dayInSeconds) {
+              const expirationDate = new Date(decoded.exp * 1000);
+              Object.assign(errors, {
+                expired:
+                  'The token is already expired or will expire by next day. Expiration date: ' +
+                  expirationDate,
+              });
+              return {
+                errors: errors,
+                disabledNext: caCertificate === undefined,
+              };
+            }
           }
         }
+      } catch {
+        Object.assign(errors, { command: 'Invalid or missing token' });
       }
-    } catch {
-      Object.assign(errors, { command: 'Invalid or missing token' });
     }
+
     return {
       errors: errors,
       disabledNext:


### PR DESCRIPTION
Since the `isPristine` value got set to `true` every time the field was empty, the Next button usually got correctly disabled, but no error was rendered.

Currently the `isPristine` doesn't get re-set when input is deleted, meaning there can be a green check mark when the value is not required, but if it is required, the error message gets rendered properly. I believe lingering green checkmark will be much less confusing for the user than disabled Next buttons without any indication of error.

JIRA: [HMS-9797](https://issues.redhat.com/browse/HMS-9797)