### PR TITLE
playwright/tests: Skip integration test if service is down

### DIFF
--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
-import { isHosted } from '../helpers/helpers';
+import { isHosted, isServiceAvailable } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
 import {
   fillInImageOutput,
@@ -21,6 +21,20 @@ test('Create a blueprint with Compliance policy selected', async ({
   cleanup,
 }) => {
   test.skip(!isHosted(), 'Compliance is not available in the plugin');
+
+  await test.step('Check if Compliance service is available', async () => {
+    const complianceLandingPageEndpoint =
+      '/api/compliance/v2/policies?limit=1&offset=0';
+    test.skip(
+      !(await isServiceAvailable(
+        complianceLandingPageEndpoint,
+        page.context(),
+        process.env.TOKEN,
+      )),
+      `Endpoint ${complianceLandingPageEndpoint} is not available - service is most likely down.`,
+    );
+  });
+
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture

--- a/playwright/Customizations/FipsMode.spec.ts
+++ b/playwright/Customizations/FipsMode.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
-import { isHosted } from '../helpers/helpers';
+import { isHosted, isServiceAvailable } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
 import {
   fillInImageOutput,
@@ -21,6 +21,19 @@ test('FIPS switch toggles and persists through save', async ({
   cleanup,
 }) => {
   test.skip(!isHosted(), 'FIPS mode is not available in the plugin');
+
+  await test.step('Check if Compliance service is available', async () => {
+    const complianceLandingPageEndpoint =
+      '/api/compliance/v2/policies?limit=1&offset=0';
+    test.skip(
+      !(await isServiceAvailable(
+        complianceLandingPageEndpoint,
+        page.context(),
+        process.env.TOKEN,
+      )),
+      `Endpoint ${complianceLandingPageEndpoint} is not available - service is most likely down.`,
+    );
+  });
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture

--- a/playwright/helpers/helpers.ts
+++ b/playwright/helpers/helpers.ts
@@ -2,7 +2,12 @@ import { execSync } from 'child_process';
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'path';
 
-import { expect, type Locator, type Page } from '@playwright/test';
+import {
+  BrowserContext,
+  expect,
+  type Locator,
+  type Page,
+} from '@playwright/test';
 
 export const togglePreview = async (page: Page) => {
   const toggleSwitch = page.locator('#preview-toggle');
@@ -119,4 +124,23 @@ export const uploadCertificateFile = async (
       unlinkSync(tempCertPath);
     }
   }
+};
+
+export const isServiceAvailable = async (
+  endpoint: string,
+  context: BrowserContext,
+  authToken: string | undefined,
+): Promise<boolean> => {
+  /* Checks if a service is available by sending GET request to endpoint belonging to the service.
+   * @param endpoint - The endpoint to check the status of
+   * @param context - The browser context
+   * @param authToken - The authentication token for consoledot
+   * @returns True if the service is available, false otherwise
+   */
+  const response = await context.request.get(endpoint, {
+    headers: {
+      Authorization: `${authToken}`,
+    },
+  });
+  return response.status() >= 200 && response.status() < 300;
 };


### PR DESCRIPTION
Send a GET request to API of the service the test is covering before it starts, so we can prevent it from blocking PRs. Skip the test if the service is down.