### PR TITLE
Wizard: refactor ManageButton since it became widely used

### DIFF
--- a/src/Components/CreateImageWizard/steps/AAP/components/AAPRegistration.tsx
+++ b/src/Components/CreateImageWizard/steps/AAP/components/AAPRegistration.tsx
@@ -22,10 +22,10 @@ import {
   selectAapTlsCertificateAuthority,
   selectAapTlsConfirmation,
 } from '../../../../../store/wizardSlice';
+import ExternalLinkButton from '../../../utilities/ExternalLinkButton';
 import { useAAPValidation } from '../../../utilities/useValidation';
 import { ValidatedInputAndTextArea } from '../../../ValidatedInput';
 import { validateMultipleCertificates } from '../../../validators';
-import ManageButton from '../../Registration/components/ManageButton';
 
 const AAPRegistration = () => {
   const dispatch = useAppDispatch();
@@ -99,9 +99,12 @@ const AAPRegistration = () => {
           <HelperText>
             <HelperTextItem>
               To generate a callback URL from the Ansible Controller, follow the{' '}
-              <ManageButton url={AAP_DOCS_URL} analyticsStepId='wizard-aap'>
+              <ExternalLinkButton
+                url={AAP_DOCS_URL}
+                analyticsStepId='wizard-aap'
+              >
                 documentation
-              </ManageButton>
+              </ExternalLinkButton>
             </HelperTextItem>
           </HelperText>
         </FormHelperText>
@@ -121,9 +124,12 @@ const AAPRegistration = () => {
             <HelperTextItem>
               To obtain a host config key from the Ansible Controller, follow
               the{' '}
-              <ManageButton url={AAP_DOCS_URL} analyticsStepId='wizard-aap'>
+              <ExternalLinkButton
+                url={AAP_DOCS_URL}
+                analyticsStepId='wizard-aap'
+              >
                 documentation
-              </ManageButton>
+              </ExternalLinkButton>
             </HelperTextItem>
           </HelperText>
         </FormHelperText>
@@ -177,9 +183,12 @@ const AAPRegistration = () => {
             <HelperText>
               <HelperTextItem>
                 To upload the certificate file, follow the{' '}
-                <ManageButton url={AAP_DOCS_URL} analyticsStepId='wizard-aap'>
+                <ExternalLinkButton
+                  url={AAP_DOCS_URL}
+                  analyticsStepId='wizard-aap'
+                >
                   documentation
-                </ManageButton>
+                </ExternalLinkButton>
               </HelperTextItem>
             </HelperText>
           </FormHelperText>

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -63,7 +63,7 @@ import {
 } from '../../../../store/wizardSlice';
 import { useFlag } from '../../../../Utilities/useGetEnvironment';
 import { useOnPremOpenSCAPAvailable } from '../../../../Utilities/useOnPremOpenSCAP';
-import ManageButton from '../Registration/components/ManageButton';
+import ExternalLinkButton from '../../utilities/ExternalLinkButton';
 
 const OscapContent = () => {
   const dispatch = useAppDispatch();
@@ -223,14 +223,14 @@ const OscapContent = () => {
                 <FormHelperText>
                   <HelperText>
                     <HelperTextItem>
-                      <ManageButton
+                      <ExternalLinkButton
                         url={COMPLIANCE_URL}
                         analyticsStepId='step-oscap'
                       >
                         Manage{' '}
                         {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'}{' '}
                         compliance
-                      </ManageButton>
+                      </ExternalLinkButton>
                     </HelperTextItem>
                   </HelperText>
                 </FormHelperText>
@@ -271,9 +271,12 @@ const OscapContent = () => {
             <FormHelperText>
               <HelperText>
                 <HelperTextItem>
-                  <ManageButton url={OSCAP_URL} analyticsStepId='step-oscap'>
+                  <ExternalLinkButton
+                    url={OSCAP_URL}
+                    analyticsStepId='step-oscap'
+                  >
                     Manage with OpenSCAP
-                  </ManageButton>
+                  </ExternalLinkButton>
                 </HelperTextItem>
               </HelperText>
             </FormHelperText>

--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
@@ -24,7 +24,6 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 import { v4 as uuidv4 } from 'uuid';
 
 import ActivationKeyInformation from './ActivationKeyInformation';
-import ManageButton from './ManageButton';
 
 import {
   ACTIVATION_KEYS_URL,
@@ -46,6 +45,7 @@ import {
 import { getErrorMessage } from '../../../../../Utilities/getErrorMessage';
 import sortfn from '../../../../../Utilities/sortfn';
 import { useGetEnvironment } from '../../../../../Utilities/useGetEnvironment';
+import ExternalLinkButton from '../../../utilities/ExternalLinkButton';
 
 const ActivationKeysList = () => {
   const dispatch = useAppDispatch();
@@ -313,12 +313,12 @@ const ActivationKeysList = () => {
             <HelperTextItem>
               Image Builder provides and defaults to a no-cost activation key if
               none exist.{' '}
-              <ManageButton
+              <ExternalLinkButton
                 url={ACTIVATION_KEYS_URL}
                 analyticsStepId='step-registration'
               >
                 Manage activation keys
-              </ManageButton>
+              </ExternalLinkButton>
             </HelperTextItem>
           </HelperText>
         </FormHelperText>

--- a/src/Components/CreateImageWizard/steps/Registration/components/SatelliteRegistration.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/SatelliteRegistration.tsx
@@ -11,7 +11,6 @@ import {
   HelperTextItem,
 } from '@patternfly/react-core';
 
-import ManageButton from './ManageButton';
 import SatelliteRegistrationCommand from './SatelliteRegistrationCommand';
 
 import { REGISTRATION_DOCS_URL } from '../../../../../constants';
@@ -20,6 +19,7 @@ import {
   changeSatelliteCaCertificate,
   selectSatelliteCaCertificate,
 } from '../../../../../store/wizardSlice';
+import ExternalLinkButton from '../../../utilities/ExternalLinkButton';
 import { useRegistrationValidation } from '../../../utilities/useValidation';
 
 const SatelliteRegistration = () => {
@@ -109,12 +109,12 @@ const SatelliteRegistration = () => {
               {(isRejected || validated !== 'success') && (
                 <HelperTextItem>
                   To find the certificate follow this{' '}
-                  <ManageButton
+                  <ExternalLinkButton
                     url={REGISTRATION_DOCS_URL}
                     analyticsStepId='step-register'
                   >
                     documentation
-                  </ManageButton>
+                  </ExternalLinkButton>
                 </HelperTextItem>
               )}
             </HelperText>

--- a/src/Components/CreateImageWizard/steps/Registration/components/SatelliteRegistrationCommand.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/SatelliteRegistrationCommand.tsx
@@ -7,8 +7,6 @@ import {
   HelperTextItem,
 } from '@patternfly/react-core';
 
-import ManageButton from './ManageButton';
-
 import {
   REGISTRATION_DOCS_URL,
   SATELLITE_SERVICE,
@@ -20,6 +18,7 @@ import {
   removeEnabledService,
   selectSatelliteRegistrationCommand,
 } from '../../../../../store/wizardSlice';
+import ExternalLinkButton from '../../../utilities/ExternalLinkButton';
 import { useRegistrationValidation } from '../../../utilities/useValidation';
 import { ValidatedInputAndTextArea } from '../../../ValidatedInput';
 
@@ -55,12 +54,12 @@ const SatelliteRegistrationCommand = () => {
         <HelperText>
           <HelperTextItem>
             To generate command from Satellite, follow the{' '}
-            <ManageButton
+            <ExternalLinkButton
               url={REGISTRATION_DOCS_URL}
               analyticsStepId='step-register'
             >
               documentation
-            </ManageButton>
+            </ExternalLinkButton>
           </HelperTextItem>
         </HelperText>
       </FormHelperText>

--- a/src/Components/CreateImageWizard/utilities/ExternalLinkButton.tsx
+++ b/src/Components/CreateImageWizard/utilities/ExternalLinkButton.tsx
@@ -4,20 +4,20 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { AMPLITUDE_MODULE_NAME } from '../../../../../constants';
-import { useGetUser } from '../../../../../Hooks';
+import { AMPLITUDE_MODULE_NAME } from '../../../constants';
+import { useGetUser } from '../../../Hooks';
 
-type ManageButtonProps = {
+type ExternalLinkButtonProps = {
   url: string;
   children?: React.ReactNode;
   analyticsStepId?: string;
 };
 
-const ManageButton = ({
+const ExternalLinkButton = ({
   url,
   children,
   analyticsStepId,
-}: ManageButtonProps) => {
+}: ExternalLinkButtonProps) => {
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
   return (
@@ -44,4 +44,4 @@ const ManageButton = ({
   );
 };
 
-export default ManageButton;
+export default ExternalLinkButton;


### PR DESCRIPTION
The former ManageButton is used in multiple different components so I took it out to the utilities folder and renamed :black_cat: 