### PR TITLE
Wizard: fix snapshot date assignment logic in Wizard (HMS-9629)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -626,7 +626,10 @@ const getImageRequests = (
       type: uploadTypeByTargetEnv(type),
       options: getImageOptions(type, state),
     },
-    snapshot_date: !useLatest && !template ? snapshotDate : undefined,
+    // Only include snapshot_date when using snapshot mode (not latest or template)
+    // Convert empty strings to undefined
+    snapshot_date:
+      !useLatest && !template && snapshotDate ? snapshotDate : undefined,
     content_template: template || undefined,
     content_template_name: templateName || undefined,
   }));

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -1048,17 +1048,19 @@ export const wizardSlice = createSlice({
     },
     changeUseLatest: (state, action: PayloadAction<boolean>) => {
       if (!action.payload && state.snapshotting.snapshotDate === '') {
-        state.snapshotting.snapshotDate = yyyyMMddFormat(new Date());
+        state.snapshotting.snapshotDate = `${yyyyMMddFormat(new Date())}T00:00:00.000Z`;
       }
 
       state.snapshotting.useLatest = action.payload;
     },
     changeSnapshotDate: (state, action: PayloadAction<string>) => {
+      // Store DatePicker's YYYY-MM-DD format as RFC3339 e.g. "2025-11-26T00:00:00.000Z" in state
       const yyyyMMDDRegex = /^\d{4}-\d{2}-\d{2}$/;
       const date = new Date(action.payload);
       if (yyyyMMDDRegex.test(action.payload) && !isNaN(date.getTime())) {
         state.snapshotting.snapshotDate = date.toISOString();
       } else {
+        // For empty strings or already-ISO formatted strings, store as-is
         state.snapshotting.snapshotDate = action.payload;
       }
     },


### PR DESCRIPTION
When a user enables repeatable builds (snapshot mode) and leaves the default value in the `DatePicker` without interacting with it, the `onChange` handler doesn't fire. This means:
- If the default value is the current date in YYYY-MM-DD format, it never gets converted to RFC3339/ISO format
- If the default value is an empty string, it remains as an empty string in the state

The `onChange` handler, which is responsible for parsing and converting the date to the proper format, only runs on user interaction - not when the field contains its initial default value.

### Description

- Ensure the content-sources `snapshots/for_date` API receives properly formatted RFC3339 dates when users don't interact with the `DatePicker`
- Ensure the default snapshot date uses midnight UTC when toggling "Use Latest" off, matching the behavior of `changeSnapshotDate` - not mixing midnight and current timestamp formats

### Notes

Related backend PR which updates the API documentation https://github.com/osbuild/image-builder-crc/pull/1734