### PR TITLE
src: Bump smol-toml to 1.5.2 and update export mocks (HMS-9807)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-router-dom": "6.27.0",
         "redux": "5.0.1",
         "redux-promise-middleware": "6.2.0",
-        "smol-toml": "1.4.2"
+        "smol-toml": "1.5.2"
       },
       "devDependencies": {
         "@babel/core": "7.28.5",
@@ -19283,9 +19283,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.4.2.tgz",
-      "integrity": "sha512-rInDH6lCNiEyn3+hH8KVGFdbjc099j47+OSgbMrfDYX1CmXLfdKd7qi6IfcWj2wFxvSVkuI46M+wPGYfEOEj6g==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
+      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react-router-dom": "6.27.0",
     "redux": "5.0.1",
     "redux-promise-middleware": "6.2.0",
-    "smol-toml": "1.4.2"
+    "smol-toml": "1.5.2"
   },
   "devDependencies": {
     "@babel/core": "7.28.5",

--- a/playwright/fixtures/data/exportBlueprintContents.ts
+++ b/playwright/fixtures/data/exportBlueprintContents.ts
@@ -1,7 +1,6 @@
 export const exportedDiskBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
-[customizations]
 [[customizations.disk.partitions]]
 type = "plain"
 mountpoint = "/data"
@@ -29,7 +28,6 @@ languages = [ "C.UTF-8" ]`;
 export const exportedFilesystemBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
-[customizations]
 [[customizations.filesystem]]
 mountpoint = "/"
 minsize = 10737418240
@@ -48,7 +46,6 @@ languages = [ "C.UTF-8" ]`;
 export const exportedFirewallBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
-[customizations]
 [customizations.timezone]
 timezone = "Etc/UTC"
 
@@ -79,7 +76,6 @@ languages = [ "C.UTF-8" ]`;
 export const exportedKernelBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
-[customizations]
 [customizations.kernel]
 name = "kernel"
 append = "rootwait console=tty0 console=ttyS0,115200n8 new=argument"
@@ -94,7 +90,6 @@ languages = [ "C.UTF-8" ]`;
 export const exportedLocaleBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
-[customizations]
 [customizations.timezone]
 timezone = "Etc/UTC"
 
@@ -106,7 +101,6 @@ keyboard = "ANSI-dvorak"`;
 export const exportedSystemdBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
-[customizations]
 [customizations.services]
 enabled = [ "enabled-service" ]
 masked = [ "masked-service" ]
@@ -122,7 +116,6 @@ languages = [ "C.UTF-8" ]`;
 export const exportedTimezoneBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
-[customizations]
 [customizations.timezone]
 timezone = "Europe/Oslo"
 ntpservers = [ "0.nl.pool.ntp.org", "0.de.pool.ntp.org" ]
@@ -134,7 +127,6 @@ languages = [ "C.UTF-8" ]`;
 export const exportedUsersBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
-[customizations]
 [[customizations.user]]
 name = "admin1"
 key = ""

--- a/src/Components/Blueprints/BlueprintActionsMenu.tsx
+++ b/src/Components/Blueprints/BlueprintActionsMenu.tsx
@@ -97,7 +97,7 @@ async function handleExportBlueprint(
   blueprint: BlueprintExportResponse | CockpitExportResponse,
 ) {
   const data = process.env.IS_ON_PREMISE
-    ? TOML.stringify(blueprint)
+    ? TOML.stringify(blueprint).trim()
     : JSON.stringify(blueprint, null, 2);
   const mime = process.env.IS_ON_PREMISE
     ? 'application/octet-stream'


### PR DESCRIPTION
In 1.5.x smol-toml changed its serializer. Now it suppresses empty parent tables, see [smol-toml release notes](https://github.com/squirrelchat/smol-toml/releases/tag/v1.5.0).

This bumps the version and updates the export mocks to reflect the changes.

JIRA: [HMS-9807](https://issues.redhat.com/browse/HMS-9807)