### PR TITLE
docstrings: Drop references to RPM-DNF

### DIFF
--- a/src/Components/ImagesTable/EmptyState.tsx
+++ b/src/Components/ImagesTable/EmptyState.tsx
@@ -95,7 +95,7 @@ const EmptyImagesTable = () => {
                 href={IB_DOCUMENTATION_URL}
                 className='pf-v6-u-pt-md'
               >
-                Image builder for RPM-DNF documentation
+                Image builder documentation
               </Button>
             </EmptyStateActions>
           </EmptyStateFooter>

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -49,7 +49,7 @@ const AboutImageBuilderPopover = () => {
               isInline
               href={IB_DOCUMENTATION_URL}
             >
-              Image builder for RPM-DNF documentation
+              Image builder documentation
             </Button>
           </Content>
         </Content>


### PR DESCRIPTION
Ever since we have removed the support for the RHEL for Edge frontend and building those image types, the hint towards 'RPM-DNF' is pointless and may actually confuse users. I suggest we drop it.

See: https://github.com/osbuild/image-builder-frontend/pull/3296