### PR TITLE
gitlab: set the correct tag for rhos runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ test:
     - schutzbot/save_journal.sh || true
     - schutzbot/upload_artifacts.sh
   tags:
-    - terraform
+    - terraform/openstack
   parallel:
     matrix:
       - RUNNER:


### PR DESCRIPTION
schutzbot uses tags for limiting the number of concurrent PRs on different platforms. This is needed because we have different quotas on AWS vs. OpenStack. See
https://github.com/osbuild/gitlab-ci-config/blob/main/config.toml.

Since this project uses solely openstack, let's use the terraform/openstack tag.