### PR TITLE
Wizard: add explanation of which services are expected in firewall (RHIN-2168)

### DIFF
--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -62,7 +62,7 @@ test('Create a blueprint with Firewall customization', async ({
 
   await test.step('Select and correctly fill the disabled services in Firewall step', async () => {
     await frame
-      .getByPlaceholder('Enter service name')
+      .getByPlaceholder('Enter firewalld service')
       .nth(0)
       .fill('cloud-init');
     await page.keyboard.press('Enter');
@@ -71,7 +71,7 @@ test('Create a blueprint with Firewall customization', async ({
 
   await test.step('Select and correctly fill the enabled services in Firewall step', async () => {
     await frame
-      .getByPlaceholder('Enter service name')
+      .getByPlaceholder('Enter firewalld service')
       .nth(1)
       .fill('telnet.socket');
     await page.keyboard.press('Enter');
@@ -86,7 +86,7 @@ test('Create a blueprint with Firewall customization', async ({
     await expect(frame.getByText('Port already exists.')).toBeVisible();
 
     await frame
-      .getByPlaceholder('Enter service name')
+      .getByPlaceholder('Enter firewalld service')
       .nth(0)
       .fill('cloud-init');
     await page.keyboard.press('Enter');
@@ -95,7 +95,7 @@ test('Create a blueprint with Firewall customization', async ({
     ).toBeVisible();
 
     await frame
-      .getByPlaceholder('Enter service name')
+      .getByPlaceholder('Enter firewalld service')
       .nth(1)
       .fill('telnet.socket');
     await page.keyboard.press('Enter');
@@ -119,21 +119,25 @@ test('Create a blueprint with Firewall customization', async ({
   });
 
   await test.step('Select and incorrectly fill the disabled services in Firewall step', async () => {
-    await frame.getByPlaceholder('Enter service name').nth(0).fill('1');
+    await frame.getByPlaceholder('Enter firewalld service').nth(0).fill('1');
     await page.keyboard.press('Enter');
     await expect(
-      frame.getByText('Expected format: <service-name>. Example: sshd').nth(0),
+      frame
+        .getByText('Expected format: <firewalld-service-name>. Example: ssh.')
+        .nth(0),
     ).toBeVisible();
   });
 
   await test.step('Select and incorrectly fill the enabled services in Firewall step', async () => {
     await frame
-      .getByPlaceholder('Enter service name')
+      .getByPlaceholder('Enter firewalld service')
       .nth(1)
       .fill('wrong--service');
     await page.keyboard.press('Enter');
     await expect(
-      frame.getByText('Expected format: <service-name>. Example: sshd').nth(1),
+      frame
+        .getByText('Expected format: <firewalld-service-name>. Example: ssh.')
+        .nth(1),
     ).toBeVisible();
   });
 
@@ -174,9 +178,9 @@ test('Create a blueprint with Firewall customization', async ({
       .getByPlaceholder('Enter port (e.g., 8080/tcp, 443:udp)')
       .fill('90:tcp');
     await page.keyboard.press('Enter');
-    await frame.getByPlaceholder('Enter service name').nth(0).fill('x');
+    await frame.getByPlaceholder('Enter firewalld service').nth(0).fill('x');
     await page.keyboard.press('Enter');
-    await frame.getByPlaceholder('Enter service name').nth(1).fill('y');
+    await frame.getByPlaceholder('Enter firewalld service').nth(1).fill('y');
     await page.keyboard.press('Enter');
 
     await frame.getByRole('button', { name: 'Close 80:tcp' }).click();

--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -98,10 +98,14 @@ const LabelInput = ({
         case 'enabledSystemdServices':
         case 'disabledSystemdServices':
         case 'maskedSystemdServices':
+          setOnStepInputErrorText(
+            'Expected format: <service-name>. Example: sshd',
+          );
+          break;
         case 'disabledServices':
         case 'enabledServices':
           setOnStepInputErrorText(
-            'Expected format: <service-name>. Example: sshd',
+            'Expected format: <firewalld-service-name>. Example: ssh.',
           );
           break;
         default:

--- a/src/Components/CreateImageWizard/steps/Firewall/components/Services.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/components/Services.tsx
@@ -25,7 +25,7 @@ const Services = () => {
       <FormGroup label='Enabled services'>
         <LabelInput
           ariaLabel='Add enabled service'
-          placeholder='Enter service name'
+          placeholder='Enter firewalld service'
           validator={isServiceValid}
           list={enabledServices}
           item='Enabled service'
@@ -38,7 +38,7 @@ const Services = () => {
       <FormGroup label='Disabled services'>
         <LabelInput
           ariaLabel='Add disabled service'
-          placeholder='Enter service name'
+          placeholder='Enter firewalld service'
           validator={isServiceValid}
           list={disabledServices}
           item='Disabled service'

--- a/src/Components/CreateImageWizard/steps/Firewall/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Content, Form, Title } from '@patternfly/react-core';
+import { ClipboardCopy, Content, Form, Title } from '@patternfly/react-core';
 
 import PortsInput from './components/PortsInput';
 import Services from './components/Services';
@@ -11,7 +11,20 @@ const FirewallStep = () => {
       <Title headingLevel='h1' size='xl'>
         Firewall
       </Title>
-      <Content>Customize firewall settings for your image.</Content>
+      <Content>
+        Customize firewall settings for your image. When enabling or disabling
+        services, use the firewalld service name rather than systemd unit names.
+        To view the list of available services, use{' '}
+        <ClipboardCopy
+          aria-label='Copy firewall-cmd --get-services'
+          hoverTip='Copy'
+          clickTip='Copied'
+          variant='inline-compact'
+          isCode
+        >
+          firewall-cmd --get-services
+        </ClipboardCopy>
+      </Content>
       <PortsInput />
       <Services />
     </Form>


### PR DESCRIPTION
Previously, we had ambiguity in the Firewall step - not specifying which services could be added to the inputs. I added the explanation to the description:

<img width="1202" height="696" alt="image" src="https://github.com/user-attachments/assets/4d874120-0a34-4451-bea4-3f403ddc697f" />
