### PR TITLE
ImagesTable: expose compose progress information (HMS-9341)

### DIFF
--- a/src/Components/ImagesTable/Status.tsx
+++ b/src/Components/ImagesTable/Status.tsx
@@ -90,7 +90,8 @@ export const AwsDetailsStatus = ({ compose }: ComposeStatusPropTypes) => {
         />
       );
     }
-
+    case 'building':
+      return <ProgressStatus status={data} />;
     default:
       return (
         <Status
@@ -124,6 +125,8 @@ export const CloudStatus = ({ compose }: CloudStatusPropTypes) => {
         />
       );
     }
+    case 'building':
+      return <ProgressStatus status={data} />;
     default:
       return (
         <Status
@@ -149,6 +152,8 @@ export const AzureStatus = ({ status }: AzureStatusPropTypes) => {
         />
       );
     }
+    case 'building':
+      return <ProgressStatus status={status} />;
     default:
       return (
         <Status
@@ -230,6 +235,8 @@ export const ExpiringStatus = ({
         error={composeStatus?.image_status.error || ''}
       />
     );
+  } else if (status === 'building') {
+    return <ProgressStatus status={composeStatus} />;
   }
 
   return <Status icon={statuses[status].icon} text={statuses[status].text} />;
@@ -258,6 +265,8 @@ export const LocalStatus = ({ compose }: LocalStatusPropTypes) => {
         error={composeStatus?.image_status.error || ''}
       />
     );
+  } else if (status === 'building') {
+    return <ProgressStatus status={composeStatus} />;
   }
   return <Status icon={statuses[status].icon} text={statuses[status].text} />;
 };
@@ -453,6 +462,36 @@ const ErrorStatus = ({ icon, text, error }: ErrorStatusPropTypes) => {
           <div className='failure-button'>{text}</div>
         </Button>
       </Popover>
+    </Flex>
+  );
+};
+
+type ProgressStatusPropTypes = {
+  status: ComposeStatus;
+};
+
+export const ProgressStatus = ({ status }: ProgressStatusPropTypes) => {
+  const icon = statuses[status.image_status.status].icon;
+  const text = statuses[status.image_status.status].text;
+  const progress = status.image_status.progress;
+
+  let progressText = '';
+  let subprogressText = '';
+  if (progress) {
+    progressText = `step ${progress.done} of ${progress.total}`;
+    if (progress.subprogress) {
+      subprogressText = `(substep ${progress.subprogress.done} of ${progress.subprogress.total})`;
+    }
+  }
+
+  return (
+    <Flex className='pf-v6-u-align-items-baseline pf-m-nowrap'>
+      <div className='pf-v6-u-mr-sm'>{icon}</div>
+      <p>
+        {text}
+        {progressText && <br />}
+        {progressText} {subprogressText}
+      </p>
     </Flex>
   );
 };

--- a/src/test/Components/ImagesTable/Status.test.tsx
+++ b/src/test/Components/ImagesTable/Status.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { ProgressStatus } from '../../../Components/ImagesTable/Status';
+import { ComposeRequest, ComposeStatus } from '../../../store/imageBuilderApi';
+
+const request: ComposeRequest = {
+  distribution: 'rhel-8',
+  image_requests: [
+    {
+      architecture: 'aarch64',
+      image_type: 'guest-image',
+      upload_request: {
+        type: 'aws.s3',
+        options: {
+          url: 'url',
+        },
+      },
+    },
+  ],
+};
+describe('Status', () => {
+  test('progress', async () => {
+    const status: ComposeStatus = {
+      image_status: {
+        status: 'building',
+        progress: {
+          done: 1,
+          total: 20,
+        },
+      },
+      request,
+    };
+    render(<ProgressStatus status={status} />);
+    expect(await screen.findByText(/Image build in progress/)).toBeVisible();
+    expect(await screen.findByText(/step 1 of 20/)).toBeVisible();
+  });
+
+  test('subprogress', async () => {
+    const status: ComposeStatus = {
+      image_status: {
+        status: 'building',
+        progress: {
+          done: 1,
+          total: 20,
+          subprogress: {
+            done: 3,
+            total: 4,
+          },
+        },
+      },
+      request,
+    };
+    render(<ProgressStatus status={status} />);
+    expect(await screen.findByText(/Image build in progress/)).toBeVisible();
+    expect(await screen.findByText(/step 1 of 20/)).toBeVisible();
+    expect(await screen.findByText(/(substep 3 of 4)/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
This introduces progress information when available. More detailed progress (including messages), still need to be implemented and forwarded from composer.

---

<img width="1271" height="263" alt="image" src="https://github.com/user-attachments/assets/f3813f28-90df-4fc4-b1a3-1d1764f6946f" />

