### PR TITLE
playwright: Fix tests after OpenSCAP configs regeneration (HMS-9862)

### DIFF
--- a/playwright/Customizations/FipsMode.spec.ts
+++ b/playwright/Customizations/FipsMode.spec.ts
@@ -56,7 +56,6 @@ test('FIPS switch toggles and persists through save', async ({
       .getByRole('option', {
         name: /Red Hat STIG for Red Hat Enterprise Linux 10/i,
       })
-      .nth(1)
       .click();
 
     const fipsInput = frame.locator('#fips-enabled-switch');


### PR DESCRIPTION
There's only one non-GUI STIG profile after the configs were regenerated.

JIRA: [HMS-9862](https://issues.redhat.com/browse/HMS-9862)