### PR TITLE
Wizard: Move activation keys alert for styling (HMS-9866)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 import {
-  Alert,
   Button,
   Flex,
   FlexItem,
@@ -46,8 +45,9 @@ import { getErrorMessage } from '../../../../../Utilities/getErrorMessage';
 import sortfn from '../../../../../Utilities/sortfn';
 import { useGetEnvironment } from '../../../../../Utilities/useGetEnvironment';
 import ExternalLinkButton from '../../../utilities/ExternalLinkButton';
+import { RegistrationProps } from '../registrationTypes';
 
-const ActivationKeysList = () => {
+const ActivationKeysList = ({ onErrorChange }: RegistrationProps) => {
   const dispatch = useAppDispatch();
   const addNotification = useAddNotification();
 
@@ -68,6 +68,10 @@ const ActivationKeysList = () => {
     isError: isErrorActivationKeys,
     refetch,
   } = useListActivationKeysQuery();
+
+  useEffect(() => {
+    onErrorChange(isErrorActivationKeys);
+  }, [isErrorActivationKeys, onErrorChange]);
 
   const [createActivationKey, { isLoading: isLoadingActivationKey }] =
     useCreateActivationKeysMutation();
@@ -323,16 +327,6 @@ const ActivationKeysList = () => {
           </HelperText>
         </FormHelperText>
       </FormGroup>
-      {isErrorActivationKeys && (
-        <Alert
-          title='Activation keys unavailable'
-          variant='danger'
-          isPlain
-          isInline
-        >
-          Activation keys cannot be reached, try again later.
-        </Alert>
-      )}
     </>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
@@ -11,8 +11,9 @@ import {
   changeRegistrationType,
   selectRegistrationType,
 } from '../../../../../store/wizardSlice';
+import { RegistrationProps } from '../registrationTypes';
 
-const Registration = () => {
+const Registration = ({ onErrorChange }: RegistrationProps) => {
   const dispatch = useAppDispatch();
   const registrationType = useAppSelector(selectRegistrationType);
 
@@ -74,7 +75,7 @@ const Registration = () => {
               {!process.env.IS_ON_PREMISE &&
                 registrationType.startsWith('register-now') && (
                   <Content className='pf-v6-u-pb-sm'>
-                    <ActivationKeysList />
+                    <ActivationKeysList onErrorChange={onErrorChange} />
                   </Content>
                 )}
               {process.env.IS_ON_PREMISE &&
@@ -93,6 +94,7 @@ const Registration = () => {
           isChecked={registrationType === 'register-later'}
           onChange={() => {
             dispatch(changeRegistrationType('register-later'));
+            onErrorChange(false);
           }}
           id='register-later'
           name='register-later'
@@ -104,6 +106,7 @@ const Registration = () => {
           isChecked={registrationType === 'register-satellite'}
           onChange={() => {
             dispatch(changeRegistrationType('register-satellite'));
+            onErrorChange(false);
           }}
           id='register-satellite'
           name='register-satellite'

--- a/src/Components/CreateImageWizard/steps/Registration/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
+  Alert,
   ClipboardCopy,
   Content,
   Form,
@@ -19,6 +20,7 @@ import { useGetUser } from '../../../../Hooks';
 const RegistrationStep = () => {
   const { auth } = useChrome();
   const { orgId } = useGetUser(auth);
+  const [showAlert, setShowAlert] = useState(false);
 
   return (
     <Form>
@@ -51,8 +53,13 @@ const RegistrationStep = () => {
             </FormGroup>
           )}
         </Content>
-        <Registration />
+        <Registration onErrorChange={setShowAlert} />
       </Content>
+      {showAlert && (
+        <Alert title='Activation keys unavailable' variant='danger' isInline>
+          Activation keys cannot be reached, try again later.
+        </Alert>
+      )}
     </Form>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Registration/registrationTypes.ts
+++ b/src/Components/CreateImageWizard/steps/Registration/registrationTypes.ts
@@ -1,0 +1,3 @@
+export type RegistrationProps = {
+  onErrorChange: (isError: boolean) => void;
+};


### PR DESCRIPTION
When the `Alert` is inside `Content` component, it inherits styling, making it a bit of a mess. This moves the alert outside so it looks nicer.

<img width="962" height="527" alt="image" src="https://github.com/user-attachments/assets/25561c65-7463-4576-8ef7-0f2da15a3263" />


JIRA: [HMS-9866](https://issues.redhat.com/browse/HMS-9866)