### PR TITLE
Wizard: add information about firstboot and registration ordering (HMS-8555)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -18,6 +18,7 @@ import {
   addEnabledService,
   removeEnabledService,
   selectFirstBootScript,
+  selectRegistrationType,
   setFirstBootScript,
 } from '../../../../store/wizardSlice';
 import { useFirstBootValidation } from '../../utilities/useValidation';
@@ -48,6 +49,7 @@ const detectScriptType = (scriptString: string): Language => {
 const FirstBootStep = () => {
   const dispatch = useAppDispatch();
   const selectedScript = useAppSelector(selectFirstBootScript);
+  const registrationType = useAppSelector(selectRegistrationType);
   const language = detectScriptType(selectedScript);
   const { errors } = useFirstBootValidation();
 
@@ -59,7 +61,11 @@ const FirstBootStep = () => {
       <Content>
         Configure the image with a custom script that will execute on its first
         boot.
+        {registrationType !== 'register-later' && (
+          <> First boot script will run after registration is done.</>
+        )}
       </Content>
+
       <Alert
         variant='warning'
         isExpandable


### PR DESCRIPTION
If a user chooses to register in any possible way, there is an extra info added in the Firstboot step specifying the order in which these two actions will be executed:

<img width="1045" height="125" alt="image" src="https://github.com/user-attachments/assets/884b5980-6018-44af-8b1a-90dcf2f01682" />

With "later" registration chosen:

<img width="1045" height="125" alt="image" src="https://github.com/user-attachments/assets/8b792fd9-d9a9-4301-baa0-a3e9bc1adb94" />

Not sure @lzap if this is exactly what you had in mind, is this visible enough in your opinion?