### PR TITLE
ImageBuildHeader: center help icon (HMS-9878)

### DIFF
--- a/src/Components/CloudProviderConfig/AWSConfig.tsx
+++ b/src/Components/CloudProviderConfig/AWSConfig.tsx
@@ -119,7 +119,7 @@ const CredsPathPopover = () => {
         icon={<HelpIcon />}
         variant='plain'
         aria-label='Credentials Path Info'
-        className='pf-v6-u-pl-sm header-button'
+        className='pf-v6-u-pl-sm'
       />
     </Popover>
   );

--- a/src/Components/ShareImageModal/RegionsSelect.tsx
+++ b/src/Components/ShareImageModal/RegionsSelect.tsx
@@ -223,7 +223,7 @@ const RegionsSelect = ({ composeId, handleClose }: RegionsSelectPropTypes) => {
               icon={<HelpIcon />}
               variant='plain'
               aria-label='About regions'
-              className='pf-v6-u-pl-sm header-button'
+              className='pf-v6-u-pl-sm'
               isInline
             />
           </Popover>

--- a/src/Components/sharedComponents/ImageBuilderHeader.scss
+++ b/src/Components/sharedComponents/ImageBuilderHeader.scss
@@ -1,7 +1,0 @@
-.title {
-    display: inline;
-}
-
-.header-button {
-    padding-right: 0;
-}

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -17,7 +17,6 @@ import { useBackendPrefetch } from '../../store/backendApi';
 import { useAppSelector } from '../../store/hooks';
 import { selectDistribution } from '../../store/wizardSlice';
 import { resolveRelPath } from '../../Utilities/path';
-import './ImageBuilderHeader.scss';
 import { ImportBlueprintModal } from '../Blueprints/ImportBlueprintModal';
 
 type ImageBuilderHeaderPropTypes = {
@@ -59,7 +58,7 @@ const AboutImageBuilderPopover = () => {
         icon={<HelpIcon />}
         variant='plain'
         aria-label='About image builder'
-        className='pf-v6-u-pl-sm header-button'
+        className='pf-v6-u-pl-sm'
       />
     </Popover>
   );
@@ -82,7 +81,6 @@ export const ImageBuilderHeader = ({
       />
       <PageHeader className='pf-m-sticky-top'>
         <PageHeaderTitle
-          className='title'
           title={
             <>
               Images <AboutImageBuilderPopover />


### PR DESCRIPTION
The custom css was causing the help icon not to be centered inside the button. This was affecting both on-prem & hosted.

Fixes: https://github.com/osbuild/image-builder-frontend/issues/3913