### PR TITLE
Wizard: add langpack if locale is selected (HMS-8766)

### DIFF
--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -44,43 +44,54 @@ test('Create a blueprint with Locale customization', async ({
     await registerLater(frame);
   });
 
+  await test.step('Check that the Locale step shows langpacks, but not the Additional packages', async () => {
+    await frame.getByRole('button', { name: 'Locale' }).click();
+    await frame.getByPlaceholder('Select a language').click();
+    await frame.getByPlaceholder('Select a language').fill('ru_RU');
+    await frame
+      .getByRole('option', { name: 'Russian - Russia (ru_RU.UTF-8)' })
+      .click();
+
+    // Wait for the loading spinner to disappear (langpack resolution can take a while)
+    await frame
+      .getByText('Resolving packages for your preferred locale…')
+      .waitFor({ state: 'hidden', timeout: 60_000 });
+
+    await expect(
+      frame.getByText(
+        'The following packages will be added based on your preferred locale:',
+      ),
+    ).toBeVisible();
+    await expect(frame.getByText('langpacks-ru')).toBeVisible();
+
+    await frame.getByRole('button', { name: 'Additional packages' }).click();
+    await frame
+      .getByRole('textbox', { name: 'Search packages' })
+      .fill('langpacks-ru');
+    await frame.getByRole('button', { name: 'Selected' }).click();
+    await expect(frame.getByText('langpacks-ru')).toHaveCount(0);
+  });
+
   await test.step('Select and fill the Locale step', async () => {
     await frame.getByRole('button', { name: 'Locale' }).click();
-    await frame.getByPlaceholder('Select a language').fill('fy');
+    await frame.getByPlaceholder('Select a language').fill('en_US');
     await frame
-      .getByRole('option', { name: 'Western Frisian - Germany (fy_DE.UTF-8)' })
-      .click();
-    await expect(
-      frame.getByRole('button', {
-        name: 'Close Western Frisian - Germany (fy_DE.UTF-8)',
-      }),
-    ).toBeEnabled();
-    await frame
-      .getByRole('button', {
-        name: 'Close Western Frisian - Germany (fy_DE.UTF-8)',
+      .getByRole('option', {
+        name: 'English - United States (en_US.UTF-8)',
       })
       .click();
     await expect(
-      frame.getByRole('button', {
-        name: 'Close Western Frisian - Germany (fy_DE.UTF-8)',
-      }),
-    ).toBeHidden();
+      frame.getByText('English - United States (en_US.UTF-8)'),
+    ).toBeVisible();
     await frame.getByPlaceholder('Select a language').fill('fy');
     await frame
-      .getByRole('option', { name: 'Western Frisian - Germany (fy_DE.UTF-8)' })
+      .getByRole('option', {
+        name: 'Western Frisian - Germany (fy_DE.UTF-8)',
+      })
       .click();
     await expect(
-      frame.getByRole('button', {
-        name: 'Close Western Frisian - Germany (fy_DE.UTF-8)',
-      }),
-    ).toBeEnabled();
-    await frame.getByPlaceholder('Select a language').fill('aa');
-    await frame
-      .getByRole('option', { name: 'aa - Djibouti (aa_DJ.UTF-8)' })
-      .click();
-    await expect(
-      frame.getByRole('button', { name: 'Close aa - Djibouti (aa_DJ.UTF-8)' }),
-    ).toBeEnabled();
+      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
+    ).toBeVisible();
     await frame.getByPlaceholder('Select a language').fill('aa');
     // Verify that the dropdown shows filtered options starting with 'aa'
     await expect(
@@ -94,6 +105,11 @@ test('Create a blueprint with Locale customization', async ({
     await frame.getByRole('button', { name: 'Menu toggle' }).nth(1).click();
     await frame.getByPlaceholder('Select a keyboard').fill('ami');
     await frame.getByRole('option', { name: 'amiga-de' }).click();
+    // Wait for the loading spinner to disappear after language/keyboard changes
+    await frame
+      .getByText('Resolving packages for your preferred locale…')
+      .waitFor({ state: 'hidden', timeout: 60_000 });
+    await expect(frame.getByText('langpacks-en')).toBeVisible();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 
@@ -101,29 +117,61 @@ test('Create a blueprint with Locale customization', async ({
     await fillInDetails(frame, blueprintName);
   });
 
-  await test.step('Create BP', async () => {
-    await createBlueprint(frame, blueprintName);
+  await test.step('Create BP and verify locale langpacks in request', async () => {
+    if (!isHosted()) {
+      await createBlueprint(frame, blueprintName);
+      return;
+    }
+    const [request] = await Promise.all([
+      page.waitForRequest(
+        (req) =>
+          req.url().includes('/api/image-builder/v1/blueprints') &&
+          req.method() === 'POST',
+      ),
+      createBlueprint(frame, blueprintName),
+    ]);
+
+    const body = request.postDataJSON();
+    const packages: string[] = body?.customizations?.packages ?? [];
+    const localeLangpacks = packages.filter((p) =>
+      /^langpacks-[a-z]+$/.test(p),
+    );
+    expect(localeLangpacks.length).toBeGreaterThan(0);
+    expect(packages).toEqual(
+      expect.arrayContaining(['langpacks-ru', 'langpacks-en']),
+    );
+    // Locale customization must match selected languages (fy has no langpack, so not in packages)
+    expect(body?.customizations?.locale?.languages).toEqual(
+      expect.arrayContaining([
+        'C.UTF-8',
+        'ru_RU.UTF-8',
+        'en_US.UTF-8',
+        'fy_DE.UTF-8',
+      ]),
+    );
   });
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
     await frame.getByLabel('Revisit Locale step').click();
     await expect(
-      frame.getByRole('button', {
-        name: 'Close Western Frisian - Germany (fy_DE.UTF-8)',
-      }),
-    ).toBeEnabled();
+      frame.getByText('English - United States (en_US.UTF-8)'),
+    ).toBeVisible();
     await expect(
-      frame.getByRole('button', { name: 'Close aa - Djibouti (aa_DJ.UTF-8)' }),
-    ).toBeEnabled();
-    await frame.getByPlaceholder('Select a language').fill('aa');
+      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
+    ).toBeVisible();
+    await expect(
+      frame.getByText('Russian - Russia (ru_RU.UTF-8)'),
+    ).toBeVisible();
+    await frame.getByPlaceholder('Select a language').fill('en_GB');
     await frame
-      .getByRole('option', { name: 'aa - Eritrea (aa_ER.UTF-8)' })
+      .getByRole('option', {
+        name: 'English - United Kingdom (en_GB.UTF-8)',
+      })
       .click();
     await expect(
-      frame.getByRole('button', { name: 'Close aa - Eritrea (aa_ER.UTF-8)' }),
-    ).toBeEnabled();
-    await frame.getByRole('button', { name: 'Clear input' }).click();
+      frame.getByText('English - United Kingdom (en_GB.UTF-8)'),
+    ).toBeVisible();
     await frame.getByRole('button', { name: 'Menu toggle' }).nth(1).click();
     await frame.getByRole('option', { name: 'ANSI-dvorak' }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
@@ -157,16 +205,17 @@ test('Create a blueprint with Locale customization', async ({
     await fillInImageOutputGuest(frame);
     await frame.getByRole('button', { name: 'Locale' }).click();
     await expect(
-      frame.getByRole('button', {
-        name: 'Close Western Frisian - Germany (fy_DE.UTF-8)',
-      }),
-    ).toBeEnabled();
+      frame.getByText('English - United States (en_US.UTF-8)'),
+    ).toBeVisible();
     await expect(
-      frame.getByRole('button', { name: 'Close aa - Djibouti (aa_DJ.UTF-8)' }),
-    ).toBeEnabled();
+      frame.getByText('English - United Kingdom (en_GB.UTF-8)'),
+    ).toBeVisible();
     await expect(
-      frame.getByRole('button', { name: 'Close aa - Eritrea (aa_ER.UTF-8)' }),
-    ).toBeEnabled();
+      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
+    ).toBeVisible();
+    await expect(
+      frame.getByText('Russian - Russia (ru_RU.UTF-8)'),
+    ).toBeVisible();
     await expect(frame.getByPlaceholder('Select a keyboard')).toHaveValue(
       'ANSI-dvorak',
     );

--- a/playwright/fixtures/data/exportBlueprintContents.ts
+++ b/playwright/fixtures/data/exportBlueprintContents.ts
@@ -109,8 +109,16 @@ export const exportedLocaleBP = (blueprintName: string): string => {
 timezone = "Etc/UTC"
 
 [customizations.locale]
-languages = [ "C.UTF-8", "fy_DE.UTF-8", "aa_DJ.UTF-8", "aa_ER.UTF-8" ]
-keyboard = "ANSI-dvorak"`;
+languages = [ "C.UTF-8", "ru_RU.UTF-8", "en_US.UTF-8", "fy_DE.UTF-8", "en_GB.UTF-8" ]
+keyboard = "ANSI-dvorak"
+
+[[packages]]
+name = "langpacks-en"
+version = "*"
+
+[[packages]]
+name = "langpacks-ru"
+version = "*"`;
 };
 
 export const exportedSystemdBP = (blueprintName: string): string => {

--- a/src/Components/CreateImageWizard/steps/Locale/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/index.tsx
@@ -1,13 +1,48 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
-import { Content, Form, Title } from '@patternfly/react-core';
+import { Content, Form, Spinner, Title } from '@patternfly/react-core';
+
+import { useSearchLanguagePacks } from '@/store/api/distributions';
 
 import KeyboardDropDown from './components/KeyboardDropDown';
 import LanguagesDropDown from './components/LanguagesDropDown';
 
+import { useGetArchitecturesQuery } from '../../../../store/backendApi';
+import { useAppSelector } from '../../../../store/hooks';
+import { asDistribution } from '../../../../store/typeGuards';
+import {
+  selectArchitecture,
+  selectDistribution,
+  selectLocaleLangpackCandidates,
+  selectVerifiedLocaleLangpacks,
+} from '../../../../store/wizardSlice';
 import { CustomizationLabels } from '../../../sharedComponents/CustomizationLabels';
 
 const LocaleStep = () => {
+  const distribution = useAppSelector(selectDistribution);
+  const arch = useAppSelector(selectArchitecture);
+  const candidateLangpacks = useAppSelector(selectLocaleLangpackCandidates);
+  const { data: distroRepositories, isLoading: isArchitecturesLoading } =
+    useGetArchitecturesQuery({
+      distribution: asDistribution(distribution),
+    });
+
+  const distroUrls = useMemo(() => {
+    return (
+      distroRepositories
+        ?.find((archItem) => archItem.arch === arch)
+        ?.repositories.filter((repo) => !!repo.baseurl)
+        .map((repo) => repo.baseurl!) ?? []
+    );
+  }, [distroRepositories, arch]);
+
+  const { isLoading: isSearchLoading } = useSearchLanguagePacks(distroUrls);
+  const verifiedLangpacks = useAppSelector(selectVerifiedLocaleLangpacks);
+
+  const isLoading =
+    candidateLangpacks.length > 0 &&
+    (isArchitecturesLoading || isSearchLoading);
+
   return (
     <Form>
       <CustomizationLabels customization='locale' />
@@ -16,6 +51,23 @@ const LocaleStep = () => {
       </Title>
       <Content>Select the locale for your image.</Content>
       <LanguagesDropDown />
+      {isLoading && (
+        <Content>
+          <Spinner size='md' /> Resolving packages for your preferred locale…
+        </Content>
+      )}
+      {!isLoading && verifiedLangpacks.length > 0 && (
+        <Content>
+          The following packages will be added based on your preferred locale:{' '}
+          {verifiedLangpacks.map((pkg, idx) => (
+            <strong key={pkg}>
+              {pkg}
+              {idx < verifiedLangpacks.length - 1 ? ', ' : ''}
+            </strong>
+          ))}
+          .
+        </Content>
+      )}
       <KeyboardDropDown />
     </Form>
   );

--- a/src/Components/CreateImageWizard/steps/Packages/components/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/Packages.tsx
@@ -96,15 +96,6 @@ const Packages = () => {
       distribution: asDistribution(distribution),
     });
 
-  const epelRepoUrlByDistribution =
-    getEpelUrlForDistribution(distribution) ?? EPEL_10_REPO_DEFINITION.url;
-
-  const { data: epelRepo, isSuccess: isSuccessEpelRepo } =
-    useListRepositoriesQuery({
-      url: epelRepoUrlByDistribution,
-      origin: ContentOrigin.COMMUNITY,
-    });
-
   const distroUrls = useMemo(() => {
     return (
       distroRepositories
@@ -113,6 +104,15 @@ const Packages = () => {
         .map((repo) => repo.baseurl!) ?? []
     );
   }, [distroRepositories, arch]);
+
+  const epelRepoUrlByDistribution =
+    getEpelUrlForDistribution(distribution) ?? EPEL_10_REPO_DEFINITION.url;
+
+  const { data: epelRepo, isSuccess: isSuccessEpelRepo } =
+    useListRepositoriesQuery({
+      url: epelRepoUrlByDistribution,
+      origin: ContentOrigin.EXTERNAL,
+    });
 
   const [currentlyRemovedPackages, setCurrentlyRemovedPackages] = useState<
     IBPackageWithRepositoryInfo[]

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -124,6 +124,7 @@ import {
   selectUseLatest,
   selectUserGroups,
   selectUsers,
+  selectVerifiedLocaleLangpacks,
   UserWithAdditionalInfo,
   wizardState,
 } from '../../../store/wizardSlice';
@@ -440,6 +441,16 @@ function commonRequestToState(
     }
   }
 
+  const rawPackageNames =
+    request.customizations.packages?.filter((pkg) => !pkg.startsWith('@')) ??
+    [];
+  const localeLangpacks = rawPackageNames.filter((p) =>
+    /^langpacks-[a-z]+$/.test(p),
+  );
+  const otherPackageNames = rawPackageNames.filter(
+    (p) => !/^langpacks-[a-z]+$/.test(p),
+  );
+
   return {
     details: {
       blueprintName: request.name || '',
@@ -528,14 +539,12 @@ function commonRequestToState(
       recommendedRepositories: [],
       redHatRepositories: [],
     },
-    packages:
-      request.customizations.packages
-        ?.filter((pkg) => !pkg.startsWith('@'))
-        .map((pkg) => ({
-          name: pkg,
-          summary: '',
-          repository: '' as PackageRepository,
-        })) || [],
+    packages: otherPackageNames.map((pkg) => ({
+      name: pkg,
+      summary: '',
+      repository: '' as PackageRepository,
+    })),
+    verifiedLocaleLangpacks: localeLangpacks,
     groups:
       request.customizations.packages
         ?.filter((grp) => grp.startsWith('@'))
@@ -1097,11 +1106,15 @@ const getFileSystem = (state: RootState): Filesystem[] | undefined => {
 const getPackages = (state: RootState) => {
   const packages = selectPackages(state);
   const groups = selectGroups(state);
+  const verifiedLocaleLangpacks = selectVerifiedLocaleLangpacks(state);
+  const packageNames = new Set(packages.map((pkg) => pkg.name));
+  for (const pkg of verifiedLocaleLangpacks) {
+    packageNames.add(pkg);
+  }
+  const list = [...packageNames].concat(groups.map((grp) => '@' + grp.name));
 
-  if (packages.length > 0 || groups.length > 0) {
-    return packages
-      .map((pkg) => pkg.name)
-      .concat(groups.map((grp) => '@' + grp.name));
+  if (list.length > 0) {
+    return list;
   }
   return undefined;
 };

--- a/src/store/api/distributions/hooks.tsx
+++ b/src/store/api/distributions/hooks.tsx
@@ -1,15 +1,18 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { simpleTargetNames } from '@/constants';
+import { useSearchRpmMutation } from '@/store/api/contentSources';
 import { selectIsOnPremise } from '@/store/envSlice';
-import { useAppSelector } from '@/store/hooks';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { ImageTypes } from '@/store/imageBuilderApi';
-import { isImageType } from '@/store/typeGuards';
+import { asDistribution, isImageType } from '@/store/typeGuards';
 import {
   selectArchitecture,
   selectDistribution,
   selectImageTypes,
   selectIsImageMode,
+  selectLocaleLangpackCandidates,
+  setVerifiedLocaleLangpacks,
 } from '@/store/wizardSlice';
 import isRhel from '@/Utilities/isRhel';
 
@@ -240,4 +243,63 @@ export const useImageTypeCustomizationSupport = (
     isOnPremise,
     isRhel: isRhel(distro),
   });
+};
+
+const extractPackageNames = (data: { package_name?: string }[]): string[] =>
+  Array.from(
+    new Set(data.flatMap((d) => (d.package_name ? [d.package_name] : []))),
+  );
+
+export const useSearchLanguagePacks = (distroUrls: string[]) => {
+  const dispatch = useAppDispatch();
+  const distribution = useAppSelector(selectDistribution);
+  const arch = useAppSelector(selectArchitecture);
+  const candidateLangpacks = useAppSelector(selectLocaleLangpackCandidates);
+  const [searchRpms, { isLoading: isSearchLoading }] = useSearchRpmMutation();
+
+  useEffect(() => {
+    if (candidateLangpacks.length === 0) {
+      dispatch(setVerifiedLocaleLangpacks([]));
+      return;
+    }
+    if (!process.env.IS_ON_PREMISE && distroUrls.length === 0) {
+      return;
+    }
+
+    let cancelled = false;
+    const run = async () => {
+      const request = process.env.IS_ON_PREMISE
+        ? {
+            packages: candidateLangpacks,
+            architecture: arch,
+            distribution: asDistribution(distribution),
+          }
+        : { exact_names: candidateLangpacks, urls: distroUrls, limit: 500 };
+
+      try {
+        const data = await searchRpms({
+          apiContentUnitSearchRequest: request,
+        }).unwrap();
+        const verified = extractPackageNames(
+          data as { package_name?: string }[],
+        );
+        if (!cancelled) dispatch(setVerifiedLocaleLangpacks(verified));
+      } catch {
+        if (!cancelled) dispatch(setVerifiedLocaleLangpacks([]));
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    arch,
+    distribution,
+    distroUrls,
+    dispatch,
+    candidateLangpacks,
+    searchRpms,
+  ]);
+
+  return { isLoading: isSearchLoading };
 };

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -217,6 +217,7 @@ export type wizardState = {
   fips: {
     enabled: boolean;
   };
+  verifiedLocaleLangpacks: string[];
   metadata?: {
     parent_id: string | null;
     exported_at: string;
@@ -332,6 +333,7 @@ export const initialState: wizardState = {
     enabled: false,
   },
   firstBoot: { script: '' },
+  verifiedLocaleLangpacks: [],
   users: [],
   userGroups: [{ name: '' }],
 };
@@ -607,6 +609,42 @@ export const selectFirewall = (state: RootState) => {
 export const selectFips = (state: RootState) => {
   return state.wizard.fips;
 };
+
+export const selectVerifiedLocaleLangpacks = (state: RootState) => {
+  return state.wizard.verifiedLocaleLangpacks;
+};
+
+const extractLanguageCode = (locale: string): string | undefined => {
+  const [regionPart] = locale.split('.');
+  const [languageCode] = regionPart.split('_');
+  if (!languageCode) {
+    return undefined;
+  }
+  const lc = languageCode.toLowerCase();
+  if (lc === 'c') {
+    return undefined;
+  }
+  return lc;
+};
+
+const getLangpackNameForLocale = (locale: string): string | undefined => {
+  const code = extractLanguageCode(locale);
+  return code ? `langpacks-${code}` : undefined;
+};
+
+export const selectLocaleLangpackCandidates = createSelector(
+  [selectLanguages],
+  (languages) => {
+    const set = new Set<string>();
+    for (const lang of languages ?? []) {
+      const pkg = getLangpackNameForLocale(lang);
+      if (pkg) {
+        set.add(pkg);
+      }
+    }
+    return Array.from(set);
+  },
+);
 
 // Derived selector for checking if we're in image mode
 export const selectIsImageMode = createSelector(
@@ -1569,6 +1607,9 @@ export const wizardSlice = createSlice({
     changeFips: (state, action: PayloadAction<boolean>) => {
       state.fips.enabled = action.payload;
     },
+    setVerifiedLocaleLangpacks: (state, action: PayloadAction<string[]>) => {
+      state.verifiedLocaleLangpacks = action.payload;
+    },
   },
 });
 
@@ -1690,5 +1731,6 @@ export const {
   removeGroupFromUserByIndex,
   changeRedHatRepositories,
   changeFips,
+  setVerifiedLocaleLangpacks,
 } = wizardSlice.actions;
 export default wizardSlice.reducer;


### PR DESCRIPTION
Adds langpack based on a user's locale selection. User selects a locale, the code looks if such a langpack for the locale exists (ignoring C langpack), and if it does, it quietly adds it to the request. There is no sign of the package in the "Additional packages" step, but I did add and information for the user in the "Locale" step, we can remove that as well if deemed unnecessary.