### PR TITLE
src: Deprecate `image-builder.aap.enabled` flag (HMS-9919)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -94,7 +94,6 @@ import {
 import { getHostArch, getHostDistro } from '../../Utilities/getHostInfo';
 import isRhel from '../../Utilities/isRhel';
 import { resolveRelPath } from '../../Utilities/path';
-import { useFlag } from '../../Utilities/useGetEnvironment';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
 type CustomWizardFooterPropType = {
@@ -184,9 +183,6 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const [searchParams] = useSearchParams();
-
-  // Feature flags
-  const isAAPRegistrationEnabled = useFlag('image-builder.aap.enabled');
 
   // IMPORTANT: Ensure the wizard starts with a fresh initial state
   useEffect(() => {
@@ -698,7 +694,6 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
               <WizardStep
                 name='Ansible Automation Platform'
                 id='wizard-aap'
-                isHidden={!isAAPRegistrationEnabled}
                 key='wizard-aap'
                 navItem={CustomStatusNavItem}
                 status={aapValidation.disabledNext ? 'error' : 'default'}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -60,8 +60,6 @@ vi.mock('@unleash/proxy-client-react', () => ({
     switch (flag) {
       case 'image-builder.templates.enabled':
         return true;
-      case 'image-builder.aap.enabled':
-        return true;
       case 'image-builder.advanced-partitioning.enabled':
         return true;
       case 'image-builder.compliance.enabled':


### PR DESCRIPTION
The feature is available in prod:stable, we should be able to remove the flag now.

JIRA: [HMS-9919](https://issues.redhat.com/browse/HMS-9919)