### PR TITLE
src: Deprecate `image-builder.compliance.enabled` flag (HMS-9920)

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -62,8 +62,6 @@ vi.mock('@unleash/proxy-client-react', () => ({
         return true;
       case 'image-builder.advanced-partitioning.enabled':
         return true;
-      case 'image-builder.compliance.enabled':
-        return true;
       case 'image-builder.layered-repos.enabled':
         return true;
       default:


### PR DESCRIPTION
The feature is available in prod:stable, we should be able to remove the flag now.

JIRA: [HMS-9920](https://issues.redhat.com/browse/HMS-9920)