### PR TITLE
src: Deprecate `platform.lightspeed-rebrand` (HMS-9921)

### DIFF
--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -19,7 +19,6 @@ import {
 import { DropEvent } from '@patternfly/react-core/dist/esm/helpers';
 import { HelpIcon } from '@patternfly/react-icons';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
-import { useFlag } from '@unleash/proxy-client-react';
 import { useNavigate } from 'react-router-dom';
 import TOML from 'smol-toml';
 
@@ -51,8 +50,6 @@ interface ImportBlueprintModalProps {
 export const ImportBlueprintModal: React.FunctionComponent<
   ImportBlueprintModalProps
 > = ({ setShowImportModal, isOpen }: ImportBlueprintModalProps) => {
-  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
-
   const onImportClose = () => {
     setShowImportModal(false);
     setFilename('');
@@ -272,9 +269,8 @@ export const ImportBlueprintModal: React.FunctionComponent<
               bodyContent={
                 <div>
                   You can import the blueprints you created by using the Red Hat
-                  image builder into{' '}
-                  {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'} images
-                  to create customized images.
+                  image builder into Red Hat Lightspeed images to create
+                  customized images.
                 </div>
               }
             >

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -68,7 +68,6 @@ import ExternalLinkButton from '../../utilities/ExternalLinkButton';
 const OscapContent = () => {
   const dispatch = useAppDispatch();
   const complianceEnabled = useFlag('image-builder.compliance.enabled');
-  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
   const complianceType = useAppSelector(selectComplianceType);
   const policyID = useAppSelector(selectCompliancePolicyID);
   const profileID = useAppSelector(selectComplianceProfileID);
@@ -151,13 +150,12 @@ const OscapContent = () => {
           Security
         </Title>
         <Content>
-          Select which {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'}{' '}
-          compliance policy or OpenSCAP profile you want your image to be
-          compliant-ready for.{' '}
-          {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'} compliance
-          allows the use of tailored policies, whereas OpenSCAP provides default
-          versions. This step automatically helps monitor the adherence of your
-          registered RHEL systems to a selected policy or profile.
+          Select which Red Hat Lightspeed compliance policy or OpenSCAP profile
+          you want your image to be compliant-ready for. Red Hat Lightspeed
+          compliance allows the use of tailored policies, whereas OpenSCAP
+          provides default versions. This step automatically helps monitor the
+          adherence of your registered RHEL systems to a selected policy or
+          profile.
         </Content>
         <FormGroup>
           <Switch
@@ -227,9 +225,7 @@ const OscapContent = () => {
                         url={COMPLIANCE_URL}
                         analyticsStepId='step-oscap'
                       >
-                        Manage{' '}
-                        {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'}{' '}
-                        compliance
+                        Manage Red Hat Lightspeed compliance
                       </ExternalLinkButton>
                     </HelperTextItem>
                   </HelperText>
@@ -296,9 +292,8 @@ const OscapContent = () => {
                 Currently there are no compliance policies in your environment.
                 To help you get started, select one of the default policies
                 below and we will create the policy for you. However, in order
-                to modify the policy or to create a new one, you must go through{' '}
-                {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'}{' '}
-                compliance.
+                to modify the policy or to create a new one, you must go through
+                Red Hat Lightspeed compliance.
               </p>
               <AlertActionLink
                 component='a'
@@ -317,9 +312,7 @@ const OscapContent = () => {
                 }}
                 href={COMPLIANCE_URL}
               >
-                Save blueprint and navigate to{' '}
-                {lightspeedEnabled ? 'Red Hat Lightspeed' : 'Insights'}{' '}
-                compliance
+                Save blueprint and navigate to Red Hat Lightspeed compliance
               </AlertActionLink>
             </Alert>
           )}

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -12,7 +12,6 @@ import {
   Popover,
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { useFlag } from '@unleash/proxy-client-react';
 
 import {
   FSReviewTable,
@@ -270,8 +269,6 @@ export const TargetEnvAWSList = () => {
 };
 
 export const TargetEnvGCPList = () => {
-  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
-
   const accountType = useAppSelector(selectGcpAccountType);
   const sharedMethod = useAppSelector(selectGcpShareMethod);
   const email = useAppSelector(selectGcpEmail);
@@ -297,7 +294,7 @@ export const TargetEnvGCPList = () => {
                 Shared with
               </Content>
               <Content component={ContentVariants.dd}>
-                Red Hat {lightspeedEnabled ? 'Lightspeed' : 'Insights'} only
+                Red Hat Lightspeed only
                 <br />
               </Content>
             </>
@@ -675,8 +672,6 @@ export const RegisterAapList = () => {
 };
 
 export const RegisterNowList = () => {
-  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
-
   const orgId = useAppSelector(selectOrgId);
   const activationKey = useAppSelector(selectActivationKey);
   const registrationType = useAppSelector(selectRegistrationType);
@@ -709,8 +704,7 @@ export const RegisterNowList = () => {
               {(registrationType === 'register-now-insights' ||
                 registrationType === 'register-now-rhc') && (
                 <Content component='li'>
-                  Connect to Red Hat{' '}
-                  {lightspeedEnabled ? 'Lightspeed' : 'Insights'}
+                  Connect to Red Hat Lightspeed
                   <br />
                 </Content>
               )}

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Gcp/index.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Gcp/index.tsx
@@ -8,7 +8,6 @@ import {
   Radio,
   Title,
 } from '@patternfly/react-core';
-import { useFlag } from '@unleash/proxy-client-react';
 
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
@@ -31,8 +30,6 @@ export type GcpAccountType =
   | undefined;
 
 const Gcp = () => {
-  const lightspeedEnabled = useFlag('platform.lightspeed-rebrand');
-
   const dispatch = useAppDispatch();
 
   const accountType = useAppSelector(selectGcpAccountType);
@@ -69,12 +66,12 @@ const Gcp = () => {
         />
         <Radio
           id='share-with-insights'
-          label={`Share image with Red Hat ${lightspeedEnabled ? 'Lightspeed' : 'Insights'} only`}
+          label={`Share image with Red Hat Lightspeed only`}
           name='gcp-share-method-type'
           description={
             <Content component={ContentVariants.small}>
-              Your image will be uploaded to GCP and shared with Red Hat{' '}
-              {lightspeedEnabled ? 'Lightspeed' : 'Insights'}.
+              Your image will be uploaded to GCP and shared with Red Hat
+              Lightspeed.
               <b> The image expires in 14 days.</b> You cannot access or
               recreate this image in your GCP project.
             </Content>

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -234,12 +234,12 @@ describe('GCP image type request generated correctly', () => {
     expect(receivedRequest).toEqual(expectedRequest);
   });
 
-  test('share image with red hat insight only', async () => {
+  test('share image with Red Hat Lightspeed only', async () => {
     const user = userEvent.setup();
     await renderCreateMode();
     await clickGCPTarget();
     const shareWithInsightOption = await screen.findByRole('radio', {
-      name: /Share image with Red Hat Insights only/i,
+      name: /Share image with Red Hat Lightspeed only/i,
     });
 
     await waitFor(() => user.click(shareWithInsightOption));


### PR DESCRIPTION
The rebrand is finished, we can deprecate the flag used for it in our code base.

JIRA: [HMS-9921](https://issues.redhat.com/browse/HMS-9921)