### PR TITLE
src: Deprecate `image-builder.shared-epel.enabled` flag (HMS-9922)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
@@ -103,15 +103,14 @@ const Repositories = () => {
   const [isTemplateSelected, setIsTemplateSelected] = useState(false);
   const [isStatusPollingEnabled, setIsStatusPollingEnabled] = useState(false);
 
-  const isSharedEPELEnabled = useFlag('image-builder.shared-epel.enabled');
   const isLayeredReposEnabled = useFlag('image-builder.layered-repos.enabled');
 
   const originParam = useMemo(() => {
     const origins = [ContentOrigin.CUSTOM];
-    if (isSharedEPELEnabled) origins.push(ContentOrigin.COMMUNITY);
+    origins.push(ContentOrigin.COMMUNITY);
     if (isLayeredReposEnabled) origins.push(ContentOrigin.REDHAT);
     return origins.join(',');
-  }, [isSharedEPELEnabled, isLayeredReposEnabled]);
+  }, [isLayeredReposEnabled]);
 
   const debouncedFilterValue = useDebounce(filterValue);
 
@@ -815,7 +814,6 @@ const Repositories = () => {
                           ) : origin === ContentOrigin.COMMUNITY ? (
                             <CommunityRepositoryLabel />
                           ) : (
-                            isSharedEPELEnabled &&
                             isEPELUrl(url) && <CustomEpelWarning />
                           )}
                         </Td>

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
@@ -8,7 +8,6 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import { useFlag } from '@unleash/proxy-client-react';
 
 import { ContentOrigin } from '../../../../constants';
 import {
@@ -34,13 +33,11 @@ type repoPropType = {
 };
 
 const RepoName = ({ repoUuid }: repoPropType) => {
-  const isSharedEPELEnabled = useFlag('image-builder.shared-epel.enabled');
-
   const originParam = useMemo(() => {
     const origins = [ContentOrigin.ALL];
-    if (isSharedEPELEnabled) origins.push(ContentOrigin.COMMUNITY);
+    origins.push(ContentOrigin.COMMUNITY);
     return origins.join(',');
-  }, [isSharedEPELEnabled]);
+  }, []);
 
   const { data, isSuccess, isFetching, isError } = useListRepositoriesQuery(
     {
@@ -144,13 +141,11 @@ export const SnapshotTable = ({
     { refetchOnMountOrArgChange: true, skip: template === '' },
   );
 
-  const isSharedEPELEnabled = useFlag('image-builder.shared-epel.enabled');
-
   const originParam = useMemo(() => {
     const origins = [ContentOrigin.REDHAT + ',' + ContentOrigin.CUSTOM];
-    if (isSharedEPELEnabled) origins.push(ContentOrigin.COMMUNITY);
+    origins.push(ContentOrigin.COMMUNITY);
     return origins.join(',');
-  }, [isSharedEPELEnabled]);
+  }, []);
 
   const { data, isSuccess, isLoading, isError } = useListRepositoriesQuery({
     uuid:

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -35,7 +35,6 @@ export const useFlagWithEphemDefault = (
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
     case 'image-builder.templates.enabled':
-    case 'image-builder.shared-epel.enabled':
       return true;
     default:
       return false;


### PR DESCRIPTION
The feature is available in prod:stable, we should be able to remove the flag now.

JIRA: [HMS-9922](https://issues.redhat.com/browse/HMS-9922)