### PR TITLE
Wizard: Rename groups function in the store

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -78,13 +78,13 @@ import {
 import { useAppSelector } from '../../../../store/hooks';
 import { Package } from '../../../../store/imageBuilderApi';
 import {
-  addGroup,
   addModule,
   addPackage,
+  addPackageGroup,
   addRecommendedRepository,
-  removeGroup,
   removeModule,
   removePackage,
+  removePackageGroup,
   removeRecommendedRepository,
   selectArchitecture,
   selectCustomRepositories,
@@ -945,10 +945,10 @@ const Packages = () => {
         setIsRepoModalOpen(true);
         setIsSelectingGroup(grp);
       } else {
-        dispatch(addGroup(grp));
+        dispatch(addPackageGroup(grp));
       }
     } else {
-      dispatch(removeGroup(grp.name));
+      dispatch(removePackageGroup(grp.name));
       if (
         isSuccessEpelRepo &&
         epelRepo?.data &&
@@ -1028,7 +1028,7 @@ const Packages = () => {
       dispatch(addPackage(isSelectingPackage!));
     }
     if (isSelectingGroup) {
-      dispatch(addGroup(isSelectingGroup!));
+      dispatch(addPackageGroup(isSelectingGroup!));
     }
     setIsRepoModalOpen(!isRepoModalOpen);
   };

--- a/src/Components/CreateImageWizard/steps/Users/components/UserRow.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserRow.tsx
@@ -18,10 +18,10 @@ import RemoveUserModal from './RemoveUserModal';
 
 import { useAppDispatch } from '../../../../../store/hooks';
 import {
+  addGroupToUserByUserIndex,
   addUser,
-  addUserGroupByIndex,
+  removeGroupFromUserByIndex,
   removeUser,
-  removeUserGroupByIndex,
   setUserAdministratorByIndex,
   setUserNameByIndex,
   setUserPasswordByIndex,
@@ -199,10 +199,10 @@ const UserRow = ({
               list={user.groups}
               item='Group'
               addAction={(value) =>
-                addUserGroupByIndex({ index: index, group: value })
+                addGroupToUserByUserIndex({ index: index, group: value })
               }
               removeAction={(value) =>
-                removeUserGroupByIndex({ index: index, group: value })
+                removeGroupFromUserByIndex({ index: index, group: value })
               }
               stepValidation={getValidationByIndex(index)}
               fieldName='groups'

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -1167,7 +1167,10 @@ export const wizardSlice = createSlice({
         state.enabled_modules.splice(index, 1);
       }
     },
-    addGroup: (state, action: PayloadAction<GroupWithRepositoryInfo>) => {
+    addPackageGroup: (
+      state,
+      action: PayloadAction<GroupWithRepositoryInfo>,
+    ) => {
       const existingGrpIndex = state.groups.findIndex(
         (grp) => grp.name === action.payload.name,
       );
@@ -1178,7 +1181,7 @@ export const wizardSlice = createSlice({
         state.groups.push(action.payload);
       }
     },
-    removeGroup: (
+    removePackageGroup: (
       state,
       action: PayloadAction<GroupWithRepositoryInfo['name']>,
     ) => {
@@ -1417,7 +1420,10 @@ export const wizardSlice = createSlice({
         user.groups = user.groups.filter((group) => group !== 'wheel');
       }
     },
-    addUserGroupByIndex: (state, action: PayloadAction<UserGroupPayload>) => {
+    addGroupToUserByUserIndex: (
+      state,
+      action: PayloadAction<UserGroupPayload>,
+    ) => {
       const { index, group } = action.payload;
       if (
         !state.users[index].groups.some(
@@ -1431,7 +1437,7 @@ export const wizardSlice = createSlice({
         }
       }
     },
-    removeUserGroupByIndex: (
+    removeGroupFromUserByIndex: (
       state,
       action: PayloadAction<UserGroupPayload>,
     ) => {
@@ -1514,8 +1520,8 @@ export const {
   removePackage,
   addModule,
   removeModule,
-  addGroup,
-  removeGroup,
+  addPackageGroup,
+  removePackageGroup,
   addLanguage,
   removeLanguage,
   clearLanguages,
@@ -1560,8 +1566,8 @@ export const {
   setUserPasswordByIndex,
   setUserSshKeyByIndex,
   setUserAdministratorByIndex,
-  addUserGroupByIndex,
-  removeUserGroupByIndex,
+  addGroupToUserByUserIndex,
+  removeGroupFromUserByIndex,
   changeRedHatRepositories,
   changeFips,
 } = wizardSlice.actions;


### PR DESCRIPTION
This PR renames group-related functions in the store to avoid confusion. We are adding a new "Groups" section to the Users step, which currently results in three different group-related sections: 
1) User groups
2) Groups
3) Package groups

This change clarifies the naming to better distinguish between them.