### PR TITLE
playwright: Clean up awaits (HMS-9923)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -168,7 +168,9 @@ module.exports = defineConfig([
         {
           'allowConditional': true
         }
-      ]
+      ],
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
     },
   },
 

--- a/playwright/Basic/basic.spec.ts
+++ b/playwright/Basic/basic.spec.ts
@@ -18,11 +18,11 @@ import {
 
 test('Basic create/build/delete test', async ({ page, cleanup }) => {
   const blueprintName = uuidv4();
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to review step in Wizard', async () => {
     await fillInImageOutput(frame);

--- a/playwright/BootTests/AAP/AAP.boot.ts
+++ b/playwright/BootTests/AAP/AAP.boot.ts
@@ -68,13 +68,13 @@ test('AAP registration boot integration test', async ({ page, cleanup }) => {
   const blueprintName = 'aap-test-' + uuidv4();
   const filePath = constructFilePath(blueprintName, 'qcow2');
 
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
 
   await ensureAuthenticated(page);
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');

--- a/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
@@ -43,10 +43,10 @@ test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
   const filePath = constructFilePath(blueprintName, 'qcow2');
 
   // Delete the blueprint compliance policy and Openstack resources after the run
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
   cleanup.add(() => deleteCompliancePolicy(page, policyName));
-  await cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
 
   // TODO: This test requires a static user for now,
   // TODO: because of the empty state in Compliance service when new user has not registered a system yet
@@ -56,7 +56,7 @@ test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
@@ -186,8 +186,8 @@ test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
   const policyType =
     'Centro Criptológico Nacional (CCN) - STIC for Red Hat Enterprise Linux 9 - Intermediate';
 
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
-  await cleanup.add(() => deleteCompliancePolicy(page, policyName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteCompliancePolicy(page, policyName));
 
   await login(page, true);
 
@@ -202,7 +202,7 @@ test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
   });
 
   await page.goto('/insights/image-builder/imagewizard?release=rhel9');
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await expect(frame.getByTestId('release_select')).toHaveText(
@@ -248,7 +248,7 @@ test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
 
   await test.step('Verify compliance warning appears in blueprint', async () => {
     await navigateToLandingPage(page);
-    const updatedFrame = await ibFrame(page);
+    const updatedFrame = ibFrame(page);
 
     const searchInput = updatedFrame.getByRole('textbox', {
       name: 'Search input',

--- a/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
@@ -43,10 +43,10 @@ test('Content integration test - Non repeatable build - URL source', async ({
   await deleteRepository(page, repositoryUrl);
 
   // Delete the blueprint, repository and Openstack resources after the run
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
-  await cleanup.add(() => deleteRepository(page, repositoryName));
-  await cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteRepository(page, repositoryName));
+  cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
 
   await ensureAuthenticated(page);
 
@@ -67,7 +67,7 @@ test('Content integration test - Non repeatable build - URL source', async ({
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
@@ -154,10 +154,10 @@ test('Content integration test - Non repeatable build - Upload source', async ({
   const dependencyPackageName = 'wolf';
 
   // Delete the blueprint, repository and Openstack resources after the run
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
-  await cleanup.add(() => deleteRepository(page, repositoryName));
-  await cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteRepository(page, repositoryName));
+  cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
 
   await ensureAuthenticated(page);
 
@@ -208,7 +208,7 @@ test('Content integration test - Non repeatable build - Upload source', async ({
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
@@ -308,15 +308,15 @@ test('Content integration test - Non repeatable build - Community repository', a
   const packageName = 'aha';
 
   // Delete the blueprint and Openstack resources after the run
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');

--- a/playwright/BootTests/Satellite/Satellite.boot.ts
+++ b/playwright/BootTests/Satellite/Satellite.boot.ts
@@ -37,13 +37,13 @@ test('Satellite registration boot integration test', async ({
   const blueprintName = 'satellite-test-' + uuidv4();
   const filePath = constructFilePath(blueprintName, 'qcow2');
 
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
-  await cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteImage(blueprintName));
+  cleanup.add(() => OpenStackWrapper.deleteInstance(blueprintName));
 
   await ensureAuthenticated(page);
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');

--- a/playwright/Cockpit/cockpit.spec.ts
+++ b/playwright/Cockpit/cockpit.spec.ts
@@ -15,7 +15,7 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
 
   await ensureAuthenticated(page);
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Cockpit worker config', async () => {
     const header = frame.getByText('Configure AWS Uploads');
@@ -84,7 +84,7 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
   });
 
   const blueprintName = uuidv4();
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await test.step('Cockpit cloud upload', async () => {
     await frame.getByTestId('blueprints-create-button').click();

--- a/playwright/Customizations/AAP.spec.ts
+++ b/playwright/Customizations/AAP.spec.ts
@@ -61,12 +61,12 @@ test('Create a blueprint with AAP registration customization', async ({
   test.skip(!isHosted(), 'AAP customization is not available in the plugin');
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -192,7 +192,7 @@ test('Create a blueprint with AAP registration customization', async ({
   await test.step('Export BP', async (step) => {
     step.skip(!isHosted(), 'Exporting is not available in the plugin');
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });

--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -24,13 +24,13 @@ test('Create a blueprint with Compliance policy selected', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);

--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -31,13 +31,13 @@ test('Create a blueprint with Disk customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Login, navigate to IB and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -239,7 +239,7 @@ test('Create a blueprint with Disk customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -249,7 +249,7 @@ test('Create a blueprint with Disk customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(exportedBP, exportedDiskBP(blueprintName));
+    verifyExportedBlueprint(exportedBP, exportedDiskBP(blueprintName));
   });
 
   await test.step('Import BP', async () => {

--- a/playwright/Customizations/Filesystem.spec.ts
+++ b/playwright/Customizations/Filesystem.spec.ts
@@ -32,13 +32,13 @@ test('Create a blueprint with Filesystem customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Login, navigate to IB and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -186,7 +186,7 @@ test('Create a blueprint with Filesystem customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -196,10 +196,7 @@ test('Create a blueprint with Filesystem customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(
-      exportedBP,
-      exportedFilesystemBP(blueprintName),
-    );
+    verifyExportedBlueprint(exportedBP, exportedFilesystemBP(blueprintName));
   });
 
   await test.step('Import BP', async () => {

--- a/playwright/Customizations/FipsMode.spec.ts
+++ b/playwright/Customizations/FipsMode.spec.ts
@@ -24,13 +24,13 @@ test('FIPS switch toggles and persists through save', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to Security step and toggle FIPS on', async () => {
     await fillInImageOutput(frame);

--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -31,13 +31,13 @@ test('Create a blueprint with Firewall customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -206,7 +206,7 @@ test('Create a blueprint with Firewall customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -216,10 +216,7 @@ test('Create a blueprint with Firewall customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(
-      exportedBP,
-      exportedFirewallBP(blueprintName),
-    );
+    verifyExportedBlueprint(exportedBP, exportedFirewallBP(blueprintName));
   });
 
   await test.step('Import BP', async () => {

--- a/playwright/Customizations/Hostname.spec.ts
+++ b/playwright/Customizations/Hostname.spec.ts
@@ -32,13 +32,13 @@ test('Create a blueprint with Hostname customization', async ({
   const hostname = 'testsystem';
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -75,7 +75,7 @@ test('Create a blueprint with Hostname customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -85,10 +85,7 @@ test('Create a blueprint with Hostname customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(
-      exportedBP,
-      exportedHostnameBP(blueprintName),
-    );
+    verifyExportedBlueprint(exportedBP, exportedHostnameBP(blueprintName));
   });
 
   await test.step('Import BP', async () => {

--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -31,13 +31,13 @@ test('Create a blueprint with Kernel customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -113,7 +113,7 @@ test('Create a blueprint with Kernel customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -123,7 +123,7 @@ test('Create a blueprint with Kernel customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(exportedBP, exportedKernelBP(blueprintName));
+    verifyExportedBlueprint(exportedBP, exportedKernelBP(blueprintName));
   });
 
   await test.step('Import BP', async () => {

--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -31,13 +31,13 @@ test('Create a blueprint with Locale customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -133,7 +133,7 @@ test('Create a blueprint with Locale customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -143,7 +143,7 @@ test('Create a blueprint with Locale customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(exportedBP, exportedLocaleBP(blueprintName));
+    verifyExportedBlueprint(exportedBP, exportedLocaleBP(blueprintName));
   });
 
   await test.step('Import BP', async () => {

--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -27,13 +27,13 @@ test('Create a blueprint with OpenSCAP customization', async ({
 
   const blueprintName = 'test-' + uuidv4();
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('WSL only disables selector', async () => {
     await frame.getByRole('button', { name: 'Create image blueprint' }).click();
@@ -234,7 +234,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });

--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -150,13 +150,13 @@ registrationModes.forEach(
       const blueprintName = `test-${name}-${uuidv4()}`;
 
       // Delete the blueprint after the run fixture
-      await cleanup.add(() => deleteBlueprint(page, blueprintName));
+      cleanup.add(() => deleteBlueprint(page, blueprintName));
 
       await ensureAuthenticated(page);
 
       // Navigate to IB landing page and get the frame
       await navigateToLandingPage(page);
-      const frame = await ibFrame(page);
+      const frame = ibFrame(page);
 
       await test.step('Navigate to Registration step', async () => {
         await fillInImageOutput(frame);
@@ -173,7 +173,7 @@ registrationModes.forEach(
             frame.getByRole('button', { name: 'View details' }),
           ).toBeVisible();
           await expect(frame.getByText('activation-key-')).toBeHidden();
-          frame.getByRole('button', { name: 'View details' }).click();
+          await frame.getByRole('button', { name: 'View details' }).click();
           await expect(
             frame.getByRole('button', { name: 'View details' }),
           ).toBeVisible();
@@ -359,7 +359,7 @@ registrationModes.forEach(
       let exportedBP = '';
       await test.step('Export blueprint', async () => {
         exportedBP = await exportBlueprint(page);
-        await cleanup.add(async () => {
+        cleanup.add(async () => {
           await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
         });
       });

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -31,13 +31,13 @@ test('Create a blueprint with Systemd customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -135,7 +135,7 @@ test('Create a blueprint with Systemd customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -145,7 +145,7 @@ test('Create a blueprint with Systemd customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(exportedBP, exportedSystemdBP(blueprintName));
+    verifyExportedBlueprint(exportedBP, exportedSystemdBP(blueprintName));
   });
 
   await test.step('Import BP', async () => {

--- a/playwright/Customizations/Timezone.spec.ts
+++ b/playwright/Customizations/Timezone.spec.ts
@@ -31,13 +31,13 @@ test('Create a blueprint with Timezone customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
@@ -110,7 +110,7 @@ test('Create a blueprint with Timezone customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -120,10 +120,7 @@ test('Create a blueprint with Timezone customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(
-      exportedBP,
-      exportedTimezoneBP(blueprintName),
-    );
+    verifyExportedBlueprint(exportedBP, exportedTimezoneBP(blueprintName));
   });
 
   await test.step('Import BP', async () => {

--- a/playwright/Customizations/Users.spec.ts
+++ b/playwright/Customizations/Users.spec.ts
@@ -36,13 +36,13 @@ test('Create a blueprint with Users customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Navigate to Users step', async () => {
     await fillInImageOutput(frame);
@@ -421,7 +421,7 @@ test('Create a blueprint with Users customization', async ({
   let exportedBP = '';
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
     });
   });
@@ -431,7 +431,7 @@ test('Create a blueprint with Users customization', async ({
       isHosted(),
       'Only verify the contents of the exported blueprint in cockpit',
     );
-    await verifyExportedBlueprint(exportedBP, exportedUsersBP(blueprintName));
+    verifyExportedBlueprint(exportedBP, exportedUsersBP(blueprintName));
   });
 
   await test.step('Import blueprint', async () => {

--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -24,19 +24,19 @@ test('Import a blueprint with invalid customization', async ({
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture
-  await cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
-  const frame = await ibFrame(page);
+  const frame = ibFrame(page);
 
   await test.step('Import BP', async () => {
     const blueprintFile = await saveBlueprintFileWithContents(
       IMPORT_WITH_DUPLICATE_VALUES,
     );
-    await cleanup.add(async () => {
+    cleanup.add(async () => {
       await fsPromises.rm(path.dirname(blueprintFile), { recursive: true });
     });
     await importBlueprint(frame, blueprintFile);

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -84,7 +84,7 @@ export const deleteBlueprint = async (page: Page, blueprintName: string) => {
     async () => {
       // Locate back to the Image Builder page every time because the test can fail at any stage
       await navigateToLandingPage(page);
-      const frame = await ibFrame(page);
+      const frame = ibFrame(page);
       await frame
         .getByRole('textbox', { name: 'Search input' })
         .fill(blueprintName);
@@ -114,8 +114,8 @@ export const deleteBlueprint = async (page: Page, blueprintName: string) => {
  * Export the blueprint
  * @param page - the page or frame object
  */
-export const exportBlueprint = async (page: Page | FrameLocator): string => {
-  const frame = await ibFrame(page);
+export const exportBlueprint = async (page: Page): Promise<string> => {
+  const frame = ibFrame(page);
   const downloadPromise = page.waitForEvent('download');
   await frame.getByRole('button', { name: 'blueprint menu toggle' }).click();
   await frame


### PR DESCRIPTION
We had a bunch of places with awaits marked as unnnecessary by IDEs, but there was no linter rule to check for those. This adds two rules to look for both unneeded and missing awaits.

JIRA: [HMS-9923](https://issues.redhat.com/browse/HMS-9923)