### PR TITLE
validation: Don't allow adding groups that match the username (HMS-9933)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -834,7 +834,16 @@ export function useUsersValidation(): UsersStepValidation {
     }
 
     const duplicateGroups = getListOfDuplicates(users[index].groups);
-    if (invalidGroups.length > 0 || duplicateGroups.length > 0) {
+    const groupMatchingUsername =
+      users[index].name && users[index].groups.includes(users[index].name)
+        ? users[index].name
+        : '';
+
+    if (
+      invalidGroups.length > 0 ||
+      duplicateGroups.length > 0 ||
+      groupMatchingUsername
+    ) {
       const groupsErrors = [];
       if (invalidGroups.length > 0) {
         groupsErrors.push(`Invalid user groups: ${invalidGroups.join(', ')}`);
@@ -842,6 +851,11 @@ export function useUsersValidation(): UsersStepValidation {
       if (duplicateGroups.length > 0) {
         groupsErrors.push(
           `Includes duplicate groups: ${duplicateGroups.join(', ')}`,
+        );
+      }
+      if (groupMatchingUsername) {
+        groupsErrors.push(
+          `Group cannot match username: ${groupMatchingUsername}`,
         );
       }
       userErrors.groups = groupsErrors.join(' | ');


### PR DESCRIPTION
A group that has the same name as the user is automatically created by `useradd`. Adding it explicitly leads to a build error, because `useradd` will exist with status 6.

The underlying problem is of course bigger: whenever a user refers to a group that doesn't exist, the build will fail.

Fixes #3932

**Note:** This will have to be amended to also check the user-specified groups once #3929 gets merged, because then customers can add groups explicitly, thus preventing the build error.