### PR TITLE
packit: Drop Fedora 41 because it's EOL

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -22,7 +22,6 @@ jobs:
     tmt_plan: /plans/all/main
     targets:
       - centos-stream-10
-      - fedora-41
       - fedora-42
       - fedora-43
 


### PR DESCRIPTION
Currently testing-farm jobs for Fedora 41 spin forever in the frontend pull requests, which is a good reminder that this version is EOL since November.
So let's drop it!