### PR TITLE
playwright: Turn snapshot date into regex (HMS-9971)

### DIFF
--- a/playwright/BootTests/Content/ContentRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentRepeatable.boot.ts
@@ -125,7 +125,9 @@ test('Content integration test - Repeatable build - URL source', async ({
 
     await frame.getByRole('button', { name: 'Toggle date picker' }).click();
     await frame
-      .getByRole('button', { name: `${dayOfMonth} ${monthName}` })
+      .getByRole('button', {
+        name: new RegExp(`^${dayOfMonth}\\s+${monthName}(\\s+\\d{4})?$`, 'i'),
+      })
       .click();
   });
 


### PR DESCRIPTION
This will help with two potential issues:
- it will ensure an exact match (just 4 January instead of 4, 14 and 24)
- it adds an optional year value so the locator shouldn't fail if there's an exact match, but also a year defined (looks like the year is not always there for some reason)

JIRA: [HMS-9971](https://issues.redhat.com/browse/HMS-9971)