### PR TITLE
Replace fedora-41 runner with fedora-43

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,8 +30,8 @@ test:
   parallel:
     matrix:
       - RUNNER:
-          - rhos-01/fedora-41-x86_64-large
           - rhos-01/fedora-42-x86_64-large
+          - rhos-01/fedora-43-x86_64-large
           - rhos-01/rhel-10.1-nightly-x86_64-large
         INTERNAL_NETWORK: ["true"]
 


### PR DESCRIPTION
Since Fedora 41 is EOL, we don't need to test on that runner anymore probably.