### PR TITLE
tsconfig: Move "node" and "vitest/globals" types to base config  (HMS-9976)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "esnext",
     "target": "es2021",
     "jsx": "react-jsx",
+    "types": ["node", "vitest/globals"],
     "sourceMap": true,
     "allowJs": true,
     "moduleResolution": "node",
@@ -25,5 +26,5 @@
     }
   },
   "include": ["./src"],
-  "exclude": ["./playwright", "./src/**/*.test.ts", "./src/**/*.test.tsx", "./src/test"]
+  "exclude": ["./playwright"]
 }


### PR DESCRIPTION
"vitest/globals" types need to stay in the base config if we want the IDEs to be able to see them. "node" types should be added there as well.

The separation of tsconfigs between vitest and base sounded good to me in theory, but since our test files are located under `src/` it might be a bit impractical in practice.

Previously when opening a vitest test file in VSCode the file would be painted red with errors, this ensures it's not the case anymore.

<img width="798" height="306" alt="image" src="https://github.com/user-attachments/assets/9f3eb6ce-76b6-48fb-a9c9-93e31472df5e" />


JIRA: [HMS-9976](https://issues.redhat.com/browse/HMS-9976)