### PR TITLE
Wizard: add description to AAP step

### DIFF
--- a/src/Components/CreateImageWizard/steps/AAP/index.tsx
+++ b/src/Components/CreateImageWizard/steps/AAP/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Form, Title } from '@patternfly/react-core';
+import { Content, Form, Title } from '@patternfly/react-core';
 
 import AAPRegistration from './components/AAPRegistration';
 
@@ -10,6 +10,9 @@ const AAPStep = () => {
       <Title headingLevel='h1' size='xl'>
         Ansible Automation Platform
       </Title>
+      <Content>
+        Configure the image with an AAP callback that will run on first boot.
+      </Content>
       <AAPRegistration />
     </Form>
   );


### PR DESCRIPTION
We got a call from a customer who did not know when AAP configuration happens. If this is a build time or first boot configuration. This should clarify it.

---

And it is fair, we do not have pretty much anything on that page that explains it.

<img width="1115" height="711" alt="image" src="https://github.com/user-attachments/assets/221ca648-e894-4cd4-b2ba-2fe79e8103ec" />

Review carefully, I copy-pasted this from Firstboot step and I have no idea what I am doing. Hopefully, tests will not blow up.