### PR TITLE
Wizard: Fix SSH validator (HMS-10004)

### DIFF
--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -111,7 +111,7 @@ export const isSshKeyValid = (sshKey: string) => {
   // 2. Base64-encoded key material.
   // 3. Optional comment at the end.
   const isPatternValid =
-    /^(ssh-(rsa|dss|ed25519)|ecdsa-sha2-nistp(256|384|521))\s+[A-Za-z0-9+/=]+(\s+\S+)?$/.test(
+    /^(ssh-(rsa|dss|ed25519)|ecdsa-sha2-nistp(256|384|521))\s+[A-Za-z0-9+/=]+(\s+\S.*)?$/.test(
       sshKey,
     );
   return isPatternValid;


### PR DESCRIPTION
The validator was previously matching only non-whitespace characters in the comment section of SSH key. This ensures comments with spaces are also valid.

JIRA: [HMS-10004](https://issues.redhat.com/browse/HMS-10004)