### PR TITLE
Wizard: revamp the check mark in Release field (HMS-10027)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseSelect.tsx
@@ -149,7 +149,7 @@ const ReleaseSelect = () => {
       <Select
         isOpen={isOpen}
         onOpenChange={(isOpen) => setIsOpen(isOpen)}
-        selected={releases.get(distribution)}
+        selected={distribution}
         onSelect={handleSelect}
         toggle={toggle}
         shouldFocusToggleOnSelect


### PR DESCRIPTION
This commit fix check mark visibility for selected release

<img width="935" height="248" alt="Screenshot 2026-01-11 at 21 45 22" src="https://github.com/user-attachments/assets/bc39a244-dec1-4cb4-b220-75d08aa80c27" />
<img width="1229" height="475" alt="Screenshot 2026-01-11 at 22 41 26" src="https://github.com/user-attachments/assets/fa614397-f7dc-4ac3-ad5f-bcd598568ac6" />





JIRA: [HMS-10027](https://issues.redhat.com/browse/HMS-10027)