### PR TITLE
Wizard: Add Red Hat Enterprise Linux (RHEL) 9 to cockpit (HMS-10028)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -109,6 +109,7 @@ export const ON_PREM_RELEASES = new Map([
   [FEDORA_42, 'Fedora Linux 42'],
   [FEDORA_43, 'Fedora Linux 43'],
   [FEDORA_44, 'Fedora Linux 44'],
+  [RHEL_9, 'Red Hat Enterprise Linux (RHEL) 9'],
   [RHEL_10, 'Red Hat Enterprise Linux (RHEL) 10'],
 ]);
 


### PR DESCRIPTION
This commit add Red Hat Enterprise Linux (RHEL) 9 to cockpit to prevent empty value in Release field when we check in RHEL9 environment
<img width="1014" height="376" alt="Screenshot 2026-01-12 at 9 07 38" src="https://github.com/user-attachments/assets/6a2451d6-4613-4518-b792-424f2e63bb00" />


JIRA: [HMS-10028](https://issues.redhat.com/browse/HMS-10028)