### PR TITLE
devDeps: Manually bump eslint-plugin-react-hooks from 5.2.0 to 7.0.1 (HMS-10036)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -120,6 +120,7 @@ module.exports = defineConfig([
         },
       ],
       'jsx-a11y/no-autofocus': 'off',
+      'react-hooks/set-state-in-effect': 'warn', // TODO address issues and enable the rule
       'prettier/prettier': ['error', {
         semi: true,
         tabWidth: 2,

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "eslint-plugin-playwright": "2.5.0",
         "eslint-plugin-prettier": "5.5.4",
         "eslint-plugin-react": "7.37.5",
-        "eslint-plugin-react-hooks": "5.2.0",
+        "eslint-plugin-react-hooks": "7.0.1",
         "eslint-plugin-react-redux": "4.2.2",
         "eslint-plugin-testing-library": "7.15.4",
         "git-revision-webpack-plugin": "5.0.0",
@@ -10809,13 +10809,20 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
@@ -12408,6 +12415,23 @@
       "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
     },
     "node_modules/history": {
       "version": "5.3.0",
@@ -21982,6 +22006,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-playwright": "2.5.0",
     "eslint-plugin-prettier": "5.5.4",
     "eslint-plugin-react": "7.37.5",
-    "eslint-plugin-react-hooks": "5.2.0",
+    "eslint-plugin-react-hooks": "7.0.1",
     "eslint-plugin-react-redux": "4.2.2",
     "eslint-plugin-testing-library": "7.15.4",
     "git-revision-webpack-plugin": "5.0.0",

--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import {
   Bullseye,
@@ -181,19 +181,25 @@ const BlueprintsSidebar = () => {
 const BlueprintSearch = ({ blueprintsTotal }: blueprintSearchProps) => {
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
   const dispatch = useAppDispatch();
-  const debouncedSearch = useCallback(
-    debounce((filter) => {
-      dispatch(setBlueprintsOffset(0));
-      dispatch(imageBuilderApi.util.invalidateTags([{ type: 'Blueprints' }]));
-      dispatch(setBlueprintSearchInput(filter.length > 0 ? filter : undefined));
-    }, DEBOUNCED_SEARCH_WAIT_TIME),
-    [],
+
+  const debouncedSearch = useMemo(
+    () =>
+      debounce((filter) => {
+        dispatch(setBlueprintsOffset(0));
+        dispatch(imageBuilderApi.util.invalidateTags([{ type: 'Blueprints' }]));
+        dispatch(
+          setBlueprintSearchInput(filter.length > 0 ? filter : undefined),
+        );
+      }, DEBOUNCED_SEARCH_WAIT_TIME),
+    [dispatch],
   );
-  React.useEffect(() => {
+
+  useEffect(() => {
     return () => {
       debouncedSearch.cancel();
     };
   }, [debouncedSearch]);
+
   const onChange = (value: string) => {
     if (value.length === 0) {
       dispatch(setBlueprintSearchInput(undefined));

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/SizeUnit.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/SizeUnit.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 
 import {
   MenuToggle,
@@ -35,7 +35,7 @@ const SizeUnit = ({ partition, customization }: SizeUnitPropTypes) => {
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
 
-  const initialValue = useRef(partition).current;
+  const [initialValue] = useState(partition);
 
   const onSelect = (event?: React.MouseEvent, selection?: string | number) => {
     if (selection === undefined) return;

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -98,6 +98,37 @@ export const CreateSaveAndBuildBtn = ({
   );
 };
 
+type SaveAndBuildImagesModalProps = {
+  showModal: boolean;
+  handleClose: () => void;
+};
+
+const SaveAndBuildImagesModal = ({
+  showModal,
+  handleClose,
+}: SaveAndBuildImagesModalProps) => {
+  return (
+    <Modal isOpen={showModal} onClose={handleClose} width='50%'>
+      <ModalHeader title='Save time by building images' />
+      <ModalBody>
+        Building blueprints and images doesn&apos;t need to be a two step
+        process. To build images simultaneously, use the dropdown arrow to the
+        right side of this button.
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          key='back'
+          variant='primary'
+          data-testid='close-button-saveandbuild-modal'
+          onClick={handleClose}
+        >
+          Close
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
 export const CreateSaveButton = ({
   setIsOpen,
   getBlueprintPayload,
@@ -118,31 +149,8 @@ export const CreateSaveButton = ({
     'imageBuilder.saveAndBuildModalSeen',
   );
 
-  const SaveAndBuildImagesModal = () => {
-    const handleClose = () => {
-      setShowModal(false);
-    };
-
-    return (
-      <Modal isOpen={showModal} onClose={handleClose} width='50%'>
-        <ModalHeader title='Save time by building images' />
-        <ModalBody>
-          Building blueprints and images doesn&apos;t need to be a two step
-          process. To build images simultaneously, use the dropdown arrow to the
-          right side of this button.
-        </ModalBody>
-        <ModalFooter>
-          <Button
-            key='back'
-            variant='primary'
-            data-testid='close-button-saveandbuild-modal'
-            onClick={handleClose}
-          >
-            Close
-          </Button>
-        </ModalFooter>
-      </Modal>
-    );
+  const handleClose = () => {
+    setShowModal(false);
   };
 
   const onClick = () => {
@@ -180,7 +188,10 @@ export const CreateSaveButton = ({
 
   return (
     <>
-      {showModal && <SaveAndBuildImagesModal />}
+      <SaveAndBuildImagesModal
+        showModal={showModal}
+        handleClose={handleClose}
+      />
       <MenuToggleAction
         onClick={onClick}
         id='wizard-create-save-btn'

--- a/src/Components/CreateImageWizard/steps/Snapshot/components/TemplatesEmpty.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/components/TemplatesEmpty.tsx
@@ -15,21 +15,21 @@ type TemplatesEmptyProps = {
   refetch: () => void;
 };
 
-const TemplatesEmpty = ({ refetch }: TemplatesEmptyProps) => {
-  const GoToTemplatesButton = () => {
-    return (
-      <Button
-        component='a'
-        target='_blank'
-        variant='link'
-        icon={<ExternalLinkAltIcon />}
-        href={TEMPLATES_URL}
-      >
-        Go to content templates
-      </Button>
-    );
-  };
+const GoToTemplatesButton = () => {
+  return (
+    <Button
+      component='a'
+      target='_blank'
+      variant='link'
+      icon={<ExternalLinkAltIcon />}
+      href={TEMPLATES_URL}
+    >
+      Go to content templates
+    </Button>
+  );
+};
 
+const TemplatesEmpty = ({ refetch }: TemplatesEmptyProps) => {
   return (
     <EmptyState
       headingLevel='h4'


### PR DESCRIPTION
This bumps eslint-plugin-react-hooks from 5.2.0 to 7.0.1, switches 'react-hooks/set-state-in-effect' rule to warning to address later and resolves the remaining issues.

JIRA: [HMS-10036](https://issues.redhat.com/browse/HMS-10036)