### PR TITLE
Wizard: Fix indentation of registration list on review step (HMS-10037)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -696,7 +696,9 @@ export const RegisterNowList = () => {
     <>
       <Content className='pf-v6-u-pb-sm'>
         <Content component={ContentVariants.dl} className='review-step-dl'>
-          <Content component={ContentVariants.dt}>Registration method</Content>
+          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+            Registration method
+          </Content>
           <Content
             component={ContentVariants.dd}
             data-testid='review-registration'
@@ -732,9 +734,13 @@ export const RegisterNowList = () => {
               )}
             </Content>
           </Content>
-          <Content component={ContentVariants.dt}>Organization ID</Content>
+          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+            Organization ID
+          </Content>
           <Content component={ContentVariants.dd}>{orgId}</Content>
-          <Content component={ContentVariants.dt}>Activation key</Content>
+          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+            Activation key
+          </Content>
           <Content component={ContentVariants.dd}>{activationKey}</Content>
         </Content>
       </Content>


### PR DESCRIPTION
The indent was smaller, this should fix the issue.

Before:
<img width="593" height="479" alt="image" src="https://github.com/user-attachments/assets/ace60fe5-5f61-4064-b26a-c8e57e359b2a" />

After:
<img width="620" height="423" alt="image" src="https://github.com/user-attachments/assets/ca236154-73a8-43ba-9c4b-d65969f21147" />


JIRA: [HMS-10037](https://issues.redhat.com/browse/HMS-10037)