### PR TITLE
Status: Update AWS S3 expiration time from 6 hours to 7 days (HMS-160)

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -46,6 +46,7 @@ import { AwsTarget, Target } from './Target';
 import {
   AMPLITUDE_MODULE_NAME,
   AWS_S3_EXPIRATION_TIME_IN_HOURS,
+  AWS_S3_EXPIRATION_TIME_IN_HOURS_LEGACY,
   OCI_STORAGE_EXPIRATION_TIME_IN_DAYS,
   PAGINATION_LIMIT,
   PAGINATION_OFFSET,
@@ -82,6 +83,7 @@ import {
   timestampToDisplayString,
   timestampToDisplayStringDetailed,
 } from '../../Utilities/time';
+import { useFlag } from '../../Utilities/useGetEnvironment';
 import { AWSLaunchModal } from '../Launch/AWSLaunchModal';
 import { AzureLaunchModal } from '../Launch/AzureLaunchModal';
 import { GcpLaunchModal } from '../Launch/GcpLaunchModal';
@@ -472,8 +474,12 @@ type AwsS3RowPropTypes = {
 };
 
 const AwsS3Row = ({ compose, rowIndex }: AwsS3RowPropTypes) => {
+  const s3ExpirationFlag = useFlag('image-builder.s3-expiration');
   const hoursToExpiration = computeHoursToExpiration(compose.created_at);
-  const isExpired = hoursToExpiration >= AWS_S3_EXPIRATION_TIME_IN_HOURS;
+  const awsS3ExpirationTime = s3ExpirationFlag
+    ? AWS_S3_EXPIRATION_TIME_IN_HOURS
+    : AWS_S3_EXPIRATION_TIME_IN_HOURS_LEGACY;
+  const isExpired = hoursToExpiration >= awsS3ExpirationTime;
 
   const details = <AwsS3Details compose={compose} />;
   const instance = <AwsS3Instance compose={compose} isExpired={isExpired} />;

--- a/src/Components/ImagesTable/Status.tsx
+++ b/src/Components/ImagesTable/Status.tsx
@@ -26,6 +26,7 @@ import {
 
 import {
   AWS_S3_EXPIRATION_TIME_IN_HOURS,
+  AWS_S3_EXPIRATION_TIME_IN_HOURS_LEGACY,
   OCI_STORAGE_EXPIRATION_TIME_IN_DAYS,
 } from '../../constants';
 import { useGetComposeStatusQuery } from '../../store/backendApi';
@@ -37,6 +38,7 @@ import {
   ComposeStatusError,
   UploadStatus,
 } from '../../store/imageBuilderApi';
+import { useFlag } from '../../Utilities/useGetEnvironment';
 
 type StatusClonePropTypes = {
   clone: ClonesResponseItem;
@@ -178,6 +180,7 @@ export const ExpiringStatus = ({
   const { data: composeStatus, isSuccess } = useGetComposeStatusQuery({
     composeId: compose.id,
   });
+  const s3ExpirationFlag = useFlag('image-builder.s3-expiration');
 
   if (!isSuccess) {
     return <Skeleton />;
@@ -195,7 +198,10 @@ export const ExpiringStatus = ({
   }
 
   const status = composeStatus!.image_status.status;
-  const remainingHours = AWS_S3_EXPIRATION_TIME_IN_HOURS - timeToExpiration;
+  const awsS3ExpirationTime = s3ExpirationFlag
+    ? AWS_S3_EXPIRATION_TIME_IN_HOURS
+    : AWS_S3_EXPIRATION_TIME_IN_HOURS_LEGACY;
+  const remainingHours = awsS3ExpirationTime - timeToExpiration;
   const remainingDays = OCI_STORAGE_EXPIRATION_TIME_IN_DAYS - timeToExpiration;
 
   const imageType = compose.request.image_requests[0].upload_request.type;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -236,7 +236,8 @@ export const AWS_REGIONS = [
   },
 ];
 
-export const AWS_S3_EXPIRATION_TIME_IN_HOURS = 168;
+export const AWS_S3_EXPIRATION_TIME_IN_HOURS = 168; // 7 days
+export const AWS_S3_EXPIRATION_TIME_IN_HOURS_LEGACY = 6; // Legacy 6 hours expiration
 export const OCI_STORAGE_EXPIRATION_TIME_IN_DAYS = 7;
 
 // Anchor element for all modals that we display so that they play nice with top-most components like Quickstarts


### PR DESCRIPTION
This is the frontend change related to bumping the S3 download expiration time to 7 days (see https://github.com/osbuild/osbuild-composer/pull/4958 for reference).

This PR:
- Changed AWS_S3_EXPIRATION_TIME_IN_HOURS from 6 to 168 hours (7 days)
- Updated Status.tsx to display expiration in days when >= 24 hours remain
- Applies to all AWS S3 uploads including qcow2 files
- Introduces a feature flag to gate this to stage for now (as production still requires infra updates)