### PR TITLE
chore: apply lint auto-fixes

### DIFF
--- a/playwright/BootTests/helpers/helpers.ts
+++ b/playwright/BootTests/helpers/helpers.ts
@@ -43,6 +43,7 @@ export const deleteCompliancePolicy = async (
 ) => {
   // Since new browser is opened during the Compliance policy cleanup, we need to call the popup closer again
   await closePopupsIfExist(page);
+
   await test.step(
     'Delete the compliance policy with name: ' + policyName,
     async () => {
@@ -77,6 +78,7 @@ export const deleteRepository = async (
   repositoryNameOrUrl: string,
 ) => {
   await closePopupsIfExist(page);
+
   await test.step(
     'Delete the repository with name: ' + repositoryNameOrUrl,
     async () => {
@@ -293,6 +295,7 @@ export const navigateToTemplates = async (page: Page) => {
  */
 export const deleteTemplate = async (page: Page, templateName: string) => {
   await closePopupsIfExist(page);
+
   await test.step(
     'Delete the template with name: ' + templateName,
     async () => {

--- a/playwright/Customizations/AAP.spec.ts
+++ b/playwright/Customizations/AAP.spec.ts
@@ -188,6 +188,7 @@ test('Create a blueprint with AAP registration customization', async ({
   });
 
   let exportedBP = '';
+
   // This is for hosted service only as these features are not available in cockpit plugin
   await test.step('Export BP', async (step) => {
     step.skip(!isHosted(), 'Exporting is not available in the plugin');

--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -184,6 +184,7 @@ test('Create a blueprint with Disk customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/Filesystem.spec.ts
+++ b/playwright/Customizations/Filesystem.spec.ts
@@ -226,6 +226,7 @@ test('Create a blueprint with Filesystem customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/FipsMode.spec.ts
+++ b/playwright/Customizations/FipsMode.spec.ts
@@ -34,6 +34,7 @@ test('FIPS switch toggles and persists through save', async ({
       `Endpoint ${complianceLandingPageEndpoint} is not available - service is most likely down.`,
     );
   });
+
   const blueprintName = 'test-' + uuidv4();
 
   // Delete the blueprint after the run fixture

--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -204,6 +204,7 @@ test('Create a blueprint with Firewall customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/Hostname.spec.ts
+++ b/playwright/Customizations/Hostname.spec.ts
@@ -73,6 +73,7 @@ test('Create a blueprint with Hostname customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -111,6 +111,7 @@ test('Create a blueprint with Kernel customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -131,6 +131,7 @@ test('Create a blueprint with Locale customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -232,6 +232,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -357,6 +357,7 @@ registrationModes.forEach(
       });
 
       let exportedBP = '';
+
       await test.step('Export blueprint', async () => {
         exportedBP = await exportBlueprint(page);
         cleanup.add(async () => {

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -133,6 +133,7 @@ test('Create a blueprint with Systemd customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/Timezone.spec.ts
+++ b/playwright/Customizations/Timezone.spec.ts
@@ -108,6 +108,7 @@ test('Create a blueprint with Timezone customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/Customizations/Users.spec.ts
+++ b/playwright/Customizations/Users.spec.ts
@@ -419,6 +419,7 @@ test('Create a blueprint with Users customization', async ({
   });
 
   let exportedBP = '';
+
   await test.step('Export BP', async () => {
     exportedBP = await exportBlueprint(page);
     cleanup.add(async () => {

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -117,6 +117,7 @@ export const fillInImageOutputGuest = async (page: Page | FrameLocator) => {
 export const deleteBlueprint = async (page: Page, blueprintName: string) => {
   // Since new browser is opened during the BP cleanup, we need to call the popup closer again
   await closePopupsIfExist(page);
+
   await test.step(
     'Delete the blueprint with name: ' + blueprintName,
     async () => {


### PR DESCRIPTION
this commit fixed linting errors by running the auto-fix command (`npm run lint:js:fix`).
This is required to pass the CI checks.