### PR TITLE
cockpit: Fix on edit crash due to getLatestRelease

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -475,7 +475,10 @@ function commonRequestToState(
         },
     partitioning_mode: request.customizations.partitioning_mode,
     architecture: arch,
-    distribution: getLatestRelease(request.distribution),
+    distribution:
+      // API needs to be updated first (distribution will become optional)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+      request.distribution && getLatestRelease(request.distribution),
     // @ts-ignore API needs to be updated first
     imageSource: request.bootc?.reference || '',
     imageTypes: request.image_requests.map((image) => image.image_type),


### PR DESCRIPTION
This ensures the `getLatestRelease` runs only when there's a distribution included in the request.

How to to reproduce the issue:
1. create a blueprint with image mode selected
2. click on Edit blueprint

Current behaviour:
- the app crashes

After the fix:
- the Edit wizard for the blueprint opens