### PR TITLE
packit: Add RHEL10 x86 & ARM COPR builds

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -33,6 +33,8 @@ jobs:
       - centos-stream-10
       - centos-stream-10-aarch64
       - fedora-all
+      - rhel-10
+      - rhel-10-aarch64
 
   - job: copr_build
     trigger: commit


### PR DESCRIPTION
Since we're releasing this into RHEL10, it'd be useful to have the RPMs ready for it for easy testing.