### PR TITLE
playwright: Use unique repos in content boot tests

### DIFF
--- a/playwright/BootTests/Content/ContentRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentRepeatable.boot.ts
@@ -35,7 +35,7 @@ test('Content integration test - Repeatable build - URL source', async ({
   const filePath = constructFilePath(blueprintName, 'qcow2');
   const repositoryName = 'content-repeatable-test-' + uuidv4().slice(0, 8);
   const initialRepositoryUrl =
-    'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/';
+    'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata-multi/1/';
   const updatedRepositoryUrl =
     'https://jlsherrill.fedorapeople.org/fake-repos/empty/';
   const packageName = 'cockateel';
@@ -69,6 +69,9 @@ test('Content integration test - Repeatable build - URL source', async ({
     await page
       .getByRole('textbox', { name: 'Name/URL filter' })
       .fill(repositoryName);
+    await expect(
+      page.getByRole('button', { name: '- 1 of 1' }).first(),
+    ).toBeVisible();
     await expect(page.getByRole('gridcell', { name: 'Valid' })).toBeVisible({
       timeout: 180000,
     });
@@ -97,6 +100,9 @@ test('Content integration test - Repeatable build - URL source', async ({
     await page
       .getByRole('textbox', { name: 'Name/URL filter' })
       .fill(repositoryName);
+    await expect(
+      page.getByRole('button', { name: '- 1 of 1' }).first(),
+    ).toBeVisible();
     await expect(
       page.getByRole('gridcell', { name: 'Valid' }).first(),
     ).toBeVisible({

--- a/playwright/helpers/login.ts
+++ b/playwright/helpers/login.ts
@@ -39,8 +39,12 @@ export const login = async (page: Page, staticUser: boolean = false) => {
 /**
  * Checks if the user is already authenticated, if not, logs them in
  * @param page - the page object
+ * @param staticUser - if true, use the static user instead of dynamically created one
  */
-export const ensureAuthenticated = async (page: Page) => {
+export const ensureAuthenticated = async (
+  page: Page,
+  staticUser: boolean = false,
+) => {
   // Navigate to the target page
   if (isHosted()) {
     await page.goto('/insights/image-builder/landing');
@@ -64,7 +68,7 @@ export const ensureAuthenticated = async (page: Page) => {
 
   if (!isAuthenticated) {
     // Not authenticated, need to login
-    await login(page);
+    await login(page, staticUser);
   }
 };
 


### PR DESCRIPTION
Use unique repos in content boot tests to avoid race conditions that occured when we used a single repository in parallel test runs. Also includes a small fix for repo snapshotting test where the repo filtering was too slow and PW checked status of other repositories as well.