### PR TITLE
Wizard: remove the shadow line in Landing page (HMS-10024)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -45,8 +45,8 @@ const ImageOutputStep = () => {
         Image output
       </Title>
       <Content>
-        Images enables you to create customized blueprints, create custom images
-        from the blueprints, and push them to target environments.
+        Image builder enables you to create customized blueprints, create custom
+        images from the blueprints, and push them to target environments.
         <br />
         <DocumentationButton />
       </Content>

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -77,6 +77,12 @@ export const ImageBuilderHeader = ({
   const [showImportModal, setShowImportModal] = useState(false);
   const [showCloudConfigModal, setShowCloudConfigModal] = useState(false);
 
+  const pageHeaderProps: React.ComponentProps<typeof PageHeader> &
+    React.ComponentPropsWithoutRef<'section'> = {
+    className: 'pf-m-sticky-top',
+    style: { boxShadow: 'none' },
+  };
+
   return (
     <>
       <ImportBlueprintModal
@@ -89,7 +95,7 @@ export const ImageBuilderHeader = ({
           isOpen={showCloudConfigModal}
         />
       )}
-      <PageHeader className='pf-m-sticky-top'>
+      <PageHeader {...pageHeaderProps}>
         <PageHeaderTitle
           title={
             <>


### PR DESCRIPTION
The random looking shadow of a section is removed to make UI less confusing. Unfortunately, the shadow is a PF6 feature, so we either have to use CSS styling directly to remove it, or CSS styling directly to not use the PF "sticky top" class, and creating our own sticky class. two solutions, same result :cry: 
Also changed the Images to Image builder in the first step.
![ahjb5n](https://github.com/user-attachments/assets/46ce555c-97cb-47b4-b953-3adbf2928fe9)
