### PR TITLE
Wizard: Work around FirstBoot editor losing keyboard focus (HMS-9956)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -81,9 +81,8 @@ const FirstBootStep = () => {
       </Alert>
       <FormGroup>
         <CodeEditor
-          isUploadEnabled
-          isDownloadEnabled
           isCopyEnabled
+          isDownloadEnabled
           isLanguageLabelVisible
           language={language}
           onCodeChange={(code) => {
@@ -97,7 +96,6 @@ const FirstBootStep = () => {
           }}
           code={selectedScript}
           height='35vh'
-          emptyStateButton='Browse'
           emptyStateLink='Start from scratch'
         />
         {errors.script && (


### PR DESCRIPTION
### Intro
This is a possible workaround for an upstream bug in patternfly-react/CodeEditor. An upstream fix has been submitted (https://github.com/patternfly/patternfly-react/pull/12212). In case we consider the bug too grave, we can consider this minimal patch as a workaround.

The downsides are that the EmptyState is broken by this workaround and not shown at all. It would be possible to alleviate that, but I've tried it and it results in rewriting portions of CodeEditor inside image-builder-frontend, so I would advise against it.

----

### Bug
When typing the first character in the FirstBoot script editor, the Monaco editor would lose focus and cursor position, making typing impossible.

### Root cause
PatternFly's CodeEditor uses conditional JSX rendering based on `isUploadEnabled` and whether `code` is empty. When code transitions from empty to non-empty, React unmounts and remounts the Monaco editor component, causing focus and cursor state to be lost.

The fix removes `isUploadEnabled` to prevent the JSX branch switch. This disables the "Browse" upload button but preserves copy, download, and "Start from scratch" functionality.