### PR TITLE
Wizard: Remove validation for non-required empty input (HMS-10081)

### DIFF
--- a/src/Components/CreateImageWizard/ValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInput.tsx
@@ -84,6 +84,9 @@ export const ValidatedInputAndTextArea = ({
     if (isDisabled) {
       setIsPristine(true);
     }
+    if (value === '' && !errorMessage) {
+      setIsPristine(true);
+    }
   }, [value, errorMessage, isDisabled]);
 
   return (


### PR DESCRIPTION
This updates the pristinity of the validated input to reset when there are no errors (=== value is not required) and the input is empty.

Important thing to check is that there is still an error message when the input is empty, but the value is required.

Before:
![pristine-before](https://github.com/user-attachments/assets/17c7eb1f-af57-4249-91de-0c56ceea2c45)

After:
![pristine-after](https://github.com/user-attachments/assets/21eb1717-b9f2-4ad3-b4b0-e05a566d50a2)


JIRA: [HMS-10081](https://issues.redhat.com/browse/HMS-10081)