### PR TITLE
Wizard: Remove question mark icon near 'included repos'  (HMS-10085)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -1629,7 +1629,7 @@ const Packages = () => {
         <Tab
           eventKey='included-repos'
           title={<TabTitleText>Included repos</TabTitleText>}
-          actions={<IncludedReposPopover />}
+          actions={!isOnPremise ? <IncludedReposPopover /> : undefined}
           aria-label='Included repositories'
         />
         {!isOnPremise && (


### PR DESCRIPTION
The question mark icon next to "Included repos" tab in package step has been removed as the popover text wasn't accurate or helpful.
<img width="697" height="387" alt="Screenshot 2026-01-22 at 14 27 47" src="https://github.com/user-attachments/assets/a67a6284-32a2-4755-8677-8882cd82bad1" />


JIRA: [HMS-10085](https://issues.redhat.com/browse/HMS-10085)