### PR TITLE
cockpit: Hide blueprint version in the UI (HMS-10086)

### DIFF
--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -10,7 +10,10 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 
-import { useDeleteBPWithNotification as useDeleteBlueprintMutation } from '../../Hooks';
+import {
+  useDeleteBPWithNotification as useDeleteBlueprintMutation,
+  useIsOnPremise,
+} from '../../Hooks';
 import {
   selectSelectedBlueprintId,
   setBlueprintId,
@@ -25,6 +28,7 @@ type blueprintProps = {
 const BlueprintCard = ({ blueprint }: blueprintProps) => {
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
   const dispatch = useAppDispatch();
+  const isOnPremise = useIsOnPremise();
 
   const { isLoading } = useDeleteBlueprintMutation({
     fixedCacheKey: 'delete-blueprint',
@@ -68,9 +72,11 @@ const BlueprintCard = ({ blueprint }: blueprintProps) => {
           </CardTitle>
         </CardHeader>
         <CardBody>{blueprint.description}</CardBody>
-        <CardFooter>
-          Version <Badge isRead>{blueprint.version}</Badge>
-        </CardFooter>
+        {!isOnPremise && (
+          <CardFooter>
+            Version <Badge isRead>{blueprint.version}</Badge>
+          </CardFooter>
+        )}
       </Card>
     </>
   );

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -247,7 +247,7 @@ const ImagesTable = () => {
             <Th>Updated</Th>
             <Th>OS</Th>
             <Th>Target</Th>
-            <Th>Version</Th>
+            {!isOnPremise && <Th>Version</Th>}
             <Th>Status</Th>
             <Th>Instance</Th>
             <Th aria-label='Actions menu' />
@@ -646,9 +646,11 @@ const Row = ({
         <Td dataLabel='Target'>
           {target ? target : <Target compose={compose} />}
         </Td>
-        <Td dataLabel='Version'>
-          <Badge isRead>{compose.blueprint_version || 'N/A'}</Badge>
-        </Td>
+        {!isOnPremise && (
+          <Td dataLabel='Version'>
+            <Badge isRead>{compose.blueprint_version || 'N/A'}</Badge>
+          </Td>
+        )}
         <Td dataLabel='Status'>{status}</Td>
         <Td dataLabel='Instance'>{instance}</Td>
         <Td>


### PR DESCRIPTION
This hides the blueprint version in blueprint table and the blueprint cards as there is no versioning in cockpit-image-builder.

JIRA: [HMS-10086](https://issues.redhat.com/browse/HMS-10086)