### PR TITLE
cockpit: Fix useFlag import (HMS-10091)

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -9,7 +9,6 @@ import {
   Toolbar,
   ToolbarContent,
 } from '@patternfly/react-core';
-import { useFlag } from '@unleash/proxy-client-react';
 import { Outlet } from 'react-router-dom';
 
 import './LandingPage.scss';
@@ -17,6 +16,7 @@ import './LandingPage.scss';
 import { NewAlert } from './NewAlert';
 import ServiceUnavailableAlert from './ServiceUnavailableAlert';
 
+import { useFlag } from '../../Utilities/useGetEnvironment';
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
 import ImagesTable from '../ImagesTable/ImagesTable';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';


### PR DESCRIPTION
This swaps default `useFlag` import for custom `useFlag` that handles on-prem properly, resolving console errors.

JIRA: [HMS-10091](https://issues.redhat.com/browse/HMS-10091)