### PR TITLE
cockpit: Fix crash in edit mode (HMS-10092)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -50,7 +50,10 @@ const ImageOutputStep = () => {
         <br />
         <DocumentationButton />
       </Content>
-      {isOnPremise && !distribution.startsWith('fedora') && <BlueprintMode />}
+      {isOnPremise &&
+        // The distribution won't be defined if the blueprint is in image mode
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        !distribution?.startsWith('fedora') && <BlueprintMode />}
       {blueprintMode === 'image' && <ImageSourceSelect />}
       {blueprintMode === 'package' && (
         <>


### PR DESCRIPTION
The edit wizard crashed for blueprints in image mode.

How to reproduce:
1. create an image mode blueprint
2. click on "Edit blueprint"
3. go back to "Image output" step (both via nav and via Back button)

Current behaviour:
- the Wizard crashes as it can't read distribution

After the fix:
- the Wizard renders Image output step

JIRA: [HMS-10092](https://issues.redhat.com/browse/HMS-10092)