### PR TITLE
cockpit: Show registration for image mode (HMS-10093)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -519,7 +519,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 name='Register'
                 id='step-register'
                 key='step-register'
-                isHidden={!isRhel(distribution)}
+                isHidden={!isRhel(distribution) && !isImageMode}
                 navItem={CustomStatusNavItem}
                 status={
                   wasRegisterVisited

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -302,7 +302,7 @@ const Review = () => {
           )}
         </Stack>
       </ExpandableSection>
-      {isRhel(distribution) && (
+      {(isRhel(distribution) || blueprintMode === 'image') && (
         <ExpandableSection
           toggleContent={composeExpandable(
             'Registration',


### PR DESCRIPTION
Since distribution can be undefined, it doesn't pass the `isRhel` check and the step with its review was incorrectly hidden when in image mode.

JIRA: [HMS-10093](https://issues.redhat.com/browse/HMS-10093)