### PR TITLE
Wizard: Fix vertical scrolling (HMS-9848)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,16 +14,6 @@ const App = () => {
     hideGlobalFilter(true);
   }, [hideGlobalFilter, updateDocumentTitle]);
 
-  // Necessary for in-page wizard overflow to behave properly
-  // The .chr-render class is defined in Insights Chrome:
-  // https://github.com/RedHatInsights/insights-chrome/blob/fe573705020ff64003ac9e6101aa978b471fe6f2/src/sass/chrome.scss#L82
-  useEffect(() => {
-    const chrRenderDiv = document.querySelector('.chr-render');
-    if (chrRenderDiv) {
-      (chrRenderDiv as HTMLElement).style.overflow = 'auto';
-    }
-  }, []);
-
   return (
     <React.Fragment>
       <NotificationsProvider>

--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -1,8 +1,3 @@
-.pf-v6-c-wizard__nav-list {
-    padding-right: 0px;
-}
-
-
 .pf-c-popover[data-popper-reference-hidden="true"] {
     font-weight: initial;
     visibility: initial;
@@ -54,7 +49,19 @@ div.pf-v6-c-alert.pf-m-inline.pf-m-plain.pf-m-warning {
     }
 }
 
-// Ensures the wizard takes up the entire height of the page in Firefox as well
-.pf-v6-c-wizard {
-    flex: 1;
+.create-image-wizard {
+    .pf-v6-c-wizard__nav-list {
+        padding-right: 0px;
+    }
+
+    // Ensures the wizard takes up the entire height of the page in Firefox as well
+    .pf-v6-c-wizard {
+        flex: 1;
+    }
+
+    .pf-v6-c-wizard__footer {
+        position: sticky;
+        bottom: 0;
+        z-index: 100;
+    }
 }

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -407,7 +407,11 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   return (
     <>
       <ImageBuilderHeader inWizard />
-      <PageSection hasBodyWrapper={false} type={PageSectionTypes.wizard}>
+      <PageSection
+        hasBodyWrapper={false}
+        type={PageSectionTypes.wizard}
+        className='create-image-wizard'
+      >
         <Wizard
           startIndex={startIndex}
           onClose={() => navigate(resolveRelPath(''))}


### PR DESCRIPTION
Fixes https://github.com/osbuild/image-builder-frontend/issues/3884

This should ensure the wizard footer stays sticky without breaking the entire HCC.

![fix-stickiness](https://github.com/user-attachments/assets/f0f2db42-bea1-4371-9ca5-2c81933525da)


JIRA: [HMS-10094](https://issues.redhat.com/browse/HMS-10094)