### PR TITLE
ImagesTable/Status: fix on-prem error messages (HMS-10099)

### DIFF
--- a/src/Components/ImagesTable/Status.tsx
+++ b/src/Components/ImagesTable/Status.tsx
@@ -450,7 +450,12 @@ const ErrorStatus = ({ icon, text, error }: ErrorStatusPropTypes) => {
     }
     if (Array.isArray(error.details)) {
       for (const line in error.details) {
-        detailsArray.push(`${error.details[line]}`);
+        const detail = error.details[line];
+        if (detail && typeof detail === 'object' && 'reason' in detail) {
+          detailsArray.push(String(detail.reason));
+        } else {
+          detailsArray.push(String(detail));
+        }
       }
     }
     if (typeof error.details === 'string') {


### PR DESCRIPTION
The on-prem messages are returned as an object rather than a string. This commit fixes this so we don't receive `[object Object] ` as the details for the error message.

<img width="703" height="338" alt="image" src="https://github.com/user-attachments/assets/6817e93f-43b1-4752-aa16-f37dc395a556" />

JIRA: [HMS-10099](https://issues.redhat.com/browse/HMS-10099)