### PR TITLE
Wizard: Update validation for firewall ports (HMS-10089)

### DIFF
--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -47,17 +47,13 @@ test('Create a blueprint with Firewall customization', async ({
   await test.step('Select and correctly fill the ports in Firewall step', async () => {
     await frame.getByRole('button', { name: 'Firewall' }).click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
-    await frame
-      .getByPlaceholder('Enter port (e.g., 8080/tcp, 443:udp)')
-      .fill('80:tcp');
+    await frame.getByPlaceholder('Enter port (e.g., 8080:tcp)').fill('80:tcp');
     await page.keyboard.press('Enter');
     await expect(frame.getByText('80:tcp')).toBeVisible();
 
-    await frame
-      .getByPlaceholder('Enter port (e.g., 8080/tcp, 443:udp)')
-      .fill('443/udp');
+    await frame.getByPlaceholder('Enter port (e.g., 8080:tcp)').fill('443:udp');
     await page.keyboard.press('Enter');
-    await expect(frame.getByText('443/udp')).toBeVisible();
+    await expect(frame.getByText('443:udp')).toBeVisible();
   });
 
   await test.step('Select and correctly fill the disabled services in Firewall step', async () => {
@@ -79,9 +75,7 @@ test('Create a blueprint with Firewall customization', async ({
   });
 
   await test.step('Prevent adding duplicate ports and services', async () => {
-    await frame
-      .getByPlaceholder('Enter port (e.g., 8080/tcp, 443:udp)')
-      .fill('80:tcp');
+    await frame.getByPlaceholder('Enter port (e.g., 8080:tcp)').fill('80:tcp');
     await page.keyboard.press('Enter');
     await expect(frame.getByText('Port already exists.')).toBeVisible();
 
@@ -106,13 +100,13 @@ test('Create a blueprint with Firewall customization', async ({
 
   await test.step('Select and incorrectly fill the ports in Firewall step', async () => {
     await frame
-      .getByPlaceholder('Enter port (e.g., 8080/tcp, 443:udp)')
+      .getByPlaceholder('Enter port (e.g., 8080:tcp)')
       .fill('00:wrongFormat');
     await page.keyboard.press('Enter');
     await expect(
       frame
         .getByText(
-          'Expected format: <port/port-name>:<protocol> or <port/port-name>/<protocol>. Example: 8080:tcp, ssh:tcp, imap/tcp',
+          'Expected format: <port/port-name>:<protocol>. Example: 8080:tcp, ssh:tcp',
         )
         .nth(0),
     ).toBeVisible();
@@ -162,7 +156,7 @@ test('Create a blueprint with Firewall customization', async ({
 
     const body = request.postDataJSON();
     expect(body?.customizations?.firewall).toEqual({
-      ports: ['80:tcp', '443/udp'],
+      ports: ['80:tcp', '443:udp'],
       services: {
         enabled: ['cloud-init'],
         disabled: ['telnet.socket'],
@@ -174,9 +168,7 @@ test('Create a blueprint with Firewall customization', async ({
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
     await frame.getByLabel('Revisit Firewall step').click();
 
-    await frame
-      .getByPlaceholder('Enter port (e.g., 8080/tcp, 443:udp)')
-      .fill('90:tcp');
+    await frame.getByPlaceholder('Enter port (e.g., 8080:tcp)').fill('90:tcp');
     await page.keyboard.press('Enter');
     await frame.getByPlaceholder('Enter firewalld service').nth(0).fill('x');
     await page.keyboard.press('Enter');
@@ -184,7 +176,7 @@ test('Create a blueprint with Firewall customization', async ({
     await page.keyboard.press('Enter');
 
     await frame.getByRole('button', { name: 'Close 80:tcp' }).click();
-    await frame.getByRole('button', { name: 'Close 443/udp' }).click();
+    await frame.getByRole('button', { name: 'Close 443:udp' }).click();
     await frame.getByRole('button', { name: 'Close cloud-init' }).click();
     await frame.getByRole('button', { name: 'Close telnet.socket' }).click();
 
@@ -193,7 +185,7 @@ test('Create a blueprint with Firewall customization', async ({
     await expect(frame.getByText('y').nth(0)).toBeVisible();
 
     await expect(frame.getByText('80:tcp')).toBeHidden();
-    await expect(frame.getByText('443/udp')).toBeHidden();
+    await expect(frame.getByText('443:udp')).toBeHidden();
     await expect(frame.getByText('telnet.socket')).toBeHidden();
     await expect(frame.getByText('cloud-init')).toBeHidden();
 
@@ -233,7 +225,7 @@ test('Create a blueprint with Firewall customization', async ({
     await expect(frame.getByText('y').nth(0)).toBeVisible();
 
     await expect(frame.getByText('80:tcp')).toBeHidden();
-    await expect(frame.getByText('443/udp')).toBeHidden();
+    await expect(frame.getByText('443:udp')).toBeHidden();
     await expect(frame.getByText('telnet.socket')).toBeHidden();
     await expect(frame.getByText('cloud-init')).toBeHidden();
 

--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -72,7 +72,7 @@ const LabelInput = ({
       switch (fieldName) {
         case 'ports':
           setOnStepInputErrorText(
-            'Expected format: <port/port-name>:<protocol> or <port/port-name>/<protocol>. Example: 8080:tcp, ssh:tcp, imap/tcp',
+            'Expected format: <port/port-name>:<protocol>. Example: 8080:tcp, ssh:tcp',
           );
           break;
         case 'kernelAppend':

--- a/src/Components/CreateImageWizard/steps/Firewall/components/PortsInput.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/components/PortsInput.tsx
@@ -21,7 +21,7 @@ const PortsInput = () => {
     <FormGroup label='Ports'>
       <LabelInput
         ariaLabel='Add ports'
-        placeholder='Enter port (e.g., 8080/tcp, 443:udp)'
+        placeholder='Enter port (e.g., 8080:tcp)'
         validator={isPortValid}
         list={ports}
         item='Port'

--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -245,7 +245,7 @@ export const isKernelArgumentValid = (arg: string) => {
 };
 
 export const isPortValid = (port: string) => {
-  return /^(\d{1,5}|[a-z]{1,6})(-\d{1,5})?[:/][a-z]{1,6}$/.test(port);
+  return /^(\d{1,5}|[a-z]{1,6})(-\d{1,5})?[:][a-z]{1,6}$/.test(port);
 };
 
 export const isServiceValid = (service: string) => {


### PR DESCRIPTION
Ports should be configured using the `port:protocol` format, otherwise the build fails.