### PR TITLE
Wizard: add checkmarks to security dropdowns (HMS-10025)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ArchSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ArchSelect.tsx
@@ -60,6 +60,12 @@ const ArchSelect = () => {
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
+      style={
+        {
+          minWidth: '50%',
+          maxWidth: '100%',
+        } as React.CSSProperties
+      }
       data-testid='arch_select'
     >
       {arch}

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseSelect.tsx
@@ -136,6 +136,7 @@ const ReleaseSelect = () => {
       data-testid='release_select'
       style={
         {
+          minWidth: '50%',
           maxWidth: '100%',
         } as React.CSSProperties
       }

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -35,17 +35,21 @@ import {
 import { useHasSpecificTargetOnly } from '../../../utilities/hasSpecificTargetOnly';
 import { removeBetaFromRelease } from '../removeBetaFromRelease';
 
-type ComplianceSelectOptionPropType = {
-  policy: PolicyRead;
-};
-
 type ComplianceSelectOptionValueType = {
   policyID?: string;
   title?: string;
   toString: () => string;
 };
 
-const ComplianceSelectOption = ({ policy }: ComplianceSelectOptionPropType) => {
+type ComplianceSelectOptionProps = {
+  policy: PolicyRead;
+  isSelected: boolean;
+};
+
+const ComplianceSelectOption = ({
+  policy,
+  isSelected,
+}: ComplianceSelectOptionProps) => {
   const selectObj = (
     policyID: string,
     title: string,
@@ -56,7 +60,11 @@ const ComplianceSelectOption = ({ policy }: ComplianceSelectOptionPropType) => {
   });
 
   return (
-    <SelectOption key={policy.id} value={selectObj(policy.id!, policy.title!)}>
+    <SelectOption
+      key={policy.id}
+      value={selectObj(policy.id!, policy.title!)}
+      isSelected={isSelected}
+    >
       {policy.title}
     </SelectOption>
   );
@@ -209,6 +217,7 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
       <SelectOption
         key='compliance-none-option'
         value={{ toString: () => 'None', compareTo: () => false }}
+        isSelected={!policyID}
       >
         None
       </SelectOption>,
@@ -220,7 +229,13 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
         continue;
       }
       const pol = p as PolicyRead;
-      res.push(<ComplianceSelectOption key={pol.id} policy={pol} />);
+      res.push(
+        <ComplianceSelectOption
+          key={pol.id}
+          policy={pol}
+          isSelected={policyID === pol.id}
+        />,
+      );
     }
     return res;
   };

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -338,6 +338,7 @@ const ProfileSelector = ({ isDisabled = false }: ProfileSelectorProps) => {
               <SelectOption
                 key='oscap-none-option'
                 value={{ toString: () => 'None', compareTo: () => false }}
+                isSelected={!profileID}
               >
                 None
               </SelectOption>,
@@ -349,6 +350,7 @@ const ProfileSelector = ({ isDisabled = false }: ProfileSelectorProps) => {
                     profileID: id,
                     toString: () => name,
                   }}
+                  isSelected={profileID === id}
                 >
                   {name}
                 </SelectOption>


### PR DESCRIPTION
Added checkmarks to selected compliance policy and oscap profile and widened the space between text and check in the image output step to have some breathing space there.

<img width="607" height="566" alt="image" src="https://github.com/user-attachments/assets/49f242ca-80e5-4101-a87a-fb7bbc3e5aac" />
<img width="860" height="758" alt="image" src="https://github.com/user-attachments/assets/18a92555-acad-4929-b658-6e7244187ac3" />
