### PR TITLE
Wizard: Fix aria issues (HMS-10108)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/components/MinimumSizePopover.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/MinimumSizePopover.tsx
@@ -19,8 +19,7 @@ const MinimumSizePopover = () => {
       <Button
         icon={<HelpIcon />}
         variant='plain'
-        aria-label='File system configuration info'
-        aria-describedby='file-system-configuration-info'
+        aria-label='Minimum size information'
         className='popover-button pf-v6-u-p-0'
       />
     </Popover>

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -180,12 +180,7 @@ export const FSCList = () => {
                 minWidth='30rem'
                 bodyContent={<FSReviewTable />}
               >
-                <Button
-                  variant='link'
-                  aria-label='File system configuration info'
-                  aria-describedby='file-system-configuration-info'
-                  className='pf-v6-u-pt-0 pf-v6-u-pb-0'
-                >
+                <Button variant='link' className='pf-v6-u-pt-0 pf-v6-u-pb-0'>
                   View partitions
                 </Button>
               </Popover>


### PR DESCRIPTION
There is no element linked via the aria-describedby, which could confuse the screen readers. Also the "View partition" button has text, the aria-label was unnecessary and different than the text of the button.

JIRA: [HMS-10108](https://issues.redhat.com/browse/HMS-10108)