### PR TITLE
Wizard: Fix crash when searching for group with repeatable build (HMS-10111)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -131,7 +131,7 @@ export type GroupWithRepositoryInfo = {
   name: string;
   description: string;
   repository: PackageRepository;
-  package_list: string[];
+  package_list?: string[];
 };
 
 export enum Repos {
@@ -1334,12 +1334,12 @@ const Packages = () => {
                     bodyContent={
                       <div
                         style={
-                          grp.package_list.length > 0
+                          grp.package_list?.length
                             ? { height: '40em', overflow: 'scroll' }
                             : {}
                         }
                       >
-                        {grp.package_list.length > 0 ? (
+                        {grp.package_list?.length ? (
                           <Table
                             variant='compact'
                             data-testid='group-included-packages-table'


### PR DESCRIPTION
Previously when repeatable build was enabled and the user searched for groups with "@" the app crashed. The package list for the group was not loaded yet. This updates the type to reflect that the package_list can be undefined during fetching.