### PR TITLE
Wizard: Fix padding of popover button for package groups (HMS-10112)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -1327,7 +1327,7 @@ const Packages = () => {
                   }}
                 />
                 <Td>
-                  @{grp.name}
+                  @{grp.name}{' '}
                   <Popover
                     minWidth='25rem'
                     headerContent='Included packages'
@@ -1359,12 +1359,12 @@ const Packages = () => {
                     }
                   >
                     <Button
-                      icon={<HelpIcon className='pf-v6-u-ml-xs' />}
+                      icon={<HelpIcon />}
                       variant='plain'
                       aria-label='About included packages'
-                      component='span'
-                      className='pf-v6-u-p-0'
                       isInline
+                      size='sm'
+                      hasNoPadding
                     />
                   </Popover>
                 </Td>


### PR DESCRIPTION
This neatens up the padding of help button for package groups.

Before:
<img width="352" height="186" alt="image" src="https://github.com/user-attachments/assets/db64c105-e130-4dda-a290-5492ae6a24a2" />

After:
<img width="352" height="186" alt="image" src="https://github.com/user-attachments/assets/1d79261a-21ca-4e38-a9e2-6e99f58361ee" />


JIRA: [HMS-10112](https://issues.redhat.com/browse/HMS-10112)