### PR TITLE
Wizard: add suggestion names to the advanced partitions (HMS-10173)

### DIFF
--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -103,7 +103,6 @@ test('Create a blueprint with Disk customization', async ({
     await frame
       .getByRole('gridcell', { name: /\/home/ })
       .getByPlaceholder('Define mount point')
-      .nth(1)
       .fill('/tmp/usb');
 
     await frame

--- a/playwright/fixtures/data/exportBlueprintContents.ts
+++ b/playwright/fixtures/data/exportBlueprintContents.ts
@@ -19,16 +19,16 @@ name = "vg-edited-name"
 type = "lvm"
 
 [[customizations.disk.partitions.logical_volumes]]
-minsize = "1 KiB"
-name = "lv1"
-fs_type = "xfs"
-mountpoint = "/home"
-
-[[customizations.disk.partitions.logical_volumes]]
-minsize = "10 GiB"
-name = "lv2-edited"
+minsize = "10 KiB"
+name = "lv2"
 fs_type = "xfs"
 mountpoint = "/tmp/usb"
+
+[[customizations.disk.partitions.logical_volumes]]
+minsize = "1 GiB"
+name = "lv2-edited"
+fs_type = "xfs"
+mountpoint = "/var"
 
 [customizations.timezone]
 timezone = "Etc/UTC"

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/AdvancedPartitioning.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/AdvancedPartitioning.tsx
@@ -20,15 +20,24 @@ import {
   changeDiskMinsize,
   selectDiskMinsize,
   selectDiskPartitions,
+  selectFilesystemPartitions,
+  selectIsImageMode,
 } from '../../../../../store/wizardSlice';
+import { getNextAvailableMountpoint } from '../fscUtilities';
 
 const AdvancedPartitioning = () => {
   const dispatch = useAppDispatch();
   const minsize = useAppSelector(selectDiskMinsize);
   const diskPartitions = useAppSelector(selectDiskPartitions);
-
+  const filesystemPartitions = useAppSelector(selectFilesystemPartitions);
+  const inImageMode = useAppSelector(selectIsImageMode);
   const handleAddPartition = () => {
     const id = uuidv4();
+    const mountpoint = getNextAvailableMountpoint(
+      filesystemPartitions,
+      diskPartitions,
+      inImageMode,
+    );
     dispatch(
       addDiskPartition({
         id,
@@ -36,7 +45,7 @@ const AdvancedPartitioning = () => {
         min_size: '1',
         unit: 'GiB',
         type: 'plain',
-        mountpoint: '/home',
+        mountpoint,
       }),
     );
   };
@@ -44,6 +53,11 @@ const AdvancedPartitioning = () => {
   const handleAddVolumeGroup = () => {
     const vgId = uuidv4();
     const lvId = uuidv4();
+    const mountpoint = getNextAvailableMountpoint(
+      filesystemPartitions,
+      diskPartitions,
+      inImageMode,
+    );
     dispatch(
       addDiskPartition({
         id: vgId,
@@ -55,7 +69,7 @@ const AdvancedPartitioning = () => {
           {
             id: lvId,
             name: '',
-            mountpoint: '/home',
+            mountpoint,
             min_size: '1',
             unit: 'GiB',
             fs_type: 'xfs',

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
@@ -23,16 +23,19 @@ import {
   addPartition,
   changePartitioningMode,
   selectBlueprintMode,
+  selectDiskPartitions,
   selectFilesystemPartitions,
   selectImageTypes,
   selectPartitioningMode,
 } from '../../../../../store/wizardSlice';
 import UsrSubDirectoriesDisabled from '../../../UsrSubDirectoriesDisabled';
+import { getNextAvailableMountpoint } from '../fscUtilities';
 
 const FileSystemConfiguration = () => {
   const environments = useAppSelector(selectImageTypes);
   const blueprintMode = useAppSelector(selectBlueprintMode);
   const filesystemPartitions = useAppSelector(selectFilesystemPartitions);
+  const diskPartitions = useAppSelector(selectDiskPartitions);
   const partitioningMode = useAppSelector(selectPartitioningMode);
   const inImageMode = blueprintMode === 'image';
 
@@ -40,10 +43,15 @@ const FileSystemConfiguration = () => {
 
   const handleAddPartition = () => {
     const id = uuidv4();
+    const mountpoint = getNextAvailableMountpoint(
+      filesystemPartitions,
+      diskPartitions,
+      inImageMode,
+    );
     dispatch(
       addPartition({
         id,
-        mountpoint: inImageMode ? '/var' : '/home',
+        mountpoint,
         min_size: '1',
         unit: 'GiB',
       }),

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/PartitionType.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/PartitionType.tsx
@@ -8,17 +8,23 @@ import {
   SelectOption,
 } from '@patternfly/react-core';
 
-import { useAppDispatch } from '../../../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   changePartitionMountpoint,
   changePartitionType,
+  selectDiskPartitions,
+  selectFilesystemPartitions,
+  selectIsImageMode,
 } from '../../../../../store/wizardSlice';
 import {
   FSType,
   LogicalVolumeWithBase,
   PartitioningCustomization,
 } from '../fscTypes';
-import { isPartitionTypeAvailable } from '../fscUtilities';
+import {
+  getNextAvailableMountpoint,
+  isPartitionTypeAvailable,
+} from '../fscUtilities';
 
 const fs_types: FSType[] = ['ext4', 'xfs', 'vfat', 'swap'];
 
@@ -33,7 +39,9 @@ const PartitionType = ({
 }: PartitionTypePropTypes) => {
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
-
+  const filesystemPartitions = useAppSelector(selectFilesystemPartitions);
+  const diskPartitions = useAppSelector(selectDiskPartitions);
+  const isImageMode = useAppSelector(selectIsImageMode);
   const onSelect = (event?: React.MouseEvent, selection?: string | number) => {
     if (selection === undefined) return;
 
@@ -48,10 +56,15 @@ const PartitionType = ({
     }
 
     if (partition.mountpoint === '' && selection !== 'swap') {
+      const mountpoint = getNextAvailableMountpoint(
+        filesystemPartitions,
+        diskPartitions,
+        isImageMode,
+      );
       dispatch(
         changePartitionMountpoint({
           id: partition.id,
-          mountpoint: '/home',
+          mountpoint,
           customization: customization,
         }),
       );


### PR DESCRIPTION
We have a really neat problem with the partition names:
<img width="753" height="573" alt="image" src="https://github.com/user-attachments/assets/5e54c5ca-00fd-435d-9384-1482ea28807b" />


This PR changes the name generation, when creating a partition or a volume group, some possible names are suggested first, and after reaching the end of the suggested list, the partition names starts to be generated with a numbered suffix.
I'm a little unsure about two things:
1. Don't think the "dir" behind a slash is the best name, maybe something else is better? Like "data" maybe?
2. I also "fixed" the validation to not accept a trailing slash behind "/var/" in image mode, because I think it's not a correct behavior.... right? :smile: 

![output-file](https://github.com/user-attachments/assets/aeb11d89-1031-4085-99af-01a930e78581)
