### PR TITLE
deps: Bump patternfly deps to 6.4.1 (HMS-10124)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "dependencies": {
         "@patternfly/patternfly": "6.4.0",
-        "@patternfly/react-code-editor": "6.4.0",
-        "@patternfly/react-core": "6.4.0",
-        "@patternfly/react-table": "6.4.0",
+        "@patternfly/react-code-editor": "6.4.1",
+        "@patternfly/react-core": "6.4.1",
+        "@patternfly/react-table": "6.4.1",
         "@redhat-cloud-services/frontend-components": "7.0.40",
         "@redhat-cloud-services/frontend-components-notifications": "6.1.41",
         "@redhat-cloud-services/frontend-components-utilities": "7.0.36",
@@ -4236,13 +4236,13 @@
       "license": "MIT"
     },
     "node_modules/@patternfly/react-code-editor": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.4.0.tgz",
-      "integrity": "sha512-jZK4qzytcriZalug3KvwTD+h8lNjUfm79opAsLJwGfuq2DD5pzrDwF4GysZrR4hUMdN0jUJqh5yvAqwZtJI/UA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-6.4.1.tgz",
+      "integrity": "sha512-308BhliLV+DatYkewaS71RDrYAmgLzDL2lAE+txGtztVeq/yaEgWBr1GStsSLrGfC+8zZL/JuW7gt8CqxUKpNQ==",
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@patternfly/react-core": "^6.4.0",
+        "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-styles": "^6.4.0",
         "react-dropzone": "14.3.5",
@@ -4272,9 +4272,9 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.4.0.tgz",
-      "integrity": "sha512-zMgJmcFohp2FqgAoZHg7EXZS7gnaFESquk0qIavemYI0FsqspVlzV2/PUru7w+86+jXfqebRhgubPRsv1eJwEg==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.4.1.tgz",
+      "integrity": "sha512-EUSV76Eifkt4R3q2JIaiB6/FHeQqOCttK1DQMXNoOCNa3ODkZ7H+KlMdminufMDfRzhwAgTVihZ62K9PFfc8Vg==",
       "license": "MIT",
       "dependencies": {
         "@patternfly/react-icons": "^6.4.0",
@@ -4326,16 +4326,16 @@
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.4.0.tgz",
-      "integrity": "sha512-yv0sFOLGts8a2q9C1xUegjp50ayYyVRe0wKjMf+aMSNIK8sVYu8qu0yfBsCDybsUCldue7+qsYKRLFZosTllWQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.4.1.tgz",
+      "integrity": "sha512-dceS5X1I5gmhRfEf6gsLIdFhrQd5hY+SWRIYzEvI19rrdN9VwCVWg+bhSsNv05pQnGs8uOlzYVBI25p7PJtFeA==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^6.4.0",
+        "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-styles": "^6.4.0",
         "@patternfly/react-tokens": "^6.4.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "tslib": "^2.8.1"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@patternfly/patternfly": "6.4.0",
-    "@patternfly/react-code-editor": "6.4.0",
-    "@patternfly/react-core": "6.4.0",
-    "@patternfly/react-table": "6.4.0",
+    "@patternfly/react-code-editor": "6.4.1",
+    "@patternfly/react-core": "6.4.1",
+    "@patternfly/react-table": "6.4.1",
     "@redhat-cloud-services/frontend-components": "7.0.40",
     "@redhat-cloud-services/frontend-components-notifications": "6.1.41",
     "@redhat-cloud-services/frontend-components-utilities": "7.0.36",


### PR DESCRIPTION
This bumps:
- @patternfly/react-code-editor
- @patternfly/react-core
- @patternfly/react-table

from 6.4.0 to 6.4.1 to get in fixes for code editor and wizard navigation.

JIRA: [HMS-10124](https://issues.redhat.com/browse/HMS-10124)