### PR TITLE
Wizard: Combine alert and empty state in Additional Packages step (HMS-10126)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -468,21 +468,30 @@ const Packages = () => {
         <Tr>
           <Td colSpan={5}>
             <Bullseye>
-              <EmptyState icon={SearchIcon} variant={EmptyStateVariant.sm}>
-                {toggleSelected === 'toggle-available' ? (
+              {toggleSelected === 'toggle-available' ? (
+                <EmptyState
+                  headingLevel='h4'
+                  titleText='Search packages'
+                  icon={SearchIcon}
+                  variant={EmptyStateVariant.sm}
+                >
                   <EmptyStateBody>
-                    Search above to add additional
-                    <br />
-                    packages to your image.
+                    Search for exact matches by specifying the package name to
+                    add additional packages to your image
                   </EmptyStateBody>
-                ) : (
+                </EmptyState>
+              ) : (
+                <EmptyState
+                  headingLevel='h4'
+                  titleText='There are no selected packages'
+                  icon={SearchIcon}
+                  variant={EmptyStateVariant.sm}
+                >
                   <EmptyStateBody>
-                    No packages selected.
-                    <br />
-                    Search above to see available packages.
+                    Search above to see available packages
                   </EmptyStateBody>
-                )}
-              </EmptyState>
+                </EmptyState>
+              )}
             </Bullseye>
           </Td>
         </Tr>

--- a/src/Components/CreateImageWizard/steps/Packages/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/index.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 
-import { Alert, Content, Form, Title } from '@patternfly/react-core';
+import { Content, Form, Title } from '@patternfly/react-core';
 
 import PackageRecommendations from './PackageRecommendations';
 import Packages from './Packages';
 
-import { useIsOnPremise } from '../../../../Hooks';
 import { useAppSelector } from '../../../../store/hooks';
 import { selectDistribution } from '../../../../store/wizardSlice';
 import isRhel from '../../../../Utilities/isRhel';
 
 const PackagesStep = () => {
   const distribution = useAppSelector(selectDistribution);
-  const isOnPremise = useIsOnPremise();
   return (
     <Form>
       <Title headingLevel='h1' size='xl'>
@@ -21,19 +19,6 @@ const PackagesStep = () => {
       <Content>
         Blueprints created with Images include all required packages.
       </Content>
-      {!isOnPremise && (
-        <Alert variant='info' isInline title='Search for package groups'>
-          Search for package groups by starting your search with the
-          &apos;@&apos; character. A single &apos;@&apos; as search input lists
-          all available package groups.
-        </Alert>
-      )}
-      {isOnPremise && (
-        <Alert variant='info' isInline title='Searching for packages'>
-          Search for exact matches by specifying the whole package name, or glob
-          using asterisk wildcards (*) before or after the package name.
-        </Alert>
-      )}
       <Packages />
       {isRhel(distribution) && <PackageRecommendations />}
     </Form>

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -225,12 +225,25 @@ describe('Step Packages', () => {
     });
   });
 
-  test('should display default state', async () => {
+  test('should display default state in Available mode', async () => {
     await renderCreateMode();
     await goToPackagesStep();
+    await screen.findByRole('heading', {
+      name: /Search packages/i,
+    });
     await screen.findByText(
-      'Search above to add additionalpackages to your image.',
+      /Search for exact matches by specifying the package name to add additional packages to your image/i,
     );
+  });
+
+  test('should display correct empty state in Selected mode', async () => {
+    await renderCreateMode();
+    await goToPackagesStep();
+    await toggleSelected();
+    await screen.findByRole('heading', {
+      name: /There are no selected packages/i,
+    });
+    await screen.findByText(/Search above to see available packages/i);
   });
 
   test('search results should be sorted with most relevant results first', async () => {


### PR DESCRIPTION
This commit removes redundant info alert and moves search instructions into the empty state message. This eliminates duplicate content and provides a cleaner UI with contextual guidance.
before in hosted env:
<img width="1367" height="528" alt="Screenshot 2026-01-29 at 16 27 21" src="https://github.com/user-attachments/assets/690e1da6-725c-4c4e-9c9a-39ef0b2bc9f6" />

before in on-prem env:
<img width="1235" height="637" alt="Screenshot 2026-02-01 at 11 11 25" src="https://github.com/user-attachments/assets/24dc3660-5e35-4406-a12f-580516b1e38e" />
after in on-prem env:
<img width="990" height="570" alt="Screenshot 2026-02-02 at 17 12 08" src="https://github.com/user-attachments/assets/1bf92216-db0a-4ebb-8ed7-4555f90f0176" />
<img width="1363" height="594" alt="Screenshot 2026-02-02 at 17 12 15" src="https://github.com/user-attachments/assets/b671b5d3-5d21-435f-bb0e-9ab17dccee5d" />


JIRA: [HMS-10126](https://issues.redhat.com/browse/HMS-10126)