### PR TITLE
tests: fix react router warning message (HMS-10131)

### DIFF
--- a/src/test/testUtils.js
+++ b/src/test/testUtils.js
@@ -52,7 +52,12 @@ export const renderCustomRoutesWithReduxRouter = async (
 
   render(
     <Provider store={store}>
-      <RouterProvider router={router} />
+      <RouterProvider
+        router={router}
+        future={{
+          v7_startTransition: true,
+        }}
+      />
     </Provider>,
   );
 


### PR DESCRIPTION
React router is switching an internal mechanism for handling router state updates, we don't use `React.Lazy`, so we should be fine. See: See: https://reactrouter.com/6.30.3/upgrading/future#v7_starttransition

JIRA: [HMS-10131](https://issues.redhat.com/browse/HMS-10131)