### PR TITLE
Wizard: Show "Add user" button by default (HMS-10133)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
@@ -75,7 +75,7 @@ const UserInfo = ({ attemptedNext = false }: UserInfoProps) => {
           variant='link'
           onClick={onAddUserClick}
           icon={<AddCircleOIcon />}
-          isDisabled={!!stepValidation.disabledNext || users.length < 1}
+          isDisabled={users.length === 0 || !!stepValidation.disabledNext}
         >
           Add user
         </Button>


### PR DESCRIPTION
Previously the button was hidden when there were no users. 
Now the button is always visible but disabled
until the default empty row is filled with valid user data.



JIRA: [HMS-10133](https://issues.redhat.com/browse/HMS-10133)