### PR TITLE
Wizard: Improve groups input in User step (HMS-10134)

### DIFF
--- a/playwright/Customizations/Users.spec.ts
+++ b/playwright/Customizations/Users.spec.ts
@@ -190,19 +190,20 @@ test('Create a blueprint with Users customization', async ({
   });
 
   await test.step('Test keyboard navigation and accessibility', async () => {
-    // Focus on the first user's fields for keyboard navigation testing
+    // Use the third user (index 2) because users 0 and 1 already have group chips
+    // from previous test steps, which would interfere with Tab navigation testing
     const usernameInput = frame
       .getByRole('textbox', {
         name: 'blueprint user name',
       })
-      .first();
+      .nth(2);
     const passwordInput = frame
       .getByRole('textbox', {
         name: 'blueprint user password',
       })
-      .first();
-    const sshInput = frame.getByPlaceholder('Set SSH key').first();
-    const groupInput = frame.getByPlaceholder('Add user group').first();
+      .nth(2);
+    const sshInput = frame.getByPlaceholder('Set SSH key').nth(2);
+    const groupInput = frame.getByPlaceholder('Add user group').nth(2);
 
     // Tab through fields to test keyboard navigation
     await usernameInput.press('Tab');
@@ -212,7 +213,6 @@ test('Create a blueprint with Users customization', async ({
     await expect(sshInput).toBeFocused();
 
     await sshInput.press('Tab');
-    await page.keyboard.press('Tab');
     await expect(groupInput).toBeFocused();
   });
 

--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -28,6 +28,8 @@ type LabelInputProps = {
   removeAction: (value: string) => UnknownAction;
   stepValidation: StepValidation;
   fieldName: string;
+  truncateLength?: number;
+  inlineChips?: boolean;
 };
 
 const LabelInput = ({
@@ -42,6 +44,8 @@ const LabelInput = ({
   removeAction,
   stepValidation,
   fieldName,
+  truncateLength = FIREWALL_LABEL_TRUNCATE_DEFAULT,
+  inlineChips = false,
 }: LabelInputProps) => {
   const dispatch = useAppDispatch();
 
@@ -135,33 +139,74 @@ const LabelInput = ({
   if (invalidImports) errors.push(invalidImports);
   if (duplicateImports) errors.push(duplicateImports);
 
+  const chipsInInput = inlineChips && list && list.length > 0 && (
+    <LabelGroup
+      isCompact
+      numLabels={4}
+      expandedText='Show less'
+      collapsedText={`${list.length - 4} more`}
+    >
+      {list.map((group) => (
+        <Label
+          key={group}
+          color='blue'
+          isCompact
+          onClose={(e) => handleRemoveItem(e, group)}
+        >
+          {group.length > truncateLength
+            ? `${group.slice(0, truncateLength)}...`
+            : group}
+        </Label>
+      ))}
+    </LabelGroup>
+  );
+
+  const inputWithInlineChips = inlineChips && (
+    <TextInputGroup>
+      <TextInputGroupMain
+        aria-label={ariaLabel}
+        placeholder={placeholder}
+        onChange={onTextInputChange}
+        value={inputValue}
+        onKeyDown={(e) => handleKeyDown(e, inputValue)}
+      >
+        {chipsInInput}
+      </TextInputGroupMain>
+    </TextInputGroup>
+  );
+
   return (
     <>
-      <TextInputGroup>
-        <TextInputGroupMain
-          aria-label={ariaLabel}
-          placeholder={placeholder}
-          onChange={onTextInputChange}
-          value={inputValue}
-          onKeyDown={(e) => handleKeyDown(e, inputValue)}
-        >
-          {list && list.length > 0 && (
-            <LabelGroup numLabels={20} className='pf-v6-u-mr-sm'>
-              {list.map((item) => (
-                <Label
-                  key={item}
-                  color='blue'
-                  onClose={(e) => handleRemoveItem(e, item)}
-                >
-                  {item.length > FIREWALL_LABEL_TRUNCATE_DEFAULT
-                    ? `${item.slice(0, FIREWALL_LABEL_TRUNCATE_DEFAULT)}...`
-                    : item}
-                </Label>
-              ))}
-            </LabelGroup>
-          )}
-        </TextInputGroupMain>
-      </TextInputGroup>
+      {inlineChips ? (
+        inputWithInlineChips
+      ) : (
+        <TextInputGroup>
+          <TextInputGroupMain
+            aria-label={ariaLabel}
+            placeholder={placeholder}
+            onChange={onTextInputChange}
+            value={inputValue}
+            onKeyDown={(e) => handleKeyDown(e, inputValue)}
+          >
+            {list && list.length > 0 && (
+              <LabelGroup numLabels={20} className='pf-v6-u-mr-sm'>
+                {list.map((item) => (
+                  <Label
+                    key={item}
+                    color='blue'
+                    onClose={(e) => handleRemoveItem(e, item)}
+                  >
+                    {item.length > FIREWALL_LABEL_TRUNCATE_DEFAULT
+                      ? `${item.slice(0, FIREWALL_LABEL_TRUNCATE_DEFAULT)}...`
+                      : item}
+                  </Label>
+                ))}
+              </LabelGroup>
+            )}
+          </TextInputGroupMain>
+        </TextInputGroup>
+      )}
+
       {errors.length > 0 && (
         <HelperText>
           {errors.map((error, index) => (

--- a/src/Components/CreateImageWizard/steps/Users/components/UserRow.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserRow.tsx
@@ -147,6 +147,8 @@ const UserRow = ({ user, index, userCount }: UserRowProps) => {
             }
             stepValidation={getValidationByIndex(index)}
             fieldName='groups'
+            truncateLength={12}
+            inlineChips={true}
           />
         </Td>
         <Td>


### PR DESCRIPTION
This commit prevent awkward textbox movement when adding or removing groups.

- Render group chips inside the input field instead of below it
- Make group chips compact to reduce visual clutter.
- Limit the number of visible chips and add proper overflow handling using:
“X more” / “Show less” toggling.

https://github.com/user-attachments/assets/b7cce09d-20b9-443c-addf-6e77524bc90f


JIRA: [HMS-10134](https://issues.redhat.com/browse/HMS-10134)