### PR TITLE
Wizard: Show checkmarks for selected languages in dropdown (HMS-10139)

### DIFF
--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -82,10 +82,12 @@ test('Create a blueprint with Locale customization', async ({
       frame.getByRole('button', { name: 'Close aa - Djibouti (aa_DJ.UTF-8)' }),
     ).toBeEnabled();
     await frame.getByPlaceholder('Select a language').fill('aa');
+    // Verify that the dropdown shows filtered options starting with 'aa'
     await expect(
-      frame.getByText(
-        'aa - Djibouti (aa_DJ.UTF-8)Language already addedaa - Eritrea (aa_ER.UTF-8)aa - Ethiopia (aa_ET.UTF-8)',
-      ),
+      frame.getByRole('option', { name: 'aa - Eritrea (aa_ER.UTF-8)' }),
+    ).toBeAttached();
+    await expect(
+      frame.getByRole('option', { name: 'aa - Ethiopia (aa_ET.UTF-8)' }),
     ).toBeAttached();
     await frame.getByPlaceholder('Select a language').fill('xxx');
     await expect(frame.getByText('No results found for')).toBeAttached();

--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -104,7 +104,11 @@ const LanguagesDropDown = () => {
     if (value && typeof value === 'string') {
       setInputValue('');
       setFilterValue('');
-      dispatch(addLanguage(value));
+      if (languages?.includes(value)) {
+        dispatch(removeLanguage(value));
+      } else {
+        dispatch(addLanguage(value));
+      }
       setIsOpen(false);
     }
   };
@@ -165,7 +169,7 @@ const LanguagesDropDown = () => {
       <Select
         isScrollable
         isOpen={isOpen}
-        selected={inputValue}
+        selected={languages}
         onSelect={onSelect}
         onOpenChange={(isOpen) => setIsOpen(isOpen)}
         toggle={toggle}
@@ -174,14 +178,7 @@ const LanguagesDropDown = () => {
         <SelectList>
           {selectOptions.length > 0 ? (
             selectOptions.map((option) => (
-              <SelectOption
-                key={option}
-                value={option}
-                isDisabled={languages?.includes(option) || false}
-                description={
-                  languages?.includes(option) && 'Language already added'
-                }
-              >
+              <SelectOption key={option} value={option}>
                 {parseLanguageOption(option)}
               </SelectOption>
             ))


### PR DESCRIPTION
This commit show checkmarks for selected languages in dropdown

- Pass languages array to Select's selected prop instead of inputValue to display blue checkmarks for selected options
- Remove isDisabled and description props from SelectOption as checkmarks now indicate selection status
- Toggle language selection on click (add if not selected, remove if selected)

<img width="733" height="479" alt="Screenshot 2026-02-03 at 15 01 57" src="https://github.com/user-attachments/assets/2ebe86c6-a0ba-450d-9fd2-3b74d8014ede" />



JIRA: [HMS-10139](https://issues.redhat.com/browse/HMS-10139)