### PR TITLE
Wizard: Add groups section to review step (HMS-8784)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -20,6 +20,7 @@ import {
   FirewallList,
   FirstBootList,
   FSCList,
+  GroupsList,
   HostnameList,
   ImageOutputList,
   KernelList,
@@ -58,6 +59,7 @@ import {
   selectRegistrationType,
   selectServices,
   selectTimezone,
+  selectUserGroups,
   selectUsers,
 } from '../../../../store/wizardSlice';
 import SecurityInformation from '../Oscap/components/SecurityInformation';
@@ -80,6 +82,7 @@ const Review = () => {
   const firewall = useAppSelector(selectFirewall);
   const services = useAppSelector(selectServices);
   const users = useAppSelector(selectUsers);
+  const userGroups = useAppSelector(selectUserGroups);
   const kernel = useAppSelector(selectKernel);
 
   const [isExpandedAap, setIsExpandedAap] = useState(true);
@@ -99,6 +102,7 @@ const Review = () => {
   const [isExpandedServices, setIsExpandedServices] = useState(true);
   const [isExpandableFirstBoot, setIsExpandedFirstBoot] = useState(true);
   const [isExpandedUsers, setIsExpandedUsers] = useState(true);
+  const [isExpandedGroups, setIsExpandedGroups] = useState(true);
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: environments,
@@ -136,6 +140,8 @@ const Review = () => {
     setIsExpandedFirstBoot(isExpandableFirstBoot);
   const onToggleUsers = (isExpandedUsers: boolean) =>
     setIsExpandedUsers(isExpandedUsers);
+  const onToggleGroups = (isExpandedGroups: boolean) =>
+    setIsExpandedGroups(isExpandedGroups);
 
   type RevisitStepButtonProps = {
     ariaLabel: string;
@@ -379,6 +385,23 @@ const Review = () => {
           data-testid='users-expandable'
         >
           <UsersList />
+        </ExpandableSection>
+      )}
+      {!restrictions.users.shouldHide && userGroups.length > 0 && (
+        <ExpandableSection
+          toggleContent={composeExpandable(
+            'Groups',
+            'revisit-groups',
+            wizardStepId,
+          )}
+          onToggle={(_event, isExpandedGroups) =>
+            onToggleGroups(isExpandedGroups)
+          }
+          isExpanded={isExpandedGroups}
+          isIndented
+          data-testid='groups-expandable'
+        >
+          <GroupsList />
         </ExpandableSection>
       )}
       {!restrictions.timezone.shouldHide &&

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -87,6 +87,7 @@ import {
   selectTemplate,
   selectTimezone,
   selectUseLatest,
+  selectUserGroups,
   selectUsers,
 } from '../../../../store/wizardSlice';
 import { toMonthAndYear, yyyyMMddFormat } from '../../../../Utilities/time';
@@ -851,6 +852,35 @@ export const UsersList = () => {
           </Content>
           <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
             {user.isAdministrator ? 'True' : 'False'}
+          </Content>
+        </Content>
+      ))}
+    </Content>
+  );
+};
+
+export const GroupsList = () => {
+  const userGroups = useAppSelector(selectUserGroups);
+
+  return (
+    <Content>
+      {userGroups.map((group) => (
+        <Content
+          key={group.name}
+          component={ContentVariants.dl}
+          className='review-step-dl'
+        >
+          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+            Group name
+          </Content>
+          <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
+            {group.name ? group.name : 'None'}
+          </Content>
+          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+            GID
+          </Content>
+          <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
+            {group.gid !== undefined ? group.gid : 'None'}
           </Content>
         </Content>
       ))}


### PR DESCRIPTION
Display user groups in the review step alongside users. The groups section appears links back to the users step via "Revisit step" button.

<img width="878" height="704" alt="Screenshot 2026-02-04 at 12 17 17" src="https://github.com/user-attachments/assets/7403dcbb-d25a-4d4a-a44c-612807e012b7" />
JIRA: https://issues.redhat.com/browse/HMS-8784


