### PR TITLE
Wizard: Add groups to user review, arrange in tables (HMS-10147)

### DIFF
--- a/playwright/Customizations/Users.spec.ts
+++ b/playwright/Customizations/Users.spec.ts
@@ -347,17 +347,17 @@ test('Create a blueprint with Users customization', async ({
     // Verify admin user details
     await expect(frame.getByText('admin1', { exact: true })).toBeVisible();
     await expect(frame.getByText('●●●●●●●●').first()).toBeVisible(); // Masked password
-    await expect(frame.getByText('True').first()).toBeVisible(); // Admin status
+    await expect(frame.getByText('Enabled').first()).toBeVisible(); // Admin status
 
     // Verify SSH user details
     await expect(frame.getByText('sshuser')).toBeVisible();
     await expect(frame.getByText('None').first()).toBeVisible(); // No password
-    await expect(frame.getByText('False').first()).toBeVisible(); // Not admin
+    await expect(frame.getByText('Disabled').first()).toBeVisible(); // Not admin
 
     // Verify admin user details
     await expect(frame.getByText('admin2', { exact: true })).toBeVisible();
     await expect(frame.getByText('●●●●●●●●').first()).toBeVisible(); // Masked password
-    await expect(frame.getByText('True').first()).toBeVisible(); // Admin status
+    await expect(frame.getByText('Enabled').first()).toBeVisible(); // Admin status
   });
 
   await test.step('Create and save blueprint', async () => {

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
@@ -24,6 +24,7 @@ import {
   selectPackages,
   selectRecommendedRepositories,
   selectTemplate,
+  UserWithAdditionalInfo,
 } from '../../../../store/wizardSlice';
 import { getEpelVersionForDistribution } from '../../../../Utilities/epel';
 import PackageInfoNotAvailablePopover from '../Packages/components/PackageInfoNotAvailablePopover';
@@ -285,6 +286,33 @@ export const RepositoriesTable = () => {
                 </Td>
               </Tr>
             )}
+          </Tbody>
+        </Table>
+      </PanelMain>
+    </Panel>
+  );
+};
+
+type UserGroupsTableProps = {
+  groups: UserWithAdditionalInfo['groups'];
+};
+
+export const UserGroupsTable = ({ groups }: UserGroupsTableProps) => {
+  return (
+    <Panel isScrollable>
+      <PanelMain maxHeight='30ch'>
+        <Table aria-label='User groups table' variant='compact'>
+          <Thead>
+            <Tr>
+              <Th>Group name</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {groups.map((group) => (
+              <Tr key={group}>
+                <Td>{group}</Td>
+              </Tr>
+            ))}
           </Tbody>
         </Table>
       </PanelMain>

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -14,13 +14,16 @@ import {
 import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
+  TimesCircleIcon,
 } from '@patternfly/react-icons';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import {
   FSReviewTable,
   PackagesTable,
   RepositoriesTable,
   SnapshotTable,
+  UserGroupsTable,
 } from './ReviewStepTables';
 
 import {
@@ -822,40 +825,61 @@ export const UsersList = () => {
   const users = useAppSelector(selectUsers);
 
   return (
-    <Content>
-      {users.map((user) => (
-        <Content
-          key={user.name}
-          component={ContentVariants.dl}
-          className='review-step-dl'
-        >
-          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
-            Username
-          </Content>
-          <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
-            {user.name ? user.name : 'None'}
-          </Content>
-          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
-            Password
-          </Content>
-          <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
-            {user.password || user.hasPassword ? '●'.repeat(8) : 'None'}
-          </Content>
-          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
-            SSH key
-          </Content>
-          <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
-            {user.ssh_key ? user.ssh_key : 'None'}
-          </Content>
-          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
-            Administrator
-          </Content>
-          <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
-            {user.isAdministrator ? 'True' : 'False'}
-          </Content>
-        </Content>
-      ))}
-    </Content>
+    <Table variant='compact' borders={false}>
+      <Thead>
+        <Tr>
+          <Th>Username</Th>
+          <Th>Password</Th>
+          <Th>SSH key</Th>
+          <Th>Groups</Th>
+          <Th>Administrator</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {users.map((user) => (
+          <Tr key={user.name}>
+            <Td width={25}>{user.name ? user.name : 'None'}</Td>
+            <Td>
+              {user.password || user.hasPassword ? '●'.repeat(8) : 'None'}
+            </Td>
+            <Td>{user.ssh_key ? user.ssh_key : 'None'}</Td>
+            <Td>
+              {user.groups.length > 0 ? (
+                <Popover
+                  position='bottom'
+                  hasAutoWidth
+                  minWidth='30rem'
+                  bodyContent={<UserGroupsTable groups={user.groups} />}
+                >
+                  <Button variant='link' isInline aria-label='View user groups'>
+                    {user.groups.length}
+                  </Button>
+                </Popover>
+              ) : (
+                'None'
+              )}
+            </Td>
+            <Td>
+              {user.isAdministrator ? (
+                <>
+                  <Icon status='success'>
+                    <CheckCircleIcon />
+                  </Icon>{' '}
+                  Enabled
+                </>
+              ) : (
+                <>
+                  <Icon status='danger'>
+                    <TimesCircleIcon />
+                  </Icon>{' '}
+                  Disabled
+                </>
+              )}
+            </Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
   );
 };
 
@@ -863,28 +887,22 @@ export const GroupsList = () => {
   const userGroups = useAppSelector(selectUserGroups);
 
   return (
-    <Content>
-      {userGroups.map((group) => (
-        <Content
-          key={group.name}
-          component={ContentVariants.dl}
-          className='review-step-dl'
-        >
-          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
-            Group name
-          </Content>
-          <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
-            {group.name ? group.name : 'None'}
-          </Content>
-          <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
-            GID
-          </Content>
-          <Content component={ContentVariants.dd} className='pf-v6-u-min-width'>
-            {group.gid !== undefined ? group.gid : 'None'}
-          </Content>
-        </Content>
-      ))}
-    </Content>
+    <Table variant='compact' borders={false} className='pf-v6-u-w-50'>
+      <Thead>
+        <Tr>
+          <Th>Group name</Th>
+          <Th>GID</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {userGroups.map((group) => (
+          <Tr key={group.name}>
+            <Td width={50}>{group.name ? group.name : 'None'}</Td>
+            <Td>{group.gid !== undefined ? group.gid : 'None'}</Td>
+          </Tr>
+        ))}
+      </Tbody>
+    </Table>
   );
 };
 


### PR DESCRIPTION
This adds "Groups" fields to the Users review list, so the groups added to the user get properly rendered.

For better overview of the users and groups the previously used description lists were replaced with a table as per revamp mocks.

JIRA: [HMS-10147](https://issues.redhat.com/browse/HMS-10147)