### PR TITLE
spec: update nodejs BuildRequires

### DIFF
--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -14,7 +14,7 @@ BuildArch:      noarch
 BuildRequires:  gettext
 BuildRequires:  libappstream-glib
 BuildRequires:  make
-BuildRequires:  nodejs
+BuildRequires:  /usr/bin/node
 
 Requires:       cockpit
 Requires:       cockpit-files


### PR DESCRIPTION
As of Fedora 44, the packaging scheme for Node.js is changing. This is compatible with both the old and new schemes.

https://pagure.io/packaging-committee/pull-request/1521
https://fedoraproject.org/wiki/Changes/NodejsAlternativesSystem