### PR TITLE
Wizard: Add conditional search instructions for Additional Packages step (HMS-10161)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -476,8 +476,7 @@ const Packages = () => {
                   variant={EmptyStateVariant.sm}
                 >
                   <EmptyStateBody>
-                    Search for exact matches by specifying the package name to
-                    add additional packages to your image
+                    Search for additional packages to add to your image
                   </EmptyStateBody>
                 </EmptyState>
               ) : (

--- a/src/Components/CreateImageWizard/steps/Packages/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/index.tsx
@@ -5,12 +5,14 @@ import { Content, Form, Title } from '@patternfly/react-core';
 import PackageRecommendations from './PackageRecommendations';
 import Packages from './Packages';
 
+import { selectIsOnPremise } from '../../../../store/envSlice';
 import { useAppSelector } from '../../../../store/hooks';
 import { selectDistribution } from '../../../../store/wizardSlice';
 import isRhel from '../../../../Utilities/isRhel';
 
 const PackagesStep = () => {
   const distribution = useAppSelector(selectDistribution);
+  const isOnPremise = useAppSelector(selectIsOnPremise);
   return (
     <Form>
       <Title headingLevel='h1' size='xl'>
@@ -18,6 +20,20 @@ const PackagesStep = () => {
       </Title>
       <Content>
         Blueprints created with Images include all required packages.
+      </Content>
+      <Content>
+        {isOnPremise ? (
+          <>
+            Search for exact matches by specifying the whole package name, or
+            glob using asterisk wildcards (*) before or after the package name.
+          </>
+        ) : (
+          <>
+            Search for package groups by starting your search with the
+            &apos;@&apos; character. A single &apos;@&apos; as search input
+            lists all available package groups.
+          </>
+        )}
       </Content>
       <Packages />
       {isRhel(distribution) && <PackageRecommendations />}

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -232,7 +232,16 @@ describe('Step Packages', () => {
       name: /Search packages/i,
     });
     await screen.findByText(
-      /Search for exact matches by specifying the package name to add additional packages to your image/i,
+      /Search for additional packages to add to your image/i,
+    );
+  });
+
+  test('shows package group search instructions', async () => {
+    await renderCreateMode();
+    await goToPackagesStep();
+
+    await screen.findByText(
+      /Search for package groups by starting your search with the '@' character/i,
     );
   });
 


### PR DESCRIPTION
Show different search instructions based on environment (on-premise vs hosted) to guide users on the available search capabilities.
<img width="1192" height="551" alt="Screenshot 2026-02-06 at 14 46 13" src="https://github.com/user-attachments/assets/4d5d1ebd-b268-4ae7-b69e-59ae8517b432" />




JIRA: [HMS-10161](https://issues.redhat.com/browse/HMS-10161)