### PR TITLE
tests: Fix cockpit unit test (HMS-10163)

### DIFF
--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -11,7 +11,7 @@ describe('Images Table', () => {
 
   const user = userEvent.setup();
   test('render ImagesTable', async () => {
-    renderCustomRoutesWithReduxRouter();
+    await renderCustomRoutesWithReduxRouter();
 
     const table = await screen.findByTestId('images-table');
 
@@ -19,7 +19,7 @@ describe('Images Table', () => {
     const emptyState = screen.queryByText(
       /Image builder is a tool for creating deployment-ready customized system images/i,
     );
-    expect(emptyState).not.toBeInTheDocument();
+    await waitFor(() => expect(emptyState).not.toBeInTheDocument());
 
     // check table
     const { getAllByRole } = within(table);


### PR DESCRIPTION
The `Images Table render imagesTable` test in vitest was flaking when running on cockpit. This should help aleviate the issues.

JIRA: [HMS-10163](https://issues.redhat.com/browse/HMS-10163)