### PR TITLE
Wizard: Hide empty user groups from review step (HMS-10164)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -61,6 +61,7 @@ import {
   selectTimezone,
   selectUserGroups,
   selectUsers,
+  UserGroup,
 } from '../../../../store/wizardSlice';
 import SecurityInformation from '../Oscap/components/SecurityInformation';
 
@@ -197,6 +198,10 @@ const Review = () => {
   };
 
   const wizardStepId = isImageMode ? 'wizard-users' : 'wizard-users-optional';
+
+  const filterNonEmptyGroups = (groups: UserGroup[]) => {
+    return groups.filter((group) => group.name.trim());
+  };
 
   return (
     <>
@@ -387,23 +392,24 @@ const Review = () => {
           <UsersList />
         </ExpandableSection>
       )}
-      {!restrictions.users.shouldHide && userGroups.length > 0 && (
-        <ExpandableSection
-          toggleContent={composeExpandable(
-            'Groups',
-            'revisit-groups',
-            wizardStepId,
-          )}
-          onToggle={(_event, isExpandedGroups) =>
-            onToggleGroups(isExpandedGroups)
-          }
-          isExpanded={isExpandedGroups}
-          isIndented
-          data-testid='groups-expandable'
-        >
-          <GroupsList />
-        </ExpandableSection>
-      )}
+      {!restrictions.users.shouldHide &&
+        filterNonEmptyGroups(userGroups).length > 0 && (
+          <ExpandableSection
+            toggleContent={composeExpandable(
+              'Groups',
+              'revisit-groups',
+              wizardStepId,
+            )}
+            onToggle={(_event, isExpandedGroups) =>
+              onToggleGroups(isExpandedGroups)
+            }
+            isExpanded={isExpandedGroups}
+            isIndented
+            data-testid='groups-expandable'
+          >
+            <GroupsList groups={filterNonEmptyGroups(userGroups)} />
+          </ExpandableSection>
+        )}
       {!restrictions.timezone.shouldHide &&
         (timezone || (ntpServers && ntpServers.length > 0)) && (
           <ExpandableSection

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -90,8 +90,8 @@ import {
   selectTemplate,
   selectTimezone,
   selectUseLatest,
-  selectUserGroups,
   selectUsers,
+  UserGroup,
 } from '../../../../store/wizardSlice';
 import { toMonthAndYear, yyyyMMddFormat } from '../../../../Utilities/time';
 import MinimumSizePopover from '../FileSystem/components/MinimumSizePopover';
@@ -883,9 +883,7 @@ export const UsersList = () => {
   );
 };
 
-export const GroupsList = () => {
-  const userGroups = useAppSelector(selectUserGroups);
-
+export const GroupsList = ({ groups }: { groups: UserGroup[] }) => {
   return (
     <Table variant='compact' borders={false} className='pf-v6-u-w-50'>
       <Thead>
@@ -895,9 +893,9 @@ export const GroupsList = () => {
         </Tr>
       </Thead>
       <Tbody>
-        {userGroups.map((group) => (
+        {groups.map((group) => (
           <Tr key={group.name}>
-            <Td width={50}>{group.name ? group.name : 'None'}</Td>
+            <Td width={50}>{group.name}</Td>
             <Td>{group.gid !== undefined ? group.gid : 'None'}</Td>
           </Tr>
         ))}


### PR DESCRIPTION
# Summary

Hide empty user groups from review step display

## Overview

Previously, the review step would display an empty Groups table with "None None" values even when no groups were configured. This created visual clutter and confused users about whether groups were actually configured. This PR filters out empty groups from the review display while preserving the initial empty group in the form, maintaining a smooth user experience when adding groups.

## Architectural Changes

None

## Key Changes

- Updated `ReviewStep.tsx` to filter empty groups in the display condition (`userGroups.filter((g) => g.name).length > 0`)
- Modified `GroupsList` component to filter out groups without names before rendering
- Removed unnecessary ternary operators in `GroupsList` since filtered groups are guaranteed to have names
- Preserved the initial empty group in the wizard state to allow immediate group entry without clicking "Add group"

## Breaking Changes

This PR is fully backward compatible.

## Testing

Manually tested the review step with:
- No groups configured (section is hidden)
- One or more valid groups (section displays correctly)
- Mix of empty and filled groups (only filled groups appear)
- Form interaction remains unchanged (initial empty group field available)

JIRA: [HMS-10164](https://issues.redhat.com/browse/HMS-10164)