### PR TITLE
Wizard: Remove option to leave empty timezone (HMS-10166)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -64,6 +64,7 @@ import {
 import {
   AARCH64,
   AMPLITUDE_MODULE_NAME,
+  DEFAULT_TIMEZONE,
   RHEL_10,
   RHEL_8,
   RHEL_9,
@@ -328,7 +329,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
 
     const defaultTimezone =
       distribution === RHEL_10 || targetEnvironments.includes('azure')
-        ? 'Etc/UTC'
+        ? DEFAULT_TIMEZONE
         : 'America/New_York';
 
     if (!timezone) {

--- a/src/Components/CreateImageWizard/steps/Timezone/components/TimezoneDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/components/TimezoneDropDown.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 import {
-  Button,
   FormGroup,
   HelperText,
   HelperTextItem,
@@ -13,10 +12,9 @@ import {
   SelectOption,
   TextInputGroup,
   TextInputGroupMain,
-  TextInputGroupUtilities,
 } from '@patternfly/react-core';
-import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 
+import { DEFAULT_TIMEZONE } from '../../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   changeTimezone,
@@ -59,7 +57,14 @@ const TimezoneDropDown = () => {
         setIsOpen(true);
       }
     }
-    setSelectOptions(filteredTimezones);
+
+    const sortedTimezones = [...filteredTimezones].sort((a, b) => {
+      if (a === DEFAULT_TIMEZONE) return -1;
+      if (b === DEFAULT_TIMEZONE) return 1;
+      return 0;
+    });
+
+    setSelectOptions(sortedTimezones);
 
     // This useEffect hook should run *only* on when the filter value changes.
     // eslint's exhaustive-deps rule does not support this use.
@@ -97,13 +102,6 @@ const TimezoneDropDown = () => {
     setIsOpen(!isOpen);
   };
 
-  const onClearButtonClick = () => {
-    setInputValue('');
-    setFilterValue('');
-    setErrorText('');
-    dispatch(changeTimezone(''));
-  };
-
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       ref={toggleRef}
@@ -120,17 +118,6 @@ const TimezoneDropDown = () => {
           placeholder='Select a timezone'
           isExpanded={isOpen}
         />
-
-        {timezone && (
-          <TextInputGroupUtilities>
-            <Button
-              icon={<TimesIcon />}
-              variant='plain'
-              onClick={onClearButtonClick}
-              aria-label='Clear input'
-            />
-          </TextInputGroupUtilities>
-        )}
       </TextInputGroup>
     </MenuToggle>
   );
@@ -151,7 +138,7 @@ const TimezoneDropDown = () => {
             selectOptions.map((option) => (
               <SelectOption key={option} value={option}>
                 {option}{' '}
-                {option === 'Etc/UTC' && (
+                {option === DEFAULT_TIMEZONE && (
                   <Label color='blue' isCompact>
                     Default
                   </Label>

--- a/src/Components/CreateImageWizard/steps/Timezone/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/index.tsx
@@ -5,6 +5,8 @@ import { Content, Form, Title } from '@patternfly/react-core';
 import NtpServersInput from './components/NtpServersInput';
 import TimezoneDropDown from './components/TimezoneDropDown';
 
+import { DEFAULT_TIMEZONE } from '../../../../constants';
+
 const TimezoneStep = () => {
   return (
     <Form>
@@ -12,8 +14,8 @@ const TimezoneStep = () => {
         Timezone
       </Title>
       <Content>
-        Select a timezone for your image. The default timezone is
-        &apos;Etc/UTC&apos;. You can also configure NTP servers - multiple
+        Select a timezone for your image. The default timezone is &apos;
+        {DEFAULT_TIMEZONE}&apos;. You can also configure NTP servers - multiple
         servers can be added.
       </Content>
       <TimezoneDropDown />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -352,3 +352,5 @@ export const PAGINATION_COUNT = 0;
 export const SEARCH_INPUT = '';
 
 export const BLUEPRINTS_DIR = 'cockpit-image-builder';
+
+export const DEFAULT_TIMEZONE = 'Etc/UTC';

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -290,10 +290,17 @@ describe('Import modal', () => {
     expect(
       await screen.findByText('Invalid NTP servers: invalid-ntp-server'),
     ).toBeInTheDocument();
-    const clearButtons = await screen.findAllByRole('button', {
-      name: /clear input/i,
-    });
-    await waitFor(async () => user.click(clearButtons[0]));
+    const timezoneDropdown =
+      await screen.findByPlaceholderText(/select a timezone/i);
+    await waitFor(() => user.click(timezoneDropdown));
+
+    const timezoneOptions = await screen.findAllByRole('option');
+    expect(timezoneOptions[0]).toHaveTextContent(/Etc\/UTC.*Default/i);
+
+    await waitFor(() => user.clear(timezoneDropdown));
+    await waitFor(() => user.type(timezoneDropdown, 'Etc/UTC'));
+    const defaultTimezone = await screen.findByText('Etc/UTC');
+    await waitFor(() => user.click(defaultTimezone));
     await waitFor(async () =>
       user.click(
         await screen.findByRole('button', {


### PR DESCRIPTION
This removes the 'clear' button from the timezone input and sorts the default timezone option to the top as a stand-in for "None" option.

Rebased on https://github.com/osbuild/image-builder-frontend/pull/4086

JIRA: [HMS-10166](https://issues.redhat.com/browse/HMS-10166)