### PR TITLE
Wizard: Add Network-installer checkbox with feature flag (HMS-9568)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -34,6 +34,7 @@ import {
   selectDistribution,
   selectImageTypes,
 } from '../../../../../store/wizardSlice';
+import { useFlag } from '../../../../../Utilities/useGetEnvironment';
 
 type TargetEnvironmentCardProps = {
   title: string;
@@ -96,6 +97,7 @@ const TargetEnvironment = () => {
   const arch = useAppSelector(selectArchitecture);
   const environments = useAppSelector(selectImageTypes);
   const distribution = useAppSelector(selectDistribution);
+  const isNetworkInstallerEnabled = useFlag('image-builder.net-installer');
 
   // NOTE: We're using 'image-mode' as a dummy distribution for the
   // on-prem frontend, this is one of the few cases where we
@@ -342,6 +344,45 @@ const TargetEnvironment = () => {
             name='Bare metal installer'
           />
         )}
+        {supportedEnvironments?.includes('network-installer') &&
+          isNetworkInstallerEnabled && (
+            <Checkbox
+              label={
+                <>
+                  Network - Installer (.iso){' '}
+                  <Popover
+                    maxWidth='30rem'
+                    position='right'
+                    bodyContent={
+                      <Content>
+                        <Content>
+                          This is a lightweight image that differs from a
+                          standard &quot;full&quot; ISO by requiring an active
+                          network connection to pull the latest software
+                          directly from RHEL repositories, as no OS packages are
+                          stored locally on the image.
+                        </Content>
+                      </Content>
+                    }
+                  >
+                    <Button
+                      icon={<HelpIcon />}
+                      variant='plain'
+                      aria-label='About Network installer'
+                      isInline
+                      hasNoPadding
+                    />
+                  </Popover>
+                </>
+              }
+              isChecked={environments.includes('network-installer')}
+              onChange={() => {
+                handleToggleEnvironment('network-installer');
+              }}
+              id='checkbox-network-installer'
+              name='Network - Installer'
+            />
+          )}
         {supportedEnvironments?.includes('wsl') && (
           <Checkbox
             label={

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -62,6 +62,7 @@ import {
   selectUserGroups,
   selectUsers,
 } from '../../../../store/wizardSlice';
+import { useFlag } from '../../../../Utilities/useGetEnvironment';
 import SecurityInformation from '../Oscap/components/SecurityInformation';
 
 const Review = () => {
@@ -84,6 +85,8 @@ const Review = () => {
   const users = useAppSelector(selectUsers);
   const userGroups = useAppSelector(selectUserGroups);
   const kernel = useAppSelector(selectKernel);
+
+  const isNetworkInstallerEnabled = useFlag('image-builder.net-installer');
 
   const [isExpandedAap, setIsExpandedAap] = useState(true);
   const [isExpandedImageOutput, setIsExpandedImageOutput] = useState(true);
@@ -289,6 +292,17 @@ const Review = () => {
               </Content>
             </StackItem>
           )}
+          {environments.includes('network-installer') &&
+            isNetworkInstallerEnabled && (
+              <StackItem>
+                <Content>
+                  <Content component={ContentVariants.h3}>
+                    {targetOptions['network-installer']} (.iso)
+                  </Content>
+                  <TargetEnvOtherList />
+                </Content>
+              </StackItem>
+            )}
           {environments.includes('wsl') && (
             <StackItem>
               <Content>

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -803,6 +803,8 @@ const uploadTypeByTargetEnv = (
       return 'aws.s3';
     case 'image-installer':
       return 'aws.s3';
+    case 'network-installer':
+      return 'aws.s3';
     case 'vsphere':
       return 'aws.s3';
     case 'vsphere-ova':

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -92,7 +92,7 @@ export const targetOptions: { [key in ImageTypes]: string } = {
   vhd: '',
   oci: 'Oracle Cloud Infrastructure',
   'pxe-tar-xz': '',
-  'network-installer': '',
+  'network-installer': 'Network - Installer',
 };
 
 export const UNIT_KIB = 1024 ** 1;


### PR DESCRIPTION
# Summary

Add Network-installer image type option to wizard with feature flag gating.

## Overview

This PR introduces the Network-installer (.iso) image type as a new target environment option in the Image Builder wizard. Network-installer images are lightweight ISOs that download packages during installation rather than bundling them, requiring an active network connection. The feature is gated behind the `image-builder.net-installer` Unleash flag to enable gradual rollout. This is the first in a series of PRs to add full network-installer support.

## Architectural Changes

None

## Key Changes

- Add Network-installer checkbox in target environment selection with explanatory help popover
- Gate feature visibility using Unleash flag `image-builder.net-installer`
- Display network-installer selection in Review step
- Map network-installer to S3 upload type in request mapper
- Update constants with proper display label

## Breaking Changes

This PR is fully backward compatible.

## Testing

Manually tested network-installer selection flow in wizard UI. Verified feature flag correctly controls checkbox visibility and that selecting network-installer allows blueprint creation without errors. Full validation, registration handling, and step restriction logic will be tested in follow-up PRs.

JIRA: https://issues.redhat.com/browse/HMS-9568