### PR TITLE
ImagesTable: Add network-installer file extension (HMS-10172)

### DIFF
--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -53,7 +53,7 @@ export const AwsS3Instance = ({
     vhd: '',
     oci: '',
     'pxe-tar-xz': '',
-    'network-installer': '',
+    'network-installer': '.iso',
   };
 
   const status = composeStatus.image_status.status;


### PR DESCRIPTION
This adds a file extension to network-installer targets.

Before:
<img width="475" height="117" alt="image" src="https://github.com/user-attachments/assets/7d22f8aa-0879-4ada-a26b-21b375133b5d" />

After:
<img width="472" height="110" alt="image" src="https://github.com/user-attachments/assets/951968fe-9c95-483a-b161-eb08b8630875" />


JIRA: [HMS-10172](https://issues.redhat.com/browse/HMS-10172)