### PR TITLE
Wizard: Use 'package repositories' instead of 'RHEL repositories' (HMS-9568)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -418,8 +418,8 @@ const TargetEnvironment = () => {
                           This is a lightweight image that differs from a
                           standard &quot;full&quot; ISO by requiring an active
                           network connection to pull the latest software
-                          directly from RHEL repositories, as no OS packages are
-                          stored locally on the image.
+                          directly from package repositories, as no OS packages
+                          are stored locally on the image.
                         </Content>
                       </Content>
                     }


### PR DESCRIPTION
# Summary

Replace "RHEL repositories" with "package repositories" in Network Installer help text

## Overview

The Network Installer help text previously referred to "RHEL repositories", which is inaccurate and confusing. The network installer pulls packages from generic package repositories that aren't necessarily RHEL-specific. This change updates the terminology to be more accurate and generic.

## Architectural Changes

None

## Key Changes

- Updated TargetEnvironment component help text to use "package repositories" instead of "RHEL repositories"

## Breaking Changes

This PR is fully backward compatible.

## Testing

Verified the help text displays correctly in the wizard UI and the popover appears as expected when clicking the help icon.