### PR TITLE
BootTests: Report to slack success only on retry (HMS-10179)

### DIFF
--- a/.github/workflows/boot-tests-nightly.yml
+++ b/.github/workflows/boot-tests-nightly.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Notify Slack on failure
         uses: slackapi/slack-github-action@v2.1.1
-        if: ${{ failure() && github.event_name == 'schedule' }}
+        if: ${{ failure() && github.event_name == 'schedule' && github.run_attempt == '1' }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -182,7 +182,7 @@ jobs:
 
       - name: Notify Slack on failure (Frontend)
         uses: slackapi/slack-github-action@v2.1.1
-        if: ${{ failure() && github.event_name == 'schedule' }}
+        if: ${{ failure() && github.event_name == 'schedule' && github.run_attempt == '1' }}
         with:
           webhook: ${{ secrets.SLACK_FRONTEND_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
Make the boot tests little less spam-y by reporting to Slack during retries only on success.

JIRA: [HMS-10179](https://issues.redhat.com/browse/HMS-10179)