### PR TITLE
Cockpit/LandingPage: Hide "What's new" banner

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -16,6 +16,8 @@ import './LandingPage.scss';
 import { NewAlert } from './NewAlert';
 import ServiceUnavailableAlert from './ServiceUnavailableAlert';
 
+import { selectIsOnPremise } from '../../store/envSlice';
+import { useAppSelector } from '../../store/hooks';
 import { useFlag } from '../../Utilities/useGetEnvironment';
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
 import ImagesTable from '../ImagesTable/ImagesTable';
@@ -23,13 +25,14 @@ import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
 export const LandingPage = () => {
   const [showAlert, setShowAlert] = useState(true);
+  const isOnPremise = useAppSelector(selectIsOnPremise);
   const serviceUnavailable = useFlag('image-builder.service-unavailable');
 
   const imageList = (
     <>
       <PageSection hasBodyWrapper={false}>
         {serviceUnavailable && <ServiceUnavailableAlert />}
-        {showAlert && <NewAlert setShowAlert={setShowAlert} />}
+        {!isOnPremise && showAlert && <NewAlert setShowAlert={setShowAlert} />}
         <Sidebar hasBorder className='pf-v6-u-background-color-100'>
           <SidebarPanel
             variant='sticky'

--- a/src/Components/LandingPage/NewAlert.tsx
+++ b/src/Components/LandingPage/NewAlert.tsx
@@ -38,6 +38,7 @@ export const NewAlert = ({ setShowAlert }: NewAlertPropTypes) => {
   if (displayAlert) {
     return (
       <Alert
+        data-testid='new-in-image-builder-banner'
         isExpandable
         style={{ margin: '0 0 16px 0' }}
         title='New in image builder: more customizations'

--- a/src/test/Components/LandingPage/LandingPage.test.tsx
+++ b/src/test/Components/LandingPage/LandingPage.test.tsx
@@ -32,4 +32,15 @@ describe('Landing Page', () => {
       /Image builder is a tool for creating deployment-ready customized system images/i,
     );
   });
+
+  test('does not show New in image builder banner when on-premises', async () => {
+    renderCustomRoutesWithReduxRouter('/', {
+      env: { isOnPremise: true },
+    });
+
+    await screen.findByRole('heading', { name: 'Image builder' });
+    expect(
+      screen.queryByTestId('new-in-image-builder-banner'),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
The "What's new" banner doesn't make much sense with our on premises release cycles, so let's hide it altogether.

**Before:**
<img width="1341" height="209" alt="image" src="https://github.com/user-attachments/assets/2a9340db-3a4e-4b2e-93fe-e467a32789f6" />


**After:**
<img width="1341" height="209" alt="image" src="https://github.com/user-attachments/assets/9d85d991-6874-4acc-9524-cdd2ab4d6006" />
