### PR TITLE
Wizard: Add a tooltip to the mount point dropdown (HMS-10185)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/components/MountpointPrefix.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/MountpointPrefix.tsx
@@ -6,6 +6,7 @@ import {
   Select,
   SelectList,
   SelectOption,
+  Tooltip,
 } from '@patternfly/react-core';
 
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
@@ -66,6 +67,8 @@ const MountpointPrefix = ({
     setIsOpen(!isOpen);
   };
 
+  const isDisabled = customization === 'fileSystem' && prefix === '/';
+
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       ref={toggleRef}
@@ -73,14 +76,14 @@ const MountpointPrefix = ({
       isExpanded={isOpen}
       // disable root partition prefix for filesystem customization
       // ensuring it will stay present
-      isDisabled={customization === 'fileSystem' && prefix === '/'}
+      isDisabled={isDisabled}
       isFullWidth
     >
       {prefix}
     </MenuToggle>
   );
 
-  return (
+  const select = (
     <Select
       isOpen={isOpen}
       selected={prefix}
@@ -108,6 +111,14 @@ const MountpointPrefix = ({
           })}
       </SelectList>
     </Select>
+  );
+
+  return isDisabled ? (
+    <Tooltip content='Root partition is required'>
+      <div>{select}</div>
+    </Tooltip>
+  ) : (
+    select
   );
 };
 


### PR DESCRIPTION
This adds a tooltip when the mount point dropdown is disabled to inform the user that the root partition is required.

<img width="620" height="227" alt="image" src="https://github.com/user-attachments/assets/a05fc301-299a-439c-a524-d61094e4f0c2" />


JIRA: [HMS-10185](https://issues.redhat.com/browse/HMS-10185)