### PR TITLE
Cockpit/ImagesTable: Populate Image Mode OS column

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -81,6 +81,8 @@ import {
   GetBlueprintComposesApiArg,
   GetBlueprintsApiArg,
 } from '../../store/imageBuilderApi';
+import { hasBootcRequest } from '../../store/typeGuards';
+import { bootcReferenceToOSDisplayLabel } from '../../Utilities/distributionToOSShortId';
 import {
   computeHoursToExpiration,
   timestampToDisplayString,
@@ -574,6 +576,7 @@ const Row = ({
   const handleToggle = () => setIsExpanded(!isExpanded);
   const dispatch = useDispatch();
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
+  const bootcCompose = hasBootcRequest(compose) ? compose : undefined;
 
   const { data } = useGetComposeStatusQuery({
     composeId: compose.id,
@@ -618,18 +621,15 @@ const Row = ({
                 {compose.image_name || compose.id}
               </Button>{' '}
               {isOnPremise &&
-                // API needs to be updated first
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-                (compose.request.distribution ? (
-                  <Label isCompact color='teal'>
-                    Package mode
-                  </Label>
-                ) : //@ts-ignore API needs to be updated first
-                compose.request.bootc ? (
+                (bootcCompose?.request.bootc ? (
                   <Label isCompact color='yellow'>
                     Image mode
                   </Label>
-                ) : null)}
+                ) : (
+                  <Label isCompact color='teal'>
+                    Package mode
+                  </Label>
+                ))}
             </>
           ) : (
             <span> {compose.image_name || compose.id}</span>
@@ -642,7 +642,15 @@ const Row = ({
           {timestampToDisplayString(compose.created_at)}
         </Td>
         <Td dataLabel='Release'>
-          <Release release={compose.request.distribution} />
+          {bootcCompose?.request.bootc?.reference ? (
+            <p>
+              {bootcReferenceToOSDisplayLabel(
+                bootcCompose.request.bootc.reference,
+              )}
+            </p>
+          ) : (
+            <Release release={compose.request.distribution} />
+          )}
         </Td>
         <Td dataLabel='Target'>
           {target ? target : <Target compose={compose} />}

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -13,8 +13,11 @@ import { LocalUploadStatus } from '../../store/cockpit/composerCloudApi';
 import { selectIsOnPremise } from '../../store/envSlice';
 import { useAppSelector } from '../../store/hooks';
 import { ComposesResponseItem, ImageTypes } from '../../store/imageBuilderApi';
-import { isAwss3UploadStatus } from '../../store/typeGuards';
-import { distributionToOSShortId } from '../../Utilities/distributionToOSShortId';
+import { hasBootcRequest, isAwss3UploadStatus } from '../../store/typeGuards';
+import {
+  bootcReferenceToOSShortId,
+  distributionToOSShortId,
+} from '../../Utilities/distributionToOSShortId';
 
 type AwsS3InstancePropTypes = {
   compose: ComposesResponseItem;
@@ -139,8 +142,14 @@ export const LocalInstance = ({ compose }: LocalInstancePropTypes) => {
   const canInstallInMachines =
     isMachinesAvailable && VM_INSTALLABLE_IMAGE_TYPES.includes(imageType);
 
-  // Parameters for cockpit-machines
-  const osShortId = distributionToOSShortId(compose.request.distribution);
+  // Parameters for cockpit-machines (derive OS from distribution or, for image mode, from bootc reference)
+  const bootcCompose = hasBootcRequest(compose) ? compose : undefined;
+  const bootcRef = bootcCompose?.request.bootc?.reference;
+  const dist = compose.request.distribution;
+  const osShortId =
+    distributionToOSShortId(dist) ||
+    (bootcRef && bootcReferenceToOSShortId(bootcRef)) ||
+    undefined;
   const vmName = (compose.request as unknown as { name?: string }).name || '';
 
   // Build cockpit-machines URLs for Create VM dialog

--- a/src/store/typeGuards.ts
+++ b/src/store/typeGuards.ts
@@ -1,8 +1,10 @@
+import { Bootc } from './cockpit/composerCloudApi';
 import {
   Awss3UploadStatus,
   AwsUploadRequestOptions,
   AzureUploadRequestOptions,
   AzureUploadStatus,
+  ComposesResponseItem,
   Distributions,
   GcpUploadRequestOptions,
   GcpUploadStatus,
@@ -59,6 +61,18 @@ export const isImageMode = (
   distribution?: Distributions | 'image-mode' | undefined,
 ): distribution is 'image-mode' => {
   return distribution === undefined || distribution === IMAGE_MODE;
+};
+
+export type ComposeWithBootc = ComposesResponseItem & {
+  request: ComposesResponseItem['request'] & {
+    bootc?: Bootc;
+  };
+};
+
+export const hasBootcRequest = (
+  compose: ComposesResponseItem,
+): compose is ComposeWithBootc => {
+  return 'bootc' in compose.request;
 };
 
 // we added a dummy distribution, 'image-mode', for image-mode

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -417,7 +417,32 @@ export const mockComposes: ComposesResponseItem[] = [
       ],
     },
   },
+  // Cockpit-only: bootc field and 'local' upload type are not in the hosted API types yet
+  {
+    id: 'image-mode-bootc-rhel9',
+    image_name: 'image-mode-rhel9',
+    created_at: '2024-01-15T10:00:00Z',
+    request: {
+      bootc: {
+        reference: 'registry.redhat.io/rhel9/rhel-bootc:9.7',
+      },
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'guest-image',
+          upload_request: {
+            type: 'local',
+            options: {},
+          },
+        },
+      ],
+    },
+  } as unknown as ComposesResponseItem,
 ];
+
+export const mockComposeImageModeRhel9 = mockComposes.find(
+  (c) => c.id === 'image-mode-bootc-rhel9',
+)!;
 
 /**
  * MockStatus should have the same composeRequest as the one defined in the
@@ -992,6 +1017,34 @@ export const mockStatus = (composeId: string): ComposeStatus => {
         ],
       },
     },
+    // Cockpit-only: bootc field and 'local' upload type are not in the hosted API types yet
+    'image-mode-bootc-rhel9': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            artifact_path: '/var/lib/osbuild/store/image-mode-rhel9.qcow2',
+          },
+          status: 'success',
+          type: 'local',
+        },
+      },
+      request: {
+        bootc: {
+          reference: 'registry.redhat.io/rhel9/rhel-bootc:9.7',
+        },
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'guest-image',
+            upload_request: {
+              type: 'local',
+              options: {},
+            },
+          },
+        ],
+      },
+    } as unknown as ComposeStatus,
   };
   return mockComposes[composeId];
 };


### PR DESCRIPTION
Currently, the `OS` column is empty for image mode. This commit changes that and extracts the major and minor version from the bootc ref.
That not only fixes the ImagesTable but also fixes our "Launch" capability via Cockpit Machines, which relies on information from the `OS` column.