### PR TITLE
Tests: Add tests for network-installer image type (HMS-10188)

### DIFF
--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -18,6 +18,7 @@ import {
   CreateBlueprintRequest,
   ImageRequest,
 } from '../../../../../store/imageBuilderApi';
+import { useFlag } from '../../../../../Utilities/useGetEnvironment';
 import { mockArchitecturesByDistro } from '../../../../fixtures/architectures';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import {
@@ -34,6 +35,7 @@ import {
   clickRegisterLater,
   enterBlueprintName,
   getNextButton,
+  goToReview,
   goToStep,
   imageRequest,
   interceptBlueprintRequest,
@@ -925,6 +927,117 @@ describe('Image output edit mode', () => {
       `${EDIT_BLUEPRINT}/${id}`,
     );
     const expectedRequest = aarch64CreateBlueprintRequest;
+    expect(receivedRequest).toEqual(expectedRequest);
+  });
+});
+
+const selectNetworkInstaller = async () => {
+  const user = userEvent.setup();
+  const checkbox = await screen.findByRole('checkbox', {
+    name: /Network - Installer/i,
+  });
+  await waitFor(() => user.click(checkbox));
+  return checkbox;
+};
+
+describe('Network installer target', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFlag).mockImplementation((flag: string) => {
+      switch (flag) {
+        case 'image-builder.net-installer':
+          return true;
+        default:
+          return false;
+      }
+    });
+  });
+
+  test('selecting network-installer shows alert and disables other checkboxes', async () => {
+    await renderCreateMode();
+    const networkInstallerCheckbox = await selectNetworkInstaller();
+
+    await screen.findByText(
+      /This image type requires specific, minimal configuration for remote installation/i,
+    );
+    const guestImageCheckbox = await screen.findByRole('checkbox', {
+      name: /Virtualization guest image/i,
+    });
+    expect(guestImageCheckbox).toBeDisabled();
+
+    const bareMetalCheckbox = await screen.findByRole('checkbox', {
+      name: /Bare metal installer/i,
+    });
+    expect(bareMetalCheckbox).toBeDisabled();
+
+    expect(networkInstallerCheckbox).toBeChecked();
+    expect(networkInstallerCheckbox).toBeEnabled();
+  });
+
+  test('selecting another target first disables network-installer', async () => {
+    await renderCreateMode();
+    await selectGuestImageTarget();
+
+    const networkInstallerCheckbox = await screen.findByRole('checkbox', {
+      name: /Network - Installer/i,
+    });
+    expect(networkInstallerCheckbox).toBeDisabled();
+  });
+
+  test('selecting network-installer only shows security, locale, and details steps', async () => {
+    await renderCreateMode();
+    await selectNetworkInstaller();
+
+    const navigation = await screen.findByRole('navigation', {
+      name: /wizard steps/i,
+    });
+
+    const stepButtons = within(navigation).getAllByRole('button');
+    expect(stepButtons).toHaveLength(6);
+
+    expect(
+      within(navigation).getByRole('button', { name: /image output/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(navigation).getByRole('button', { name: /optional steps/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(navigation).getByRole('button', { name: /security/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(navigation).getByRole('button', { name: /locale/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(navigation).getByRole('button', { name: /details/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(navigation).getByRole('button', { name: /review/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('can create a blueprint with network-installer', async () => {
+    await renderCreateMode();
+    await selectNetworkInstaller();
+
+    await goToReview();
+
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    const expectedRequest: CreateBlueprintRequest = {
+      ...blueprintRequest,
+      distribution: RHEL_10,
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'network-installer',
+          upload_request: {
+            options: {},
+            type: 'aws.s3',
+          },
+        },
+      ],
+    };
+
     expect(receivedRequest).toEqual(expectedRequest);
   });
 });

--- a/src/test/fixtures/architectures.ts
+++ b/src/test/fixtures/architectures.ts
@@ -13,6 +13,7 @@ export const mockArchitecturesByDistro = (
           'gcp',
           'guest-image',
           'image-installer',
+          'network-installer',
           'oci',
           'wsl',
         ],


### PR DESCRIPTION
The network-installer type was recently added. These tests ensure it works as expected: alert is shown and other targets are disabled when selected, it becomes disabled when another target is selected first, only the relevant wizard steps are displayed, and a blueprint can be created successfully.

JIRA: [HMS-10188](https://issues.redhat.com/browse/HMS-10188)