### PR TITLE
cockpit: Update images select (HMS-10196)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -98,6 +98,12 @@ const ImageSourceSelect = () => {
           onClick={onToggleClick}
           isExpanded={isOpen}
           isDisabled
+          style={
+            {
+              minWidth: '50%',
+              maxWidth: '100%',
+            } as React.CSSProperties
+          }
         >
           <Spinner size='sm' /> Loading images...
         </MenuToggle>
@@ -109,7 +115,16 @@ const ImageSourceSelect = () => {
       : 'Select an image';
 
     return (
-      <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+      <MenuToggle
+        ref={toggleRef}
+        onClick={onToggleClick}
+        isExpanded={isOpen}
+        style={
+          {
+            width: '100%',
+          } as React.CSSProperties
+        }
+      >
         {optionText}
       </MenuToggle>
     );
@@ -154,7 +169,14 @@ const ImageSourceSelect = () => {
       )}
 
       <Flex>
-        <FlexItem>
+        <FlexItem
+          style={
+            {
+              minWidth: '50%',
+              maxWidth: '100%',
+            } as React.CSSProperties
+          }
+        >
           <Select
             isOpen={isOpen}
             selected={imageSource}
@@ -164,18 +186,15 @@ const ImageSourceSelect = () => {
             shouldFocusToggleOnSelect
           >
             <SelectList>
-              <SelectOption
-                key='none-option'
-                value={undefined}
-                isSelected={!imageSource}
-              >
-                Select an image
-              </SelectOption>
-              {images?.map((option) => (
-                <SelectOption key={option.image} value={option.image}>
-                  Red Hat Enterprise Linux (RHEL - bootc) {option.tag}
-                </SelectOption>
-              ))}
+              {images && images.length > 0 ? (
+                images.map((option) => (
+                  <SelectOption key={option.image} value={option.image}>
+                    Red Hat Enterprise Linux (RHEL - bootc) {option.tag}
+                  </SelectOption>
+                ))
+              ) : (
+                <SelectOption isDisabled>{'No images found'}</SelectOption>
+              )}
             </SelectList>
           </Select>
           {isLoading && (


### PR DESCRIPTION
This adjusts the width of the select to be consistent with other dropdowns on the screen.

The "Select an image" option was removed and "No images found" empty state was added.

Empty state:
<img width="979" height="379" alt="Screenshot_20260213_121754" src="https://github.com/user-attachments/assets/01ced881-095d-4bea-abe8-cb9f943a5c6e" />

Image list:
<img width="979" height="379" alt="Screenshot_20260213_121821" src="https://github.com/user-attachments/assets/ef8561b2-7bc0-48f6-a02e-555a05e8cdb1" />

No "Select an image" option after one was already selected:
<img width="918" height="259" alt="image" src="https://github.com/user-attachments/assets/36a09fe9-6e21-4732-bc5c-b60b4bff1dd7" />

Since the image source is a required field a 'None' option shouldn't be needed.

JIRA: [HMS-10196](https://issues.redhat.com/browse/HMS-10196)