### PR TITLE
src/constants: add support for fedora 45

### DIFF
--- a/playwright/helpers/helpers.ts
+++ b/playwright/helpers/helpers.ts
@@ -61,6 +61,7 @@ const ON_PREM_RELEASES = new Map([
   ['fedora-42', 'Fedora Linux 42'],
   ['fedora-43', 'Fedora Linux 43'],
   ['fedora-44', 'Fedora Linux 44'],
+  ['fedora-45', 'Fedora Linux 45'],
   ['rhel-10', 'Red Hat Enterprise Linux (RHEL) 10'],
 ]);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,6 +71,7 @@ export const FEDORA_41 = 'fedora-41';
 export const FEDORA_42 = 'fedora-42';
 export const FEDORA_43 = 'fedora-43';
 export const FEDORA_44 = 'fedora-44';
+export const FEDORA_45 = 'fedora-45';
 export const IMAGE_MODE = 'image-mode';
 export const X86_64 = 'x86_64';
 export const AARCH64 = 'aarch64';
@@ -114,6 +115,7 @@ export const ON_PREM_RELEASES = new Map([
   [FEDORA_42, 'Fedora Linux 42'],
   [FEDORA_43, 'Fedora Linux 43'],
   [FEDORA_44, 'Fedora Linux 44'],
+  [FEDORA_45, 'Fedora Linux 45'],
   [RHEL_9, 'Red Hat Enterprise Linux (RHEL) 9'],
   [RHEL_10, 'Red Hat Enterprise Linux (RHEL) 10'],
 ]);


### PR DESCRIPTION
Also add fedora 45 to the playwright helpers.

---

downstream tests are failing https://src.fedoraproject.org/rpms/cockpit-image-builder/pull-request/65 https://src.fedoraproject.org/rpms/cockpit-image-builder/pull-request/63 ; it's unclear why the fedora 44 distgit tests are failing because os-release contains fedora 45 though O.o