### PR TITLE
Wizard: Disable PXE checkbox when network installer selected (HMS-10197)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -514,6 +514,7 @@ const TargetEnvironment = () => {
             aria-label='PXE boot image checkbox'
             id='checkbox-pxe-boot'
             name='PXE boot image'
+            isDisabled={isOnlyNetworkInstallerSelected}
           />
         )}
         {supportedEnvironments?.includes('wsl') && (


### PR DESCRIPTION
Network installer cannot be built in combination with other targets. This disables the PXE checkbox for consistent behaviour with the other target types.

JIRA: [HMS-10197](https://issues.redhat.com/browse/HMS-10197)