### PR TITLE
Wizard: Hide "Other" label when it's the only category (HMS-10198)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -283,6 +283,15 @@ const TargetEnvironment = () => {
     );
   };
 
+  const privateCloudsSupported = () => {
+    return (
+      supportedEnvironments?.includes('vsphere') ||
+      supportedEnvironments?.includes('vsphere-ova')
+    );
+  };
+
+  const showOtherLabel = publicCloudsSupported() || privateCloudsSupported();
+
   if (isFetching) {
     return (
       <EmptyState
@@ -411,7 +420,10 @@ const TargetEnvironment = () => {
           )}
         </FormGroup>
       )}
-      <FormGroup label={<small>Other</small>} className='pf-v6-u-mt-sm'>
+      <FormGroup
+        label={showOtherLabel ? <small>Other</small> : undefined}
+        className='pf-v6-u-mt-sm'
+      >
         {supportedEnvironments?.includes('guest-image') && (
           <Checkbox
             label='Virtualization - Guest image (.qcow2)'


### PR DESCRIPTION
This hides the "Other" form group label if the only supported environments are from that category.

<img width="566" height="176" alt="image" src="https://github.com/user-attachments/assets/0ea93788-74d4-46ca-a285-b99a2844190b" />


JIRA: [HMS-10198](https://issues.redhat.com/browse/HMS-10198)