### PR TITLE
Wizard: hide openscap for network-installer (HMS-10200)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -592,7 +592,13 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 name='Security'
                 id='step-oscap'
                 key='step-oscap'
-                isHidden={restrictions.openscap.shouldHide}
+                isHidden={
+                  // this is specifically for the net-installer image,
+                  // it allows fips but not openscap/compliance. We will
+                  // handle that in the step itself instead.
+                  restrictions.openscap.shouldHide &&
+                  restrictions.fips.shouldHide
+                }
                 navItem={CustomStatusNavItem}
                 footer={
                   <CustomWizardFooter


### PR DESCRIPTION
## Summary
Hides OpenSCAP compliance options in the wizard when the network installer image type is selected, as OpenSCAP is not supported for this image type.

### Changes
- Add `useCustomizationRestrictions` hook to check image type restrictions
- Conditionally hide compliance policy and OpenSCAP profile selectors based on restrictions

JIRA: [HMS-10200](https://issues.redhat.com/browse/HMS-10200)