### PR TITLE
Fix undefined distro handling for image-mode in requestMapper (HMS-10207)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -261,9 +261,11 @@ const convertLogicalVolume = (volume: LogicalVolume) => {
  * Minor releases were previously used and are still present in older blueprints
  * @param distribution blueprint distribution
  */
-const getLatestRelease = (distribution: Distributions | 'image-mode') => {
+const getLatestRelease = (
+  distribution: Distributions | 'image-mode',
+): Distributions | 'image-mode' => {
   if (isImageModeDistribution(distribution)) {
-    return distribution;
+    return 'image-mode';
   }
 
   return distribution.startsWith('rhel-10')


### PR DESCRIPTION
## Summary
Fixes a bug where `getLatestRelease` could return `undefined` when handling image-mode distributions. The function now explicitly returns the `'image-mode'` string literal instead of the potentially undefined `distribution` parameter.

## Changes
- Added explicit return type annotation `Distributions | 'image-mode'` to `getLatestRelease` function
- Changed image-mode branch to return the literal `'image-mode'` instead of the `distribution` variable

JIRA: [HMS-10207](https://issues.redhat.com/browse/HMS-10207)