### PR TITLE
Wizard: Update firewall description (HMS-10211)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Firewall/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ClipboardCopy, Content, Form, Title } from '@patternfly/react-core';
+import { Content, Form, Title } from '@patternfly/react-core';
 
 import PortsInput from './components/PortsInput';
 import Services from './components/Services';
@@ -17,16 +17,6 @@ const FirewallStep = () => {
       <Content>
         Customize firewall settings for your image. When enabling or disabling
         services, use the firewalld service name rather than systemd unit names.
-        To view the list of available services, use{' '}
-        <ClipboardCopy
-          aria-label='Copy firewall-cmd --get-services'
-          hoverTip='Copy'
-          clickTip='Copied'
-          variant='inline-compact'
-          isCode
-        >
-          firewall-cmd --get-services
-        </ClipboardCopy>
       </Content>
       <PortsInput />
       <Services />


### PR DESCRIPTION
This removes the last sentence to remove the clipboard copy pattern from the description. The user would have to run the command on the image that isn't built yet.

JIRA: [HMS-10211](https://issues.redhat.com/browse/HMS-10211)