### PR TITLE
ImagesTable: change permission of artifact dir on launch

### DIFF
--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -190,8 +190,13 @@ export const LocalInstance = ({ compose }: LocalInstancePropTypes) => {
       component='a'
       target='_blank'
       variant='link'
-      onClick={(ev) => {
+      onClick={async (ev) => {
         ev.preventDefault();
+        // Make sure the file is readable for the user, the artefact
+        // directory is created as 700 by default.
+        await cockpit.spawn(['chmod', '755', parsedPath.dir], {
+          superuser: 'try',
+        });
         cockpit.jump(href, cockpit.transport.host);
       }}
       href={href}


### PR DESCRIPTION
While cockpit-files does not need the artifact directory to be world-readable, cockpit-machines does need it when creating a VM.