### PR TITLE
Wizard/Review: fix section visibility for net-installer type (HMS-9568)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -331,7 +331,7 @@ const Review = () => {
           )}
         </Stack>
       </ExpandableSection>
-      {isRhel(distribution) && (
+      {isRhel(distribution) && !restrictions.registration.shouldHide && (
         <ExpandableSection
           toggleContent={composeExpandable(
             'Registration',
@@ -353,7 +353,7 @@ const Review = () => {
         </ExpandableSection>
       )}
 
-      {!restrictions.openscap.shouldHide && (
+      {!(restrictions.openscap.shouldHide && restrictions.fips.shouldHide) && (
         <ExpandableSection
           toggleContent={composeExpandable(
             'Security',


### PR DESCRIPTION
# Summary

Fix Review step to hide Registration and show Security for net-installer images.

## Overview

When selecting the `network-installer` image type, the Review step incorrectly displayed the Registration section and hid the Security (FIPS) section. The Registration section was gated only on `isRhel()` instead of also checking the customization restrictions. The Security section only checked `openscap` restrictions, ignoring `fips`, which is a supported customization for net-installer.

## Architectural Changes

None

## Key Changes

- Hide Registration in Review when `restrictions.registration.shouldHide` is true, not just based on RHEL distribution
- Show Security section in Review when either `openscap` or `fips` is supported, matching the wizard step visibility logic in `CreateImageWizard.tsx`

## Breaking Changes

This PR is fully backward compatible.

## Testing

Verified that the Review step visibility conditions now match the wizard step conditions defined in `CreateImageWizard.tsx`. Existing behavior for non-net-installer image types is preserved since the restrictions system already returns the correct values for those types.

JIRA: HMS-9568