### PR TITLE
Wizard: commit pending LabelInput value on blur

### DIFF
--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -126,10 +126,17 @@ const LabelInput = ({
     setOnStepInputErrorText('');
   };
 
+  const commitInputValue = (value: string) => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      addItem(trimmed);
+    }
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent, value: string) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      addItem(value);
+      commitInputValue(value);
     }
   };
 
@@ -154,6 +161,7 @@ const LabelInput = ({
           onChange={onTextInputChange}
           value={inputValue}
           onKeyDown={(e) => handleKeyDown(e, inputValue)}
+          onBlur={() => commitInputValue(inputValue)}
         >
           {totalItems > 0 && (
             <LabelGroup


### PR DESCRIPTION
Previously, LabelInput only committed typed values when the user pressed Enter. This meant pending input was silently discarded when clicking away, navigating to the next wizard step, or interacting with other controls. Adding an onBlur handler ensures the pending value is validated and added automatically when the input loses focus, providing consistent behavior across all LabelInput consumers (kernel arguments, user groups, NTP servers, ports, firewall and systemd services).

Fixes: https://github.com/osbuild/image-builder-frontend/issues/3943