### PR TITLE
Wizard: Revamp first boot step ( HMS-9522)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -1,9 +1,15 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 
-import { CodeEditor, Language } from '@patternfly/react-code-editor';
+import {
+  CodeEditor,
+  CodeEditorControl,
+  Language,
+} from '@patternfly/react-code-editor';
 import {
   Alert,
   Content,
+  DropEvent,
+  FileUpload,
   Form,
   FormGroup,
   FormHelperText,
@@ -11,6 +17,7 @@ import {
   HelperTextItem,
   Title,
 } from '@patternfly/react-core';
+import { UndoIcon } from '@patternfly/react-icons';
 
 import { useFirstBootValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
@@ -25,11 +32,24 @@ import {
 } from '@/store/slices/wizard';
 import { useFlag } from '@/Utilities/useGetEnvironment';
 
+// Inline <style> needed because sassPrefix wraps SCSS in .imageBuilder,
+// but the wizard Modal renders in a portal outside that wrapper.
+const editorStyles = `
+.first-boot-editor .pf-v6-c-code-editor__header-content {
+  background-color: var(--pf-t--global--background--color--primary--default);
+}
+.first-boot-editor .pf-v6-c-code-editor__controls {
+  flex: 1;
+  justify-content: flex-end;
+}
+.first-boot-editor button[aria-label='Upload code'] {
+  display: none;
+}`;
+
 const detectScriptType = (scriptString: string): Language => {
   const lines = scriptString.split('\n');
 
   if (lines[0].startsWith('#!')) {
-    // Extract the path from the shebang
     const path = lines[0].slice(2);
 
     if (path.includes('bin/bash') || path.includes('bin/sh')) {
@@ -44,7 +64,6 @@ const detectScriptType = (scriptString: string): Language => {
       return Language.yaml;
     }
   }
-  // default
   return Language.shell;
 };
 
@@ -57,6 +76,59 @@ const FirstBootStep = () => {
   const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
 
   const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
+
+  const initialScriptRef = useRef(selectedScript);
+  const [filename, setFilename] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [uploadedScript, setUploadedScript] = useState('');
+
+  const handleScriptChange = (newScript: string) => {
+    if (!selectedScript && !!newScript) {
+      dispatch(addEnabledService(FIRST_BOOT_SERVICE));
+    } else if (!!selectedScript && !newScript) {
+      dispatch(removeEnabledService(FIRST_BOOT_SERVICE));
+    }
+    // In case the user is on windows
+    dispatch(setFirstBootScript(newScript.replace(/\r\n/g, '\n')));
+  };
+
+  const handleFileInputChange = (_event: DropEvent, file: File) => {
+    setFilename(file.name);
+  };
+
+  const handleDataChange = (_event: DropEvent, value: string) => {
+    const normalizedValue = value.replace(/\r\n/g, '\n');
+    setUploadedScript(normalizedValue);
+    handleScriptChange(value);
+  };
+
+  const handleClear = () => {
+    setFilename('');
+    setUploadedScript('');
+    handleScriptChange('');
+  };
+
+  const handleFileReadStarted = () => {
+    setIsLoading(true);
+  };
+
+  const handleFileReadFinished = () => {
+    setIsLoading(false);
+  };
+
+  const handleRevert = () => {
+    handleScriptChange(uploadedScript || initialScriptRef.current);
+  };
+
+  const customControls = [
+    <CodeEditorControl
+      key='revert-button'
+      icon={<UndoIcon />}
+      aria-label='Revert changes'
+      onClick={handleRevert}
+      tooltipProps={{ content: 'Revert changes' }}
+    />,
+  ];
 
   return (
     <Wrapper>
@@ -91,26 +163,43 @@ const FirstBootStep = () => {
         </Content>
       </Alert>
       <FormGroup>
+        <FileUpload
+          id='first-boot-script-upload'
+          type='text'
+          filename={filename}
+          filenamePlaceholder='Drag and drop a file or upload'
+          onFileInputChange={handleFileInputChange}
+          onDataChange={handleDataChange}
+          onReadStarted={handleFileReadStarted}
+          onReadFinished={handleFileReadFinished}
+          onClearClick={handleClear}
+          isLoading={isLoading}
+          allowEditingUploadedText={false}
+          browseButtonText='Upload'
+          hideDefaultPreview
+        />
+      </FormGroup>
+      <FormGroup>
         <CodeEditor
-          isUploadEnabled
-          isDownloadEnabled
-          isCopyEnabled
-          isLanguageLabelVisible
+          className='first-boot-editor'
           language={language}
-          onCodeChange={(code) => {
-            if (!selectedScript && !!code) {
-              dispatch(addEnabledService(FIRST_BOOT_SERVICE));
-            } else if (!!selectedScript && !code) {
-              dispatch(removeEnabledService(FIRST_BOOT_SERVICE));
-            }
-            // In case the user is on windows
-            dispatch(setFirstBootScript(code.replace('\r\n', '\n')));
-          }}
+          onCodeChange={(code) => handleScriptChange(code)}
           code={selectedScript}
           height='35vh'
-          emptyStateButton='Browse'
+          isCopyEnabled
+          isDownloadEnabled
+          isUploadEnabled
+          emptyStateBody='Drag a file here, upload files, or start from scratch.'
+          emptyStateButton='Upload files'
           emptyStateLink='Start from scratch'
+          customControls={customControls}
         />
+        <style>{editorStyles}</style>
+        <HelperText className='pf-v6-u-pt-sm'>
+          <HelperTextItem>
+            Supports bash shell, python, or Ansible playbooks
+          </HelperTextItem>
+        </HelperText>
         {errors.script && (
           <FormHelperText>
             <HelperText>

--- a/src/Components/CreateImageWizard/steps/FirstBoot/tests/FirstBoot.test.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/tests/FirstBoot.test.tsx
@@ -1,14 +1,17 @@
 import { screen } from '@testing-library/react';
 
-import { initialState } from '@/store/slices/wizard';
+import { FIRST_BOOT_SERVICE } from '@/constants';
 import { createUser, waitForAction } from '@/test/testUtils';
 
-import { openCodeEditor, renderFirstBootStep, uploadScript } from './helpers';
+import { renderFirstBootStep, uploadScript } from './helpers';
 
 const VALID_SCRIPT = `#!/bin/bash
 echo "Hello, World!"`;
 
 const SCRIPT_WITHOUT_SHEBANG = `echo "Hello, World!"`;
+
+const CRLF_SCRIPT = '#!/bin/bash\r\necho "line1"\r\necho "line2"';
+const LF_SCRIPT = '#!/bin/bash\necho "line1"\necho "line2"';
 
 describe('FirstBoot Component', () => {
   describe('Rendering', () => {
@@ -35,11 +38,13 @@ describe('FirstBoot Component', () => {
       ).toBeInTheDocument();
     });
 
-    test('displays start from scratch button initially', async () => {
+    test('displays helper text for supported script types', async () => {
       renderFirstBootStep();
 
       expect(
-        await screen.findByRole('button', { name: /Start from scratch/i }),
+        await screen.findByText(
+          /Supports bash shell, python, or Ansible playbooks/i,
+        ),
       ).toBeInTheDocument();
     });
   });
@@ -49,7 +54,6 @@ describe('FirstBoot Component', () => {
       renderFirstBootStep();
       const user = createUser();
 
-      await openCodeEditor(user);
       await uploadScript(user, SCRIPT_WITHOUT_SHEBANG);
 
       expect(await screen.findByText(/Missing shebang/i)).toBeInTheDocument();
@@ -59,7 +63,6 @@ describe('FirstBoot Component', () => {
       renderFirstBootStep();
       const user = createUser();
 
-      await openCodeEditor(user);
       await uploadScript(user, VALID_SCRIPT);
 
       expect(screen.queryByText(/Missing shebang/i)).not.toBeInTheDocument();
@@ -67,6 +70,14 @@ describe('FirstBoot Component', () => {
   });
 
   describe('Initial State', () => {
+    test('displays empty state with Start from scratch button', async () => {
+      renderFirstBootStep();
+
+      expect(
+        await screen.findByRole('button', { name: /Start from scratch/i }),
+      ).toBeInTheDocument();
+    });
+
     test('does not show empty state when script is pre-populated', async () => {
       renderFirstBootStep({
         firstBoot: {
@@ -84,39 +95,54 @@ describe('FirstBoot Component', () => {
     });
   });
 
-  describe('Registration Message', () => {
-    test('shows registration message when not using register-later', async () => {
-      renderFirstBootStep({
-        registration: {
-          ...initialState.registration,
-          registrationType: 'register-now-insights',
-        },
-      });
+  describe('File Upload Component', () => {
+    test('displays file upload with placeholder text', async () => {
+      renderFirstBootStep();
 
       expect(
-        await screen.findByText(
-          /The first boot script will run after registration is done/i,
-        ),
+        await screen.findByPlaceholderText(/Drag and drop a file or upload/i),
       ).toBeInTheDocument();
     });
 
-    test('does not show registration message when using register-later', async () => {
-      renderFirstBootStep({
-        registration: {
-          ...initialState.registration,
-          registrationType: 'register-later',
-        },
-      });
+    test('displays upload button', async () => {
+      renderFirstBootStep();
 
-      await screen.findByRole('heading', {
-        name: /First boot configuration/i,
+      const uploadButton = await screen.findByRole('button', {
+        name: 'Upload',
+      });
+      expect(uploadButton).toBeInTheDocument();
+    });
+  });
+
+  describe('Custom Controls', () => {
+    test('displays revert button', async () => {
+      renderFirstBootStep({
+        firstBoot: { script: VALID_SCRIPT },
       });
 
       expect(
-        screen.queryByText(
-          /The first boot script will run after registration is done/i,
-        ),
-      ).not.toBeInTheDocument();
+        await screen.findByRole('button', { name: /Revert changes/i }),
+      ).toBeInTheDocument();
+    });
+
+    test('revert restores uploaded script', async () => {
+      const { store } = renderFirstBootStep();
+      const user = createUser();
+
+      await uploadScript(user, VALID_SCRIPT);
+
+      await waitForAction(() => {
+        expect(store.getState().wizard.firstBoot.script).toBe(VALID_SCRIPT);
+      });
+
+      const revertButton = screen.getByRole('button', {
+        name: /Revert changes/i,
+      });
+      await waitForAction(() => user.click(revertButton));
+
+      await waitForAction(() => {
+        expect(store.getState().wizard.firstBoot.script).toBe(VALID_SCRIPT);
+      });
     });
   });
 
@@ -127,13 +153,36 @@ describe('FirstBoot Component', () => {
 
       expect(store.getState().wizard.firstBoot.script).toBe('');
 
-      await openCodeEditor(user);
       await uploadScript(user, VALID_SCRIPT);
 
-      // The FileReader processes the file asynchronously, so we need to wait
-      // for the state to be updated after the upload completes
       await waitForAction(() => {
         expect(store.getState().wizard.firstBoot.script).toBe(VALID_SCRIPT);
+      });
+    });
+
+    test('adds first boot service when script is uploaded', async () => {
+      const { store } = renderFirstBootStep();
+      const user = createUser();
+
+      await uploadScript(user, VALID_SCRIPT);
+
+      await waitForAction(() => {
+        expect(store.getState().wizard.services.enabled).toContain(
+          FIRST_BOOT_SERVICE,
+        );
+      });
+    });
+
+    test('normalizes CRLF line endings to LF', async () => {
+      const { store } = renderFirstBootStep();
+      const user = createUser();
+
+      await uploadScript(user, CRLF_SCRIPT);
+
+      await waitForAction(() => {
+        const storedScript = store.getState().wizard.firstBoot.script;
+        expect(storedScript).toBe(LF_SCRIPT);
+        expect(storedScript).not.toContain('\r\n');
       });
     });
   });

--- a/src/Components/CreateImageWizard/steps/FirstBoot/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/tests/helpers.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
-import { screen, waitFor } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
 
 import {
-  clickWithWait,
   renderWithRedux,
   type UserEventInstance,
   waitForAction,
@@ -16,13 +15,6 @@ export const renderFirstBootStep = (
   wizardStateOverrides: WizardStateOverrides = {},
 ) => {
   return renderWithRedux(<FirstBootStep />, wizardStateOverrides);
-};
-
-export const openCodeEditor = async (user: UserEventInstance) => {
-  const startBtn = await screen.findByRole('button', {
-    name: /Start from scratch/i,
-  });
-  await clickWithWait(user, startBtn);
 };
 
 export const uploadScript = async (

--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -72,14 +72,6 @@ const selectSimplifiedOscapProfile = async () => {
   await waitFor(() => user.click(simplifiedProfile));
 };
 
-const openCodeEditor = async (): Promise<void> => {
-  const user = userEvent.setup();
-  const startBtn = await screen.findByRole('button', {
-    name: /Start from scratch/i,
-  });
-  await waitFor(() => user.click(startBtn));
-};
-
 const uploadFile = async (scriptName: string): Promise<void> => {
   const user = userEvent.setup();
   const fileInput: HTMLElement | null =
@@ -124,7 +116,6 @@ describe('First Boot step', () => {
   test('should validate shebang', async () => {
     await renderCreateMode();
     await goToFirstBootStep();
-    await openCodeEditor();
     await uploadFile(SCRIPT_WITHOUT_SHEBANG);
     expect(await screen.findByText(/Missing shebang/i)).toBeInTheDocument();
     expect(await getNextButton()).toBeDisabled();
@@ -149,7 +140,6 @@ describe('First boot request generated correctly', () => {
     await enterBlueprintName();
     await clickRegisterLater();
     await goToFirstBootStep();
-    await openCodeEditor();
     await uploadFile(SCRIPT);
     await goToReview();
     // informational modal pops up in the first test only as it's tied
@@ -180,7 +170,6 @@ describe('First boot request generated correctly', () => {
     await clickRegisterLater();
     await selectSimplifiedOscapProfile();
     await goToStep(/First boot/);
-    await openCodeEditor();
     await uploadFile(SCRIPT);
     await goToReview();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
@@ -214,7 +203,6 @@ describe('First boot request generated correctly', () => {
     await goToOscapStep();
     await selectSimplifiedOscapProfile();
     await goToStep(/First boot/);
-    await openCodeEditor();
     await uploadFile(SCRIPT_DOS);
     await goToReview();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);


### PR DESCRIPTION
Add a FileUpload component above the CodeEditor for drag-and-drop
script uploads. Enhance the CodeEditor with custom controls for
copy, download, and revert actions.

- Add FileUpload with drag-and-drop support above CodeEditor
- Add custom CodeEditor controls (copy, download, revert)
- Add revert functionality to restore initial or uploaded script
- Add helper text clarifying supported script types
- Remove registration ordering text from step description
- Move inline styles to SCSS file
- Add unit tests for new functionality
JIRA: [HMS-9522](https://redhat.atlassian.net/browse/HMS-9522)

[HMS-9522]: https://redhat.atlassian.net/browse/HMS-9522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ