### PR TITLE
Wizard: add image mode on hosted service (HMS-10361)

### DIFF
--- a/api/config/imageBuilder.ts
+++ b/api/config/imageBuilder.ts
@@ -26,6 +26,7 @@ const config: ConfigFile = {
     'getBlueprintComposes',
     'deleteBlueprint',
     'getBlueprint',
+    'getDistributions',
     'recommendPackage',
     'fixupBlueprint',
   ],

--- a/playwright/Basic/imageMode.spec.ts
+++ b/playwright/Basic/imageMode.spec.ts
@@ -1,0 +1,164 @@
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
+
+import { expect } from '@playwright/test';
+import { v4 as uuidv4 } from 'uuid';
+
+import { test } from '../fixtures/customizations';
+import { isHosted } from '../helpers/helpers';
+import { ensureAuthenticated } from '../helpers/login';
+import { ibFrame, navigateToLandingPage } from '../helpers/navHelpers';
+import {
+  createBlueprint,
+  deleteBlueprint,
+  exportBlueprint,
+  importBlueprint,
+} from '../helpers/wizardHelpers';
+
+test('Image mode blueprint create, edit, export, import', async ({
+  page,
+  cleanup,
+}) => {
+  test.skip(!isHosted(), 'Image mode on hosted only');
+
+  const blueprintName = 'test-' + uuidv4();
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
+
+  await ensureAuthenticated(page);
+  await navigateToLandingPage(page);
+
+  // Enable preview so the image-mode Unleash flag is active
+  const previewToggle = page.locator('#preview-toggle');
+  if (!(await previewToggle.isChecked())) {
+    await previewToggle.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(2000);
+  }
+  await expect(page.getByRole('heading', { name: 'All images' })).toBeVisible({
+    timeout: 30000,
+  });
+
+  const frame = ibFrame(page);
+
+  await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+
+  // Skip the test if the image mode flag is not enabled in this environment
+  const imageModeToggle = frame.getByRole('button', { name: 'Image mode' });
+  try {
+    await expect(imageModeToggle).toBeVisible({ timeout: 10000 });
+  } catch {
+    test.skip(true, 'Image mode flag not enabled');
+  }
+
+  await test.step('Fill in details', async () => {
+    await frame
+      .getByRole('textbox', { name: 'Blueprint name' })
+      .fill(blueprintName);
+    await frame
+      .getByRole('textbox', { name: 'Blueprint description' })
+      .fill('Testing blueprint');
+  });
+
+  await test.step('Fill in image output with image mode', async () => {
+    await imageModeToggle.click();
+
+    const imageSourceDropdown = frame.getByRole('button', {
+      name: /Select a bootc image/,
+    });
+    await expect(imageSourceDropdown).toBeVisible({ timeout: 10000 });
+    await imageSourceDropdown.click();
+
+    const firstOption = frame.getByRole('option').first();
+    await expect(firstOption).toBeVisible();
+    await firstOption.click();
+
+    await frame.getByRole('checkbox', { name: 'Virtualization' }).click();
+  });
+
+  await test.step('Fill in user', async () => {
+    await frame
+      .getByRole('textbox', { name: 'blueprint user name' })
+      .fill('testuser');
+  });
+
+  await test.step('Create blueprint', async () => {
+    await frame.getByRole('button', { name: 'Next', exact: true }).click();
+    const nextButton = frame.getByRole('button', { name: 'Next', exact: true });
+    await expect(nextButton).toBeEnabled({ timeout: 10000 });
+    await nextButton.click();
+    await createBlueprint(frame, blueprintName);
+  });
+
+  await test.step('Edit blueprint and verify image output', async () => {
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(2000);
+
+    await frame.getByRole('button', { name: 'Edit blueprint' }).click();
+
+    await frame.getByRole('button', { name: 'Base settings' }).click();
+
+    const imageModeButton = frame.getByRole('button', { name: 'Image mode' });
+    await expect(imageModeButton).toHaveAttribute('aria-pressed', 'true');
+
+    await expect(
+      frame.getByRole('button', { name: /Select a bootc image/ }),
+    ).toBeHidden();
+
+    await expect(
+      frame.getByRole('checkbox', { name: 'Virtualization' }),
+    ).toBeChecked();
+  });
+
+  await test.step('Verify user in edit modal', async () => {
+    await expect(
+      frame.getByRole('textbox', { name: 'blueprint user name' }),
+    ).toHaveValue('testuser');
+
+    await frame.getByRole('button', { name: 'Next', exact: true }).click();
+    const saveNextButton = frame.getByRole('button', {
+      name: 'Next',
+      exact: true,
+    });
+    await expect(saveNextButton).toBeEnabled({ timeout: 10000 });
+    await saveNextButton.click();
+    await frame
+      .getByRole('button', { name: 'Save changes to blueprint' })
+      .click();
+  });
+
+  let exportedBP = '';
+
+  await test.step('Export blueprint', async () => {
+    exportedBP = await exportBlueprint(page);
+    cleanup.add(async () => {
+      await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
+    });
+  });
+
+  const importedName = blueprintName + '-imported';
+  cleanup.add(() => deleteBlueprint(page, importedName));
+
+  await test.step('Import blueprint', async () => {
+    await importBlueprint(frame, exportedBP);
+  });
+
+  await test.step('Verify imported blueprint', async () => {
+    const importedImageMode = frame.getByRole('button', {
+      name: 'Image mode',
+    });
+    await expect(importedImageMode).toBeVisible({ timeout: 10000 });
+    await expect(importedImageMode).toHaveAttribute('aria-pressed', 'true');
+
+    // Export doesn't include image_requests, so image types must be re-selected
+    await frame.getByRole('checkbox', { name: 'Virtualization' }).click();
+
+    await expect(
+      frame.getByRole('textbox', { name: 'blueprint user name' }),
+    ).toHaveValue('testuser');
+
+    // Change the name to avoid "name already exists" conflict
+    await frame
+      .getByRole('textbox', { name: 'Blueprint name' })
+      .fill(importedName);
+  });
+});

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -180,6 +180,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
                 name: blueprintFromFile.name,
                 description: blueprintFromFile.description,
                 distribution: blueprintFromFile.distribution,
+                bootc: blueprintFromFile.bootc,
                 customizations: blueprintFromFile.customizations,
                 metadata: blueprintFromFile.metadata,
                 content_sources: blueprintFromFile.content_sources,

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import {
   Content,
@@ -9,9 +9,11 @@ import {
 import { BuildIcon, RepositoryIcon } from '@patternfly/react-icons';
 
 import { Distributions } from '@/store/api/backend';
+import { selectIsOnPremise } from '@/store/slices/env';
 import {
   changeBlueprintMode,
   changeDistribution,
+  selectDistribution,
   selectIsImageMode,
 } from '@/store/slices/wizard';
 
@@ -22,10 +24,14 @@ import { getHostDistro } from '../../../../../Utilities/getHostInfo';
 
 const BlueprintMode = () => {
   const dispatch = useAppDispatch();
+  const isOnPremise = useAppSelector(selectIsOnPremise);
   const isImageMode = useAppSelector(selectIsImageMode);
+  const distribution = useAppSelector(selectDistribution);
   const [defaultDistro, setDefaultDistro] = useState<Distributions>(RHEL_10);
+  const previousDistro = useRef<Distributions>(RHEL_10);
 
   useEffect(() => {
+    if (!isOnPremise) return;
     const fetchDefaultDistro = async () => {
       try {
         const distro = await getHostDistro();
@@ -38,7 +44,7 @@ const BlueprintMode = () => {
     };
 
     fetchDefaultDistro();
-  }, []);
+  }, [isOnPremise]);
 
   return (
     <FormGroup label='Image type' isRequired>
@@ -50,7 +56,11 @@ const BlueprintMode = () => {
           isSelected={!isImageMode}
           onChange={() => {
             dispatch(changeBlueprintMode('package'));
-            dispatch(changeDistribution(defaultDistro));
+            dispatch(
+              changeDistribution(
+                isOnPremise ? defaultDistro : previousDistro.current,
+              ),
+            );
           }}
           aria-describedby='blueprint-mode-description'
         />
@@ -60,6 +70,9 @@ const BlueprintMode = () => {
           buttonId='blueprint-mode-image'
           isSelected={isImageMode}
           onChange={() => {
+            if (!isOnPremise) {
+              previousDistro.current = distribution as Distributions;
+            }
             dispatch(changeBlueprintMode('image'));
             dispatch(changeDistribution('image-mode'));
           }}

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -20,10 +20,16 @@ import {
 } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
 
-import { usePodmanImagesQuery } from '@/store/api/backend';
+import {
+  BootcDistributionItem,
+  useGetDistributionsQuery,
+  usePodmanImagesQuery,
+} from '@/store/api/backend';
+import { selectIsOnPremise } from '@/store/slices/env';
 import {
   changeImageSource,
   ImageSource,
+  selectArchitecture,
   selectImageSource,
 } from '@/store/slices/wizard';
 
@@ -58,7 +64,7 @@ const InfoMessageContent = ({ source }: { source: string }) => {
   );
 };
 
-const ImageSourceSelect = () => {
+const PodmanImageSourceSelect = () => {
   const dispatch = useAppDispatch();
   const imageSource = useAppSelector(selectImageSource);
   const [isOpen, setIsOpen] = useState(false);
@@ -226,6 +232,122 @@ const ImageSourceSelect = () => {
       </Flex>
     </FormGroup>
   );
+};
+
+const BootcImageSourceSelect = () => {
+  const dispatch = useAppDispatch();
+  const arch = useAppSelector(selectArchitecture);
+  const imageSource = useAppSelector(selectImageSource);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const {
+    data: distributions,
+    isLoading,
+    isError,
+  } = useGetDistributionsQuery({ kind: 'bootc', arch });
+
+  const bootcDistributions = distributions as
+    | BootcDistributionItem[]
+    | undefined;
+
+  // Deduplicate by name — the API returns one entry per target type,
+  // but the dropdown should show one entry per base image.
+  const uniqueDistributions = bootcDistributions?.reduce<
+    BootcDistributionItem[]
+  >((acc, item) => {
+    if (!acc.some((d) => d.name === item.name)) {
+      acc.push(item);
+    }
+    return acc;
+  }, []);
+
+  const selectedItem = uniqueDistributions?.find(
+    (d) => d.image_name === imageSource,
+  );
+
+  const onSelect = (_event?: React.MouseEvent, selection?: string | number) => {
+    dispatch(changeImageSource(selection as string));
+    setIsOpen(false);
+  };
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => {
+    if (isLoading) {
+      return (
+        <MenuToggle
+          ref={toggleRef}
+          isDisabled
+          style={
+            {
+              maxWidth: '100%',
+            } as React.CSSProperties
+          }
+        >
+          <Spinner size='sm' /> Loading bootc images...
+        </MenuToggle>
+      );
+    }
+
+    return (
+      <MenuToggle
+        ref={toggleRef}
+        onClick={() => setIsOpen(!isOpen)}
+        isExpanded={isOpen}
+        style={
+          {
+            maxWidth: '100%',
+          } as React.CSSProperties
+        }
+      >
+        {selectedItem ? selectedItem.name : 'Select a bootc image'}
+      </MenuToggle>
+    );
+  };
+
+  return (
+    <FormGroup label='Image source' isRequired>
+      {isError && (
+        <Alert
+          title='Error loading bootc images'
+          variant='danger'
+          className='pf-v6-u-mb-md'
+        >
+          Unable to load available bootc images. Please try again later.
+        </Alert>
+      )}
+      <Select
+        isOpen={isOpen}
+        selected={imageSource}
+        onSelect={onSelect}
+        onOpenChange={(open) => setIsOpen(open)}
+        toggle={toggle}
+        shouldFocusToggleOnSelect
+      >
+        <SelectList>
+          {uniqueDistributions && uniqueDistributions.length > 0 ? (
+            uniqueDistributions.map((item) => (
+              <SelectOption key={item.image_name} value={item.image_name}>
+                {item.name}
+              </SelectOption>
+            ))
+          ) : (
+            <SelectOption isDisabled>
+              No bootc images available for {arch}
+            </SelectOption>
+          )}
+        </SelectList>
+      </Select>
+    </FormGroup>
+  );
+};
+
+const ImageSourceSelect = () => {
+  const isOnPremise = useAppSelector(selectIsOnPremise);
+
+  if (isOnPremise) {
+    return <PodmanImageSourceSelect />;
+  }
+
+  return <BootcImageSourceSelect />;
 };
 
 export default ImageSourceSelect;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -10,9 +10,15 @@ import {
 } from '@patternfly/react-core';
 
 import { rhsmApi } from '@/store/api';
-import { ImageTypes, useGetArchitecturesQuery } from '@/store/api/backend';
+import {
+  BootcDistributionItem,
+  ImageTypes,
+  useGetArchitecturesQuery,
+  useGetDistributionsQuery,
+} from '@/store/api/backend';
 import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { selectIsOnPremise } from '@/store/slices';
 import {
   addImageType,
   changeRegistrationType,
@@ -23,6 +29,7 @@ import {
   selectArchitecture,
   selectDistribution,
   selectImageTypes,
+  selectIsImageMode,
 } from '@/store/slices/wizard';
 
 import Aws from './Aws';
@@ -34,24 +41,36 @@ const PRIVATE_CLOUD_TYPES = new Set<string>(['vsphere', 'vsphere-ova']);
 const PUBLIC_CLOUD_TYPES = new Set<string>(['aws', 'azure', 'gcp', 'oci']);
 const EMPTY_ENVIRONMENTS: string[] = [];
 
+const bootcTypeToImageType: Record<string, string> = {
+  ec2: 'aws',
+  azure: 'azure',
+  gcp: 'gcp',
+  qcow2: 'guest-image',
+};
+
 const TargetEnvironment = () => {
   const arch = useAppSelector(selectArchitecture);
   const environments = useAppSelector(selectImageTypes);
   const distribution = useAppSelector(selectDistribution);
+  const isImageMode = useAppSelector(selectIsImageMode);
+  const isOnPremise = useAppSelector(selectIsOnPremise);
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: environments,
   });
 
+  const skipArchitectures = isImageMode && !isOnPremise;
+
   const {
-    isError,
-    isFetching,
-    environments: supportedEnvironments,
+    isError: isArchError,
+    isFetching: isArchFetching,
+    environments: archEnvironments,
   } = useGetArchitecturesQuery(
     {
       distribution,
     },
     {
+      skip: skipArchitectures,
       selectFromResult: ({ data, isFetching, isError }) => ({
         isError,
         isFetching,
@@ -61,6 +80,35 @@ const TargetEnvironment = () => {
           EMPTY_ENVIRONMENTS,
       }),
     },
+  );
+
+  const {
+    data: bootcDistributionsRaw,
+    isError: isBootcError,
+    isFetching: isBootcFetching,
+  } = useGetDistributionsQuery(
+    { kind: 'bootc', arch },
+    { skip: !isImageMode || isOnPremise },
+  );
+  const bootcDistributions = bootcDistributionsRaw as
+    | BootcDistributionItem[]
+    | undefined;
+
+  const isFetching = isArchFetching || isBootcFetching;
+  const isError = isArchError || isBootcError;
+
+  const supportedEnvironments = useMemo(
+    () =>
+      skipArchitectures
+        ? [
+            ...new Set(
+              bootcDistributions
+                ?.map((d) => bootcTypeToImageType[d.type])
+                .filter(Boolean) ?? EMPTY_ENVIRONMENTS,
+            ),
+          ]
+        : archEnvironments,
+    [skipArchitectures, bootcDistributions, archEnvironments],
   );
 
   const dispatch = useAppDispatch();
@@ -152,6 +200,22 @@ const TargetEnvironment = () => {
         Target environments couldn&apos;t be loaded, please refresh the page or
         try again later.
       </Alert>
+    );
+  }
+
+  if (supportedEnvironments.length === 0) {
+    return (
+      <FormGroup
+        isRequired={true}
+        role='group'
+        label='Target environments'
+        fieldId='target-environments'
+      >
+        <Content component='p'>
+          No target environments are currently available for the selected
+          architecture.
+        </Content>
+      </FormGroup>
     );
   }
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect } from 'react';
 
-import { Content, Form, Title } from '@patternfly/react-core';
+import { Content, Form, FormGroup, Title } from '@patternfly/react-core';
 
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
+  changeArchitecture,
   changeBlueprintName,
   selectArchitecture,
   selectBlueprintName,
@@ -21,17 +22,20 @@ import ReleaseSelect from './components/ReleaseSelect';
 import TargetEnvironment from './components/TargetEnvironment';
 
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import { useFlag } from '../../../../Utilities/useGetEnvironment';
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
 import { generateDefaultName } from '../../utilities/useGenerateDefaultName';
 
 const ImageOutputStep = () => {
-  const isOnPremise = useAppSelector(selectIsOnPremise);
   const dispatch = useAppDispatch();
   const isImageMode = useAppSelector(selectIsImageMode);
   const blueprintName = useAppSelector(selectBlueprintName);
   const distribution = useAppSelector(selectDistribution);
   const arch = useAppSelector(selectArchitecture);
   const isCustomName = useAppSelector(selectIsCustomName);
+  const isOnPremise = useAppSelector(selectIsOnPremise);
+  const isImageModeEnabled = useFlag('image-builder.image-mode.enabled');
+  const isHostedImageMode = isImageMode && !isOnPremise;
 
   useEffect(() => {
     const defaultName = generateDefaultName(distribution, arch);
@@ -39,6 +43,12 @@ const ImageOutputStep = () => {
       dispatch(changeBlueprintName(defaultName));
     }
   }, [dispatch, distribution, arch, isCustomName]);
+
+  useEffect(() => {
+    if (isHostedImageMode) {
+      dispatch(changeArchitecture('x86_64'));
+    }
+  }, [dispatch, isHostedImageMode]);
 
   return (
     <Form>
@@ -49,11 +59,10 @@ const ImageOutputStep = () => {
         Select the release, architecture, and a target environment to build your
         image. Learn more about <DocumentationButton />
       </Content>
-      {isOnPremise &&
-        // The distribution is 'image-mode' when the blueprint is in image mode
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        !distribution?.startsWith('fedora') && <BlueprintMode />}
-      {isImageMode && <ImageSourceSelect />}
+      {isImageModeEnabled && !(distribution as string).startsWith('fedora') && (
+        <BlueprintMode />
+      )}
+      {isImageModeEnabled && isImageMode && <ImageSourceSelect />}
       {!isImageMode && (
         <>
           <ReleaseSelect />
@@ -61,7 +70,11 @@ const ImageOutputStep = () => {
           <ReleaseLifecycle />
         </>
       )}
-      <ArchSelect />
+      {isHostedImageMode ? (
+        <FormGroup label='Architecture'>x86_64</FormGroup>
+      ) : (
+        <ArchSelect />
+      )}
       <TargetEnvironment />
     </Form>
   );

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -687,13 +687,14 @@ export const mapExportRequestToState = (
     distribution: request.distribution,
     customizations: request.customizations,
     image_requests: image_requests,
+    bootc: request.bootc,
   };
 
   return {
     wizardMode,
-    // API needs to be updated first
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    blueprintMode: request.distribution ? 'package' : 'image',
+    blueprintMode: isImageModeDistribution(request.distribution)
+      ? 'image'
+      : 'package',
     metadata: getMetadata(request.metadata),
     env: initialState.env,
     registration: initialState.registration,

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -39,8 +39,8 @@ export const useFlagWithEphemDefault = (
 
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
-    // case '<flag>':
-    //   return true;
+    case 'image-builder.image-mode.enabled':
+      return true;
     default:
       return false;
   }

--- a/src/store/api/backend/hosted/imageBuilderApi.ts
+++ b/src/store/api/backend/hosted/imageBuilderApi.ts
@@ -1,6 +1,20 @@
 import { emptyImageBuilderApi as api } from "./emptyImageBuilderApi";
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
+    getDistributions: build.query<
+      GetDistributionsApiResponse,
+      GetDistributionsApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/distributions`,
+        params: {
+          kind: queryArg.kind,
+          distro: queryArg.distro,
+          arch: queryArg.arch,
+          type: queryArg["type"],
+        },
+      }),
+    }),
     getArchitectures: build.query<
       GetArchitecturesApiResponse,
       GetArchitecturesApiArg
@@ -167,6 +181,24 @@ const injectedRtkApi = api.injectEndpoints({
   overrideExisting: false,
 });
 export { injectedRtkApi as imageBuilderApi };
+export type GetDistributionsApiResponse =
+  /** status 200 A list of distributions. The items in the array depend on the 'kind' parameter.
+   */ DistributionsResponse;
+export type GetDistributionsApiArg = {
+  /** Kind of distributions to return. When set to 'bootc', returns bootc/image-mode
+    distributions (each with id, name, type, arch, and image). Defaults to classic distributions.
+     */
+  kind?: DistributionKind;
+  /** Filter bootc distributions by distribution name. Only applies when kind=bootc.
+   */
+  distro?: string;
+  /** Filter bootc distributions by CPU architecture. Only applies when kind=bootc.
+   */
+  arch?: string;
+  /** Filter bootc distributions by image type. Only applies when kind=bootc.
+   */
+  type?: string;
+};
 export type GetArchitecturesApiResponse =
   /** status 200 a list of available architectures and their associated image types */ Architectures;
 export type GetArchitecturesApiArg = {
@@ -315,6 +347,24 @@ export type FixupBlueprintApiArg = {
   /** UUID of a blueprint */
   id: string;
 };
+export type DistributionItem = {
+  description: string;
+  name: string;
+};
+export type BootcDistributionItem = {
+  id: string;
+  distro: string;
+  name: string;
+  type: string;
+  arch: string;
+  /** part of the container image name used as the base for composing */
+  image_name: string;
+};
+export type DistributionsResponse = (
+  | DistributionItem
+  | BootcDistributionItem
+)[];
+export type DistributionKind = "bootc";
 export type Repository = {
   /** An ID referring to a repository defined in content sources can be used instead of
     'baseurl', 'mirrorlist' or 'metalink'.
@@ -1014,6 +1064,8 @@ export type RecommendPackageRequest = {
   distribution: string;
 };
 export const {
+  useGetDistributionsQuery,
+  useLazyGetDistributionsQuery,
   useGetArchitecturesQuery,
   useLazyGetArchitecturesQuery,
   useGetBlueprintsQuery,

--- a/src/store/api/backend/hosted/index.ts
+++ b/src/store/api/backend/hosted/index.ts
@@ -10,6 +10,7 @@ export {
   useGetBlueprintComposesQuery,
   useGetBlueprintQuery,
   useGetBlueprintsQuery,
+  useGetDistributionsQuery,
   useGetComposesQuery,
   useGetComposeStatusQuery,
   useGetOscapCustomizationsForPolicyQuery,

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -90,6 +90,7 @@ export {
   useComposeImageMutation,
   useExportBlueprintQuery,
   useFixupBlueprintMutation,
+  useGetDistributionsQuery,
   useGetPackagesQuery,
   useLazyExportBlueprintQuery,
   useLazyGetPackagesQuery,


### PR DESCRIPTION
Add the "Image mode" toggle for hosted service, get the possible bootc containers from the CRC API using the GET distributions endpoint.
<img width="1556" height="885" alt="image" src="https://github.com/user-attachments/assets/666df4d3-1b80-4f5d-9db2-79e262c049e6" />

The architecture is set for now, so I didn't use the dropdown we have for it in package mode.


