### PR TITLE
Wizard: Visually gate repositories and packages (HMS-10420)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/Packages.tsx
@@ -7,7 +7,6 @@ import {
   Select,
   SelectList,
   SelectOption,
-  Stack,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -68,58 +67,54 @@ const Packages = () => {
         epelRepo={epelRepo}
       />
       <Toolbar>
-        <Stack>
-          <ToolbarContent>
-            <ToolbarItem>
-              <FormGroup label='Package type'>
-                <Select
-                  id='package-type-select'
-                  isOpen={isPackageTypeDropdownOpen}
-                  selected={packageType}
-                  onSelect={(_event, value) => {
-                    setPackageType(value as 'packages' | 'groups');
-                    setIsPackageTypeDropdownOpen(false);
-                  }}
-                  onOpenChange={(isOpen) =>
-                    setIsPackageTypeDropdownOpen(isOpen)
-                  }
-                  toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                    <MenuToggle
-                      ref={toggleRef}
-                      onClick={() =>
-                        setIsPackageTypeDropdownOpen(!isPackageTypeDropdownOpen)
-                      }
-                      isExpanded={isPackageTypeDropdownOpen}
-                    >
-                      {packageType === 'packages'
-                        ? 'Individual packages'
-                        : 'Package groups'}
-                    </MenuToggle>
-                  )}
-                >
-                  <SelectList>
-                    <SelectOption value='packages'>
-                      Individual packages
-                    </SelectOption>
-                    <SelectOption value='groups'>Package groups</SelectOption>
-                  </SelectList>
-                </Select>
-              </FormGroup>
-            </ToolbarItem>
-            <ToolbarItem>
-              <PackageSearch
-                packageType={packageType}
-                isSuccessEpelRepo={isSuccessEpelRepo}
-                epelRepo={epelRepo}
-                setIsRepoModalOpen={setIsRepoModalOpen}
-                setIsSelectingPackage={setIsSelectingPackage}
-                setIsSelectingGroup={setIsSelectingGroup}
-                activeStream={activeStream}
-                setActiveStream={setActiveStream}
-              />
-            </ToolbarItem>
-          </ToolbarContent>
-        </Stack>
+        <ToolbarContent>
+          <ToolbarItem>
+            <FormGroup label='Package type'>
+              <Select
+                id='package-type-select'
+                isOpen={isPackageTypeDropdownOpen}
+                selected={packageType}
+                onSelect={(_event, value) => {
+                  setPackageType(value as 'packages' | 'groups');
+                  setIsPackageTypeDropdownOpen(false);
+                }}
+                onOpenChange={(isOpen) => setIsPackageTypeDropdownOpen(isOpen)}
+                toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+                  <MenuToggle
+                    ref={toggleRef}
+                    onClick={() =>
+                      setIsPackageTypeDropdownOpen(!isPackageTypeDropdownOpen)
+                    }
+                    isExpanded={isPackageTypeDropdownOpen}
+                  >
+                    {packageType === 'packages'
+                      ? 'Individual packages'
+                      : 'Package groups'}
+                  </MenuToggle>
+                )}
+              >
+                <SelectList>
+                  <SelectOption value='packages'>
+                    Individual packages
+                  </SelectOption>
+                  <SelectOption value='groups'>Package groups</SelectOption>
+                </SelectList>
+              </Select>
+            </FormGroup>
+          </ToolbarItem>
+          <ToolbarItem>
+            <PackageSearch
+              packageType={packageType}
+              isSuccessEpelRepo={isSuccessEpelRepo}
+              epelRepo={epelRepo}
+              setIsRepoModalOpen={setIsRepoModalOpen}
+              setIsSelectingPackage={setIsSelectingPackage}
+              setIsSelectingGroup={setIsSelectingGroup}
+              activeStream={activeStream}
+              setActiveStream={setActiveStream}
+            />
+          </ToolbarItem>
+        </ToolbarContent>
       </Toolbar>
       <PackagesTable
         isSuccessEpelRepo={isSuccessEpelRepo}

--- a/src/Components/CreateImageWizard/steps/Packages/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/index.tsx
@@ -46,31 +46,34 @@ const PackagesStep = () => {
   return (
     <Wrapper>
       <CustomizationLabels customization='packages' />
-      <Title
-        headingLevel='h1'
-        size='xl'
-        className='pf-v6-u-display-flex pf-v6-u-align-items-center'
-      >
-        Packages
-        {requiredByOpenSCAPCount > 0 && (
-          <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
-            {requiredByOpenSCAPCount} Added by OpenSCAP
-          </Label>
-        )}
-      </Title>
       <Content>
-        Search and add individual packages to include in your image. You can
-        select packages from the repositories included in the previous step.
+        <Title
+          headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+          size={isWizardRevampEnabled ? 'lg' : 'xl'}
+          className='pf-v6-u-display-flex pf-v6-u-align-items-center'
+        >
+          Packages
+          {requiredByOpenSCAPCount > 0 && (
+            <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
+              {requiredByOpenSCAPCount} Added by OpenSCAP
+            </Label>
+          )}
+        </Title>
+        <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
+          Search and add individual packages to include in your image. You can
+          select packages from the repositories included in the previous step.
+        </Content>
+        <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
+          {isOnPremise && (
+            <>
+              Search for exact matches by specifying the whole package name, or
+              glob using asterisk wildcards (*) before or after the package
+              name.
+            </>
+          )}
+        </Content>
+        <Packages />
       </Content>
-      <Content>
-        {isOnPremise && (
-          <>
-            Search for exact matches by specifying the whole package name, or
-            glob using asterisk wildcards (*) before or after the package name.
-          </>
-        )}
-      </Content>
-      <Packages />
       {!isOnPremise && isRhel(distribution) && <PackageRecommendations />}
     </Wrapper>
   );

--- a/src/Components/CreateImageWizard/steps/Repositories/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/index.tsx
@@ -9,6 +9,7 @@ import {
   selectRecommendedRepositories,
   selectWizardMode,
 } from '@/store/slices/wizard';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import ManageRepositoriesButton from './components/ManageRepositoriesButton';
 import Repositories from './components/Repositories';
@@ -18,15 +19,26 @@ const RepositoriesStep = () => {
   const packages = useAppSelector(selectPackages);
   const recommendedRepos = useAppSelector(selectRecommendedRepositories);
 
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
+
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
   return (
-    <Form>
+    <Wrapper>
       <CustomizationLabels customization='repositories' />
-      <Title headingLevel='h1' size='xl'>
-        Included repositories
-      </Title>
       <Content>
-        Can&apos;t find a repository? Ensure it&apos;s been added on{' '}
-        <ManageRepositoriesButton label={'the Repositories page'} icon={true} />
+        <Title
+          headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+          size={isWizardRevampEnabled ? 'lg' : 'xl'}
+        >
+          Included repositories
+        </Title>
+        <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
+          Can&apos;t find a repository? Ensure it&apos;s been added on{' '}
+          <ManageRepositoriesButton
+            label={'the Repositories page'}
+            icon={true}
+          />
+        </Content>
       </Content>
       {wizardMode === 'edit' && (
         <Alert
@@ -50,7 +62,7 @@ const RepositoriesStep = () => {
         ''
       )}
       <Repositories />
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
+++ b/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
@@ -291,6 +291,10 @@ const CreateImageWizard3 = () => {
     );
   }
 
+  const handleFormSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+  };
+
   return (
     <Modal
       isOpen={showWizardModal}
@@ -368,7 +372,7 @@ const CreateImageWizard3 = () => {
             <CustomWizardFooter disableNext={false} isOnPremise={isOnPremise} />
           }
         >
-          <Form>
+          <Form onSubmit={handleFormSubmit}>
             <Title headingLevel='h1' size='xl'>
               Repositories and packages
             </Title>


### PR DESCRIPTION
This moves stuff out and inside of `Content` blocks and adds some conditionals to render the final step closer to the mocks with regards to spacing and text sizes.