### PR TITLE
Wizard: Add allowed characters for kernel arguments (HMS-9508)

### DIFF
--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -272,7 +272,7 @@ export const isKernelNameValid = (kernelName: string) => {
 };
 
 export const isKernelArgumentValid = (arg: string) => {
-  return /^[a-zA-Z0-9=\-_,."'/:#+]*$/.test(arg);
+  return /^[a-zA-Z0-9=\-_,."'/:#+;\\]*$/.test(arg);
 };
 
 export const isPortValid = (port: string) => {


### PR DESCRIPTION
This updates the validation for the kernel arguments to contain semicolon and backslash as allowed characters.