### PR TITLE
feat: move ImageBuilderWidget source code from landing-page-frontend

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -113,6 +113,10 @@ module.exports = {
   moduleFederation: {
     exposes: {
       './RootApp': path.resolve(__dirname, './src/AppEntry.tsx'),
+      './ImageBuilderWidget': path.resolve(
+        __dirname,
+        './src/Components/Widgets/image-builder-widget.tsx'
+      ),
     },
     shared: [{ 'react-router-dom': { singleton: true, version: '*' } }],
     exclude: ['react-router-dom'],

--- a/src/Components/Widgets/image-builder-widget.tsx
+++ b/src/Components/Widgets/image-builder-widget.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { SimpleServiceWidget } from './simple-service-widget';
+
+const ImageBuilderWidget: React.FunctionComponent = () => {
+  return (
+    <>
+      <SimpleServiceWidget
+        id={3}
+        body="Create customized system images for disks, VMs, and cloud platforms. Image Builder automates configurations, saving you time and ensuring consistent, deployment-ready images every time."
+        linkTitle="Images"
+        url="/insights/image-builder"
+      />
+    </>
+  );
+};
+
+export default ImageBuilderWidget;

--- a/src/Components/Widgets/image-builder-widget.tsx
+++ b/src/Components/Widgets/image-builder-widget.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import { SimpleServiceWidget } from './simple-service-widget';
 
 const ImageBuilderWidget: React.FunctionComponent = () => {
@@ -6,9 +7,9 @@ const ImageBuilderWidget: React.FunctionComponent = () => {
     <>
       <SimpleServiceWidget
         id={3}
-        body="Create customized system images for disks, VMs, and cloud platforms. Image Builder automates configurations, saving you time and ensuring consistent, deployment-ready images every time."
-        linkTitle="Images"
-        url="/insights/image-builder"
+        body='Create customized system images for disks, VMs, and cloud platforms. Image Builder automates configurations, saving you time and ensuring consistent, deployment-ready images every time.'
+        linkTitle='Images'
+        url='/insights/image-builder'
       />
     </>
   );

--- a/src/Components/Widgets/simple-service-widget.scss
+++ b/src/Components/Widgets/simple-service-widget.scss
@@ -1,0 +1,12 @@
+// non-scrollable widgets using flex
+.landing-edge, .landing-rhel, .landing-ansible, .landing-openshift, .landing-quay, .landing-openshiftAi, .landing-acs, .landing-imageBuilder, [class*="landing-landing-./EdgeWidget"], [class*="landing-landing-./RhelWidget"], [class*="landing-landing-./AnsibleWidget"], [class*="landing-landing-./OpenShiftWidget"], [class*="landing-landing-./QuayWidget"], [class*="landing-landing-./OpenShiftAiWidget"], [class*="landing-landing-./AcsWidget"], [class*="landing-landing-./ImageBuilderWidget"] { 
+  display: flex; 
+  overflow: hidden;
+  a {
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+

--- a/src/Components/Widgets/simple-service-widget.scss
+++ b/src/Components/Widgets/simple-service-widget.scss
@@ -1,5 +1,5 @@
 // non-scrollable widgets using flex
-.landing-edge, .landing-rhel, .landing-ansible, .landing-openshift, .landing-quay, .landing-openshiftAi, .landing-acs, .landing-imageBuilder, [class*="landing-landing-./EdgeWidget"], [class*="landing-landing-./RhelWidget"], [class*="landing-landing-./AnsibleWidget"], [class*="landing-landing-./OpenShiftWidget"], [class*="landing-landing-./QuayWidget"], [class*="landing-landing-./OpenShiftAiWidget"], [class*="landing-landing-./AcsWidget"], [class*="landing-landing-./ImageBuilderWidget"] { 
+.landing-imageBuilder, [class*="landing-landing-./ImageBuilderWidget"] {
   display: flex; 
   overflow: hidden;
   a {

--- a/src/Components/Widgets/simple-service-widget.tsx
+++ b/src/Components/Widgets/simple-service-widget.tsx
@@ -1,0 +1,56 @@
+import { Card } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardBody } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { CardFooter } from '@patternfly/react-core/dist/dynamic/components/Card';
+import { Icon } from '@patternfly/react-core/dist/dynamic/components/Icon';
+import React from 'react';
+import { Content } from '@patternfly/react-core/dist/dynamic/components/Content';
+import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
+import { Link } from 'react-router-dom';
+import './simple-service-widget.scss';
+
+interface SimpleServiceWidgetProps {
+  id: number;
+  body: string;
+  linkTitle: string;
+  url: string;
+  isExternal?: boolean;
+}
+
+export const SimpleServiceWidget: React.FunctionComponent<
+  SimpleServiceWidgetProps
+> = (props) => {
+  return (
+    <Card isPlain>
+      <>
+        <CardBody className="pf-v5-u-p-md pf-v5-u-pb-0">
+          <Content
+            key={props.id}
+            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column"
+          >
+            <Content component="p" className="pf-v5-u-flex-grow-1">
+              {props.body}{' '}
+            </Content>
+          </Content>
+        </CardBody>
+        <CardFooter className="pf-v5-u-p-md">
+          {props.isExternal ? (
+            <a href={props.url}>
+              {props.linkTitle}
+              <Icon className="pf-v5-u-ml-sm" isInline>
+                <ExternalLinkAltIcon />
+              </Icon>
+            </a>
+          ) : (
+            <Link to={props.url}>
+              {props.linkTitle}
+              <Icon className="pf-v5-u-ml-sm" isInline>
+                <ArrowRightIcon />
+              </Icon>
+            </Link>
+          )}
+        </CardFooter>
+      </>
+    </Card>
+  );
+};

--- a/src/Components/Widgets/simple-service-widget.tsx
+++ b/src/Components/Widgets/simple-service-widget.tsx
@@ -23,28 +23,28 @@ export const SimpleServiceWidget: React.FunctionComponent<
   return (
     <Card isPlain>
       <>
-        <CardBody className="pf-v5-u-p-md pf-v5-u-pb-0">
+        <CardBody className="pf-v6-u-p-md pf-v6-u-pb-0">
           <Content
             key={props.id}
-            className="pf-v5-u-display-flex pf-v5-u-flex-direction-column"
+            className="pf-v6-u-display-flex pf-v6-u-flex-direction-column"
           >
-            <Content component="p" className="pf-v5-u-flex-grow-1">
+            <Content component="p" className="pf-v6-u-flex-grow-1">
               {props.body}{' '}
             </Content>
           </Content>
         </CardBody>
-        <CardFooter className="pf-v5-u-p-md">
+        <CardFooter className="pf-v6-u-p-md">
           {props.isExternal ? (
             <a href={props.url}>
               {props.linkTitle}
-              <Icon className="pf-v5-u-ml-sm" isInline>
+              <Icon className="pf-v6-u-ml-sm" isInline>
                 <ExternalLinkAltIcon />
               </Icon>
             </a>
           ) : (
             <Link to={props.url}>
               {props.linkTitle}
-              <Icon className="pf-v5-u-ml-sm" isInline>
+              <Icon className="pf-v6-u-ml-sm" isInline>
                 <ArrowRightIcon />
               </Icon>
             </Link>

--- a/src/Components/Widgets/simple-service-widget.tsx
+++ b/src/Components/Widgets/simple-service-widget.tsx
@@ -1,21 +1,25 @@
-import { Card } from '@patternfly/react-core/dist/dynamic/components/Card';
-import { CardBody } from '@patternfly/react-core/dist/dynamic/components/Card';
-import { CardFooter } from '@patternfly/react-core/dist/dynamic/components/Card';
-import { Icon } from '@patternfly/react-core/dist/dynamic/components/Icon';
 import React from 'react';
+
+import {
+  Card,
+  CardBody,
+  CardFooter,
+} from '@patternfly/react-core/dist/dynamic/components/Card';
 import { Content } from '@patternfly/react-core/dist/dynamic/components/Content';
+import { Icon } from '@patternfly/react-core/dist/dynamic/components/Icon';
 import ArrowRightIcon from '@patternfly/react-icons/dist/js/icons/arrow-right-icon';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { Link } from 'react-router-dom';
+
 import './simple-service-widget.scss';
 
-interface SimpleServiceWidgetProps {
+type SimpleServiceWidgetProps = {
   id: number;
   body: string;
   linkTitle: string;
   url: string;
   isExternal?: boolean;
-}
+};
 
 export const SimpleServiceWidget: React.FunctionComponent<
   SimpleServiceWidgetProps
@@ -23,28 +27,28 @@ export const SimpleServiceWidget: React.FunctionComponent<
   return (
     <Card isPlain>
       <>
-        <CardBody className="pf-v6-u-p-md pf-v6-u-pb-0">
+        <CardBody className='pf-v6-u-p-md pf-v6-u-pb-0'>
           <Content
             key={props.id}
-            className="pf-v6-u-display-flex pf-v6-u-flex-direction-column"
+            className='pf-v6-u-display-flex pf-v6-u-flex-direction-column'
           >
-            <Content component="p" className="pf-v6-u-flex-grow-1">
+            <Content component='p' className='pf-v6-u-flex-grow-1'>
               {props.body}{' '}
             </Content>
           </Content>
         </CardBody>
-        <CardFooter className="pf-v6-u-p-md">
+        <CardFooter className='pf-v6-u-p-md'>
           {props.isExternal ? (
             <a href={props.url}>
               {props.linkTitle}
-              <Icon className="pf-v6-u-ml-sm" isInline>
+              <Icon className='pf-v6-u-ml-sm' isInline>
                 <ExternalLinkAltIcon />
               </Icon>
             </a>
           ) : (
             <Link to={props.url}>
               {props.linkTitle}
-              <Icon className="pf-v6-u-ml-sm" isInline>
+              <Icon className='pf-v6-u-ml-sm' isInline>
                 <ArrowRightIcon />
               </Icon>
             </Link>


### PR DESCRIPTION
## Summary
- Moves the `ImageBuilderWidget` module federation expose from `landing-page-frontend` into this repo
- Adds widget source files (`image-builder-widget.tsx`, `simple-service-widget.tsx`, `simple-service-widget.scss`)
- Updates `fec.config.js` to expose `./ImageBuilderWidget`

Part of [RHCLOUD-40474](https://redhat.atlassian.net/browse/RHCLOUD-40474) — decoupling widget dashboard backend from Chrome service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-40474]: https://redhat.atlassian.net/browse/RHCLOUD-40474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ