### PR TITLE
Wizard: Redesign Locale languages field with row-based UI (HMS-9517)

### DIFF
--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -46,10 +46,13 @@ test('Create a blueprint with Locale customization', async ({
 
   await test.step('Check that the Locale step shows langpacks, but not the Additional packages', async () => {
     await frame.getByRole('button', { name: 'Locale' }).click();
-    await frame.getByPlaceholder('Select a language').click();
-    await frame.getByPlaceholder('Select a language').fill('ru_RU');
+    await frame.getByRole('button', { name: 'Add language' }).click();
+    await frame.getByRole('button', { name: 'Select a language' }).click();
+    const searchInput = frame.getByPlaceholder('Search by name').last();
+    await searchInput.click();
+    await searchInput.fill('ru_RU');
     await frame
-      .getByRole('option', { name: 'Russian - Russia (ru_RU.UTF-8)' })
+      .getByRole('menuitem', { name: 'Russian - Russia (ru_RU.UTF-8)' })
       .click();
 
     // Wait for the loading spinner to disappear (langpack resolution can take a while)
@@ -73,37 +76,64 @@ test('Create a blueprint with Locale customization', async ({
 
   await test.step('Select and fill the Locale step', async () => {
     await frame.getByRole('button', { name: 'Locale' }).click();
-    await frame.getByPlaceholder('Select a language').fill('en_US');
+    const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
+    // Add en_US language
+    await frame.getByRole('button', { name: 'Add language' }).click();
+    await frame.getByRole('button', { name: 'Select a language' }).click();
+    let langSearch = frame.getByPlaceholder('Search by name').last();
+    await langSearch.click();
+    await langSearch.fill('en_US');
     await frame
-      .getByRole('option', {
+      .getByRole('menuitem', {
         name: 'English - United States (en_US.UTF-8)',
       })
       .click();
     await expect(
-      frame.getByText('English - United States (en_US.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United States (en_US.UTF-8)',
+      }),
     ).toBeVisible();
-    await frame.getByPlaceholder('Select a language').fill('fy');
+    // Add fy_DE language
+    await frame.getByRole('button', { name: 'Add language' }).click();
+    await frame.getByRole('button', { name: 'Select a language' }).click();
+    langSearch = frame.getByPlaceholder('Search by name').last();
+    await langSearch.click();
+    await langSearch.fill('fy');
     await frame
-      .getByRole('option', {
+      .getByRole('menuitem', {
         name: 'Western Frisian - Germany (fy_DE.UTF-8)',
       })
       .click();
     await expect(
-      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Western Frisian - Germany (fy_DE.UTF-8)',
+      }),
     ).toBeVisible();
-    await frame.getByPlaceholder('Select a language').fill('aa');
+    // Test filtering by adding a temporary row
+    await frame.getByRole('button', { name: 'Add language' }).click();
+    await frame.getByRole('button', { name: 'Select a language' }).click();
+    langSearch = frame.getByPlaceholder('Search by name').last();
+    await langSearch.click();
+    await langSearch.fill('aa');
     // Verify that the dropdown shows filtered options starting with 'aa'
     await expect(
-      frame.getByRole('option', { name: 'aa - Eritrea (aa_ER.UTF-8)' }),
+      frame.getByRole('menuitem', { name: 'aa - Eritrea (aa_ER.UTF-8)' }),
     ).toBeAttached();
     await expect(
-      frame.getByRole('option', { name: 'aa - Ethiopia (aa_ET.UTF-8)' }),
+      frame.getByRole('menuitem', { name: 'aa - Ethiopia (aa_ET.UTF-8)' }),
     ).toBeAttached();
-    await frame.getByPlaceholder('Select a language').fill('xxx');
+    await langSearch.fill('xxx');
     await expect(frame.getByText('No results found for')).toBeAttached();
-    await frame.getByRole('button', { name: 'Menu toggle' }).nth(1).click();
-    await frame.getByPlaceholder('Select a keyboard').fill('ami');
-    await frame.getByRole('option', { name: 'amiga-de' }).click();
+    // Remove the temporary row
+    await frame.getByRole('button', { name: 'Remove language' }).last().click();
+    // Select keyboard
+    await keyboardGroup
+      .getByRole('button', { name: 'Select a keyboard' })
+      .click();
+    const kbSearch = frame.getByPlaceholder('Search by name').last();
+    await kbSearch.click();
+    await kbSearch.fill('ami');
+    await frame.getByRole('menuitem', { name: 'amiga-de' }).click();
     // Wait for the loading spinner to disappear after language/keyboard changes
     await frame
       .getByText('Resolving packages for your preferred locale…')
@@ -153,26 +183,41 @@ test('Create a blueprint with Locale customization', async ({
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
     await frame.getByLabel('Revisit Locale step').click();
+    const languagesGroup = frame.getByRole('group', { name: 'Languages' });
+    const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     await expect(
-      frame.getByText('English - United States (en_US.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United States (en_US.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Western Frisian - Germany (fy_DE.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('Russian - Russia (ru_RU.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Russian - Russia (ru_RU.UTF-8)',
+      }),
     ).toBeVisible();
-    await frame.getByPlaceholder('Select a language').fill('en_GB');
+    // Change the first language to en_GB
+    await languagesGroup.locator('.locale-language-toggle').first().click();
+    const editSearch = frame.getByPlaceholder('Search by name').last();
+    await editSearch.click();
+    await editSearch.fill('en_GB');
     await frame
-      .getByRole('option', {
+      .getByRole('menuitem', {
         name: 'English - United Kingdom (en_GB.UTF-8)',
       })
       .click();
     await expect(
-      frame.getByText('English - United Kingdom (en_GB.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United Kingdom (en_GB.UTF-8)',
+      }),
     ).toBeVisible();
-    await frame.getByRole('button', { name: 'Menu toggle' }).nth(1).click();
-    await frame.getByRole('option', { name: 'ANSI-dvorak' }).click();
+    // Change keyboard
+    await keyboardGroup.getByRole('button', { name: 'amiga-de' }).click();
+    await frame.getByRole('menuitem', { name: 'ANSI-dvorak' }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
@@ -203,21 +248,30 @@ test('Create a blueprint with Locale customization', async ({
   await test.step('Review imported BP', async () => {
     await fillInImageOutputGuest(frame);
     await frame.getByRole('button', { name: 'Locale' }).click();
+    const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     await expect(
-      frame.getByText('English - United States (en_US.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United States (en_US.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('English - United Kingdom (en_GB.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United Kingdom (en_GB.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Western Frisian - Germany (fy_DE.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('Russian - Russia (ru_RU.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Russian - Russia (ru_RU.UTF-8)',
+      }),
     ).toBeVisible();
-    await expect(frame.getByPlaceholder('Select a keyboard')).toHaveValue(
-      'ANSI-dvorak',
-    );
+    await expect(
+      keyboardGroup.getByRole('button', { name: 'ANSI-dvorak' }),
+    ).toBeVisible();
     await frame.getByRole('button', { name: 'Cancel' }).click();
   });
 });

--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -78,12 +78,9 @@ test('Import a blueprint with invalid customization', async ({
     await expect(frame.getByText('Unknown languages: random:')).toBeVisible();
     await expect(frame.getByText('Duplicated languages: af_ZA.')).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
-    await frame.getByRole('button', { name: 'Close random' }).click();
+    await frame.getByRole('button', { name: 'Remove language' }).last().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
-    await frame
-      .getByRole('button', { name: 'Close Afrikaans - South' })
-      .nth(1)
-      .click();
+    await frame.getByRole('button', { name: 'Remove language' }).last().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
   });
 

--- a/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
@@ -1,25 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
-import {
-  Button,
-  FormGroup,
-  HelperText,
-  HelperTextItem,
-  MenuToggle,
-  MenuToggleElement,
-  Select,
-  SelectList,
-  SelectOption,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
-} from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
+import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 
 import { changeKeyboard, selectKeyboard } from '@/store/slices/wizard';
 
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
-import sortfn from '../../../../../Utilities/sortfn';
+import SearchableSelect from '../../../../sharedComponents/SearchableSelect';
 import { useLocaleValidation } from '../../../utilities/useValidation';
 import { keyboardsList } from '../data/keyboardsList';
 
@@ -30,125 +16,26 @@ const KeyboardDropDown = () => {
   const stepValidation = useLocaleValidation();
 
   const [errorText, setErrorText] = useState(stepValidation.errors['keyboard']);
-  const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState<string>('');
-  const [filterValue, setFilterValue] = useState<string>('');
-  const [selectOptions, setSelectOptions] = useState<string[]>(keyboardsList);
 
-  useEffect(() => {
-    let filteredKeyboards = keyboardsList;
-
-    if (filterValue) {
-      filteredKeyboards = keyboardsList.filter((keyboard: string) =>
-        String(keyboard).toLowerCase().includes(filterValue.toLowerCase()),
-      );
-      if (!isOpen) {
-        setIsOpen(true);
-      }
-    }
-    setSelectOptions(
-      filteredKeyboards.sort((a, b) => sortfn(a, b, filterValue)),
-    );
-
-    // This useEffect hook should run *only* on when the filter value changes.
-    // eslint's exhaustive-deps rule does not support this use.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterValue]);
-
-  const onInputClick = () => {
-    if (!isOpen) {
-      setIsOpen(true);
-    } else if (!inputValue) {
-      setIsOpen(false);
-    }
-  };
-
-  const onSelect = (_event?: React.MouseEvent, value?: string | number) => {
-    if (value && typeof value === 'string') {
-      setInputValue(value);
-      setFilterValue('');
-      setErrorText('');
-      dispatch(changeKeyboard(value));
-      setIsOpen(false);
-    }
-  };
-
-  const onTextInputChange = (_event: React.FormEvent, value: string) => {
-    setInputValue(value);
-    setFilterValue(value);
-
-    if (value !== keyboard) {
-      dispatch(changeKeyboard(''));
-    }
-  };
-
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const onClearButtonClick = () => {
-    setInputValue('');
-    setFilterValue('');
-    setErrorText('');
-    dispatch(changeKeyboard(''));
-  };
-
-  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      variant='typeahead'
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-    >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={keyboard ? keyboard : inputValue}
-          onClick={onInputClick}
-          onChange={onTextInputChange}
-          autoComplete='off'
-          placeholder='Select a keyboard'
-          isExpanded={isOpen}
-        />
-
-        {keyboard && (
-          <TextInputGroupUtilities>
-            <Button
-              icon={<TimesIcon />}
-              variant='plain'
-              onClick={onClearButtonClick}
-              aria-label='Clear input'
-            />
-          </TextInputGroupUtilities>
-        )}
-      </TextInputGroup>
-    </MenuToggle>
+  const options = useMemo(
+    () => keyboardsList.map((kb) => ({ value: kb, label: kb })),
+    [],
   );
 
+  const handleSelect = (value: string) => {
+    dispatch(changeKeyboard(value));
+    setErrorText('');
+  };
+
   return (
-    <FormGroup isRequired={false} label='Keyboard'>
-      <Select
-        isScrollable
-        isOpen={isOpen}
+    <FormGroup isRequired={false} label='Keyboard' role='group'>
+      <SearchableSelect
+        options={options}
         selected={keyboard}
-        onSelect={onSelect}
-        onOpenChange={(isOpen) => setIsOpen(isOpen)}
-        toggle={toggle}
-        shouldFocusFirstItemOnOpen={false}
-      >
-        <SelectList>
-          {selectOptions.length > 0 ? (
-            selectOptions.map((option) => (
-              <SelectOption key={option} value={option}>
-                {option}
-              </SelectOption>
-            ))
-          ) : (
-            <SelectOption isDisabled>
-              {`No results found for "${filterValue}"`}
-            </SelectOption>
-          )}
-        </SelectList>
-      </Select>
+        placeholder='Select a keyboard'
+        onSelect={handleSelect}
+        isFullWidth
+      />
       {errorText && (
         <HelperText>
           <HelperTextItem variant={'error'}>{errorText}</HelperTextItem>

--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -1,22 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import {
   Button,
   FormGroup,
   HelperText,
   HelperTextItem,
-  Label,
-  LabelGroup,
-  MenuToggle,
-  MenuToggleElement,
-  Select,
-  SelectList,
-  SelectOption,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
 } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import {
   addLanguage,
@@ -25,7 +15,7 @@ import {
 } from '@/store/slices/wizard';
 
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
-import sortfn from '../../../../../Utilities/sortfn';
+import SearchableSelect from '../../../../sharedComponents/SearchableSelect';
 import { useLocaleValidation } from '../../../utilities/useValidation';
 import { languagesList } from '../data/languagesList';
 
@@ -47,9 +37,60 @@ const parseLanguageOption = (language: string) => {
   }
 };
 
+const parsedLanguages: Record<string, string> = Object.fromEntries(
+  languagesList.map((lang) => [lang, parseLanguageOption(lang)]),
+);
+
+type LanguageRowProps = {
+  selectedLanguage?: string;
+  onSelect: (language: string) => void;
+  onRemove: () => void;
+  existingLanguages: string[];
+};
+
+const LanguageRow = ({
+  selectedLanguage,
+  onSelect,
+  onRemove,
+  existingLanguages,
+}: LanguageRowProps) => {
+  const options = useMemo(
+    () =>
+      Object.entries(parsedLanguages)
+        .filter(
+          ([raw]) =>
+            !existingLanguages.includes(raw) || raw === selectedLanguage,
+        )
+        .map(([raw, parsed]) => ({ value: raw, label: parsed })),
+    [existingLanguages, selectedLanguage],
+  );
+
+  return (
+    <div className='pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-gap-sm pf-v6-u-mb-sm'>
+      <div style={{ width: '50%', maxWidth: '400px', minWidth: '200px' }}>
+        <SearchableSelect
+          options={options}
+          selected={selectedLanguage}
+          placeholder='Select a language'
+          onSelect={onSelect}
+          isFullWidth
+          toggleClassName='locale-language-toggle'
+        />
+      </div>
+      <Button
+        variant='plain'
+        onClick={onRemove}
+        aria-label='Remove language'
+        icon={<MinusCircleIcon />}
+      />
+    </div>
+  );
+};
+
 const LanguagesDropDown = () => {
-  const languages = useAppSelector(selectLanguages);
+  const languages = useAppSelector(selectLanguages) ?? [];
   const dispatch = useAppDispatch();
+  const [showNewRow, setShowNewRow] = useState(false);
 
   const stepValidation = useLocaleValidation();
   const unknownLanguages = stepValidation.errors['unknownLanguages']
@@ -59,169 +100,64 @@ const LanguagesDropDown = () => {
     ? stepValidation.errors['duplicateLanguages'].split(' ')
     : [];
 
-  const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState<string>('');
-  const [filterValue, setFilterValue] = useState<string>('');
-  const [selectOptions, setSelectOptions] = useState<string[]>(languagesList);
-
-  type ParsedLanguages = { [key: string]: string };
-
-  const parsedLanguages = languagesList.reduce((acc, language) => {
-    acc[language] = parseLanguageOption(language);
-    return acc;
-  }, {} as ParsedLanguages);
-
-  useEffect(() => {
-    let filteredLanguages = Object.entries(parsedLanguages);
-
-    if (filterValue) {
-      filteredLanguages = filteredLanguages.filter(([, parsed]) =>
-        String(parsed).toLowerCase().includes(filterValue.toLowerCase()),
-      );
-      if (!isOpen) {
-        setIsOpen(true);
-      }
-    }
-    setSelectOptions(
-      filteredLanguages
-        .sort((a, b) => sortfn(a[1], b[1], filterValue))
-        .map(([raw]) => raw),
-    );
-
-    // This useEffect hook should run *only* on when the filter value changes.
-    // eslint's exhaustive-deps rule does not support this use.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterValue]);
-
-  const onInputClick = () => {
-    if (!isOpen) {
-      setIsOpen(true);
-    } else if (!inputValue) {
-      setIsOpen(false);
-    }
+  const handleSelectNewLanguage = (language: string) => {
+    dispatch(addLanguage(language));
+    setShowNewRow(false);
   };
 
-  const onSelect = (_event?: React.MouseEvent, value?: string | number) => {
-    if (value && typeof value === 'string') {
-      setInputValue('');
-      setFilterValue('');
-      if (languages?.includes(value)) {
-        dispatch(removeLanguage(value));
-      } else {
-        dispatch(addLanguage(value));
-      }
-      setIsOpen(false);
-    }
+  const handleChangeLanguage = (oldLang: string, newLang: string) => {
+    dispatch(removeLanguage(oldLang));
+    dispatch(addLanguage(newLang));
   };
 
-  const onTextInputChange = (_event: React.FormEvent, value: string) => {
-    setInputValue(value);
-    setFilterValue(value);
+  const handleRemoveLanguage = (language: string) => {
+    dispatch(removeLanguage(language));
   };
-
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const onClearButtonClick = () => {
-    setInputValue('');
-    setFilterValue('');
-  };
-
-  const handleRemoveLang = (_event: React.MouseEvent, value: string) => {
-    dispatch(removeLanguage(value));
-    if (unknownLanguages.length > 0) {
-      unknownLanguages.filter((lang) => lang !== value);
-    }
-  };
-
-  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      variant='typeahead'
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-    >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={inputValue}
-          onClick={onInputClick}
-          onChange={onTextInputChange}
-          autoComplete='off'
-          placeholder='Select a language'
-          isExpanded={isOpen}
-        />
-        {inputValue && (
-          <TextInputGroupUtilities>
-            <Button
-              icon={<TimesIcon />}
-              variant='plain'
-              onClick={onClearButtonClick}
-              aria-label='Clear input'
-            />
-          </TextInputGroupUtilities>
-        )}
-      </TextInputGroup>
-    </MenuToggle>
-  );
 
   return (
-    <FormGroup isRequired={false} label='Languages'>
-      <Select
-        isScrollable
-        isOpen={isOpen}
-        selected={languages}
-        onSelect={onSelect}
-        onOpenChange={(isOpen) => setIsOpen(isOpen)}
-        toggle={toggle}
-        shouldFocusFirstItemOnOpen={false}
-      >
-        <SelectList>
-          {selectOptions.length > 0 ? (
-            selectOptions.map((option) => (
-              <SelectOption key={option} value={option}>
-                {parseLanguageOption(option)}
-              </SelectOption>
-            ))
-          ) : (
-            <SelectOption isDisabled>
-              {`No results found for "${filterValue}"`}
-            </SelectOption>
-          )}
-        </SelectList>
-      </Select>
+    <FormGroup isRequired={false} label='Languages' role='group'>
+      {languages.map((lang) => (
+        <LanguageRow
+          key={lang}
+          selectedLanguage={lang}
+          onSelect={(newLang) => handleChangeLanguage(lang, newLang)}
+          onRemove={() => handleRemoveLanguage(lang)}
+          existingLanguages={languages}
+        />
+      ))}
+      {showNewRow && (
+        <LanguageRow
+          onSelect={handleSelectNewLanguage}
+          onRemove={() => setShowNewRow(false)}
+          existingLanguages={languages}
+        />
+      )}
       <HelperText>
         <HelperTextItem>Search by country, language or UTF code</HelperTextItem>
       </HelperText>
       {unknownLanguages.length > 0 && (
         <HelperText>
-          <HelperTextItem
-            variant={'error'}
-          >{`Unknown languages: ${unknownLanguages.join(
+          <HelperTextItem variant='error'>{`Unknown languages: ${unknownLanguages.join(
             ', ',
           )}`}</HelperTextItem>
         </HelperText>
       )}
       {duplicateLanguages.length > 0 && (
         <HelperText>
-          <HelperTextItem
-            variant={'error'}
-          >{`Duplicated languages: ${duplicateLanguages.join(
+          <HelperTextItem variant='error'>{`Duplicated languages: ${duplicateLanguages.join(
             ', ',
           )}`}</HelperTextItem>
         </HelperText>
       )}
-      <LabelGroup numLabels={5} className='pf-v6-u-mt-sm pf-v6-u-w-100'>
-        {languages?.map((lang) => (
-          <Label
-            key={lang}
-            onClose={(e) => handleRemoveLang(e, lang)}
-            isCompact
-          >
-            {parseLanguageOption(lang)}
-          </Label>
-        ))}
-      </LabelGroup>
+      <Button
+        className='pf-v6-u-text-align-left'
+        variant='link'
+        icon={<PlusCircleIcon />}
+        onClick={() => setShowNewRow(true)}
+        isDisabled={showNewRow}
+      >
+        Add language
+      </Button>
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -5,6 +5,7 @@ import { createUser } from '@/test/testUtils';
 import {
   clearKeyboardSearch,
   clearLanguageSearch,
+  clickAddLanguage,
   renderLocaleStep,
   searchForKeyboard,
   searchForLanguage,
@@ -54,14 +55,14 @@ describe('Locale Component', () => {
       ).toBeInTheDocument();
     });
 
-    test('displays dropdowns with helper text', async () => {
+    test('displays add language button and dropdowns', async () => {
       renderLocaleStep();
 
       expect(
-        await screen.findByPlaceholderText(/select a language/i),
+        await screen.findByRole('button', { name: /add language/i }),
       ).toBeInTheDocument();
       expect(
-        screen.getByPlaceholderText(/select a keyboard/i),
+        screen.getByRole('button', { name: /select a keyboard/i }),
       ).toBeInTheDocument();
       expect(
         screen.getByText(/Search by country, language or UTF code/i),
@@ -74,9 +75,10 @@ describe('Locale Component', () => {
       renderLocaleStep();
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
 
-      const options = await screen.findAllByRole('option');
+      const options = await screen.findAllByRole('menuitem');
       expect(options.length).toBeGreaterThan(0);
       expect(options[0]).toHaveTextContent('Dutch');
     });
@@ -85,9 +87,10 @@ describe('Locale Component', () => {
       renderLocaleStep();
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
 
-      const nlOptions = await screen.findAllByRole('option');
+      const nlOptions = await screen.findAllByRole('menuitem');
       expect(nlOptions[0]).toHaveTextContent('Dutch - Aruba (nl_AW.UTF-8)');
       expect(nlOptions[1]).toHaveTextContent('Dutch - Belgium (nl_BE.UTF-8)');
       expect(nlOptions[2]).toHaveTextContent(
@@ -99,69 +102,61 @@ describe('Locale Component', () => {
       renderLocaleStep();
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'foo');
 
       expect(screen.getByText(/no results found/i)).toBeInTheDocument();
-
-      const option = await screen.findByRole('option', {
-        name: /no results found/i,
-      });
-      expect(option).toBeDisabled();
     });
 
     test('can clear language search', async () => {
       renderLocaleStep();
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
-      await screen.findAllByRole('option');
+      await screen.findAllByRole('menuitem');
 
       await clearLanguageSearch(user);
 
-      const languageInput =
-        await screen.findByPlaceholderText(/select a language/i);
-      expect(languageInput).toHaveValue('');
+      expect(screen.getByLabelText(/search by name/i)).toHaveValue('');
     });
   });
 
   describe('Language Selection', () => {
     test('can select a language', async () => {
-      renderLocaleStep();
+      renderLocaleStep({ locale: { languages: [], keyboard: '' } });
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
       expect(
         screen.getByRole('button', {
-          name: /close dutch - netherlands/i,
+          name: /remove language/i,
         }),
       ).toBeInTheDocument();
     });
 
     test('can select multiple languages', async () => {
-      renderLocaleStep();
+      renderLocaleStep({ locale: { languages: [], keyboard: '' } });
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'en');
       await selectLanguageOption(
         user,
         'English - United Kingdom (en_GB.UTF-8)',
       );
 
-      expect(
-        screen.getByRole('button', {
-          name: /close dutch - netherlands/i,
-        }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', {
-          name: /close english - united kingdom/i,
-        }),
-      ).toBeInTheDocument();
+      const removeButtons = screen.getAllByRole('button', {
+        name: /remove language/i,
+      });
+      expect(removeButtons).toHaveLength(2);
     });
   });
 
@@ -172,7 +167,7 @@ describe('Locale Component', () => {
 
       await searchForKeyboard(user, 'us');
 
-      const options = await screen.findAllByRole('option');
+      const options = await screen.findAllByRole('menuitem');
       expect(options.length).toBeGreaterThan(0);
       expect(options[0]).toHaveTextContent('us');
     });
@@ -183,7 +178,7 @@ describe('Locale Component', () => {
 
       await searchForKeyboard(user, 'us');
 
-      const options = await screen.findAllByRole('option');
+      const options = await screen.findAllByRole('menuitem');
       expect(options[0]).toHaveTextContent('us');
       expect(options[1]).toHaveTextContent('us-acentos');
       expect(options[2]).toHaveTextContent('us-alt-intl');
@@ -196,11 +191,6 @@ describe('Locale Component', () => {
       await searchForKeyboard(user, 'foo');
 
       expect(screen.getByText(/no results found/i)).toBeInTheDocument();
-
-      const option = await screen.findByRole('option', {
-        name: /no results found/i,
-      });
-      expect(option).toBeDisabled();
     });
 
     test('can clear keyboard search', async () => {
@@ -208,13 +198,11 @@ describe('Locale Component', () => {
       const user = createUser();
 
       await searchForKeyboard(user, 'us');
-      await screen.findAllByRole('option');
+      await screen.findAllByRole('menuitem');
 
       await clearKeyboardSearch(user);
 
-      const keyboardInput =
-        await screen.findByPlaceholderText(/select a keyboard/i);
-      expect(keyboardInput).toHaveValue('');
+      expect(screen.getByLabelText(/search by name/i)).toHaveValue('');
     });
   });
 
@@ -226,9 +214,9 @@ describe('Locale Component', () => {
       await searchForKeyboard(user, 'us');
       await selectKeyboardOption(user, 'us');
 
-      const keyboardInput =
-        await screen.findByPlaceholderText(/select a keyboard/i);
-      expect(keyboardInput).toHaveValue('us');
+      expect(
+        await screen.findByRole('button', { name: 'us' }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -242,10 +230,14 @@ describe('Locale Component', () => {
       });
 
       expect(
-        screen.getByText('English - United States (en_US.UTF-8)'),
+        screen.getByRole('button', {
+          name: 'English - United States (en_US.UTF-8)',
+        }),
       ).toBeInTheDocument();
       expect(
-        screen.getByText('German - Germany (de_DE.UTF-8)'),
+        screen.getByRole('button', {
+          name: 'German - Germany (de_DE.UTF-8)',
+        }),
       ).toBeInTheDocument();
     });
 
@@ -257,9 +249,9 @@ describe('Locale Component', () => {
         },
       });
 
-      const keyboardInput =
-        await screen.findByPlaceholderText(/select a keyboard/i);
-      expect(keyboardInput).toHaveValue('de');
+      expect(
+        await screen.findByRole('button', { name: 'de' }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -275,6 +267,7 @@ describe('Locale Component', () => {
 
       expect(store.getState().wizard.locale.languages).toHaveLength(0);
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
@@ -290,9 +283,11 @@ describe('Locale Component', () => {
       });
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'en');
       await selectLanguageOption(
         user,

--- a/src/Components/CreateImageWizard/steps/Locale/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/helpers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 
 import {
   clearWithWait,
@@ -19,24 +19,45 @@ export const renderLocaleStep = (
   return renderWithRedux(<LocaleStep />, wizardStateOverrides);
 };
 
+export const clickAddLanguage = async (user: UserEventInstance) => {
+  const addButton = await screen.findByRole('button', {
+    name: /add language/i,
+  });
+  await clickWithWait(user, addButton);
+  const toggle = await screen.findByRole('button', {
+    name: /select a language/i,
+  });
+  await clickWithWait(user, toggle);
+};
+
+export const removeLanguageAtIndex = async (
+  user: UserEventInstance,
+  index: number,
+) => {
+  const removeButtons = screen.getAllByRole('button', {
+    name: /remove language/i,
+  });
+  await clickWithWait(user, removeButtons[index]);
+};
+
 export const searchForLanguage = async (
   user: UserEventInstance,
   search: string,
 ) => {
-  const input = await screen.findByPlaceholderText(/select a language/i);
-  await typeWithWait(user, input, search);
+  const searchInput = await screen.findByLabelText(/search by name/i);
+  await typeWithWait(user, searchInput, search);
 };
 
 export const clearLanguageSearch = async (user: UserEventInstance) => {
-  const input = await screen.findByPlaceholderText(/select a language/i);
-  await clearWithWait(user, input);
+  const searchInput = screen.getByLabelText(/search by name/i);
+  await clearWithWait(user, searchInput);
 };
 
 export const selectLanguageOption = async (
   user: UserEventInstance,
   optionName: string | RegExp,
 ) => {
-  const option = await screen.findByRole('option', { name: optionName });
+  const option = await screen.findByRole('menuitem', { name: optionName });
   await clickWithWait(user, option);
 };
 
@@ -44,19 +65,24 @@ export const searchForKeyboard = async (
   user: UserEventInstance,
   search: string,
 ) => {
-  const input = await screen.findByPlaceholderText(/select a keyboard/i);
-  await typeWithWait(user, input, search);
+  const keyboardGroup = screen.getByRole('group', { name: /keyboard/i });
+  const toggle = within(keyboardGroup).getByRole('button', {
+    name: /select a keyboard|Menu toggle/i,
+  });
+  await clickWithWait(user, toggle);
+  const searchInput = await screen.findByLabelText(/search by name/i);
+  await typeWithWait(user, searchInput, search);
 };
 
 export const clearKeyboardSearch = async (user: UserEventInstance) => {
-  const input = await screen.findByPlaceholderText(/select a keyboard/i);
-  await clearWithWait(user, input);
+  const searchInput = screen.getByLabelText(/search by name/i);
+  await clearWithWait(user, searchInput);
 };
 
 export const selectKeyboardOption = async (
   user: UserEventInstance,
   optionName: string | RegExp,
 ) => {
-  const option = await screen.findByRole('option', { name: optionName });
+  const option = await screen.findByRole('menuitem', { name: optionName });
   await clickWithWait(user, option);
 };

--- a/src/Components/sharedComponents/SearchableSelect.tsx
+++ b/src/Components/sharedComponents/SearchableSelect.tsx
@@ -1,0 +1,159 @@
+import React, { useMemo, useRef, useState } from 'react';
+
+import {
+  Divider,
+  Menu,
+  MenuContainer,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  MenuSearch,
+  MenuSearchInput,
+  MenuToggle,
+  SearchInput,
+} from '@patternfly/react-core';
+
+import sortfn from '@/Utilities/sortfn';
+
+type SearchableSelectOption = {
+  value: string;
+  label: string;
+};
+
+type SearchableSelectProps = {
+  options: SearchableSelectOption[];
+  selected?: string | undefined;
+  placeholder?: string | undefined;
+  onSelect: (value: string) => void;
+  isFullWidth?: boolean | undefined;
+  toggleClassName?: string | undefined;
+};
+
+const SearchableSelect = ({
+  options,
+  selected,
+  placeholder = 'Select an option',
+  onSelect,
+  isFullWidth,
+  toggleClassName,
+}: SearchableSelectProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const selectedLabel = useMemo(() => {
+    const match = options.find((opt) => opt.value === selected);
+    return match?.label;
+  }, [options, selected]);
+
+  const filteredOptions = useMemo(() => {
+    if (!searchValue) {
+      return options;
+    }
+
+    return [...options]
+      .filter((opt) =>
+        opt.label.toLowerCase().includes(searchValue.toLowerCase()),
+      )
+      .sort((a, b) => sortfn(a.label, b.label, searchValue));
+  }, [searchValue, options]);
+
+  const handleSelect = (
+    _event: React.MouseEvent | undefined,
+    itemId: string | number | undefined,
+  ) => {
+    if (itemId && typeof itemId === 'string') {
+      onSelect(itemId);
+      setSearchValue('');
+      setIsOpen(false);
+    }
+  };
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+      {...(isFullWidth !== undefined && { isFullWidth })}
+      {...(toggleClassName !== undefined && { className: toggleClassName })}
+      style={{
+        width: '100%',
+        minWidth: '100%',
+      }}
+    >
+      <span
+        style={{
+          display: 'block',
+          width: '100%',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+        title={selectedLabel || selected || undefined}
+      >
+        {selectedLabel || selected || placeholder}
+      </span>
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu
+      ref={menuRef}
+      onSelect={handleSelect}
+      activeItemId={selected || ''}
+      isScrollable
+    >
+      <MenuSearch>
+        <MenuSearchInput>
+          <SearchInput
+            value={searchValue}
+            aria-label='Search by name'
+            placeholder='Search by name'
+            onChange={(_event, value) => setSearchValue(value)}
+            onClear={(event) => {
+              event.stopPropagation();
+              setSearchValue('');
+            }}
+          />
+        </MenuSearchInput>
+      </MenuSearch>
+      <Divider />
+      <MenuContent maxMenuHeight='300px'>
+        <MenuList>
+          {filteredOptions.length > 0 ? (
+            filteredOptions.map((option) => (
+              <MenuItem key={option.value} itemId={option.value}>
+                {option.label}
+              </MenuItem>
+            ))
+          ) : (
+            <MenuItem isDisabled key='no-results'>
+              {`No results found for "${searchValue}"`}
+            </MenuItem>
+          )}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <MenuContainer
+      menu={menu}
+      menuRef={menuRef}
+      toggle={toggle}
+      toggleRef={toggleRef}
+      isOpen={isOpen}
+      onOpenChange={(isOpen) => {
+        setIsOpen(isOpen);
+        if (!isOpen) {
+          setSearchValue('');
+        }
+      }}
+      onOpenChangeKeys={['Escape']}
+    />
+  );
+};
+
+export default SearchableSelect;

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -189,11 +189,15 @@ describe('Import modal', () => {
     // Locale
     await clickNext();
     await screen.findByRole('heading', { name: /Locale/ });
-    await screen.findByText('English - United States (en_US.UTF-8)');
-    await screen.findByText('Japanese - Japan (ja_JP.UTF-8)');
-    const keyboardInput =
-      await screen.findByPlaceholderText(/select a keyboard/i);
-    expect(keyboardInput).toHaveValue('us');
+    await screen.findByRole('button', {
+      name: 'English - United States (en_US.UTF-8)',
+    });
+    await screen.findByRole('button', {
+      name: 'Japanese - Japan (ja_JP.UTF-8)',
+    });
+    expect(
+      await screen.findByRole('button', { name: 'us' }),
+    ).toBeInTheDocument();
 
     // Hostname
     await clickNext();
@@ -300,17 +304,18 @@ describe('Import modal', () => {
     await waitFor(async () =>
       user.click(
         await screen.findByRole('button', {
-          name: /close invalid-language/i,
+          name: /remove language/i,
         }),
       ),
     );
-    await waitFor(async () =>
-      user.click(
-        await screen.findByRole('button', {
-          name: /clear input/i,
-        }),
-      ),
-    );
+    const keyboardToggle = await screen.findByRole('button', {
+      name: 'invalid-keyboard',
+    });
+    await waitFor(() => user.click(keyboardToggle));
+    const keyboardSearch = await screen.findByLabelText(/search by name/i);
+    await waitFor(() => user.type(keyboardSearch, 'us'));
+    const keyboardOption = await screen.findByRole('menuitem', { name: 'us' });
+    await waitFor(() => user.click(keyboardOption));
 
     // Hostname
     await clickNext();


### PR DESCRIPTION
Replace the multi-select dropdown with individual language rows,
each with its own search input and remove button. Add an "Add
language" button to insert new rows.

<img width="780" height="468" alt="Screenshot 2026-04-13 at 11 33 47" src="https://github.com/user-attachments/assets/3566059e-2303-4337-8c77-dcf9340f256c" />
JIRA: https://redhat.atlassian.net/browse/HMS-9517