### PR TITLE
Wizard: fix Snapshot date bug when importing a bp  (HMS-10323)

### DIFF
--- a/playwright/BootTests/Content/helpers.ts
+++ b/playwright/BootTests/Content/helpers.ts
@@ -54,8 +54,8 @@ export const deleteRepository = async (
         .getByLabel('Kebab toggle')
         .click();
       await page.getByRole('menuitem', { name: 'Delete' }).click();
-      // Wait until the repo is loaded in the delete modal
-      await expect(page.getByRole('gridcell').first()).not.toBeEmpty();
+      // Wait until the delete confirmation modal is fully rendered
+      await expect(page.getByRole('dialog')).toBeVisible();
       await page.getByRole('button', { name: 'Delete' }).click();
     },
     { box: true },

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -1,5 +1,5 @@
-// import * as fsPromises from 'fs/promises';
-// import * as path from 'path';
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
 
 import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
@@ -9,7 +9,6 @@ import {
   navigateToRepositories,
 } from '../BootTests/Content/helpers';
 import { test } from '../fixtures/customizations';
-// import { exportedLocaleBP } from '../fixtures/data/exportBlueprintContents';
 import { isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
 import {
@@ -20,12 +19,12 @@ import {
 import {
   createBlueprint,
   deleteBlueprint,
-  // exportBlueprint,
+  exportBlueprint,
   fillInDetails,
-  // fillInImageOutputGuest,
-  //importBlueprint,
+  fillInImageOutputGuest,
+  importBlueprint,
   registerLater,
-  // verifyExportedBlueprint,
+  verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
 
 test('Create a blueprint with Repeatable build customization', async ({
@@ -172,37 +171,41 @@ test('Create a blueprint with Repeatable build customization', async ({
       .click();
   });
 
-  //  let exportedBP = '';
-  //
-  //  await test.step('Export BP', async () => {
-  //    exportedBP = await exportBlueprint(page);
-  //    cleanup.add(async () => {
-  //      await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
-  //    });
-  //  });
-  //
-  //  await test.step('Review exported BP', async (step) => {
-  //    step.skip(
-  //      isHosted(),
-  //      'Only verify the contents of the exported blueprint in cockpit',
-  //    );
-  //    verifyExportedBlueprint(exportedBP, exportedRepeatableBuildBP(blueprintName));
-  //  });
-  //
-  //  await test.step('Import BP', async () => {
-  //    await importBlueprint(frame, exportedBP);
-  //  });
-  //
+  let exportedBP = '';
+
+  await test.step('Export BP', async () => {
+    exportedBP = await exportBlueprint(page);
+    cleanup.add(async () => {
+      await fsPromises.rm(path.dirname(exportedBP), { recursive: true });
+    });
+  });
+
+  await test.step('Review exported BP', async (step) => {
+    step.skip(
+      isHosted(),
+      'Only verify the contents of the exported blueprint in cockpit',
+    );
+    verifyExportedBlueprint(exportedBP, exportedRepeatableBuildBP());
+  });
+
+  await test.step('Import BP', async () => {
+    await importBlueprint(frame, exportedBP);
+  });
+
   // TO DO: Importing needs to be fixed first
-  // await test.step('Review imported BP', async () => {
-  //   await fillInImageOutputGuest(frame);
-  //   await frame.getByRole('button', { name: 'Repeatable build' }).click();
-  //   await expect(
-  //     frame.getByRole('radio', { name: /Enable repeatable build/i }),
-  //   ).toBeEnabled();
-  //   await expect(
-  //     frame.getByRole('textbox', { name: /date picker/i }),
-  //   ).toHaveValue('2026-01-01');
-  //   await frame.getByRole('button', { name: 'Cancel' }).click();
-  // });
+  await test.step('Review imported BP', async () => {
+    await fillInImageOutputGuest(frame);
+    await frame.getByRole('button', { name: 'Repeatable build' }).click();
+    await expect(
+      frame.getByRole('radio', { name: /Enable repeatable build/i }),
+    ).toBeEnabled();
+    await expect(
+      frame.getByRole('textbox', { name: /date picker/i }),
+    ).toHaveValue('2026-01-01');
+    await frame.getByRole('button', { name: 'Cancel' }).click();
+  });
 });
+
+function exportedRepeatableBuildBP(): string {
+  throw new Error('Function not implemented.');
+}

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -9,7 +9,7 @@ import {
   navigateToRepositories,
 } from '../BootTests/Content/helpers';
 import { test } from '../fixtures/customizations';
-import { isHosted } from '../helpers/helpers';
+import { enablePreview, isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
 import {
   fillInImageOutput,
@@ -20,11 +20,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   exportBlueprint,
-  fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
-  registerLater,
-  verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
 
 test('Create a blueprint with Repeatable build customization', async ({
@@ -39,14 +35,19 @@ test('Create a blueprint with Repeatable build customization', async ({
   const repositoryUrl =
     'https://jlsherrill.fedorapeople.org/fake-repos/really-empty/';
 
-  // Here we want to be sure that the repository is deleted due to URL exclusivity per repository
-  await deleteRepository(page, repositoryUrl);
-
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));
   cleanup.add(() => deleteRepository(page, repositoryName));
 
   await ensureAuthenticated(page);
+
+  await enablePreview(page);
+  await expect(page.getByRole('heading', { name: 'All images' })).toBeVisible({
+    timeout: 30000,
+  });
+
+  // Here we want to be sure that the repository is deleted due to URL exclusivity per repository
+  await deleteRepository(page, repositoryUrl);
 
   await test.step('Create a custom repository', async () => {
     await navigateToRepositories(page);
@@ -65,15 +66,16 @@ test('Create a blueprint with Repeatable build customization', async ({
 
   // Navigate to IB landing page and get the frame
   await navigateToLandingPage(page);
+  await enablePreview(page);
   const frame = ibFrame(page);
 
   await test.step('Navigate to optional steps in Wizard', async () => {
     await fillInImageOutput(frame);
-    await registerLater(frame);
+    await frame.getByRole('button', { name: 'Back' }).click();
+    await frame.getByRole('radio', { name: 'Register later' }).click();
   });
 
   await test.step('Check non-snapshot repository is disabled', async () => {
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
     await frame
       .getByRole('radio', { name: /Enable repeatable build/i })
       .click();
@@ -83,8 +85,12 @@ test('Create a blueprint with Repeatable build customization', async ({
       .fill('2025-12-24');
     await frame.getByRole('button', { name: /Repositories/i }).click();
     await expect(frame.getByText(/Loading/i)).toBeHidden();
-    await frame.getByRole('textbox').fill(repositoryName);
-    await expect(frame.getByRole('row')).toHaveCount(3); // two base distro repos + header
+    await frame
+      .getByRole('textbox', { name: 'Filter repositories' })
+      .fill(repositoryName);
+    await expect(frame.getByRole('grid').first().getByRole('row')).toHaveCount(
+      3,
+    ); // one base distro repo + header
     await expect(
       frame.getByRole('option', { name: repositoryName }),
     ).toBeVisible();
@@ -99,25 +105,27 @@ test('Create a blueprint with Repeatable build customization', async ({
   });
 
   await test.step('Check Repeatable build step behaviour with no repos', async () => {
-    await frame.getByRole('button', { name: /Review and finish/i }).click();
-    const repeatableBuildCard = frame
-      .locator('.pf-v6-c-card')
-      .filter({ hasText: 'Enable repeatable build' });
-    await expect(repeatableBuildCard).toBeVisible();
-    await expect(repeatableBuildCard.getByText('Enabled')).toBeVisible();
-    await expect(repeatableBuildCard.getByText('Dec 24, 2025')).toBeVisible();
+    await frame.getByRole('button', { name: 'Review image' }).click();
+    await expect(
+      frame.getByRole('heading', { name: 'Enable repeatable build' }),
+    ).toBeVisible();
+    await expect(frame.getByText('Dec 24, 2025')).toBeVisible();
   });
 
   await test.step('Check Repeatable build step behaviour with 1 repo', async () => {
-    await frame.getByRole('button', { name: 'Repositories' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await expect(
       frame.getByRole('columnheader', { name: 'Snapshot date' }),
     ).toBeVisible();
-    await frame.getByRole('textbox').fill('EPEL 10 Everything x86_64');
+    await frame
+      .getByRole('textbox', { name: 'Filter repositories' })
+      .fill('EPEL 10 Everything x86_64');
     await frame
       .getByRole('option', { name: 'EPEL 10 Everything x86_64' })
       .click();
-    await frame.getByRole('button', { name: /Review and finish/i }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await expect(
       frame.getByRole('heading', { name: 'Enable repeatable build' }),
     ).toBeVisible();
@@ -126,20 +134,24 @@ test('Create a blueprint with Repeatable build customization', async ({
   });
 
   await test.step('Check Repeatable build with content template', async () => {
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame.getByRole('radio', { name: /Use a content template/i }).click();
     await frame
       .getByRole('button', { name: /Select content template/i })
       .click();
-    await expect(frame.getByText(/Loading/i)).toBeHidden();
+    // Wait for menu to appear (any item, including the loading spinner item),
+    // then wait for the spinner to disappear before clicking.
+    await expect(frame.getByRole('menuitem').first()).toBeVisible();
+    await expect(frame.getByRole('progressbar')).toBeHidden();
     await frame.getByRole('menuitem').first().click();
-    await frame.getByRole('button', { name: /Review and finish/i }).click();
-    // TODO: content templates are not yet shown in the review step
-    // await expect(frame.getByText(/Use a content template/i)).toBeVisible();
+    await frame.getByRole('button', { name: 'Review image' }).click();
+    await expect(
+      frame.getByRole('heading', { name: 'Enable repeatable build' }),
+    ).toBeVisible();
   });
 
   await test.step('Select and fill the Repeatable build step', async () => {
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame
       .getByRole('radio', { name: /Enable repeatable build/i })
       .click();
@@ -147,11 +159,13 @@ test('Create a blueprint with Repeatable build customization', async ({
     await frame
       .getByRole('textbox', { name: /date picker/i })
       .fill('2026-01-01');
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 
   await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame
+      .getByRole('textbox', { name: 'Blueprint name' })
+      .fill(blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -160,12 +174,12 @@ test('Create a blueprint with Repeatable build customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Repeatable build' }).click(); // there is no revisit button specific to repeatable build
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await expect(
       frame.getByRole('textbox', { name: /date picker/i }),
     ).toHaveValue('2026-01-01');
     await frame.getByRole('button', { name: /today's date/i }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -180,32 +194,19 @@ test('Create a blueprint with Repeatable build customization', async ({
     });
   });
 
-  await test.step('Review exported BP', async (step) => {
-    step.skip(
-      isHosted(),
-      'Only verify the contents of the exported blueprint in cockpit',
-    );
-    verifyExportedBlueprint(exportedBP, exportedRepeatableBuildBP());
-  });
-
+  // TODO: verify exported blueprint contents when running in cockpit
   await test.step('Import BP', async () => {
     await importBlueprint(frame, exportedBP);
   });
 
-  // TO DO: Importing needs to be fixed first
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
     await expect(
       frame.getByRole('radio', { name: /Enable repeatable build/i }),
-    ).toBeEnabled();
+    ).toBeChecked();
+    const today = new Date().toISOString().split('T')[0];
     await expect(
       frame.getByRole('textbox', { name: /date picker/i }),
-    ).toHaveValue('2026-01-01');
+    ).toHaveValue(today);
     await frame.getByRole('button', { name: 'Cancel' }).click();
   });
 });
-
-function exportedRepeatableBuildBP(): string {
-  throw new Error('Function not implemented.');
-}

--- a/playwright/helpers/helpers.ts
+++ b/playwright/helpers/helpers.ts
@@ -24,6 +24,16 @@ export const togglePreview = async (page: Page) => {
   await expect(toggleSwitch).not.toBeChecked();
 };
 
+export const enablePreview = async (page: Page) => {
+  const toggleSwitch = page.locator('#preview-toggle');
+
+  if (!(await toggleSwitch.isChecked())) {
+    await toggleSwitch.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(4000);
+  }
+};
+
 export const isHosted = (): boolean => {
   return process.env.BASE_URL?.includes('redhat.com') || false;
 };

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -286,7 +286,11 @@ export const importBlueprint = async (
   await expect(
     page.getByRole('textbox', { name: 'File upload' }),
   ).not.toBeEmpty();
-  await page.getByRole('button', { name: 'Review and Finish' }).click();
+  // Wait for the blueprint to finish parsing (including any async repo import API
+  // calls) before clicking. The button is disabled until importedBlueprint is set.
+  const reviewBtn = page.getByRole('button', { name: /review and finish/i });
+  await expect(reviewBtn).toBeEnabled();
+  await reviewBtn.click();
 };
 
 export const saveBlueprintFileWithContents = async (content: string) => {

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -43,7 +43,7 @@ import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { getErrorMessage } from '../../Utilities/getErrorMessage';
 import { useFlag } from '../../Utilities/useGetEnvironment';
 import {
-  mapExportRequestToState,
+  mapBlueprintExportToState,
   mapToCustomRepositories,
 } from '../CreateImageWizard/utilities/requestMapper';
 
@@ -147,7 +147,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
             const blueprintFromFile = await mapOnPremToHosted(
               tomlBlueprint as BlueprintItem,
             );
-            const importBlueprintState = mapExportRequestToState(
+            const importBlueprintState = mapBlueprintExportToState(
               blueprintFromFile,
               [],
             );
@@ -190,7 +190,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
                 customRepos;
               blueprintExportedResponse.customizations.payload_repositories =
                 undefined;
-              const importBlueprintState = mapExportRequestToState(
+              const importBlueprintState = mapBlueprintExportToState(
                 blueprintExportedResponse,
                 blueprintFromFile.image_requests || [],
               );
@@ -210,7 +210,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
               }
               const blueprintFromFileMapped =
                 await mapOnPremToHosted(blueprintFromFile);
-              const importBlueprintState = mapExportRequestToState(
+              const importBlueprintState = mapBlueprintExportToState(
                 blueprintFromFileMapped,
                 [],
               );

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -184,6 +184,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
                 customizations: blueprintFromFile.customizations,
                 metadata: blueprintFromFile.metadata,
                 content_sources: blueprintFromFile.content_sources,
+                snapshot_date: blueprintFromFile.snapshot_date,
               };
               blueprintExportedResponse.customizations.custom_repositories =
                 customRepos;

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -363,7 +363,9 @@ export const ImportBlueprintModal: React.FunctionComponent<
       <ModalFooter>
         <Button
           type='button'
-          isDisabled={isRejected || isInvalidFormat || !fileContent}
+          isDisabled={
+            isRejected || isInvalidFormat || !fileContent || !importedBlueprint
+          }
           onClick={handleReviewAndFinish}
         >
           Review and finish

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -681,9 +681,7 @@ const getMetadata = (metadata: BlueprintMetadata) => {
 };
 
 /**
- * This function maps the blueprint response to the wizard state, used to populate the wizard with the blueprint details
- * @param request BlueprintExportResponse
- * @returns wizardState
+ * Maps a BlueprintExportResponse to the wizard state, used to populate the wizard when importing a blueprint.
  */
 export const mapExportRequestToState = (
   request: BlueprintExportResponse,
@@ -699,6 +697,26 @@ export const mapExportRequestToState = (
     bootc: request.bootc,
   };
 
+  const commonState = commonRequestToState(blueprintResponse);
+
+  let { snapshotting } = commonState;
+  if (request.snapshot_date && !commonState.snapshotting.snapshotDate) {
+    let normalizedDate = '';
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(request.snapshot_date)) {
+      normalizedDate = request.snapshot_date;
+    } else if (/^\d{4}-\d{2}-\d{2}$/.test(request.snapshot_date)) {
+      normalizedDate = request.snapshot_date + 'T00:00:00Z';
+    }
+    if (normalizedDate) {
+      snapshotting = {
+        useLatest: false,
+        snapshotDate: normalizedDate,
+        template: '',
+        templateName: '',
+      };
+    }
+  }
+
   return {
     wizardMode,
     blueprintMode:
@@ -713,13 +731,15 @@ export const mapExportRequestToState = (
       enabled: request.customizations.aap_registration !== undefined,
       callbackUrl:
         request.customizations.aap_registration?.ansible_callback_url,
-      hostConfigKey: request.customizations.aap_registration?.host_config_key,
+      hostConfigKey:
+        request.customizations.aap_registration?.host_config_key,
       tlsCertificateAuthority:
         request.customizations.aap_registration?.tls_certificate_authority,
       skipTlsVerification:
         request.customizations.aap_registration?.skip_tls_verification,
     },
-    ...commonRequestToState(blueprintResponse),
+    ...commonState,
+    snapshotting,
   };
 };
 

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -683,29 +683,29 @@ const getMetadata = (metadata: BlueprintMetadata) => {
 /**
  * Maps a BlueprintExportResponse to the wizard state, used to populate the wizard when importing a blueprint.
  */
-export const mapExportRequestToState = (
-  request: BlueprintExportResponse,
+export const mapBlueprintExportToState = (
+  blueprint: BlueprintExportResponse,
   image_requests: ImageRequest[],
 ): wizardState => {
   const wizardMode = 'create';
   const blueprintResponse: CreateBlueprintRequest = {
-    name: request.name,
-    description: request.description,
-    distribution: request.distribution,
-    customizations: request.customizations,
+    name: blueprint.name,
+    description: blueprint.description,
+    distribution: blueprint.distribution,
+    customizations: blueprint.customizations,
     image_requests: image_requests,
-    bootc: request.bootc,
+    bootc: blueprint.bootc,
   };
 
   const commonState = commonRequestToState(blueprintResponse);
 
   let { snapshotting } = commonState;
-  if (request.snapshot_date && !commonState.snapshotting.snapshotDate) {
+  if (blueprint.snapshot_date && !commonState.snapshotting.snapshotDate) {
     let normalizedDate = '';
-    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(request.snapshot_date)) {
-      normalizedDate = request.snapshot_date;
-    } else if (/^\d{4}-\d{2}-\d{2}$/.test(request.snapshot_date)) {
-      normalizedDate = request.snapshot_date + 'T00:00:00Z';
+    if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(blueprint.snapshot_date)) {
+      normalizedDate = blueprint.snapshot_date;
+    } else if (/^\d{4}-\d{2}-\d{2}$/.test(blueprint.snapshot_date)) {
+      normalizedDate = blueprint.snapshot_date + 'T00:00:00Z';
     }
     if (normalizedDate) {
       snapshotting = {
@@ -720,23 +720,22 @@ export const mapExportRequestToState = (
   return {
     wizardMode,
     blueprintMode:
-      isImageModeDistribution(request.distribution) || request.bootc
+      isImageModeDistribution(blueprint.distribution) || blueprint.bootc
         ? 'image'
         : 'package',
     bootcDistributions: [],
-    metadata: getMetadata(request.metadata),
+    metadata: getMetadata(blueprint.metadata),
     env: initialState.env,
     registration: initialState.registration,
     aapRegistration: {
-      enabled: request.customizations.aap_registration !== undefined,
+      enabled: blueprint.customizations.aap_registration !== undefined,
       callbackUrl:
-        request.customizations.aap_registration?.ansible_callback_url,
-      hostConfigKey:
-        request.customizations.aap_registration?.host_config_key,
+        blueprint.customizations.aap_registration?.ansible_callback_url,
+      hostConfigKey: blueprint.customizations.aap_registration?.host_config_key,
       tlsCertificateAuthority:
-        request.customizations.aap_registration?.tls_certificate_authority,
+        blueprint.customizations.aap_registration?.tls_certificate_authority,
       skipTlsVerification:
-        request.customizations.aap_registration?.skip_tls_verification,
+        blueprint.customizations.aap_registration?.skip_tls_verification,
     },
     ...commonState,
     snapshotting,


### PR DESCRIPTION
Fixed a bug with snapshot date when importing a blueprint - the exported blueprint format (BlueprintExportResponse) stores snapshot_date at the top level, not in image_requests. 

On a side note, in the second commit, I renamed a variable called `request` that had a `...Response` type, which was a bit confusing.