### PR TITLE
Wizard: Remove Share with Lightspeed GCP option (HMS-9754)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/index.tsx
@@ -5,7 +5,6 @@ import {
   FormGroup,
   MenuToggle,
   MenuToggleElement,
-  Radio,
   Select,
   SelectList,
   SelectOption,
@@ -20,13 +19,10 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeGcpAccountType,
   changeGcpEmail,
-  changeGcpShareMethod,
   selectGcpAccountType,
   selectGcpEmail,
-  selectGcpShareMethod,
 } from '@/store/slices/wizard';
 
-export type GcpShareMethod = 'withGoogle' | 'withInsights';
 export type GcpAccountType =
   | 'user'
   | 'serviceAccount'
@@ -45,7 +41,6 @@ const Gcp = () => {
   const dispatch = useAppDispatch();
 
   const accountType = useAppSelector(selectGcpAccountType);
-  const shareMethod = useAppSelector(selectGcpShareMethod);
   const gcpEmail = useAppSelector(selectGcpEmail);
   const [isOpen, setIsOpen] = useState(false);
 
@@ -73,75 +68,50 @@ const Gcp = () => {
 
   return (
     <Form className='pf-v6-u-pb-md'>
-      <FormGroup label='Select image sharing' isRequired>
-        <Radio
-          id='share-with-google'
-          label='Share with a Google account'
-          name='gcp-share-method-type'
-          isChecked={shareMethod === 'withGoogle'}
-          onChange={() => {
-            dispatch(changeGcpShareMethod('withGoogle'));
+      <FormGroup label='GCP account type' isRequired>
+        <Select
+          isOpen={isOpen}
+          selected={accountType}
+          onSelect={(_event, value) => {
+            dispatch(changeGcpAccountType(value));
+            setIsOpen(false);
           }}
-          autoFocus
-        />
-        <Radio
-          id='share-with-insights'
-          label={`Share with Red Hat Lightspeed only`}
-          name='gcp-share-method-type'
-          isChecked={shareMethod === 'withInsights'}
-          onChange={() => {
-            dispatch(changeGcpShareMethod('withInsights'));
-          }}
+          onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
+          toggle={toggle}
+          shouldFocusToggleOnSelect
+        >
+          <SelectList>
+            {Array.from(GCP_ACCOUNT_TYPE_OPTIONS, ([key, label]) => (
+              <SelectOption key={key} value={key}>
+                {label}
+              </SelectOption>
+            ))}
+          </SelectList>
+        </Select>
+      </FormGroup>
+      <FormGroup
+        label={accountType === 'domain' ? 'Domain' : 'Principal'}
+        isRequired
+      >
+        <ValidatedInput
+          aria-label='google principal'
+          value={gcpEmail || ''}
+          validator={
+            accountType === 'domain' ? isGcpDomainValid : isGcpEmailValid
+          }
+          onChange={(_event, value) => dispatch(changeGcpEmail(value))}
+          helperText={
+            !gcpEmail
+              ? accountType === 'domain'
+                ? 'Domain is required'
+                : 'E-mail address is required'
+              : accountType === 'domain'
+                ? 'Please enter a valid domain'
+                : 'Please enter a valid e-mail address'
+          }
+          handleClear={() => dispatch(changeGcpEmail(''))}
         />
       </FormGroup>
-      {shareMethod === 'withGoogle' && (
-        <>
-          <FormGroup label='GCP account type' isRequired>
-            <Select
-              isOpen={isOpen}
-              selected={accountType}
-              onSelect={(_event, value) => {
-                dispatch(changeGcpAccountType(value));
-                setIsOpen(false);
-              }}
-              onOpenChange={(isOpen: boolean) => setIsOpen(isOpen)}
-              toggle={toggle}
-              shouldFocusToggleOnSelect
-            >
-              <SelectList>
-                {Array.from(GCP_ACCOUNT_TYPE_OPTIONS, ([key, label]) => (
-                  <SelectOption key={key} value={key}>
-                    {label}
-                  </SelectOption>
-                ))}
-              </SelectList>
-            </Select>
-          </FormGroup>
-          <FormGroup
-            label={accountType === 'domain' ? 'Domain' : 'Principal'}
-            isRequired
-          >
-            <ValidatedInput
-              aria-label='google principal'
-              value={gcpEmail || ''}
-              validator={
-                accountType === 'domain' ? isGcpDomainValid : isGcpEmailValid
-              }
-              onChange={(_event, value) => dispatch(changeGcpEmail(value))}
-              helperText={
-                !gcpEmail
-                  ? accountType === 'domain'
-                    ? 'Domain is required'
-                    : 'E-mail address is required'
-                  : accountType === 'domain'
-                    ? 'Please enter a valid domain'
-                    : 'Please enter a valid e-mail address'
-              }
-              handleClear={() => dispatch(changeGcpEmail(''))}
-            />
-          </FormGroup>
-        </>
-      )}
     </Form>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -46,7 +46,6 @@ import {
   selectFscMode,
   selectGcpAccountType,
   selectGcpEmail,
-  selectGcpShareMethod,
   selectGroups,
   selectHostname,
   selectImageSource,
@@ -275,7 +274,6 @@ export const TargetEnvAWSList = () => {
 
 export const TargetEnvGCPList = () => {
   const accountType = useAppSelector(selectGcpAccountType);
-  const sharedMethod = useAppSelector(selectGcpShareMethod);
   const email = useAppSelector(selectGcpEmail);
   return (
     <Content>
@@ -289,49 +287,22 @@ export const TargetEnvGCPList = () => {
           <br />
           <ExpirationWarning />
         </Content>
-        <>
-          {sharedMethod === 'withInsights' ? (
-            <>
-              <Content
-                component={ContentVariants.dt}
-                className='pf-v6-u-min-width'
-              >
-                Shared with
-              </Content>
-              <Content component={ContentVariants.dd}>
-                Red Hat Lightspeed only
-                <br />
-              </Content>
-            </>
-          ) : (
-            <>
-              <Content
-                component={ContentVariants.dt}
-                className='pf-v6-u-min-width'
-              >
-                Account type
-              </Content>
-              <Content component={ContentVariants.dd}>
-                {accountType === 'group'
-                  ? 'Google group'
-                  : accountType === 'serviceAccount'
-                    ? 'Service account'
-                    : accountType === 'user'
-                      ? 'Google account'
-                      : 'Domain'}
-              </Content>
-              <Content
-                component={ContentVariants.dt}
-                className='pf-v6-u-min-width'
-              >
-                {accountType === 'domain' ? 'Domain' : 'Principal'}
-              </Content>
-              <Content component={ContentVariants.dd}>
-                {email || accountType}
-              </Content>
-            </>
-          )}
-        </>
+        <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+          Account type
+        </Content>
+        <Content component={ContentVariants.dd}>
+          {accountType === 'group'
+            ? 'Google group'
+            : accountType === 'serviceAccount'
+              ? 'Service account'
+              : accountType === 'user'
+                ? 'Google account'
+                : 'Domain'}
+        </Content>
+        <Content component={ContentVariants.dt} className='pf-v6-u-min-width'>
+          {accountType === 'domain' ? 'Domain' : 'Principal'}
+        </Content>
+        <Content component={ContentVariants.dd}>{email || accountType}</Content>
       </Content>
     </Content>
   );

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -73,7 +73,6 @@ import {
   selectFscMode,
   selectGcpAccountType,
   selectGcpEmail,
-  selectGcpShareMethod,
   selectGroups,
   selectHostname,
   selectImageSource,
@@ -133,10 +132,7 @@ import {
 } from '../steps/FileSystem/fscTypes';
 import { getConversionFactor } from '../steps/FileSystem/fscUtilities';
 import { AwsShareMethod } from '../steps/ImageOutput/components/Aws';
-import {
-  GcpAccountType,
-  GcpShareMethod,
-} from '../steps/ImageOutput/components/Gcp';
+import { GcpAccountType } from '../steps/ImageOutput/components/Gcp';
 import { PackageRepository } from '../steps/Packages/packagesTypes';
 import {
   convertSchemaToIBCustomRepo,
@@ -333,7 +329,6 @@ const gcpTargetOptions = (options: GcpUploadRequestOptions) => {
     options.share_with_accounts.length === 0
   ) {
     return {
-      shareMethod: 'withInsights' as GcpShareMethod,
       accountType: undefined as GcpAccountType | undefined,
       email: '',
     };
@@ -342,7 +337,6 @@ const gcpTargetOptions = (options: GcpUploadRequestOptions) => {
   const [accountType, email] = options.share_with_accounts[0].split(':');
 
   return {
-    shareMethod: 'withGoogle' as GcpShareMethod,
     accountType: accountType as GcpAccountType,
     email: email || '',
   };
@@ -849,26 +843,22 @@ const getImageOptions = (
         hyper_v_generation: selectAzureHyperVGeneration(state),
       };
     case 'gcp': {
+      const gcpEmail = selectGcpEmail(state);
       let googleAccount: string = '';
-      if (selectGcpShareMethod(state) === 'withGoogle') {
-        const gcpEmail = selectGcpEmail(state);
-        switch (selectGcpAccountType(state)) {
-          case 'user':
-            googleAccount = `user:${gcpEmail}`;
-            break;
-          case 'serviceAccount':
-            googleAccount = `serviceAccount:${gcpEmail}`;
-            break;
-          case 'group':
-            googleAccount = `group:${gcpEmail}`;
-            break;
-          case 'domain':
-            googleAccount = `domain:${gcpEmail}`;
-        }
-        return { share_with_accounts: [googleAccount] };
+      switch (selectGcpAccountType(state)) {
+        case 'user':
+          googleAccount = `user:${gcpEmail}`;
+          break;
+        case 'serviceAccount':
+          googleAccount = `serviceAccount:${gcpEmail}`;
+          break;
+        case 'group':
+          googleAccount = `group:${gcpEmail}`;
+          break;
+        case 'domain':
+          googleAccount = `domain:${gcpEmail}`;
       }
-      // TODO: GCP withInsights is not implemented yet
-      return {};
+      return { share_with_accounts: [googleAccount] };
     }
   }
   return {};

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -32,7 +32,6 @@ import {
   selectFscMode,
   selectGcpAccountType,
   selectGcpEmail,
-  selectGcpShareMethod,
   selectHostname,
   selectImageTypes,
   selectKernel,
@@ -1185,7 +1184,6 @@ export function useGcpValidation(): StepValidation {
   const imageTypes = useAppSelector(selectImageTypes);
   const errors: Record<string, string> = {};
 
-  const gcpShareMethod = useAppSelector(selectGcpShareMethod);
   const gcpAccountType = useAppSelector(selectGcpAccountType);
   const gcpEmail = useAppSelector(selectGcpEmail);
 
@@ -1193,15 +1191,13 @@ export function useGcpValidation(): StepValidation {
     return { errors, disabledNext: false };
   }
 
-  if (gcpShareMethod === 'withGoogle') {
-    if (gcpAccountType === 'domain') {
-      if (!isGcpDomainValid(gcpEmail)) {
-        errors.email = 'Invalid domain';
-      }
-    } else {
-      if (!isGcpEmailValid(gcpEmail)) {
-        errors.email = 'Invalid email';
-      }
+  if (gcpAccountType === 'domain') {
+    if (!isGcpDomainValid(gcpEmail)) {
+      errors.email = 'Invalid domain';
+    }
+  } else {
+    if (!isGcpEmailValid(gcpEmail)) {
+      errors.email = 'Invalid email';
     }
   }
 

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -12,10 +12,7 @@ import type {
   Units,
 } from '@/Components/CreateImageWizard/steps/FileSystem/fscTypes';
 import type { AwsShareMethod } from '@/Components/CreateImageWizard/steps/ImageOutput/components/Aws';
-import type {
-  GcpAccountType,
-  GcpShareMethod,
-} from '@/Components/CreateImageWizard/steps/ImageOutput/components/Gcp';
+import type { GcpAccountType } from '@/Components/CreateImageWizard/steps/ImageOutput/components/Gcp';
 import {
   GroupWithRepositoryInfo,
   IBPackageWithRepositoryInfo,
@@ -142,7 +139,6 @@ export type wizardState = {
     hyperVGeneration: 'V1' | 'V2';
   };
   gcp: {
-    shareMethod: GcpShareMethod;
     accountType: GcpAccountType;
     email: string;
   };
@@ -252,7 +248,6 @@ export const initialState: wizardState = {
     hyperVGeneration: 'V2',
   },
   gcp: {
-    shareMethod: 'withGoogle',
     accountType: 'user',
     email: '',
   },
@@ -397,10 +392,6 @@ export const selectAzureResourceGroup = (state: RootState) => {
 
 export const selectAzureHyperVGeneration = (state: RootState) => {
   return state.wizard.azure.hyperVGeneration;
-};
-
-export const selectGcpShareMethod = (state: RootState) => {
-  return state.wizard.gcp.shareMethod;
 };
 
 export const selectGcpAccountType = (state: RootState) => {
@@ -738,17 +729,6 @@ export const wizardSlice = createSlice({
       state.azure.subscriptionId = undefined;
       state.azure.resourceGroup = undefined;
     },
-    changeGcpShareMethod: (state, action: PayloadAction<GcpShareMethod>) => {
-      switch (action.payload) {
-        case 'withInsights':
-          state.gcp.accountType = undefined;
-          state.gcp.email = '';
-          break;
-        case 'withGoogle':
-          state.gcp.accountType = 'user';
-      }
-      state.gcp.shareMethod = action.payload;
-    },
     changeGcpAccountType: (state, action: PayloadAction<GcpAccountType>) => {
       state.gcp.accountType = action.payload;
     },
@@ -756,7 +736,6 @@ export const wizardSlice = createSlice({
       state.gcp.email = action.payload;
     },
     reinitializeGcp: (state) => {
-      state.gcp.shareMethod = 'withGoogle';
       state.gcp.accountType = 'user';
       state.gcp.email = '';
     },
@@ -1624,7 +1603,6 @@ export const {
   changeAzureResourceGroup,
   changeAzureHyperVGeneration,
   reinitializeAzure,
-  changeGcpShareMethod,
   changeGcpAccountType,
   changeGcpEmail,
   reinitializeGcp,

--- a/src/store/slices/wizard/tests/targets.test.ts
+++ b/src/store/slices/wizard/tests/targets.test.ts
@@ -10,7 +10,6 @@ import wizardReducer, {
   changeAzureTenantId,
   changeGcpAccountType,
   changeGcpEmail,
-  changeGcpShareMethod,
   initialState,
   reinitializeAws,
   reinitializeAzure,
@@ -206,39 +205,6 @@ describe('target environment reducers', () => {
   });
 
   describe('GCP', () => {
-    describe('changeGcpShareMethod', () => {
-      it('should set to withGoogle and initialize accountType', () => {
-        const result = wizardReducer(
-          initialState,
-          changeGcpShareMethod('withGoogle'),
-        );
-
-        expect(result.gcp.shareMethod).toBe('withGoogle');
-        expect(result.gcp.accountType).toBe('user');
-      });
-
-      it('should set to withInsights and clear accountType and email', () => {
-        const stateWithGcpConfig: wizardState = {
-          ...initialState,
-          gcp: {
-            ...initialState.gcp,
-            shareMethod: 'withGoogle',
-            accountType: 'serviceAccount',
-            email: 'test@example.com',
-          },
-        };
-
-        const result = wizardReducer(
-          stateWithGcpConfig,
-          changeGcpShareMethod('withInsights'),
-        );
-
-        expect(result.gcp.shareMethod).toBe('withInsights');
-        expect(result.gcp.accountType).toBeUndefined();
-        expect(result.gcp.email).toBe('');
-      });
-    });
-
     describe('changeGcpAccountType', () => {
       it('should update account type to user', () => {
         const result = wizardReducer(
@@ -293,7 +259,6 @@ describe('target environment reducers', () => {
         const modifiedState: wizardState = {
           ...initialState,
           gcp: {
-            shareMethod: 'withInsights',
             accountType: 'serviceAccount',
             email: 'sa@example.com',
           },
@@ -301,7 +266,6 @@ describe('target environment reducers', () => {
 
         const result = wizardReducer(modifiedState, reinitializeGcp());
 
-        expect(result.gcp.shareMethod).toBe('withGoogle');
         expect(result.gcp.accountType).toBe('user');
         expect(result.gcp.email).toBe('');
       });

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -254,25 +254,6 @@ describe('GCP image type request generated correctly', () => {
     expect(receivedRequest).toEqual(expectedRequest);
   });
 
-  test('share image with Red Hat Lightspeed only', async () => {
-    const user = userEvent.setup();
-    await renderCreateMode();
-    await clickGCPTarget();
-    const shareWithInsightOption = await screen.findByRole('radio', {
-      name: /Share with Red Hat Lightspeed only/i,
-    });
-
-    await waitFor(() => user.click(shareWithInsightOption));
-    await goToReviewStep();
-    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
-    const expectedImageRequest = createGCPCloudImage('gcp', {});
-    const expectedRequest: CreateBlueprintRequest = {
-      ...blueprintRequest,
-      image_requests: [expectedImageRequest],
-    };
-    expect(receivedRequest).toEqual(expectedRequest);
-  });
-
   test('after selecting and deselecting gcp', async () => {
     await renderCreateMode();
     await clickGCPTarget();


### PR DESCRIPTION
Removes "Share with Red Hat Lightspeed only" option from GCP, which also means removing the entire "Select image sharing" form from the GCP configuration. This was done due to the Sources integration being removed entirely, thus this option was a dead code.

---
**Before**:
<img width="1078" height="377" alt="image" src="https://github.com/user-attachments/assets/e26c58ef-7eb5-45ca-a122-e0a084fe94b5" />

---
**After**:
<img width="1079" height="339" alt="image" src="https://github.com/user-attachments/assets/b0b57296-a19a-4ef3-a29a-661d39d8eb10" />
