### PR TITLE
Wizard: Packages revamp follow up (HMS-9397)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -9,9 +9,6 @@ import {
   EmptyStateBody,
   EmptyStateFooter,
   FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
   MenuToggle,
   MenuToggleElement,
   Select,
@@ -771,6 +768,12 @@ const PackageSearch = ({
             <SelectOption isDisabled>
               Start typing to search {packageTypeLabel}
             </SelectOption>
+          ) : packageType === 'packages' && debouncedSearchTerm.length === 1 ? (
+            <EmptyState variant='sm'>
+              <EmptyStateBody>
+                The search value must be greater than 1 character
+              </EmptyStateBody>
+            </EmptyState>
           ) : isLoadingDistroPackages ||
             isLoadingCustomPackages ||
             isLoadingRecommendedPackages ||
@@ -844,15 +847,6 @@ const PackageSearch = ({
             </>
           )}
       </Select>
-      {debouncedSearchTerm.length === 1 && (
-        <FormHelperText>
-          <HelperText>
-            <HelperTextItem variant='error'>
-              The search value must be greater than 1 character
-            </HelperTextItem>
-          </HelperText>
-        </FormHelperText>
-      )}
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -559,9 +559,9 @@ const PackageSearch = ({
 
   const getPackageDescription = (pkg: IBPackageWithRepositoryInfo) => {
     const parts = [];
-    if (pkg.stream) {
-      parts.push(pkg.stream);
-    }
+
+    parts.push(pkg.stream || 'N/A');
+
     if (pkg.end_date) {
       const retirementDate = new Date(pkg.end_date);
       const formattedDate =


### PR DESCRIPTION
This moves the "too short" state inside the dropdown and renders 'N/A' when there's no application stream as per mocks.