### PR TITLE
playwright: Update boot tests to reflect packages revamp changes (HMS-10536)

### DIFF
--- a/playwright/BootTests/Compliance/ComplianceOpenSCAP.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceOpenSCAP.boot.ts
@@ -92,13 +92,9 @@ test('Compliance step integration test - OpenSCAP default profile', async ({
       .getByRole('textbox', { name: 'Search packages' })
       .fill('perl-XML-XPath');
     await expect(
-      frame.getByRole('gridcell', { name: 'perl-XML-XPath' }),
+      frame.getByRole('option', { name: 'perl-XML-XPath' }),
     ).toBeVisible({ timeout: 60000 });
-    await frame
-      .getByRole('row')
-      .filter({ hasText: 'perl-XML-XPath' })
-      .getByLabel('Select row')
-      .click();
+    await frame.getByRole('option', { name: 'perl-XML-XPath' }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 

--- a/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
@@ -95,7 +95,7 @@ test('Content integration test - Non repeatable build - URL source', async ({
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
-    await frame.getByRole('checkbox', { name: 'Select row 0' }).click();
+    await frame.getByRole('option', { name: packageName }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 
@@ -240,16 +240,16 @@ test('Content integration test - Non repeatable build - Upload source', async ({
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
     await expect(
-      frame.getByRole('gridcell', { name: packageName }),
+      frame.getByRole('option', { name: packageName }),
     ).toBeVisible();
-    await frame.getByRole('checkbox', { name: 'Select row 0' }).click();
+    await frame.getByRole('option', { name: packageName }).click();
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(dependencyPackageName);
     await expect(
-      frame.getByRole('gridcell', { name: dependencyPackageName }),
+      frame.getByRole('option', { name: dependencyPackageName }),
     ).toBeVisible();
-    await frame.getByRole('checkbox', { name: 'Select row 0' }).click();
+    await frame.getByRole('option', { name: dependencyPackageName }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 
@@ -341,7 +341,7 @@ test('Content integration test - Non repeatable build - Community repository', a
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
-    await frame.getByRole('checkbox', { name: 'Select row 0' }).click();
+    await frame.getByRole('option', { name: packageName }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 

--- a/playwright/BootTests/Content/ContentRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentRepeatable.boot.ts
@@ -151,7 +151,7 @@ test('Content integration test - Repeatable build - URL source', async ({
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
-    await frame.getByRole('checkbox', { name: 'Select row 0' }).click();
+    await frame.getByRole('option', { name: packageName }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
   });
 

--- a/playwright/BootTests/Content/ContentTemplate.boot.ts
+++ b/playwright/BootTests/Content/ContentTemplate.boot.ts
@@ -217,14 +217,10 @@ test('Content integration test - Content Template', async ({
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
-    await expect(
-      frame.getByRole('gridcell', { name: packageName }),
-    ).toBeVisible({ timeout: 60000 });
-    await frame
-      .getByRole('row')
-      .filter({ hasText: packageName })
-      .getByLabel('Select row')
-      .click();
+    await expect(frame.getByRole('option', { name: packageName })).toBeVisible({
+      timeout: 60000,
+    });
+    await frame.getByRole('option', { name: packageName }).click();
   });
 
   await test.step('Set hostname for system identification', async () => {


### PR DESCRIPTION
The packages step was revamped, but the boot tests were not updates to reflect the changes. This should fix that.