### PR TITLE
Update default bugs epic

### DIFF
--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
           jira_token: ${{ secrets.IMAGEBUILDER_BOT_JIRA_TOKEN }}
-          new_issues_jira_epic: HMS-9974
+          new_issues_jira_epic: HMS-10501


### PR DESCRIPTION
This updates the link to the bugs epic for newly created issues to Q2.

This is the current epic: https://redhat.atlassian.net/browse/HMS-10501