### PR TITLE
Wizard: Don't include default timezone and locale for unsupported image types

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -22,12 +22,16 @@ import {
   addImageType,
   changeArchitecture,
   changeDistribution,
+  changeKeyboard,
   changeTimezone,
+  clearLanguages,
   initializeWizard,
   selectDistribution,
   selectImageSource,
   selectImageTypes,
   selectIsImageMode,
+  selectKeyboard,
+  selectLanguages,
   selectTimezone,
 } from '@/store/slices/wizard';
 
@@ -232,6 +236,8 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
 
   const distribution = useAppSelector(selectDistribution);
   const timezone = useAppSelector(selectTimezone);
+  const languages = useAppSelector(selectLanguages);
+  const keyboard = useAppSelector(selectKeyboard);
 
   // Image Output
   const targetEnvironments = useAppSelector(selectImageTypes);
@@ -306,6 +312,13 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
       return;
     }
 
+    if (restrictions.timezone.shouldHide) {
+      if (timezone) {
+        dispatch(changeTimezone(''));
+      }
+      return;
+    }
+
     const defaultTimezone =
       distribution === RHEL_10 || targetEnvironments.includes('azure')
         ? DEFAULT_TIMEZONE
@@ -314,7 +327,29 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
     if (!timezone) {
       dispatch(changeTimezone(defaultTimezone));
     }
-  }, [distribution, targetEnvironments, isEdit, dispatch]);
+  }, [
+    distribution,
+    targetEnvironments,
+    isEdit,
+    dispatch,
+    restrictions.timezone.shouldHide,
+    timezone,
+  ]);
+
+  useEffect(() => {
+    if (isEdit) {
+      return;
+    }
+
+    if (restrictions.locale.shouldHide) {
+      if (languages && languages.length > 0) {
+        dispatch(clearLanguages());
+      }
+      if (keyboard) {
+        dispatch(changeKeyboard(''));
+      }
+    }
+  }, [isEdit, dispatch, restrictions.locale.shouldHide, languages, keyboard]);
 
   // Duplicating some of the logic from the Wizard component to allow for custom nav items status
   // for original code see https://github.com/patternfly/patternfly-react/blob/184c55f8d10e1d94ffd72e09212db56c15387c5e/packages/react-core/src/components/Wizard/WizardNavInternal.tsx#L128

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -38,6 +38,7 @@ import {
   VolumeGroup,
 } from '@/store/api/backend';
 import { ApiRepositoryImportResponseRead } from '@/store/api/contentSources';
+import { DISTRO_DETAILS } from '@/store/api/distributions/constants';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
   ComplianceType,
@@ -1139,12 +1140,36 @@ const getModules = (state: RootState) => {
   return undefined;
 };
 
+const noTypeSupportsOption = (
+  state: RootState,
+  option: 'timezone' | 'locale',
+): boolean => {
+  const imageTypes = selectImageTypes(state);
+  return (
+    imageTypes.length > 0 &&
+    imageTypes.every((type) => {
+      if (!(type in DISTRO_DETAILS)) {
+        return false;
+      }
+      const details = DISTRO_DETAILS[type];
+      return (
+        details.supported_blueprint_options !== undefined &&
+        !details.supported_blueprint_options.includes(option)
+      );
+    })
+  );
+};
+
 const getTimezone = (state: RootState) => {
   const timezone = selectTimezone(state);
   const ntpservers = selectNtpServers(state);
   const isImageMode = selectIsImageMode(state);
 
   if (isImageMode) {
+    return undefined;
+  }
+
+  if (noTypeSupportsOption(state, 'timezone')) {
     return undefined;
   }
 
@@ -1201,6 +1226,10 @@ const getLocale = (state: RootState) => {
   const isImageMode = selectIsImageMode(state);
 
   if (isImageMode) {
+    return undefined;
+  }
+
+  if (noTypeSupportsOption(state, 'locale')) {
     return undefined;
   }
 

--- a/src/store/api/distributions/constants.ts
+++ b/src/store/api/distributions/constants.ts
@@ -69,7 +69,7 @@ export const DISTRO_DETAILS: Record<string, ImageTypeInfo> = {
   },
   'network-installer': {
     name: 'network-installer',
-    supported_blueprint_options: ['locale', 'fips'],
+    supported_blueprint_options: ['fips'],
   },
   'pxe-tar-xz': {
     name: 'pxe-tar-xz',

--- a/src/store/api/distributions/tests/distributionDetailsApi.test.ts
+++ b/src/store/api/distributions/tests/distributionDetailsApi.test.ts
@@ -50,11 +50,11 @@ describe('DISTRO_DETAILS configuration', () => {
   });
 
   describe('network-installer restrictions', () => {
-    it('should only allow locale and fips for network-installer', () => {
+    it('should only allow fips for network-installer', () => {
       const networkInstallerSupported =
         DISTRO_DETAILS['network-installer'].supported_blueprint_options;
 
-      expect(networkInstallerSupported).toEqual(['locale', 'fips']);
+      expect(networkInstallerSupported).toEqual(['fips']);
     });
   });
 

--- a/src/store/api/distributions/tests/hooks.test.tsx
+++ b/src/store/api/distributions/tests/hooks.test.tsx
@@ -247,6 +247,7 @@ describe('useCustomizationRestrictions hook logic', () => {
       expect(result.packages.shouldHide).toBe(true);
       expect(result.filesystem.shouldHide).toBe(true);
       expect(result.kernel.shouldHide).toBe(true);
+      expect(result.timezone.shouldHide).toBe(true);
       expect(result.users.shouldHide).toBe(true);
     });
 

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -3,7 +3,16 @@
 // Redux State → mapRequestFromState() → API Request. They could be replaced by unit
 // tests for the request mapper functions (mapRequestToState/mapRequestFromState) which
 // would be faster and more focused than full integration tests.
-import { EDIT_BLUEPRINT } from '../../../../../constants';
+import { screen, waitFor, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { CreateBlueprintRequest } from '@/store/api/backend';
+
+import {
+  CREATE_BLUEPRINT,
+  EDIT_BLUEPRINT,
+  RHEL_10,
+} from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import {
   aarch64CreateBlueprintRequest,
@@ -13,8 +22,14 @@ import {
   x86_64CreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
 import {
+  blueprintRequest,
+  enterBlueprintName,
+  goToReview,
+  interceptBlueprintRequest,
   interceptEditBlueprintRequest,
+  renderCreateMode,
   renderEditMode,
+  selectGuestImageTarget,
 } from '../../wizardTestUtils';
 
 describe('Image output edit mode', () => {
@@ -79,6 +94,99 @@ describe('Image output edit mode', () => {
       `${EDIT_BLUEPRINT}/${id}`,
     );
     const expectedRequest = aarch64CreateBlueprintRequest;
+    expect(receivedRequest).toEqual(expectedRequest);
+  });
+});
+
+const selectNetworkInstaller = async () => {
+  const user = userEvent.setup();
+  const checkbox = await screen.findByRole('checkbox', {
+    name: /Network installer checkbox/i,
+  });
+  await waitFor(() => user.click(checkbox));
+  return checkbox;
+};
+
+describe('Network installer target', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('selecting network-installer shows alert and disables other checkboxes', async () => {
+    await renderCreateMode();
+    const networkInstallerCheckbox = await selectNetworkInstaller();
+
+    await screen.findByText(
+      /This image type requires specific, minimal configuration for remote installation/i,
+    );
+    const guestImageCheckbox = await screen.findByRole('checkbox', {
+      name: /Virtualization guest image/i,
+    });
+    expect(guestImageCheckbox).toBeDisabled();
+
+    const bareMetalCheckbox = await screen.findByRole('checkbox', {
+      name: /Bare metal installer/i,
+    });
+    expect(bareMetalCheckbox).toBeDisabled();
+
+    expect(networkInstallerCheckbox).toBeChecked();
+    expect(networkInstallerCheckbox).toBeEnabled();
+  });
+
+  test('selecting another target first disables network-installer', async () => {
+    await renderCreateMode();
+    await selectGuestImageTarget();
+
+    const networkInstallerCheckbox = await screen.findByRole('checkbox', {
+      name: /Network installer checkbox/i,
+    });
+    expect(networkInstallerCheckbox).toBeDisabled();
+  });
+
+  test('selecting network-installer only shows base settings and review steps', async () => {
+    await renderCreateMode();
+    await selectNetworkInstaller();
+
+    const navigation = await screen.findByRole('navigation', {
+      name: /wizard steps/i,
+    });
+
+    const stepButtons = within(navigation).getAllByRole('button');
+    expect(stepButtons).toHaveLength(2);
+
+    expect(
+      within(navigation).getByRole('button', { name: /base settings/i }),
+    ).toBeInTheDocument();
+    expect(
+      within(navigation).getByRole('button', { name: /review/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('can create a blueprint with network-installer', async () => {
+    await renderCreateMode();
+    await selectNetworkInstaller();
+    await enterBlueprintName('Red Velvet');
+
+    await goToReview();
+
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    const expectedRequest: CreateBlueprintRequest = {
+      ...blueprintRequest,
+      distribution: RHEL_10,
+      customizations: {},
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'network-installer',
+          upload_request: {
+            options: {},
+            type: 'aws.s3',
+          },
+        },
+      ],
+    };
+
     expect(receivedRequest).toEqual(expectedRequest);
   });
 });


### PR DESCRIPTION
Don't include default timezone and locale if the image type doesn't support it.   To test this, simply build a network installer and try to boot it, prior to this it would fail to fully boot.

Fixes HMS-10456 