### PR TITLE
Wizard: Fix bug re-initializing registration (HMS-10540)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -122,10 +122,9 @@ const TargetEnvironment = () => {
   }, []);
 
   useEffect(() => {
-    const registrationType = restrictions.registration.shouldHide
-      ? 'register-later'
-      : 'register-now-rhc';
-    dispatch(changeRegistrationType(registrationType));
+    if (restrictions.registration.shouldHide) {
+      dispatch(changeRegistrationType('register-later'));
+    }
   }, [restrictions.registration.shouldHide, dispatch]);
 
   const isOnlyNetworkInstallerSelected =


### PR DESCRIPTION
How to reproduce the bug:
1. set registration to 'register-later'
2. return to the first step of the wizard
3. check the registration again

Current behaviour:
- registration will be set as 'register-now' again

Desired behaviour:
- the 'register-later' option stays selected