### PR TITLE
Wizard: Enable navigation when the first step is valid (HMS-10541)

### DIFF
--- a/playwright/Basic/imageMode.spec.ts
+++ b/playwright/Basic/imageMode.spec.ts
@@ -66,10 +66,11 @@ test('Image mode blueprint create, edit, export, import', async ({
       name: /Select a bootc image/,
     });
     await expect(imageSourceDropdown).toBeVisible({ timeout: 10000 });
+    await expect(imageSourceDropdown).toBeEnabled({ timeout: 5000 });
     await imageSourceDropdown.click();
 
     const firstOption = frame.getByRole('option').first();
-    await expect(firstOption).toBeVisible();
+    await expect(firstOption).toBeVisible({ timeout: 10000 });
     await firstOption.click();
 
     await frame.getByRole('checkbox', { name: 'Virtualization' }).click();
@@ -82,7 +83,12 @@ test('Image mode blueprint create, edit, export, import', async ({
   });
 
   await test.step('Create blueprint', async () => {
-    await frame.getByRole('button', { name: 'Next', exact: true }).click();
+    const firstNextButton = frame.getByRole('button', {
+      name: 'Next',
+      exact: true,
+    });
+    await expect(firstNextButton).toBeEnabled({ timeout: 10000 });
+    await firstNextButton.click();
     const nextButton = frame.getByRole('button', { name: 'Next', exact: true });
     await expect(nextButton).toBeEnabled({ timeout: 10000 });
     await nextButton.click();

--- a/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
+++ b/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
@@ -258,13 +258,23 @@ const CreateImageWizard3 = () => {
   ) => {
     const status = (step.id !== activeStep.id && step.status) || 'default';
 
+    const isBaseSettingsStep = step.id === 'base-settings-step';
+    const hasVisitedBaseSettings = _steps.find(
+      (s) => s.id === 'base-settings-step',
+    )?.isVisited;
+    const canNavigate =
+      mode === 'edit' ||
+      step.isVisited ||
+      isBaseSettingsStep ||
+      (hasVisitedBaseSettings && !baseSettingsHasErrors);
+
     return (
       <WizardNavItem
         key={step.id}
         id={step.id}
         content={step.name}
         isCurrent={activeStep.id === step.id}
-        isDisabled={step.isDisabled || (mode !== 'edit' && !step.isVisited)}
+        isDisabled={step.isDisabled || !canNavigate}
         isVisited={step.isVisited || false}
         stepIndex={step.index}
         onClick={() => goToStepByIndex(step.index)}


### PR DESCRIPTION
Since only the first step has really required fields, it should be safe to enable the left hand navigation as soon as it's correctly filled in.