### PR TITLE
Wizard: Fix LabelInput silently discarding typed values on navigation

### DIFF
--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -133,6 +133,13 @@ const LabelInput = ({
     }
   };
 
+  const handleBlur = () => {
+    const trimmed = inputValue.trim();
+    if (trimmed) {
+      addItem(trimmed);
+    }
+  };
+
   const handleRemoveItem = (e: React.MouseEvent, value: string) => {
     dispatch(removeAction(value));
   };
@@ -154,6 +161,7 @@ const LabelInput = ({
           onChange={onTextInputChange}
           value={inputValue}
           onKeyDown={(e) => handleKeyDown(e, inputValue)}
+          onBlur={handleBlur}
         >
           {totalItems > 0 && (
             <LabelGroup


### PR DESCRIPTION
When a user types a value (e.g. "8080:tcp") into any LabelInput field and navigates away without pressing Enter, the value is silently lost. The input text lives in local component state and is never dispatched to the Redux store. On unmount the local state is destroyed, so returning to the step shows empty fields and the review step has no record of the entry.

This affects all ~10 LabelInput instances across the wizard: firewall ports, firewall enabled/disabled services, NTP servers, kernel arguments, systemd enabled/disabled/masked services, and user groups.

The bug was introduced in a6b6645c ("Wizard: remove add and clear buttons from the LabelInput") which removed the Add (+) button, leaving Enter as the only way to commit a value — with no visual indication that Enter is required. Users who type a value and click Next, Back, or Review naturally expect the visible text to be saved.

Fix: add an onBlur handler that auto-commits valid input when the field loses focus (e.g. clicking Next). This is consistent with how other design systems handle tag/chip inputs — Ark UI, Chakra UI, and Tagify all commit on blur by default to prevent data loss. PatternFly form guidelines also recognize loss-of-focus as a trigger for processing input.

PatternFly design guidelines supporting this fix:

- [Form guidelines](https://www.patternfly.org/components/forms/form/design-guidelines): "In a wizard, form error validation should occur when or by the time the user clicks the Next button." If validation fires at Next, input data must be captured by that point too.

- [Form guidelines](https://www.patternfly.org/components/forms/form/design-guidelines): "Validation on loss of focus occurs as soon as a field loses focus." PF recognizes blur as a trigger for processing input.

- [Wizard guidelines](https://www.patternfly.org/components/wizard/design-guidelines): "Visited step: A step that has been already visited. In most cases users can click this step to return to a prior point in the flow." Returning to a step should show previously entered data.

- [Wizard guidelines](https://www.patternfly.org/components/wizard/design-guidelines): "Be aware that anytime the user navigates away from the wizard, there is a risk that any information entered up until that point will be lost. At a minimum, we recommend opening a modal alert … warning of potential data loss." If leaving the entire wizard warrants a warning, silently discarding data within the wizard is worse.