### PR TITLE
Wizard: Add SearchableSelect component and refactor KeyboardDropDown (HMS-9517)

### DIFF
--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -101,9 +101,14 @@ test('Create a blueprint with Locale customization', async ({
     ).toBeAttached();
     await frame.getByPlaceholder('Select a language').fill('xxx');
     await expect(frame.getByText('No results found for')).toBeAttached();
-    await frame.getByRole('button', { name: 'Menu toggle' }).nth(1).click();
-    await frame.getByPlaceholder('Select a keyboard').fill('ami');
-    await frame.getByRole('option', { name: 'amiga-de' }).click();
+    const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
+    await keyboardGroup
+      .getByRole('button', { name: 'Select a keyboard' })
+      .click();
+    const kbSearch = frame.getByPlaceholder('Search by name').last();
+    await kbSearch.click();
+    await kbSearch.fill('ami');
+    await frame.getByRole('menuitem', { name: 'amiga-de' }).click();
     // Wait for the loading spinner to disappear after language/keyboard changes
     await frame
       .getByText('Resolving packages for your preferred locale…')
@@ -153,6 +158,7 @@ test('Create a blueprint with Locale customization', async ({
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
     await frame.getByRole('button', { name: 'Locale' }).click();
+    const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     await expect(
       frame.getByText('English - United States (en_US.UTF-8)'),
     ).toBeVisible();
@@ -171,8 +177,8 @@ test('Create a blueprint with Locale customization', async ({
     await expect(
       frame.getByText('English - United Kingdom (en_GB.UTF-8)'),
     ).toBeVisible();
-    await frame.getByRole('button', { name: 'Menu toggle' }).nth(1).click();
-    await frame.getByRole('option', { name: 'ANSI-dvorak' }).click();
+    await keyboardGroup.getByRole('button', { name: 'amiga-de' }).click();
+    await frame.getByRole('menuitem', { name: 'ANSI-dvorak' }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
@@ -203,6 +209,7 @@ test('Create a blueprint with Locale customization', async ({
   await test.step('Review imported BP', async () => {
     await fillInImageOutputGuest(frame);
     await frame.getByRole('button', { name: 'Locale' }).click();
+    const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     await expect(
       frame.getByText('English - United States (en_US.UTF-8)'),
     ).toBeVisible();
@@ -215,9 +222,9 @@ test('Create a blueprint with Locale customization', async ({
     await expect(
       frame.getByText('Russian - Russia (ru_RU.UTF-8)'),
     ).toBeVisible();
-    await expect(frame.getByPlaceholder('Select a keyboard')).toHaveValue(
-      'ANSI-dvorak',
-    );
+    await expect(
+      keyboardGroup.getByRole('button', { name: 'ANSI-dvorak' }),
+    ).toBeVisible();
     await frame.getByRole('button', { name: 'Cancel' }).click();
   });
 });

--- a/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
@@ -1,25 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
-import {
-  Button,
-  FormGroup,
-  HelperText,
-  HelperTextItem,
-  MenuToggle,
-  MenuToggleElement,
-  Select,
-  SelectList,
-  SelectOption,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
-} from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
+import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 
 import { changeKeyboard, selectKeyboard } from '@/store/slices/wizard';
 
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
-import sortfn from '../../../../../Utilities/sortfn';
+import SearchableSelect from '../../../../sharedComponents/SearchableSelect';
 import { useLocaleValidation } from '../../../utilities/useValidation';
 import { keyboardsList } from '../data/keyboardsList';
 
@@ -30,125 +16,25 @@ const KeyboardDropDown = () => {
   const stepValidation = useLocaleValidation();
 
   const [errorText, setErrorText] = useState(stepValidation.errors['keyboard']);
-  const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState<string>('');
-  const [filterValue, setFilterValue] = useState<string>('');
-  const [selectOptions, setSelectOptions] = useState<string[]>(keyboardsList);
 
-  useEffect(() => {
-    let filteredKeyboards = keyboardsList;
-
-    if (filterValue) {
-      filteredKeyboards = keyboardsList.filter((keyboard: string) =>
-        String(keyboard).toLowerCase().includes(filterValue.toLowerCase()),
-      );
-      if (!isOpen) {
-        setIsOpen(true);
-      }
-    }
-    setSelectOptions(
-      filteredKeyboards.sort((a, b) => sortfn(a, b, filterValue)),
-    );
-
-    // This useEffect hook should run *only* on when the filter value changes.
-    // eslint's exhaustive-deps rule does not support this use.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterValue]);
-
-  const onInputClick = () => {
-    if (!isOpen) {
-      setIsOpen(true);
-    } else if (!inputValue) {
-      setIsOpen(false);
-    }
-  };
-
-  const onSelect = (_event?: React.MouseEvent, value?: string | number) => {
-    if (value && typeof value === 'string') {
-      setInputValue(value);
-      setFilterValue('');
-      setErrorText('');
-      dispatch(changeKeyboard(value));
-      setIsOpen(false);
-    }
-  };
-
-  const onTextInputChange = (_event: React.FormEvent, value: string) => {
-    setInputValue(value);
-    setFilterValue(value);
-
-    if (value !== keyboard) {
-      dispatch(changeKeyboard(''));
-    }
-  };
-
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const onClearButtonClick = () => {
-    setInputValue('');
-    setFilterValue('');
-    setErrorText('');
-    dispatch(changeKeyboard(''));
-  };
-
-  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      variant='typeahead'
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-    >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={keyboard ? keyboard : inputValue}
-          onClick={onInputClick}
-          onChange={onTextInputChange}
-          autoComplete='off'
-          placeholder='Select a keyboard'
-          isExpanded={isOpen}
-        />
-
-        {keyboard && (
-          <TextInputGroupUtilities>
-            <Button
-              icon={<TimesIcon />}
-              variant='plain'
-              onClick={onClearButtonClick}
-              aria-label='Clear input'
-            />
-          </TextInputGroupUtilities>
-        )}
-      </TextInputGroup>
-    </MenuToggle>
+  const options = useMemo(
+    () => keyboardsList.map((kb) => ({ value: kb, label: kb })),
+    [],
   );
 
+  const handleSelect = (value: string | undefined) => {
+    dispatch(changeKeyboard(value ?? ''));
+    setErrorText('');
+  };
+
   return (
-    <FormGroup isRequired={false} label='Keyboard'>
-      <Select
-        isScrollable
-        isOpen={isOpen}
+    <FormGroup isRequired={false} label='Keyboard' role='group'>
+      <SearchableSelect
+        options={options}
         selected={keyboard}
-        onSelect={onSelect}
-        onOpenChange={(isOpen) => setIsOpen(isOpen)}
-        toggle={toggle}
-        shouldFocusFirstItemOnOpen={false}
-      >
-        <SelectList>
-          {selectOptions.length > 0 ? (
-            selectOptions.map((option) => (
-              <SelectOption key={option} value={option}>
-                {option}
-              </SelectOption>
-            ))
-          ) : (
-            <SelectOption isDisabled>
-              {`No results found for "${filterValue}"`}
-            </SelectOption>
-          )}
-        </SelectList>
-      </Select>
+        placeholder='Select a keyboard'
+        onSelect={handleSelect}
+      />
       {errorText && (
         <HelperText>
           <HelperTextItem variant={'error'}>{errorText}</HelperTextItem>

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -61,7 +61,7 @@ describe('Locale Component', () => {
         await screen.findByPlaceholderText(/select a language/i),
       ).toBeInTheDocument();
       expect(
-        screen.getByPlaceholderText(/select a keyboard/i),
+        screen.getByRole('button', { name: /select a keyboard/i }),
       ).toBeInTheDocument();
       expect(
         screen.getByText(/Search by country, language or UTF code/i),
@@ -172,7 +172,7 @@ describe('Locale Component', () => {
 
       await searchForKeyboard(user, 'us');
 
-      const options = await screen.findAllByRole('option');
+      const options = await screen.findAllByRole('menuitem');
       expect(options.length).toBeGreaterThan(0);
       expect(options[0]).toHaveTextContent('us');
     });
@@ -183,7 +183,7 @@ describe('Locale Component', () => {
 
       await searchForKeyboard(user, 'us');
 
-      const options = await screen.findAllByRole('option');
+      const options = await screen.findAllByRole('menuitem');
       expect(options[0]).toHaveTextContent('us');
       expect(options[1]).toHaveTextContent('us-acentos');
       expect(options[2]).toHaveTextContent('us-alt-intl');
@@ -196,11 +196,6 @@ describe('Locale Component', () => {
       await searchForKeyboard(user, 'foo');
 
       expect(screen.getByText(/no results found/i)).toBeInTheDocument();
-
-      const option = await screen.findByRole('option', {
-        name: /no results found/i,
-      });
-      expect(option).toBeDisabled();
     });
 
     test('can clear keyboard search', async () => {
@@ -208,13 +203,11 @@ describe('Locale Component', () => {
       const user = createUser();
 
       await searchForKeyboard(user, 'us');
-      await screen.findAllByRole('option');
+      await screen.findAllByRole('menuitem');
 
       await clearKeyboardSearch(user);
 
-      const keyboardInput =
-        await screen.findByPlaceholderText(/select a keyboard/i);
-      expect(keyboardInput).toHaveValue('');
+      expect(screen.getByLabelText(/search by name/i)).toHaveValue('');
     });
   });
 
@@ -226,9 +219,9 @@ describe('Locale Component', () => {
       await searchForKeyboard(user, 'us');
       await selectKeyboardOption(user, 'us');
 
-      const keyboardInput =
-        await screen.findByPlaceholderText(/select a keyboard/i);
-      expect(keyboardInput).toHaveValue('us');
+      expect(
+        await screen.findByRole('button', { name: 'us' }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -257,9 +250,9 @@ describe('Locale Component', () => {
         },
       });
 
-      const keyboardInput =
-        await screen.findByPlaceholderText(/select a keyboard/i);
-      expect(keyboardInput).toHaveValue('de');
+      expect(
+        await screen.findByRole('button', { name: 'de' }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -327,14 +320,11 @@ describe('Locale Component', () => {
       renderLocaleStep();
       const user = createUser();
 
-      const keyboardInput =
-        await screen.findByPlaceholderText(/select a keyboard/i);
-      await typeWithWait(user, keyboardInput, 'us-dvorak{Enter}');
+      await searchForKeyboard(user, 'us-dvorak{Enter}');
 
       expect(
         screen.getByPlaceholderText(/select a language/i),
       ).toBeInTheDocument();
-      expect(keyboardInput).toBeInTheDocument();
     });
 
     test('pressing Enter in language search does not trigger page reload', async () => {
@@ -346,7 +336,7 @@ describe('Locale Component', () => {
       await typeWithWait(user, languageInput, 'Dutch{Enter}');
 
       expect(
-        screen.getByPlaceholderText(/select a keyboard/i),
+        screen.getByRole('button', { name: /select a keyboard/i }),
       ).toBeInTheDocument();
       expect(languageInput).toBeInTheDocument();
     });

--- a/src/Components/CreateImageWizard/steps/Locale/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/helpers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 
 import {
   clearWithWait,
@@ -44,19 +44,24 @@ export const searchForKeyboard = async (
   user: UserEventInstance,
   search: string,
 ) => {
-  const input = await screen.findByPlaceholderText(/select a keyboard/i);
-  await typeWithWait(user, input, search);
+  const keyboardGroup = screen.getByRole('group', { name: /keyboard/i });
+  const toggle = within(keyboardGroup).getByRole('button', {
+    name: /select a keyboard|Menu toggle/i,
+  });
+  await clickWithWait(user, toggle);
+  const searchInput = await screen.findByLabelText(/search by name/i);
+  await typeWithWait(user, searchInput, search);
 };
 
 export const clearKeyboardSearch = async (user: UserEventInstance) => {
-  const input = await screen.findByPlaceholderText(/select a keyboard/i);
-  await clearWithWait(user, input);
+  const searchInput = screen.getByLabelText(/search by name/i);
+  await clearWithWait(user, searchInput);
 };
 
 export const selectKeyboardOption = async (
   user: UserEventInstance,
   optionName: string | RegExp,
 ) => {
-  const option = await screen.findByRole('option', { name: optionName });
+  const option = await screen.findByRole('menuitem', { name: optionName });
   await clickWithWait(user, option);
 };

--- a/src/Components/sharedComponents/SearchableSelect.tsx
+++ b/src/Components/sharedComponents/SearchableSelect.tsx
@@ -1,0 +1,137 @@
+import React, { useMemo, useRef, useState } from 'react';
+
+import {
+  Divider,
+  Menu,
+  MenuContainer,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  MenuSearch,
+  MenuSearchInput,
+  MenuToggle,
+  SearchInput,
+} from '@patternfly/react-core';
+
+import sortfn from '@/Utilities/sortfn';
+
+type SearchableSelectOption = {
+  value: string;
+  label: string;
+};
+
+type SearchableSelectProps = {
+  options: SearchableSelectOption[];
+  selected?: string | undefined;
+  placeholder?: string | undefined;
+  onSelect: (value: string | undefined) => void;
+};
+
+const SearchableSelect = ({
+  options,
+  selected,
+  placeholder = 'Select an option',
+  onSelect,
+}: SearchableSelectProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const filteredOptions = useMemo(() => {
+    if (!searchValue) {
+      return options;
+    }
+
+    return options
+      .filter((opt) =>
+        opt.label.toLowerCase().includes(searchValue.toLowerCase()),
+      )
+      .sort((a, b) => sortfn(a.label, b.label, searchValue));
+  }, [searchValue, options]);
+
+  const handleSelect = (
+    _event: React.MouseEvent | undefined,
+    itemId: string | number | undefined,
+  ) => {
+    if (itemId && typeof itemId === 'string') {
+      onSelect(itemId === selected ? undefined : itemId);
+      setSearchValue('');
+      setIsOpen(false);
+    }
+  };
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+    >
+      {selected || placeholder}
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu
+      ref={menuRef}
+      onSelect={handleSelect}
+      activeItemId={selected || ''}
+      isScrollable
+    >
+      <MenuSearch>
+        <MenuSearchInput>
+          <SearchInput
+            value={searchValue}
+            aria-label='Search by name'
+            placeholder='Search by name'
+            onChange={(_event, value) => setSearchValue(value)}
+            onClear={(event) => {
+              event.stopPropagation();
+              setSearchValue('');
+            }}
+          />
+        </MenuSearchInput>
+      </MenuSearch>
+      <Divider />
+      <MenuContent maxMenuHeight='300px'>
+        <MenuList>
+          {filteredOptions.length > 0 ? (
+            filteredOptions.map((option) => (
+              <MenuItem
+                key={option.value}
+                itemId={option.value}
+                isSelected={option.value === selected}
+              >
+                {option.label}
+              </MenuItem>
+            ))
+          ) : (
+            <MenuItem isDisabled key='no-results'>
+              {`No results found for "${searchValue}"`}
+            </MenuItem>
+          )}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <MenuContainer
+      menu={menu}
+      menuRef={menuRef}
+      toggle={toggle}
+      toggleRef={toggleRef}
+      isOpen={isOpen}
+      onOpenChange={(isOpen) => {
+        setIsOpen(isOpen);
+        if (!isOpen) {
+          setSearchValue('');
+        }
+      }}
+      onOpenChangeKeys={['Escape']}
+    />
+  );
+};
+
+export default SearchableSelect;

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -181,9 +181,9 @@ describe('Import modal', () => {
     await screen.findByRole('heading', { name: /Locale/ });
     await screen.findByText('English - United States (en_US.UTF-8)');
     await screen.findByText('Japanese - Japan (ja_JP.UTF-8)');
-    const keyboardInput =
-      await screen.findByPlaceholderText(/select a keyboard/i);
-    expect(keyboardInput).toHaveValue('us');
+    expect(
+      await screen.findByRole('button', { name: 'us' }),
+    ).toBeInTheDocument();
 
     // Hostname
     const hostnameInput = await screen.findByPlaceholderText(/Add a hostname/i);
@@ -280,13 +280,14 @@ describe('Import modal', () => {
         }),
       ),
     );
-    await waitFor(async () =>
-      user.click(
-        await screen.findByRole('button', {
-          name: /clear input/i,
-        }),
-      ),
-    );
+    const keyboardToggle = await screen.findByRole('button', {
+      name: 'invalid-keyboard',
+    });
+    await waitFor(() => user.click(keyboardToggle));
+    const keyboardSearch = await screen.findByLabelText(/search by name/i);
+    await waitFor(() => user.type(keyboardSearch, 'us'));
+    const keyboardOption = await screen.findByRole('menuitem', { name: 'us' });
+    await waitFor(() => user.click(keyboardOption));
 
     // Hostname
     expect(await screen.findByText(/Invalid hostname/)).toBeInTheDocument();


### PR DESCRIPTION
Replace the Select/typeahead dropdown in the Keyboard section of the
Locale step with a new reusable SearchableSelect component that uses
Menu/MenuContainer/SearchInput from PatternFly.

The SearchableSelect component provides a cleaner dropdown with a
dedicated search input field, replacing the inline typeahead pattern.
It will also be used in a follow-up PR to redesign the Languages
dropdown.

JIRA: HMS-9517