### PR TITLE
Wizard: Locale languages redesign (HMS-9517)

### DIFF
--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -46,10 +46,13 @@ test('Create a blueprint with Locale customization', async ({
 
   await test.step('Check that the Locale step shows langpacks, but not the Additional packages', async () => {
     await frame.getByRole('button', { name: 'Locale' }).click();
-    await frame.getByPlaceholder('Select a language').click();
-    await frame.getByPlaceholder('Select a language').fill('ru_RU');
+    await frame.getByRole('button', { name: 'Add language' }).click();
+    await frame.getByRole('button', { name: 'Select a language' }).click();
+    const searchInput = frame.getByPlaceholder('Search by name').last();
+    await searchInput.click();
+    await searchInput.fill('ru_RU');
     await frame
-      .getByRole('option', { name: 'Russian - Russia (ru_RU.UTF-8)' })
+      .getByRole('menuitem', { name: 'Russian - Russia (ru_RU.UTF-8)' })
       .click();
 
     // Wait for the loading spinner to disappear (langpack resolution can take a while)
@@ -73,35 +76,57 @@ test('Create a blueprint with Locale customization', async ({
 
   await test.step('Select and fill the Locale step', async () => {
     await frame.getByRole('button', { name: 'Locale' }).click();
-    await frame.getByPlaceholder('Select a language').fill('en_US');
+    const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
+    // Add en_US language
+    await frame.getByRole('button', { name: 'Add language' }).click();
+    await frame.getByRole('button', { name: 'Select a language' }).click();
+    let langSearch = frame.getByPlaceholder('Search by name').last();
+    await langSearch.click();
+    await langSearch.fill('en_US');
     await frame
-      .getByRole('option', {
+      .getByRole('menuitem', {
         name: 'English - United States (en_US.UTF-8)',
       })
       .click();
     await expect(
-      frame.getByText('English - United States (en_US.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United States (en_US.UTF-8)',
+      }),
     ).toBeVisible();
-    await frame.getByPlaceholder('Select a language').fill('fy');
+    // Add fy_DE language
+    await frame.getByRole('button', { name: 'Add language' }).click();
+    await frame.getByRole('button', { name: 'Select a language' }).click();
+    langSearch = frame.getByPlaceholder('Search by name').last();
+    await langSearch.click();
+    await langSearch.fill('fy');
     await frame
-      .getByRole('option', {
+      .getByRole('menuitem', {
         name: 'Western Frisian - Germany (fy_DE.UTF-8)',
       })
       .click();
     await expect(
-      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Western Frisian - Germany (fy_DE.UTF-8)',
+      }),
     ).toBeVisible();
-    await frame.getByPlaceholder('Select a language').fill('aa');
+    // Test filtering by adding a temporary row
+    await frame.getByRole('button', { name: 'Add language' }).click();
+    await frame.getByRole('button', { name: 'Select a language' }).click();
+    langSearch = frame.getByPlaceholder('Search by name').last();
+    await langSearch.click();
+    await langSearch.fill('aa');
     // Verify that the dropdown shows filtered options starting with 'aa'
     await expect(
-      frame.getByRole('option', { name: 'aa - Eritrea (aa_ER.UTF-8)' }),
+      frame.getByRole('menuitem', { name: 'aa - Eritrea (aa_ER.UTF-8)' }),
     ).toBeAttached();
     await expect(
-      frame.getByRole('option', { name: 'aa - Ethiopia (aa_ET.UTF-8)' }),
+      frame.getByRole('menuitem', { name: 'aa - Ethiopia (aa_ET.UTF-8)' }),
     ).toBeAttached();
-    await frame.getByPlaceholder('Select a language').fill('xxx');
+    await langSearch.fill('xxx');
     await expect(frame.getByText('No results found for')).toBeAttached();
-    const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
+    // Remove the temporary row
+    await frame.getByRole('button', { name: 'Remove language' }).last().click();
+    // Select keyboard
     await keyboardGroup
       .getByRole('button', { name: 'Select a keyboard' })
       .click();
@@ -158,25 +183,43 @@ test('Create a blueprint with Locale customization', async ({
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
     await frame.getByRole('button', { name: 'Locale' }).click();
+    const languagesGroup = frame.getByRole('group', { name: 'Languages' });
     const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     await expect(
-      frame.getByText('English - United States (en_US.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United States (en_US.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Western Frisian - Germany (fy_DE.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('Russian - Russia (ru_RU.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Russian - Russia (ru_RU.UTF-8)',
+      }),
     ).toBeVisible();
-    await frame.getByPlaceholder('Select a language').fill('en_GB');
+    // Change the first language to en_GB
+    await languagesGroup
+      .getByRole('button', {
+        name: 'English - United States (en_US.UTF-8)',
+      })
+      .click();
+    const editSearch = frame.getByPlaceholder('Search by name').last();
+    await editSearch.click();
+    await editSearch.fill('en_GB');
     await frame
-      .getByRole('option', {
+      .getByRole('menuitem', {
         name: 'English - United Kingdom (en_GB.UTF-8)',
       })
       .click();
     await expect(
-      frame.getByText('English - United Kingdom (en_GB.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United Kingdom (en_GB.UTF-8)',
+      }),
     ).toBeVisible();
+    // Change keyboard
     await keyboardGroup.getByRole('button', { name: 'amiga-de' }).click();
     await frame.getByRole('menuitem', { name: 'ANSI-dvorak' }).click();
     await frame.getByRole('button', { name: 'Review and finish' }).click();
@@ -211,16 +254,19 @@ test('Create a blueprint with Locale customization', async ({
     await frame.getByRole('button', { name: 'Locale' }).click();
     const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     await expect(
-      frame.getByText('English - United States (en_US.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'English - United Kingdom (en_GB.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('English - United Kingdom (en_GB.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Western Frisian - Germany (fy_DE.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
-      frame.getByText('Western Frisian - Germany (fy_DE.UTF-8)'),
-    ).toBeVisible();
-    await expect(
-      frame.getByText('Russian - Russia (ru_RU.UTF-8)'),
+      frame.getByRole('button', {
+        name: 'Russian - Russia (ru_RU.UTF-8)',
+      }),
     ).toBeVisible();
     await expect(
       keyboardGroup.getByRole('button', { name: 'ANSI-dvorak' }),

--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -78,12 +78,9 @@ test('Import a blueprint with invalid customization', async ({
     await expect(frame.getByText('Unknown languages: random:')).toBeVisible();
     await expect(frame.getByText('Duplicated languages: af_ZA.')).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
-    await frame.getByRole('button', { name: 'Close random' }).click();
+    await frame.getByRole('button', { name: 'Remove language' }).last().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
-    await frame
-      .getByRole('button', { name: 'Close Afrikaans - South' })
-      .nth(1)
-      .click();
+    await frame.getByRole('button', { name: 'Remove language' }).last().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
   });
 

--- a/playwright/fixtures/data/exportBlueprintContents.ts
+++ b/playwright/fixtures/data/exportBlueprintContents.ts
@@ -109,7 +109,7 @@ export const exportedLocaleBP = (blueprintName: string): string => {
 timezone = "Etc/UTC"
 
 [customizations.locale]
-languages = [ "C.UTF-8", "ru_RU.UTF-8", "en_US.UTF-8", "fy_DE.UTF-8", "en_GB.UTF-8" ]
+languages = [ "C.UTF-8", "ru_RU.UTF-8", "en_GB.UTF-8", "fy_DE.UTF-8" ]
 keyboard = "ANSI-dvorak"
 
 [[packages]]

--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -1,31 +1,22 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import {
   Button,
   FormGroup,
   HelperText,
   HelperTextItem,
-  Label,
-  LabelGroup,
-  MenuToggle,
-  MenuToggleElement,
-  Select,
-  SelectList,
-  SelectOption,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
 } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
+import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import {
   addLanguage,
   removeLanguage,
+  replaceLanguage,
   selectLanguages,
 } from '@/store/slices/wizard';
 
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
-import sortfn from '../../../../../Utilities/sortfn';
+import SearchableSelect from '../../../../sharedComponents/SearchableSelect';
 import { useLocaleValidation } from '../../../utilities/useValidation';
 import { languagesList } from '../data/languagesList';
 
@@ -47,9 +38,63 @@ const parseLanguageOption = (language: string) => {
   }
 };
 
+const parsedLanguages: Record<string, string> = Object.fromEntries(
+  languagesList.map((lang) => [lang, parseLanguageOption(lang)]),
+);
+
+type LanguageRowProps = {
+  selectedLanguage?: string;
+  onSelect: (language: string | undefined) => void;
+  onRemove: () => void;
+  existingLanguages: string[];
+};
+
+const LanguageRow = ({
+  selectedLanguage,
+  onSelect,
+  onRemove,
+  existingLanguages,
+}: LanguageRowProps) => {
+  const options = useMemo(
+    () =>
+      Object.entries(parsedLanguages)
+        .filter(
+          ([raw]) =>
+            !existingLanguages.includes(raw) || raw === selectedLanguage,
+        )
+        .map(([raw, parsed]) => ({ value: raw, label: parsed })),
+    [existingLanguages, selectedLanguage],
+  );
+
+  return (
+    <div className='pf-v6-u-display-flex pf-v6-u-align-items-center pf-v6-u-gap-sm pf-v6-u-mb-sm'>
+      <div style={{ width: '50%' }}>
+        <SearchableSelect
+          options={options}
+          selected={selectedLanguage}
+          placeholder='Select a language'
+          onSelect={onSelect}
+          isFullWidth
+        />
+      </div>
+      <Button
+        variant='plain'
+        onClick={onRemove}
+        aria-label={
+          selectedLanguage
+            ? `Remove language ${selectedLanguage}`
+            : 'Remove language'
+        }
+        icon={<MinusCircleIcon />}
+      />
+    </div>
+  );
+};
+
 const LanguagesDropDown = () => {
-  const languages = useAppSelector(selectLanguages);
+  const languages = useAppSelector(selectLanguages) ?? [];
   const dispatch = useAppDispatch();
+  const [showNewRow, setShowNewRow] = useState(false);
 
   const stepValidation = useLocaleValidation();
   const unknownLanguages = stepValidation.errors['unknownLanguages']
@@ -59,169 +104,70 @@ const LanguagesDropDown = () => {
     ? stepValidation.errors['duplicateLanguages'].split(' ')
     : [];
 
-  const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState<string>('');
-  const [filterValue, setFilterValue] = useState<string>('');
-  const [selectOptions, setSelectOptions] = useState<string[]>(languagesList);
-
-  type ParsedLanguages = { [key: string]: string };
-
-  const parsedLanguages = languagesList.reduce((acc, language) => {
-    acc[language] = parseLanguageOption(language);
-    return acc;
-  }, {} as ParsedLanguages);
-
-  useEffect(() => {
-    let filteredLanguages = Object.entries(parsedLanguages);
-
-    if (filterValue) {
-      filteredLanguages = filteredLanguages.filter(([, parsed]) =>
-        String(parsed).toLowerCase().includes(filterValue.toLowerCase()),
-      );
-      if (!isOpen) {
-        setIsOpen(true);
-      }
-    }
-    setSelectOptions(
-      filteredLanguages
-        .sort((a, b) => sortfn(a[1], b[1], filterValue))
-        .map(([raw]) => raw),
-    );
-
-    // This useEffect hook should run *only* on when the filter value changes.
-    // eslint's exhaustive-deps rule does not support this use.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filterValue]);
-
-  const onInputClick = () => {
-    if (!isOpen) {
-      setIsOpen(true);
-    } else if (!inputValue) {
-      setIsOpen(false);
+  const handleSelectNewLanguage = (language: string | undefined) => {
+    if (language) {
+      dispatch(addLanguage(language));
+      setShowNewRow(false);
     }
   };
 
-  const onSelect = (_event?: React.MouseEvent, value?: string | number) => {
-    if (value && typeof value === 'string') {
-      setInputValue('');
-      setFilterValue('');
-      if (languages?.includes(value)) {
-        dispatch(removeLanguage(value));
-      } else {
-        dispatch(addLanguage(value));
-      }
-      setIsOpen(false);
+  const handleChangeLanguage = (
+    oldLang: string,
+    newLang: string | undefined,
+  ) => {
+    if (newLang) {
+      dispatch(replaceLanguage({ oldLanguage: oldLang, newLanguage: newLang }));
     }
   };
 
-  const onTextInputChange = (_event: React.FormEvent, value: string) => {
-    setInputValue(value);
-    setFilterValue(value);
+  const handleRemoveLanguage = (language: string) => {
+    dispatch(removeLanguage(language));
   };
-
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const onClearButtonClick = () => {
-    setInputValue('');
-    setFilterValue('');
-  };
-
-  const handleRemoveLang = (_event: React.MouseEvent, value: string) => {
-    dispatch(removeLanguage(value));
-    if (unknownLanguages.length > 0) {
-      unknownLanguages.filter((lang) => lang !== value);
-    }
-  };
-
-  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      variant='typeahead'
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-    >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={inputValue}
-          onClick={onInputClick}
-          onChange={onTextInputChange}
-          autoComplete='off'
-          placeholder='Select a language'
-          isExpanded={isOpen}
-        />
-        {inputValue && (
-          <TextInputGroupUtilities>
-            <Button
-              icon={<TimesIcon />}
-              variant='plain'
-              onClick={onClearButtonClick}
-              aria-label='Clear input'
-            />
-          </TextInputGroupUtilities>
-        )}
-      </TextInputGroup>
-    </MenuToggle>
-  );
 
   return (
-    <FormGroup isRequired={false} label='Languages'>
-      <Select
-        isScrollable
-        isOpen={isOpen}
-        selected={languages}
-        onSelect={onSelect}
-        onOpenChange={(isOpen) => setIsOpen(isOpen)}
-        toggle={toggle}
-        shouldFocusFirstItemOnOpen={false}
-      >
-        <SelectList>
-          {selectOptions.length > 0 ? (
-            selectOptions.map((option) => (
-              <SelectOption key={option} value={option}>
-                {parseLanguageOption(option)}
-              </SelectOption>
-            ))
-          ) : (
-            <SelectOption isDisabled>
-              {`No results found for "${filterValue}"`}
-            </SelectOption>
-          )}
-        </SelectList>
-      </Select>
+    <FormGroup isRequired={false} label='Languages' role='group'>
+      {languages.map((lang) => (
+        <LanguageRow
+          key={lang}
+          selectedLanguage={lang}
+          onSelect={(newLang) => handleChangeLanguage(lang, newLang)}
+          onRemove={() => handleRemoveLanguage(lang)}
+          existingLanguages={languages}
+        />
+      ))}
+      {showNewRow && (
+        <LanguageRow
+          onSelect={handleSelectNewLanguage}
+          onRemove={() => setShowNewRow(false)}
+          existingLanguages={languages}
+        />
+      )}
       <HelperText>
         <HelperTextItem>Search by country, language or UTF code</HelperTextItem>
       </HelperText>
       {unknownLanguages.length > 0 && (
         <HelperText>
-          <HelperTextItem
-            variant={'error'}
-          >{`Unknown languages: ${unknownLanguages.join(
+          <HelperTextItem variant='error'>{`Unknown languages: ${unknownLanguages.join(
             ', ',
           )}`}</HelperTextItem>
         </HelperText>
       )}
       {duplicateLanguages.length > 0 && (
         <HelperText>
-          <HelperTextItem
-            variant={'error'}
-          >{`Duplicated languages: ${duplicateLanguages.join(
+          <HelperTextItem variant='error'>{`Duplicated languages: ${duplicateLanguages.join(
             ', ',
           )}`}</HelperTextItem>
         </HelperText>
       )}
-      <LabelGroup numLabels={5} className='pf-v6-u-mt-sm pf-v6-u-w-100'>
-        {languages?.map((lang) => (
-          <Label
-            key={lang}
-            onClose={(e) => handleRemoveLang(e, lang)}
-            isCompact
-          >
-            {parseLanguageOption(lang)}
-          </Label>
-        ))}
-      </LabelGroup>
+      <Button
+        className='pf-v6-u-text-align-left pf-v6-u-mt-sm'
+        variant='link'
+        icon={<PlusCircleIcon />}
+        onClick={() => setShowNewRow(true)}
+        isDisabled={showNewRow}
+      >
+        Add language
+      </Button>
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -1,10 +1,12 @@
 import { screen } from '@testing-library/react';
 
-import { createUser, typeWithWait } from '@/test/testUtils';
+import { createUser } from '@/test/testUtils';
 
 import {
   clearKeyboardSearch,
   clearLanguageSearch,
+  clickAddLanguage,
+  removeLanguageAtIndex,
   renderLocaleStep,
   searchForKeyboard,
   searchForLanguage,
@@ -54,11 +56,11 @@ describe('Locale Component', () => {
       ).toBeInTheDocument();
     });
 
-    test('displays dropdowns with helper text', async () => {
+    test('displays add language button and dropdowns', async () => {
       renderLocaleStep();
 
       expect(
-        await screen.findByPlaceholderText(/select a language/i),
+        await screen.findByRole('button', { name: /add language/i }),
       ).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: /select a keyboard/i }),
@@ -67,6 +69,22 @@ describe('Locale Component', () => {
         screen.getByText(/Search by country, language or UTF code/i),
       ).toBeInTheDocument();
     });
+
+    test('disables Add language button while new language row is visible', async () => {
+      renderLocaleStep({ locale: { languages: [], keyboard: '' } });
+      const user = createUser();
+
+      const addButton = await screen.findByRole('button', {
+        name: /add language/i,
+      });
+      expect(addButton).toBeEnabled();
+
+      await user.click(addButton);
+      expect(addButton).toBeDisabled();
+
+      await removeLanguageAtIndex(user, 0);
+      expect(addButton).toBeEnabled();
+    });
   });
 
   describe('Language Search', () => {
@@ -74,9 +92,10 @@ describe('Locale Component', () => {
       renderLocaleStep();
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
 
-      const options = await screen.findAllByRole('option');
+      const options = await screen.findAllByRole('menuitem');
       expect(options.length).toBeGreaterThan(0);
       expect(options[0]).toHaveTextContent('Dutch');
     });
@@ -85,9 +104,10 @@ describe('Locale Component', () => {
       renderLocaleStep();
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
 
-      const nlOptions = await screen.findAllByRole('option');
+      const nlOptions = await screen.findAllByRole('menuitem');
       expect(nlOptions[0]).toHaveTextContent('Dutch - Aruba (nl_AW.UTF-8)');
       expect(nlOptions[1]).toHaveTextContent('Dutch - Belgium (nl_BE.UTF-8)');
       expect(nlOptions[2]).toHaveTextContent(
@@ -99,69 +119,61 @@ describe('Locale Component', () => {
       renderLocaleStep();
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'foo');
 
       expect(screen.getByText(/no results found/i)).toBeInTheDocument();
-
-      const option = await screen.findByRole('option', {
-        name: /no results found/i,
-      });
-      expect(option).toBeDisabled();
     });
 
     test('can clear language search', async () => {
       renderLocaleStep();
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
-      await screen.findAllByRole('option');
+      await screen.findAllByRole('menuitem');
 
       await clearLanguageSearch(user);
 
-      const languageInput =
-        await screen.findByPlaceholderText(/select a language/i);
-      expect(languageInput).toHaveValue('');
+      expect(screen.getByLabelText(/search by name/i)).toHaveValue('');
     });
   });
 
   describe('Language Selection', () => {
     test('can select a language', async () => {
-      renderLocaleStep();
+      renderLocaleStep({ locale: { languages: [], keyboard: '' } });
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
       expect(
         screen.getByRole('button', {
-          name: /close dutch - netherlands/i,
+          name: /remove language/i,
         }),
       ).toBeInTheDocument();
     });
 
     test('can select multiple languages', async () => {
-      renderLocaleStep();
+      renderLocaleStep({ locale: { languages: [], keyboard: '' } });
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'en');
       await selectLanguageOption(
         user,
         'English - United Kingdom (en_GB.UTF-8)',
       );
 
-      expect(
-        screen.getByRole('button', {
-          name: /close dutch - netherlands/i,
-        }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', {
-          name: /close english - united kingdom/i,
-        }),
-      ).toBeInTheDocument();
+      const removeButtons = screen.getAllByRole('button', {
+        name: /remove language/i,
+      });
+      expect(removeButtons).toHaveLength(2);
     });
   });
 
@@ -235,10 +247,14 @@ describe('Locale Component', () => {
       });
 
       expect(
-        screen.getByText('English - United States (en_US.UTF-8)'),
+        screen.getByRole('button', {
+          name: 'English - United States (en_US.UTF-8)',
+        }),
       ).toBeInTheDocument();
       expect(
-        screen.getByText('German - Germany (de_DE.UTF-8)'),
+        screen.getByRole('button', {
+          name: 'German - Germany (de_DE.UTF-8)',
+        }),
       ).toBeInTheDocument();
     });
 
@@ -268,6 +284,7 @@ describe('Locale Component', () => {
 
       expect(store.getState().wizard.locale.languages).toHaveLength(0);
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
@@ -283,9 +300,11 @@ describe('Locale Component', () => {
       });
       const user = createUser();
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
+      await clickAddLanguage(user);
       await searchForLanguage(user, 'en');
       await selectLanguageOption(
         user,
@@ -323,7 +342,7 @@ describe('Locale Component', () => {
       await searchForKeyboard(user, 'us-dvorak{Enter}');
 
       expect(
-        screen.getByPlaceholderText(/select a language/i),
+        screen.getByRole('heading', { name: /Locale/i }),
       ).toBeInTheDocument();
     });
 
@@ -331,14 +350,12 @@ describe('Locale Component', () => {
       renderLocaleStep();
       const user = createUser();
 
-      const languageInput =
-        await screen.findByPlaceholderText(/select a language/i);
-      await typeWithWait(user, languageInput, 'Dutch{Enter}');
+      await clickAddLanguage(user);
+      await searchForLanguage(user, 'Dutch{Enter}');
 
       expect(
-        screen.getByRole('button', { name: /select a keyboard/i }),
+        screen.getByRole('heading', { name: /Locale/i }),
       ).toBeInTheDocument();
-      expect(languageInput).toBeInTheDocument();
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Locale/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/helpers.tsx
@@ -19,24 +19,45 @@ export const renderLocaleStep = (
   return renderWithRedux(<LocaleStep />, wizardStateOverrides);
 };
 
+export const clickAddLanguage = async (user: UserEventInstance) => {
+  const addButton = await screen.findByRole('button', {
+    name: /add language/i,
+  });
+  await clickWithWait(user, addButton);
+  const toggle = await screen.findByRole('button', {
+    name: /select a language/i,
+  });
+  await clickWithWait(user, toggle);
+};
+
+export const removeLanguageAtIndex = async (
+  user: UserEventInstance,
+  index: number,
+) => {
+  const removeButtons = screen.getAllByRole('button', {
+    name: /remove language/i,
+  });
+  await clickWithWait(user, removeButtons[index]);
+};
+
 export const searchForLanguage = async (
   user: UserEventInstance,
   search: string,
 ) => {
-  const input = await screen.findByPlaceholderText(/select a language/i);
-  await typeWithWait(user, input, search);
+  const searchInput = await screen.findByLabelText(/search by name/i);
+  await typeWithWait(user, searchInput, search);
 };
 
 export const clearLanguageSearch = async (user: UserEventInstance) => {
-  const input = await screen.findByPlaceholderText(/select a language/i);
-  await clearWithWait(user, input);
+  const searchInput = screen.getByLabelText(/search by name/i);
+  await clearWithWait(user, searchInput);
 };
 
 export const selectLanguageOption = async (
   user: UserEventInstance,
   optionName: string | RegExp,
 ) => {
-  const option = await screen.findByRole('option', { name: optionName });
+  const option = await screen.findByRole('menuitem', { name: optionName });
   await clickWithWait(user, option);
 };
 

--- a/src/Components/sharedComponents/SearchableSelect.tsx
+++ b/src/Components/sharedComponents/SearchableSelect.tsx
@@ -24,20 +24,29 @@ type SearchableSelectProps = {
   options: SearchableSelectOption[];
   selected?: string | undefined;
   placeholder?: string | undefined;
+  searchPlaceholder?: string | undefined;
   onSelect: (value: string | undefined) => void;
+  isFullWidth?: boolean;
 };
 
 const SearchableSelect = ({
   options,
   selected,
   placeholder = 'Select an option',
+  searchPlaceholder = 'Search by name',
   onSelect,
+  isFullWidth = false,
 }: SearchableSelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
 
   const toggleRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  const selectedLabel = useMemo(
+    () => options.find((opt) => opt.value === selected)?.label,
+    [options, selected],
+  );
 
   const filteredOptions = useMemo(() => {
     if (!searchValue) {
@@ -67,8 +76,23 @@ const SearchableSelect = ({
       ref={toggleRef}
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
+      {...(isFullWidth && {
+        isFullWidth,
+        style: { width: '100%', minWidth: '100%' },
+      })}
     >
-      {selected || placeholder}
+      <span
+        style={{
+          display: 'block',
+          width: '100%',
+          whiteSpace: 'nowrap',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+        title={selectedLabel || selected || undefined}
+      >
+        {selectedLabel || selected || placeholder}
+      </span>
     </MenuToggle>
   );
 
@@ -83,8 +107,8 @@ const SearchableSelect = ({
         <MenuSearchInput>
           <SearchInput
             value={searchValue}
-            aria-label='Search by name'
-            placeholder='Search by name'
+            aria-label={searchPlaceholder}
+            placeholder={searchPlaceholder}
             onChange={(_event, value) => setSearchValue(value)}
             onClear={(event) => {
               event.stopPropagation();

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -1415,6 +1415,19 @@ export const wizardSlice = createSlice({
         }
       }
     },
+    replaceLanguage: (
+      state,
+      action: PayloadAction<{ oldLanguage: string; newLanguage: string }>,
+    ) => {
+      if (state.locale.languages) {
+        const index = state.locale.languages.findIndex(
+          (lang) => lang === action.payload.oldLanguage,
+        );
+        if (index !== -1) {
+          state.locale.languages[index] = action.payload.newLanguage;
+        }
+      }
+    },
     clearLanguages: (state) => {
       state.locale.languages = [];
     },
@@ -1792,6 +1805,7 @@ export const {
   removeUserGroup,
   addLanguage,
   removeLanguage,
+  replaceLanguage,
   clearLanguages,
   changeKeyboard,
   changeBlueprintName,

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -179,8 +179,12 @@ describe('Import modal', () => {
 
     // Locale
     await screen.findByRole('heading', { name: /Locale/ });
-    await screen.findByText('English - United States (en_US.UTF-8)');
-    await screen.findByText('Japanese - Japan (ja_JP.UTF-8)');
+    await screen.findByRole('button', {
+      name: 'English - United States (en_US.UTF-8)',
+    });
+    await screen.findByRole('button', {
+      name: 'Japanese - Japan (ja_JP.UTF-8)',
+    });
     expect(
       await screen.findByRole('button', { name: 'us' }),
     ).toBeInTheDocument();
@@ -276,7 +280,7 @@ describe('Import modal', () => {
     await waitFor(async () =>
       user.click(
         await screen.findByRole('button', {
-          name: /close invalid-language/i,
+          name: /remove language/i,
         }),
       ),
     );


### PR DESCRIPTION
## Summary
- Replace the multi-select typeahead language dropdown with individual rows, each with its own SearchableSelect and remove button
- Add an "Add language" button to insert new language rows
- Depends on #PR1 (locale-searchable-select) which introduces the SearchableSelect component

## Test plan
- [ ] Verify adding a language via "Add language" button works
- [ ] Verify removing a language via the remove button works
- [ ] Verify language search and selection within each row
- [ ] Verify pre-populated languages render correctly on edit
- [ ] Run unit tests: `npm run test:unit`
- [ ] Run Playwright E2E: locale customization flow
JIRA: HMS-9517