### PR TITLE
Wizard/Review: address follow-up comments from review step revamp

### DIFF
--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -106,7 +106,7 @@ test('Create a blueprint with Repeatable build customization', async ({
       .filter({ hasText: 'Enable repeatable build' });
     await expect(repeatableBuildCard).toBeVisible();
     await expect(repeatableBuildCard.getByText('Enabled')).toBeVisible();
-    await expect(repeatableBuildCard.getByText('2025-12-24')).toBeVisible();
+    await expect(repeatableBuildCard.getByText('Dec 24, 2025')).toBeVisible();
   });
 
   await test.step('Check Repeatable build step behaviour with 1 repo', async () => {
@@ -122,7 +122,7 @@ test('Create a blueprint with Repeatable build customization', async ({
     await expect(
       frame.getByRole('heading', { name: 'Enable repeatable build' }),
     ).toBeVisible();
-    await expect(frame.getByText('2025-12-24')).toBeVisible();
+    await expect(frame.getByText('Dec 24, 2025')).toBeVisible();
     await expect(frame.getByText('EPEL 10 Everything x86_64')).toBeVisible();
   });
 

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Kernel.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Kernel.tsx
@@ -34,8 +34,7 @@ export const Kernel = ({ shouldHide, oscapKernelArgs = [] }: KernelProps) => {
       )}
       {args.length > 0 && (
         <ReviewGroup
-          // TODO: maybe we should rename this to `Args`?
-          heading='Append'
+          heading='Args'
           description={
             <LabelMapper
               id='kernel-append-review'

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Kernel.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Kernel.tsx
@@ -38,6 +38,7 @@ export const Kernel = ({ shouldHide, oscapKernelArgs = [] }: KernelProps) => {
           description={
             <LabelMapper
               id='kernel-append-review'
+              ariaLabel='Kernel arguments'
               emptyMessage='No kernel args selected'
               items={args}
               oscapItems={oscapKernelArgs}

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Services.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Services.tsx
@@ -49,6 +49,7 @@ export const Services = ({
         description={
           <LabelMapper
             id='enabled-service-review'
+            ariaLabel='Enabled services'
             emptyMessage='No services selected'
             items={enabled}
             oscapItems={oscapServices.enabled}
@@ -60,6 +61,7 @@ export const Services = ({
         description={
           <LabelMapper
             id='disabled-service-review'
+            ariaLabel='Disabled services'
             emptyMessage='No services selected'
             items={disabled}
             oscapItems={oscapServices.disabled}
@@ -71,6 +73,7 @@ export const Services = ({
         description={
           <LabelMapper
             id='masked-service-review'
+            ariaLabel='Masked services'
             emptyMessage='No services selected'
             items={masked}
             oscapItems={oscapServices.masked}

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Timezone.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Timezone.tsx
@@ -25,7 +25,11 @@ export const Timezone = ({ shouldHide }: Hideable) => {
         <ReviewGroup
           heading='NTP servers'
           description={
-            <LabelMapper id='ntp-server-review' items={ntpServers} />
+            <LabelMapper
+              id='ntp-server-review'
+              ariaLabel='NTP servers'
+              items={ntpServers}
+            />
           }
           className='pf-v6-u-mb-md'
         />

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Users.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Users.tsx
@@ -47,7 +47,7 @@ export const Users = ({ shouldHide }: Hideable) => {
           items={users.map(({ groups }, index) => (
             <Truncate
               key={`inner-groups-key-${index}`}
-              content={groups.filter((group) => group.trim()).join('')}
+              content={groups.filter((group) => group.trim()).join(', ')}
               position='end'
               maxCharsDisplayed={15}
             />

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -402,7 +402,7 @@ describe('AdvancedSettingsOverview', () => {
         },
       );
 
-      expect(screen.getByText('Append')).toBeInTheDocument();
+      expect(screen.getByText('Args')).toBeInTheDocument();
       expect(screen.getByText('quiet')).toBeInTheDocument();
       expect(screen.getByText('splash')).toBeInTheDocument();
       expect(screen.getByText('rhgb')).toBeInTheDocument();
@@ -422,7 +422,7 @@ describe('AdvancedSettingsOverview', () => {
 
       expect(screen.getByText('Kernel package')).toBeInTheDocument();
       expect(screen.getByText('kernel-debug')).toBeInTheDocument();
-      expect(screen.getByText('Append')).toBeInTheDocument();
+      expect(screen.getByText('Args')).toBeInTheDocument();
       expect(screen.getByText('debug')).toBeInTheDocument();
       expect(screen.getByText('console=ttyS0')).toBeInTheDocument();
     });
@@ -440,7 +440,7 @@ describe('AdvancedSettingsOverview', () => {
       );
 
       expect(screen.queryByText('Kernel package')).not.toBeInTheDocument();
-      expect(screen.queryByText('Append')).not.toBeInTheDocument();
+      expect(screen.queryByText('Args')).not.toBeInTheDocument();
     });
 
     test('displays user-selected kernel args with blue labels', () => {
@@ -827,7 +827,7 @@ echo 'Hello there, General Kenobi!'`;
       );
 
       expect(screen.getByText('Groups')).toBeInTheDocument();
-      expect(screen.getByText('wheeldocker')).toBeInTheDocument();
+      expect(screen.getByText('wheel, docker')).toBeInTheDocument();
     });
 
     test('displays multiple users with all their data', () => {

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -403,6 +403,9 @@ describe('AdvancedSettingsOverview', () => {
       );
 
       expect(screen.getByText('Args')).toBeInTheDocument();
+      expect(
+        screen.getByRole('list', { name: 'Kernel arguments' }),
+      ).toBeInTheDocument();
       expect(screen.getByText('quiet')).toBeInTheDocument();
       expect(screen.getByText('splash')).toBeInTheDocument();
       expect(screen.getByText('rhgb')).toBeInTheDocument();
@@ -540,6 +543,9 @@ describe('AdvancedSettingsOverview', () => {
         },
       );
 
+      expect(
+        screen.getByRole('list', { name: 'Enabled services' }),
+      ).toBeInTheDocument();
       expect(screen.getByText('httpd')).toBeInTheDocument();
       expect(screen.getByText('sshd')).toBeInTheDocument();
     });

--- a/src/Components/CreateImageWizard/steps/Review/components/Content/components/PackageDetails.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Content/components/PackageDetails.tsx
@@ -36,6 +36,7 @@ export const PackageDetails = ({
       description={
         <LabelMapper
           id='package-review'
+          ariaLabel='Packages'
           emptyMessage='No packages selected'
           items={pkgs}
           oscapItems={oscapPackages}

--- a/src/Components/CreateImageWizard/steps/Review/components/Content/components/PackageGroupDetails.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Content/components/PackageGroupDetails.tsx
@@ -19,6 +19,7 @@ export const PackageGroupDetails = ({ shouldHide }: Hideable) => {
       description={
         <LabelMapper
           id='package-group-review'
+          ariaLabel='Package groups'
           emptyMessage='No groups selected'
           items={groups.map((group) => group.name)}
         />

--- a/src/Components/CreateImageWizard/steps/Review/components/Content/components/RepositoryDetails.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Content/components/RepositoryDetails.tsx
@@ -42,7 +42,7 @@ export const RepositoryDetails = ({ shouldHide }: Hideable) => {
     <ReviewGroup
       heading='Repositories'
       description={
-        <LabelGroup>
+        <LabelGroup aria-label='Custom repositories'>
           {validRepos.map((uuid, index) => (
             <RepositoryLabel
               key={`repo-review-${index}`}

--- a/src/Components/CreateImageWizard/steps/Review/components/Registration/components/RegisterNow.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Registration/components/RegisterNow.tsx
@@ -46,7 +46,7 @@ export const RegisterNow = ({
           )
         }
       />
-      <ReviewGroup heading='Organisation ID' description={orgId} />
+      <ReviewGroup heading='Organization ID' description={orgId} />
       <ReviewGroup heading='Activation key' description={activationKey} />
     </>
   );

--- a/src/Components/CreateImageWizard/steps/Review/components/Registration/tests/Registration.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Registration/tests/Registration.test.tsx
@@ -123,7 +123,7 @@ describe('Registration', () => {
       expect(
         screen.getByText('Register with Red Hat Subscription Manager (RHSM)'),
       ).toBeInTheDocument();
-      expect(screen.getByText('Organisation ID')).toBeInTheDocument();
+      expect(screen.getByText('Organization ID')).toBeInTheDocument();
       expect(screen.getByText('12345')).toBeInTheDocument();
       expect(screen.getByText('Activation key')).toBeInTheDocument();
       expect(screen.getByText('my-key')).toBeInTheDocument();

--- a/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/index.tsx
@@ -4,6 +4,7 @@ import { Card, CardBody } from '@patternfly/react-core';
 
 import { useAppSelector } from '@/store/hooks';
 import { selectSnapshotDate, selectUseLatest } from '@/store/slices';
+import { timestampToDisplayString } from '@/Utilities/time';
 import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import {
@@ -38,7 +39,10 @@ const RepeatableBuild = ({ restrictions }: ReviewCardProps) => {
             description={<StatusItem>Enabled</StatusItem>}
           />
           {snapshotDate && (
-            <ReviewGroup heading='Snapshot date' description={snapshotDate} />
+            <ReviewGroup
+              heading='Snapshot date'
+              description={timestampToDisplayString(snapshotDate)}
+            />
           )}
         </ReviewList>
       </CardBody>

--- a/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/index.tsx
@@ -29,7 +29,9 @@ const RepeatableBuild = ({ restrictions }: ReviewCardProps) => {
       <ReviewCardHeader
         title='Enable repeatable build'
         stepId={
-          isWizardRevampEnabled ? 'content-step' : 'wizard-repository-snapshot'
+          isWizardRevampEnabled
+            ? 'base-settings-step'
+            : 'wizard-repository-snapshot'
         }
       />
       <CardBody>

--- a/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/tests/RepeatableBuild.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/tests/RepeatableBuild.test.tsx
@@ -42,7 +42,7 @@ describe('RepeatableBuild', () => {
     );
 
     expect(screen.getByText('Snapshot date')).toBeInTheDocument();
-    expect(screen.getByText('2026-04-10')).toBeInTheDocument();
+    expect(screen.getByText('Apr 10, 2026')).toBeInTheDocument();
   });
 
   test('does not display snapshot date when not provided', () => {

--- a/src/Components/CreateImageWizard/steps/Review/components/Security/components/SecurityDetails.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Security/components/SecurityDetails.tsx
@@ -38,7 +38,7 @@ export const SecurityDetails = ({
         <ReviewGroup
           heading='Added items'
           description={
-            <LabelGroup>
+            <LabelGroup aria-label='Compliance added items'>
               {packages.length > 0 && <Label>{packages.length} packages</Label>}
               {services.total > 0 && <Label>{services.total} services</Label>}
             </LabelGroup>

--- a/src/Components/CreateImageWizard/steps/Review/components/Security/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Security/index.tsx
@@ -36,7 +36,9 @@ const Security = ({ restrictions, security }: SecurityCardProps) => {
           isOnPremise ? 'Security configuration' : 'Compliance configuration'
         }
         stepId={
-          isWizardRevampEnabled ? 'content-step' : 'wizard-repository-snapshot'
+          isWizardRevampEnabled
+            ? 'base-settings-step'
+            : 'wizard-repository-snapshot'
         }
       />
       <CardBody>

--- a/src/Components/CreateImageWizard/steps/Review/components/shared/LabelMapper.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/shared/LabelMapper.tsx
@@ -4,6 +4,7 @@ import { Label, LabelGroup } from '@patternfly/react-core';
 
 type LabelMapperProps = {
   id: string;
+  ariaLabel: string;
   emptyMessage?: string | undefined;
   items: string[];
   oscapItems?: string[] | undefined;
@@ -12,6 +13,7 @@ type LabelMapperProps = {
 
 export const LabelMapper = ({
   id,
+  ariaLabel,
   emptyMessage,
   items,
   oscapItems: oscap = [],
@@ -21,7 +23,7 @@ export const LabelMapper = ({
   const oscapSet = new Set(oscap);
 
   return (
-    <LabelGroup numLabels={numLabels}>
+    <LabelGroup numLabels={numLabels} aria-label={ariaLabel}>
       {items.map((item, index) => (
         <Label
           color={oscapSet.has(item) ? 'grey' : 'blue'}

--- a/src/Components/CreateImageWizard/steps/Review/components/shared/StatusItem.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/shared/StatusItem.tsx
@@ -1,7 +1,10 @@
 import React, { PropsWithChildren } from 'react';
 
 import { Icon } from '@patternfly/react-core';
-import { CheckCircleIcon, CloseIcon } from '@patternfly/react-icons';
+import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@patternfly/react-icons';
 
 export const StatusItem = ({
   variant = 'success',
@@ -11,7 +14,7 @@ export const StatusItem = ({
     <>
       <Icon status={variant}>
         {variant === 'success' && <CheckCircleIcon />}
-        {variant === 'danger' && <CloseIcon />}
+        {variant === 'danger' && <ExclamationCircleIcon />}
       </Icon>{' '}
       {children}
     </>

--- a/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
+++ b/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
@@ -400,7 +400,7 @@ const CreateImageWizard3 = () => {
         </WizardStep>
         <WizardStep
           name='Advanced settings'
-          id='advance-settings-step'
+          id='advanced-settings-step'
           navItem={CustomStatusNavItem}
           status={advancedSettingsHasErrors ? 'error' : 'default'}
           isHidden={

--- a/src/store/api/distributions/hooks.tsx
+++ b/src/store/api/distributions/hooks.tsx
@@ -71,7 +71,10 @@ export const isCustomizationSupported = (
   }
 
   // only rhel distros support registration
-  if (!ctx.isRhel && customization === 'registration') {
+  if (
+    !ctx.isRhel &&
+    (customization === 'registration' || customization === 'aap')
+  ) {
     return false;
   }
 

--- a/src/store/api/distributions/tests/hooks.test.tsx
+++ b/src/store/api/distributions/tests/hooks.test.tsx
@@ -400,6 +400,28 @@ describe('isCustomizationSupported', () => {
       ).toBe(false);
     });
 
+    it('should hide aap for non-RHEL distributions', () => {
+      const nonRhelCtx: SupportContext = {
+        isImageMode: false,
+        isOnPremise: false,
+        isRhel: false,
+      };
+
+      expect(isCustomizationSupported('aap', undefined, nonRhelCtx)).toBe(
+        false,
+      );
+    });
+
+    it('should allow aap for RHEL distributions', () => {
+      const rhelCtx: SupportContext = {
+        isImageMode: false,
+        isOnPremise: false,
+        isRhel: true,
+      };
+
+      expect(isCustomizationSupported('aap', undefined, rhelCtx)).toBe(true);
+    });
+
     it('should allow registration for RHEL distributions', () => {
       const rhelCtx: SupportContext = {
         isImageMode: false,


### PR DESCRIPTION
## Summary

Addresses unresolved review comments from #4294 (review step revamp) covering text corrections, accessibility, navigation bugs, and a restrictions fix.

## Changes
- Fix text: rename kernel heading to 'Args', comma-separate user groups, use American spelling 'Organization ID', and format snapshot dates with `timestampToDisplayString`
- Add `aria-label` to all `LabelGroup` components via a new required `ariaLabel` prop on `LabelMapper`, plus direct labels on `SecurityDetails` and `RepositoryDetails`
- Use `ExclamationCircleIcon` for the danger variant in `StatusItem` to match the PF6 status icon pattern
- Fix edit button navigation: correct the wizard step ID typo (`advance-settings-step` → `advanced-settings-step`) and point RepeatableBuild/Security cards to `base-settings-step`
- Hide registration card for non-RHEL distros by adding `aap` to the non-RHEL guard in `isCustomizationSupported`