### PR TITLE
playwright: Migrate tests to Wizard v3 (HMS-10492)

### DIFF
--- a/playwright/Basic/basic.spec.ts
+++ b/playwright/Basic/basic.spec.ts
@@ -21,17 +21,28 @@ test('Basic create/build/delete test', async ({ page, cleanup }) => {
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
-  await navigateToLandingPage(page);
-  const frame = ibFrame(page);
 
-  await test.step('Navigate to review step in Wizard', async () => {
-    await fillInImageOutput(frame);
-    await registerLater(frame);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
   });
 
-  await test.step('Fill in BP details', async () => {
+  const frame = ibFrame(page);
+
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
     await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
+    await fillInImageOutput(frame);
+    await registerLater(frame);
+  });
+
+  await test.step('Review image', async () => {
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -76,17 +87,28 @@ test('Basic delete BP tests', async ({ page }) => {
   const blueprintName = uuidv4();
 
   await ensureAuthenticated(page);
-  await navigateToLandingPage(page);
-  const frame = ibFrame(page);
 
-  await test.step('Navigate to review step in Wizard', async () => {
-    await fillInImageOutput(frame);
-    await registerLater(frame);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
   });
 
-  await test.step('Fill in BP details', async () => {
+  const frame = ibFrame(page);
+
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
     await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
+    await fillInImageOutput(frame);
+    await registerLater(frame);
+  });
+
+  await test.step('Review image', async () => {
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/Basic/basic.spec.ts
+++ b/playwright/Basic/basic.spec.ts
@@ -13,6 +13,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../helpers/wizardHelpers';
 
@@ -29,10 +30,7 @@ test('Basic create/build/delete test', async ({ page, cleanup }) => {
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {
@@ -98,10 +96,7 @@ test('Basic delete BP tests', async ({ page }) => {
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Basic/basic.spec.ts
+++ b/playwright/Basic/basic.spec.ts
@@ -29,7 +29,10 @@ test('Basic create/build/delete test', async ({ page, cleanup }) => {
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -95,7 +98,10 @@ test('Basic delete BP tests', async ({ page }) => {
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Basic/blueprintUrlParam.spec.ts
+++ b/playwright/Basic/blueprintUrlParam.spec.ts
@@ -14,6 +14,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../helpers/wizardHelpers';
 
@@ -35,7 +36,7 @@ test('Navigate with valid blueprint_id URL parameter', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Create a blueprint', async () => {

--- a/playwright/Basic/blueprintUrlParam.spec.ts
+++ b/playwright/Basic/blueprintUrlParam.spec.ts
@@ -27,14 +27,22 @@ test('Navigate with valid blueprint_id URL parameter', async ({
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
-  await navigateToLandingPage(page);
+
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
   await test.step('Create a blueprint', async () => {
+    await fillInDetails(frame, blueprintName);
     await fillInImageOutput(frame);
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await createBlueprint(frame, blueprintName);
   });
 

--- a/playwright/Basic/imageMode.spec.ts
+++ b/playwright/Basic/imageMode.spec.ts
@@ -13,6 +13,7 @@ import {
   deleteBlueprint,
   exportBlueprint,
   importBlueprint,
+  openWizard,
 } from '../helpers/wizardHelpers';
 
 test('Image mode blueprint create, edit, export, import', async ({
@@ -46,7 +47,7 @@ test('Image mode blueprint create, edit, export, import', async ({
 
   const frame = ibFrame(page);
 
-  await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  await openWizard(frame);
 
   // Skip the test if the image mode flag is not enabled in this environment
   const imageModeToggle = frame.getByRole('button', { name: 'Image mode' });

--- a/playwright/Basic/imageMode.spec.ts
+++ b/playwright/Basic/imageMode.spec.ts
@@ -89,15 +89,11 @@ test('Image mode blueprint create, edit, export, import', async ({
   });
 
   await test.step('Create blueprint', async () => {
-    const firstNextButton = frame.getByRole('button', {
-      name: 'Next',
-      exact: true,
+    const reviewImageButton = frame.getByRole('button', {
+      name: 'Review image',
     });
-    await expect(firstNextButton).toBeEnabled({ timeout: 10000 });
-    await firstNextButton.click();
-    const nextButton = frame.getByRole('button', { name: 'Next', exact: true });
-    await expect(nextButton).toBeEnabled({ timeout: 10000 });
-    await nextButton.click();
+    await expect(reviewImageButton).toBeEnabled({ timeout: 10000 });
+    await reviewImageButton.click();
     await createBlueprint(frame, blueprintName);
   });
 
@@ -126,13 +122,11 @@ test('Image mode blueprint create, edit, export, import', async ({
       frame.getByRole('textbox', { name: 'blueprint user name' }),
     ).toHaveValue('testuser');
 
-    await frame.getByRole('button', { name: 'Next', exact: true }).click();
-    const saveNextButton = frame.getByRole('button', {
-      name: 'Next',
-      exact: true,
+    const reviewImageButton = frame.getByRole('button', {
+      name: 'Review image',
     });
-    await expect(saveNextButton).toBeEnabled({ timeout: 10000 });
-    await saveNextButton.click();
+    await expect(reviewImageButton).toBeEnabled({ timeout: 10000 });
+    await reviewImageButton.click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();

--- a/playwright/BootTests/AAP/AAP.boot.ts
+++ b/playwright/BootTests/AAP/AAP.boot.ts
@@ -76,7 +76,15 @@ test('AAP registration boot integration test', async ({ page, cleanup }) => {
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
     await registerLater(frame);
   });
@@ -92,11 +100,7 @@ test('AAP registration boot integration test', async ({ page, cleanup }) => {
     await frame
       .getByRole('textbox', { name: 'File upload' })
       .fill(validCertificate);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/BootTests/AAP/AAP.boot.ts
+++ b/playwright/BootTests/AAP/AAP.boot.ts
@@ -13,6 +13,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../../helpers/wizardHelpers';
 import {
@@ -77,7 +78,7 @@ test('AAP registration boot integration test', async ({ page, cleanup }) => {
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
@@ -15,6 +15,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
 } from '../../helpers/wizardHelpers';
 import {
   buildImage,
@@ -79,7 +80,7 @@ test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
@@ -78,33 +78,33 @@ test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
   });
 
   await test.step('Register system', async () => {
-    await page.getByRole('button', { name: 'Register' }).click();
-    await page
+    await frame
       .getByRole('radio', { name: 'Automatically register to Red Hat' })
       .click();
   });
 
   await test.step('Select and fill the Compliance step', async () => {
-    await frame
-      .getByLabel('Wizard steps')
-      .getByRole('button', { name: 'Security' })
-      .click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame
       .getByRole('radio', { name: 'Use a custom compliance policy' })
       .click();
     await frame.getByRole('button', { name: 'None' }).click();
     await frame.getByRole('option', { name: policyName }).click();
-    await expect(frame.getByRole('button', { name: policyName })).toBeVisible(); // Wait for the policy to get selected
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await expect(frame.getByRole('button', { name: policyName })).toBeVisible();
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/BootTests/Compliance/ComplianceOpenSCAP.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceOpenSCAP.boot.ts
@@ -13,6 +13,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
 } from '../../helpers/wizardHelpers';
 import {
   buildImage,
@@ -45,7 +46,7 @@ test('Compliance step integration test - OpenSCAP default profile', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/BootTests/Compliance/ComplianceOpenSCAP.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceOpenSCAP.boot.ts
@@ -44,13 +44,20 @@ test('Compliance step integration test - OpenSCAP default profile', async ({
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
   });
 
   await test.step('Register system', async () => {
-    await page.getByRole('button', { name: 'Register' }).click();
-    await page
+    await frame
       .getByRole('radio', { name: 'Automatically register to Red Hat' })
       .click();
   });
@@ -63,16 +70,15 @@ test('Compliance step integration test - OpenSCAP default profile', async ({
   const baselineOscapScorePercent = 90;
 
   await test.step('Select OpenSCAP profile', async () => {
-    await frame
-      .getByLabel('Wizard steps')
-      .getByRole('button', { name: 'Security' })
-      .click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame
       .getByRole('radio', { name: 'Use a default OpenSCAP profile' })
       .click();
-    const profileDropdown = frame.getByRole('textbox', {
-      name: 'Type to filter',
-    });
+    const profileDropdown = frame
+      .getByRole('textbox', {
+        name: 'Type to filter',
+      })
+      .nth(1);
     await expect(profileDropdown).toBeEnabled({ timeout: 30000 });
     await profileDropdown.click();
     await expect(frame.getByRole('option').first()).toBeVisible({
@@ -87,7 +93,9 @@ test('Compliance step integration test - OpenSCAP default profile', async ({
   });
 
   await test.step('Add perl-XML-XPath package for OSCAP results parsing', async () => {
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill('perl-XML-XPath');
@@ -95,11 +103,7 @@ test('Compliance step integration test - OpenSCAP default profile', async ({
       frame.getByRole('option', { name: 'perl-XML-XPath' }),
     ).toBeVisible({ timeout: 60000 });
     await frame.getByRole('option', { name: 'perl-XML-XPath' }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
@@ -70,20 +70,30 @@ test('Content integration test - Non repeatable build - URL source', async ({
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
     await registerLater(frame);
   });
 
   await test.step('Disable repeatable build', async () => {
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame
       .getByRole('radio', { name: 'Disable repeatable build' })
       .click();
   });
 
   await test.step('Select the repository', async () => {
-    await frame.getByRole('button', { name: 'Repositories' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
@@ -91,16 +101,11 @@ test('Content integration test - Non repeatable build - URL source', async ({
   });
 
   await test.step('Select the package', async () => {
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
     await frame.getByRole('option', { name: packageName }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -209,20 +214,30 @@ test('Content integration test - Non repeatable build - Upload source', async ({
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
     await registerLater(frame);
   });
 
   await test.step('Disable repeatable build', async () => {
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame
       .getByRole('radio', { name: 'Disable repeatable build' })
       .click();
   });
 
   await test.step('Select the repository', async () => {
-    await frame.getByRole('button', { name: 'Repositories' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
@@ -235,7 +250,6 @@ test('Content integration test - Non repeatable build - Upload source', async ({
   });
 
   await test.step('Select the package', async () => {
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
@@ -250,11 +264,7 @@ test('Content integration test - Non repeatable build - Upload source', async ({
       frame.getByRole('option', { name: dependencyPackageName }),
     ).toBeVisible();
     await frame.getByRole('option', { name: dependencyPackageName }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -316,20 +326,30 @@ test('Content integration test - Non repeatable build - Community repository', a
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
     await registerLater(frame);
   });
 
   await test.step('Disable repeatable build', async () => {
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame
       .getByRole('radio', { name: 'Disable repeatable build' })
       .click();
   });
 
   await test.step('Select the repository', async () => {
-    await frame.getByRole('button', { name: 'Repositories' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
@@ -337,16 +357,11 @@ test('Content integration test - Non repeatable build - Community repository', a
   });
 
   await test.step('Select the package', async () => {
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
     await frame.getByRole('option', { name: packageName }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
@@ -16,6 +16,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../../helpers/wizardHelpers';
 import {
@@ -71,7 +72,7 @@ test('Content integration test - Non repeatable build - URL source', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {
@@ -215,7 +216,7 @@ test('Content integration test - Non repeatable build - Upload source', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {
@@ -327,7 +328,7 @@ test('Content integration test - Non repeatable build - Community repository', a
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/BootTests/Content/ContentRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentRepeatable.boot.ts
@@ -15,6 +15,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../../helpers/wizardHelpers';
 import {
@@ -115,7 +116,7 @@ test('Content integration test - Repeatable build - URL source', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/BootTests/Content/ContentRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentRepeatable.boot.ts
@@ -114,13 +114,21 @@ test('Content integration test - Repeatable build - URL source', async ({
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
     await registerLater(frame);
   });
 
   await test.step('Enable repeatable build and select snapshot date', async () => {
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame.getByRole('radio', { name: 'Enable repeatable build' }).click();
 
     // TODO Would this work on the 1st?
@@ -139,7 +147,9 @@ test('Content integration test - Repeatable build - URL source', async ({
   });
 
   await test.step('Select the repository', async () => {
-    await frame.getByRole('button', { name: 'Repositories' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
@@ -147,16 +157,11 @@ test('Content integration test - Repeatable build - URL source', async ({
   });
 
   await test.step('Select the package', async () => {
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
     await frame.getByRole('option', { name: packageName }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/BootTests/Content/ContentTemplate.boot.ts
+++ b/playwright/BootTests/Content/ContentTemplate.boot.ts
@@ -22,6 +22,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerAutomatically,
 } from '../../helpers/wizardHelpers';
 import {
@@ -168,7 +169,7 @@ test('Content integration test - Content Template', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Set Blueprint name', async () => {

--- a/playwright/BootTests/Content/ContentTemplate.boot.ts
+++ b/playwright/BootTests/Content/ContentTemplate.boot.ts
@@ -167,6 +167,14 @@ test('Content integration test - Content Template', async ({
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Set Blueprint name', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
   await test.step('Fill in image output', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
   });
@@ -176,7 +184,7 @@ test('Content integration test - Content Template', async ({
   });
 
   await test.step('Select Content Template in Repeatable build step', async () => {
-    await frame.getByRole('button', { name: 'Repeatable build' }).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame.getByRole('radio', { name: 'Use a content template' }).click();
 
     const templatesDropdown = frame.getByRole('button', {
@@ -202,7 +210,9 @@ test('Content integration test - Content Template', async ({
   // SMELL: This shouldn't be necessary, but without loading this wizard step, the package search will fail
   await test.step('Verify repositories are included from template', async () => {
     // Navigate to Repositories step to ensure the template's repositories are loaded
-    await frame.getByRole('button', { name: 'Repositories' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await expect(
       frame.getByRole('row').filter({ hasText: repositoryName }),
     ).toBeVisible({ timeout: 30000 });
@@ -213,7 +223,6 @@ test('Content integration test - Content Template', async ({
 
   // Custom package is installed here, not layered package (pcs)
   await test.step('Select the package from custom repository', async () => {
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill(packageName);
@@ -224,13 +233,9 @@ test('Content integration test - Content Template', async ({
   });
 
   await test.step('Set hostname for system identification', async () => {
-    await frame.getByRole('button', { name: 'Hostname' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await frame.getByRole('textbox', { name: 'hostname input' }).fill(hostname);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Set Blueprint name', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Save the Blueprint', async () => {

--- a/playwright/BootTests/Satellite/Satellite.boot.ts
+++ b/playwright/BootTests/Satellite/Satellite.boot.ts
@@ -18,6 +18,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
 } from '../../helpers/wizardHelpers';
 import {
   buildImage,
@@ -46,7 +47,7 @@ test('Satellite registration boot integration test', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/BootTests/Satellite/Satellite.boot.ts
+++ b/playwright/BootTests/Satellite/Satellite.boot.ts
@@ -45,9 +45,16 @@ test('Satellite registration boot integration test', async ({
   await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output', async () => {
     await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
-    await page.getByRole('button', { name: 'Register' }).click();
   });
 
   await test.step('Select and fill Satellite on Registration step', async () => {
@@ -62,11 +69,7 @@ test('Satellite registration boot integration test', async ({
     await frame
       .getByRole('textbox', { name: 'File upload' })
       .fill(validCertificate);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/Cockpit/cockpit.spec.ts
+++ b/playwright/Cockpit/cockpit.spec.ts
@@ -91,14 +91,14 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
   await test.step('Cockpit cloud upload', async () => {
     await frame.getByTestId('blueprints-create-button').click();
     await expect(
-      frame.getByRole('heading', { name: 'Image output' }),
+      frame.getByRole('heading', { name: 'Base settings' }),
     ).toBeVisible();
     await frame.getByRole('checkbox', { name: /amazon web services/i }).click();
-    await frame.getByRole('button', { name: 'Next', exact: true }).click();
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame.getByRole('button', { name: 'Back', exact: true }).click();
 
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await expect(
       frame.getByRole('heading', { name: 'Image details' }),
     ).toBeVisible();
@@ -108,7 +108,7 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
     await expect(
       frame.getByRole('textbox', { name: 'blueprint name' }),
     ).toHaveValue(blueprintName);
-    await frame.getByRole('button', { name: 'Next', exact: true }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
 
     await frame.getByRole('button', { name: 'Create blueprint' }).click();
     await frame.getByTestId('close-button-saveandbuild-modal').click();

--- a/playwright/Customizations/AAP.spec.ts
+++ b/playwright/Customizations/AAP.spec.ts
@@ -18,6 +18,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
 } from '../helpers/wizardHelpers';
 
@@ -70,7 +71,7 @@ test('Create a blueprint with AAP registration customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/AAP.spec.ts
+++ b/playwright/Customizations/AAP.spec.ts
@@ -17,7 +17,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
 } from '../helpers/wizardHelpers';
@@ -64,11 +63,21 @@ test('Create a blueprint with AAP registration customization', async ({
   cleanup.add(() => deleteBlueprint(page, blueprintName));
   await ensureAuthenticated(page);
 
-  // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
   });
@@ -154,11 +163,7 @@ test('Create a blueprint with AAP registration customization', async ({
   });
 
   await test.step('Complete AAP configuration and proceed to review', async () => {
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -167,7 +172,7 @@ test('Create a blueprint with AAP registration customization', async ({
 
   await test.step('Edit BP and verify AAP configuration persists', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Register' }).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
 
     await expect(
       frame.getByRole('textbox', { name: 'ansible callback url' }),
@@ -179,7 +184,7 @@ test('Create a blueprint with AAP registration customization', async ({
       frame.getByRole('textbox', { name: 'File upload' }),
     ).toHaveValue(validCertificate);
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -203,8 +208,9 @@ test('Create a blueprint with AAP registration customization', async ({
 
   await test.step('Review imported BP', async (step) => {
     step.skip(!isHosted(), 'Importing is not available in the plugin');
-    await fillInImageOutputGuest(page);
-    await page.getByRole('button', { name: 'Register' }).click();
+    await fillInImageOutput(page);
+    await page.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await page.getByRole('button', { name: 'Base settings' }).click();
     await expect(
       page.getByRole('textbox', { name: 'ansible callback url' }),
     ).toHaveValue(validCallbackUrl);

--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../BootTests/Compliance/helpers';
 import { test } from '../fixtures/customizations';
 import { isServiceAvailable } from '../helpers/apiHelpers';
-import { isHosted, togglePreview } from '../helpers/helpers';
+import { isHosted } from '../helpers/helpers';
 import { login } from '../helpers/login';
 import {
   fillInImageOutput,

--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -20,6 +20,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../helpers/wizardHelpers';
 
@@ -55,7 +56,7 @@ test('Create a blueprint with Compliance policy selected', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {
@@ -134,7 +135,7 @@ test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -48,18 +48,26 @@ test('Create a blueprint with Compliance policy selected', async ({
 
   await login(page, true);
 
-  // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
   });
 
   await test.step('Select Compliance and choose a mock policy', async () => {
-    await frame.getByRole('button', { name: 'Security' }).nth(1).click();
-
     await frame
       .getByRole('radio', { name: 'Use a custom Compliance policy' })
       .check();
@@ -79,11 +87,7 @@ test('Create a blueprint with Compliance policy selected', async ({
       frame.getByRole('button', { name: 'placehollder' }),
     ).toBeVisible();
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -92,7 +96,7 @@ test('Create a blueprint with Compliance policy selected', async ({
 
   await test.step('Edit BP and verify Compliance selection persisted', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Security' }).nth(1).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
 
     await expect(
       frame.getByRole('radio', { name: 'Use a custom compliance policy' }),
@@ -126,24 +130,23 @@ test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
     });
   });
 
-  await togglePreview(page);
-  await page.goto('/insights/image-builder/imagewizard?release=rhel9');
+  await navigateToLandingPage(page);
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
-    await expect(frame.getByTestId('release_select')).toHaveText(
-      'Red Hat Enterprise Linux (RHEL) 9',
-    );
-    await frame.getByRole('checkbox', { name: 'Virtualization' }).click();
-    await frame.getByRole('button', { name: 'Next' }).click();
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
+    await fillInImageOutput(frame, 'qcow2', 'rhel9', 'x86_64');
     await registerLater(frame);
   });
 
   await test.step('Select and fill the Compliance step', async () => {
-    await frame
-      .getByLabel('Wizard steps')
-      .getByRole('button', { name: 'Security' })
-      .click();
     await frame
       .getByRole('radio', { name: 'Use a custom compliance policy' })
       .click();
@@ -155,11 +158,7 @@ test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
     await expect(frame.getByRole('option', { name: policyName })).toBeVisible();
     await frame.getByRole('option', { name: policyName }).click();
     await expect(frame.getByRole('button', { name: policyName })).toBeVisible();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -41,7 +41,10 @@ test('Create a blueprint with Disk customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -203,6 +206,9 @@ test('Create a blueprint with Disk customization', async ({
 
   await test.step('Review imported BP', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
 

--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -19,6 +19,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -41,10 +42,7 @@ test('Create a blueprint with Disk customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -18,7 +18,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -35,19 +34,27 @@ test('Create a blueprint with Disk customization', async ({
 
   await ensureAuthenticated(page);
 
-  // Login, navigate to IB and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
   });
 
   await test.step('Check basic structure of advanced partitioning', async () => {
-    await frame
-      .getByRole('button', { name: 'File system configuration' })
-      .click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await frame
       .getByRole('radio', { name: 'Advanced disk partitioning' })
       .click();
@@ -120,9 +127,8 @@ test('Create a blueprint with Disk customization', async ({
     await frame.getByRole('option', { name: 'KiB' }).click();
   });
 
-  await test.step('Fill the BP details', async () => {
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-    await fillInDetails(frame, blueprintName);
+  await test.step('Review image', async () => {
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -131,9 +137,7 @@ test('Create a blueprint with Disk customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame
-      .getByRole('button', { name: 'File system configuration' })
-      .click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     const removeRootButton = frame
       .getByRole('row')
@@ -170,7 +174,7 @@ test('Create a blueprint with Disk customization', async ({
     await secondRow.getByRole('button', { name: 'xfs' }).click();
     await frame.getByRole('option', { name: 'ext4' }).click();
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -198,10 +202,9 @@ test('Create a blueprint with Disk customization', async ({
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame
-      .getByRole('button', { name: 'File system configuration' })
-      .click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     const removeRootButton = frame
       .getByRole('row')

--- a/playwright/Customizations/Filesystem.spec.ts
+++ b/playwright/Customizations/Filesystem.spec.ts
@@ -20,6 +20,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -42,10 +43,7 @@ test('Create a blueprint with Filesystem customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Filesystem.spec.ts
+++ b/playwright/Customizations/Filesystem.spec.ts
@@ -42,7 +42,10 @@ test('Create a blueprint with Filesystem customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -227,6 +230,9 @@ test('Create a blueprint with Filesystem customization', async ({
 
   await test.step('Review imported BP', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
 

--- a/playwright/Customizations/Filesystem.spec.ts
+++ b/playwright/Customizations/Filesystem.spec.ts
@@ -19,7 +19,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -36,19 +35,27 @@ test('Create a blueprint with Filesystem customization', async ({
 
   await ensureAuthenticated(page);
 
-  // Login, navigate to IB and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
   });
 
   await test.step('Check URLs for documentation', async () => {
-    await frame
-      .getByRole('button', { name: 'File system configuration' })
-      .click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await frame
       .getByRole('radio', { name: 'Use automatic partitioning' })
       .click();
@@ -137,9 +144,8 @@ test('Create a blueprint with Filesystem customization', async ({
     await expect(closeTmpButton).toBeEnabled();
   });
 
-  await test.step('Fill the BP details', async () => {
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-    await fillInDetails(frame, blueprintName);
+  await test.step('Review image', async () => {
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -148,9 +154,7 @@ test('Create a blueprint with Filesystem customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame
-      .getByRole('button', { name: 'File system configuration' })
-      .click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     await expect(
       frame.getByRole('radio', {
@@ -194,7 +198,7 @@ test('Create a blueprint with Filesystem customization', async ({
     await frame.getByRole('button', { name: 'MiB' }).click();
     await frame.getByRole('option', { name: 'GiB' }).click();
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -222,10 +226,9 @@ test('Create a blueprint with Filesystem customization', async ({
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame
-      .getByRole('button', { name: 'File system configuration' })
-      .click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     await expect(
       frame.getByRole('checkbox', {

--- a/playwright/Customizations/FipsMode.spec.ts
+++ b/playwright/Customizations/FipsMode.spec.ts
@@ -14,6 +14,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../helpers/wizardHelpers';
 
@@ -46,7 +47,7 @@ test('FIPS switch toggles and persists through save', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/FipsMode.spec.ts
+++ b/playwright/Customizations/FipsMode.spec.ts
@@ -39,16 +39,26 @@ test('FIPS switch toggles and persists through save', async ({
 
   await ensureAuthenticated(page);
 
-  // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to Security step and toggle FIPS on', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
+  });
 
-    await frame.getByRole('button', { name: 'Security' }).nth(1).click();
-
+  await test.step('Toggle FIPS and select OpenSCAP profile', async () => {
     const fipsSwitch = frame.locator('label[for="fips-enabled-switch"]');
     await expect(fipsSwitch).toBeVisible();
     await fipsSwitch.click();
@@ -73,18 +83,14 @@ test('FIPS switch toggles and persists through save', async ({
     await expect(fipsInput).toBeChecked();
   });
 
-  await test.step('Navigate to Kernel step and verify FIPS alert', async () => {
-    await frame.getByRole('button', { name: 'Kernel' }).click();
+  await test.step('Navigate to Advanced settings and verify FIPS alert on Kernel', async () => {
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(
       frame.getByText(
         'Kernel will be configured to use FIPS, no additional configuration needed.',
       ),
     ).toBeVisible();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -93,7 +99,7 @@ test('FIPS switch toggles and persists through save', async ({
 
   await test.step('Edit BP and verify FIPS remained enabled', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Security' }).nth(1).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     const fipsInput = frame.locator('#fips-enabled-switch');
     await expect(fipsInput).toBeChecked();
   });

--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -18,7 +18,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -35,17 +34,27 @@ test('Create a blueprint with Firewall customization', async ({
 
   await ensureAuthenticated(page);
 
-  // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
   });
 
   await test.step('Select and correctly fill the ports in Firewall step', async () => {
-    await frame.getByRole('button', { name: 'Firewall' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByPlaceholder('Enter port (e.g., 8080:tcp)').fill('80:tcp');
     await page.keyboard.press('Enter');
@@ -135,12 +144,8 @@ test('Create a blueprint with Firewall customization', async ({
     ).toBeVisible();
   });
 
-  await test.step('Fill the BP details', async () => {
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-    await fillInDetails(frame, blueprintName);
-  });
-
   await test.step('Create BP and verify firewall payload', async () => {
+    await frame.getByRole('button', { name: 'Review image' }).click();
     if (!isHosted()) {
       await createBlueprint(frame, blueprintName);
       return;
@@ -166,7 +171,7 @@ test('Create a blueprint with Firewall customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Firewall' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     await frame.getByPlaceholder('Enter port (e.g., 8080:tcp)').fill('90:tcp');
     await page.keyboard.press('Enter');
@@ -189,7 +194,7 @@ test('Create a blueprint with Firewall customization', async ({
     await expect(frame.getByText('telnet.socket')).toBeHidden();
     await expect(frame.getByText('cloud-init')).toBeHidden();
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -217,8 +222,9 @@ test('Create a blueprint with Firewall customization', async ({
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Firewall' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     await expect(frame.getByText('90:tcp')).toBeVisible();
     await expect(frame.getByText('x').nth(0)).toBeVisible();
@@ -242,13 +248,28 @@ test('Firewall fields collapse chips with show less / more', async ({
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
-  await navigateToLandingPage(page);
+
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to Firewall step', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Firewall' }).click();
+  });
+
+  await test.step('Open Advanced settings', async () => {
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
   });
 
   await test.step('Ports: shows all chips when 4 or fewer', async () => {
@@ -313,7 +334,7 @@ test('Firewall fields collapse chips with show less / more', async ({
       await page.keyboard.press('Enter');
     }
 
-    await expect(frame.getByText('ssh')).toBeVisible();
+    await expect(frame.getByText('ssh', { exact: true })).toBeVisible();
     await expect(frame.getByText('http', { exact: true })).toBeVisible();
     await expect(frame.getByText('https')).toBeVisible();
     await expect(frame.getByText('dhcp')).toBeVisible();

--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -41,7 +41,10 @@ test('Create a blueprint with Firewall customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -223,6 +226,9 @@ test('Create a blueprint with Firewall customization', async ({
 
   await test.step('Review imported BP', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
@@ -256,7 +262,10 @@ test('Firewall fields collapse chips with show less / more', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -19,6 +19,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -41,10 +42,7 @@ test('Create a blueprint with Firewall customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {
@@ -262,10 +260,7 @@ test('Firewall fields collapse chips with show less / more', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Hostname.spec.ts
+++ b/playwright/Customizations/Hostname.spec.ts
@@ -18,7 +18,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -37,22 +36,29 @@ test('Create a blueprint with Hostname customization', async ({
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
   });
 
   await test.step('Select and fill the Hostname step', async () => {
-    await frame.getByRole('button', { name: 'Hostname' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await frame.getByRole('textbox', { name: 'hostname input' }).fill(hostname);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -61,12 +67,12 @@ test('Create a blueprint with Hostname customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Hostname' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await frame.getByRole('textbox', { name: 'hostname input' }).click();
     await frame
       .getByRole('textbox', { name: 'hostname input' })
       .fill(hostname + 'edited');
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -94,8 +100,9 @@ test('Create a blueprint with Hostname customization', async ({
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Hostname' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(
       frame.getByRole('textbox', { name: 'hostname input' }),
     ).toHaveValue(hostname + 'edited');

--- a/playwright/Customizations/Hostname.spec.ts
+++ b/playwright/Customizations/Hostname.spec.ts
@@ -43,7 +43,10 @@ test('Create a blueprint with Hostname customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -101,6 +104,9 @@ test('Create a blueprint with Hostname customization', async ({
 
   await test.step('Review imported BP', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(

--- a/playwright/Customizations/Hostname.spec.ts
+++ b/playwright/Customizations/Hostname.spec.ts
@@ -19,6 +19,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -43,10 +44,7 @@ test('Create a blueprint with Hostname customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -42,7 +42,10 @@ test('Create a blueprint with Kernel customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -184,6 +187,9 @@ test('Create a blueprint with Kernel customization', async ({
 
   await test.step('Review imported BP', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(

--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -18,7 +18,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -36,13 +35,27 @@ test('Create a blueprint with Kernel customization', async ({
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Kernel' }).click();
+  });
+
+  await test.step('Navigate to Advanced settings', async () => {
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
   });
 
   await test.step('Shows all chips when 4 or fewer', async () => {
@@ -127,11 +140,7 @@ test('Create a blueprint with Kernel customization', async ({
       .getByPlaceholder('Add kernel argument')
       .fill('console=ttyS0,115200n8');
     await frame.getByPlaceholder('Add kernel argument').press('Enter');
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -140,13 +149,13 @@ test('Create a blueprint with Kernel customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Kernel' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await frame.getByRole('button', { name: 'kernel', exact: true }).click();
     await frame.getByRole('option', { name: 'kernel-debug' }).click();
     await frame.getByPlaceholder('Add kernel argument').fill('new=argument');
     await frame.getByPlaceholder('Add kernel argument').press('Enter');
     await frame.getByRole('button', { name: 'Remove xxnosmp' }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -174,8 +183,9 @@ test('Create a blueprint with Kernel customization', async ({
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Kernel' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(
       frame.getByRole('button', { name: 'kernel-debug' }),
     ).toBeVisible();

--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -19,6 +19,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -42,10 +43,7 @@ test('Create a blueprint with Kernel customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -18,7 +18,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -36,16 +35,27 @@ test('Create a blueprint with Locale customization', async ({
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
   });
 
-  await test.step('Check that the Locale step shows langpacks, but not the Additional packages', async () => {
-    await frame.getByRole('button', { name: 'Locale' }).click();
+  await test.step('Check that the Locale step shows langpacks, but not the Repositories and packages', async () => {
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await frame.getByRole('button', { name: 'Add language' }).click();
     await frame.getByRole('button', { name: 'Select a language' }).click();
     const searchInput = frame.getByPlaceholder('Search by name').last();
@@ -67,7 +77,9 @@ test('Create a blueprint with Locale customization', async ({
     ).toBeVisible();
     await expect(frame.getByText('langpacks-ru')).toBeVisible();
 
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await frame
       .getByRole('textbox', { name: 'Search packages' })
       .fill('langpacks-ru');
@@ -75,7 +87,7 @@ test('Create a blueprint with Locale customization', async ({
   });
 
   await test.step('Select and fill the Locale step', async () => {
-    await frame.getByRole('button', { name: 'Locale' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     // Add en_US language
     await frame.getByRole('button', { name: 'Add language' }).click();
@@ -139,11 +151,7 @@ test('Create a blueprint with Locale customization', async ({
       .getByText('Resolving packages for your preferred locale…')
       .waitFor({ state: 'hidden', timeout: 60_000 });
     await expect(frame.getByText('langpacks-en')).toBeVisible();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP and verify locale langpacks in request', async () => {
@@ -182,7 +190,7 @@ test('Create a blueprint with Locale customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Locale' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     const languagesGroup = frame.getByRole('group', { name: 'Languages' });
     const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     await expect(
@@ -222,7 +230,7 @@ test('Create a blueprint with Locale customization', async ({
     // Change keyboard
     await keyboardGroup.getByRole('button', { name: 'amiga-de' }).click();
     await frame.getByRole('menuitem', { name: 'ANSI-dvorak' }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -250,8 +258,9 @@ test('Create a blueprint with Locale customization', async ({
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Locale' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });
     await expect(
       frame.getByRole('button', {

--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -42,7 +42,10 @@ test('Create a blueprint with Locale customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -259,6 +262,9 @@ test('Create a blueprint with Locale customization', async ({
 
   await test.step('Review imported BP', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
     const keyboardGroup = frame.getByRole('group', { name: 'Keyboard' });

--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -19,6 +19,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -42,10 +43,7 @@ test('Create a blueprint with Locale customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -7,14 +7,17 @@ import { v4 as uuidv4 } from 'uuid';
 import { test } from '../fixtures/cleanup';
 import { isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
-import { ibFrame, navigateToLandingPage } from '../helpers/navHelpers';
+import {
+  fillInImageOutput,
+  ibFrame,
+  navigateToLandingPage,
+} from '../helpers/navHelpers';
 import { selectDistro } from '../helpers/targetChooser';
 import {
   createBlueprint,
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
 } from '../helpers/wizardHelpers';
@@ -31,22 +34,28 @@ test('Create a blueprint with OpenSCAP customization', async ({
 
   await ensureAuthenticated(page);
 
-  // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('WSL + Installer shows WSL is not supported', async () => {
-    // Back to Image output and add Installer
+  await test.step('Open Wizard', async () => {
     await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('WSL + Installer shows WSL is not supported', async () => {
     await selectDistro(frame, 'rhel9');
     await frame
       .getByRole('checkbox', { name: 'Windows Subsystem for Linux' })
       .click();
     await frame.getByRole('checkbox', { name: 'Bare metal installer' }).click();
-    await frame.getByRole('button', { name: 'Next' }).click();
     await registerLater(frame);
 
-    await frame.getByRole('button', { name: 'Security' }).nth(1).click();
     await expect(
       frame.getByText('WSL: customization is not supported'),
     ).toBeVisible();
@@ -73,11 +82,13 @@ test('Create a blueprint with OpenSCAP customization', async ({
   await test.step('Verify Packages show no OpenSCAP additions', async () => {
     // NOTE: fsc check was removed since we now hide steps when
     // none of the image types support the customization
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
   });
 
   await test.step('Select OpenSCAP profile, and check if dependencies are preselected', async () => {
-    await frame.getByRole('button', { name: 'Security' }).nth(1).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame
       .getByRole('radio', { name: 'Use a default OpenSCAP profile' })
       .check();
@@ -88,7 +99,9 @@ test('Create a blueprint with OpenSCAP customization', async ({
         name: 'CIS Red Hat Enterprise Linux 9 Benchmark for Level 1 - Server',
       })
       .click();
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await expect(frame.getByRole('gridcell', { name: 'aide' })).toBeVisible();
     await expect(frame.getByRole('gridcell', { name: 'chrony' })).toBeVisible();
     await expect(frame.getByRole('gridcell', { name: 'cronie' })).toBeVisible();
@@ -108,7 +121,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await expect(
       frame.getByRole('gridcell', { name: 'systemd-journal-remote' }),
     ).toBeVisible();
-    await frame.getByRole('button', { name: 'Systemd services' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(frame.getByText('11 Added by OpenSCAP')).toBeVisible();
     await frame.getByPlaceholder('Add masked service').fill('nftables');
     await frame.getByPlaceholder('Add masked service').press('Enter');
@@ -122,11 +135,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await expect(frame.getByText('autofs')).toBeVisible();
     await expect(frame.getByText('bluetooth')).toBeVisible();
     await expect(frame.getByText('nftables')).toBeVisible();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -135,7 +144,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Security' }).nth(1).click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame.getByRole('textbox', { name: 'Type to filter' }).click();
     await expect(
       frame.getByText(
@@ -150,12 +159,16 @@ test('Create a blueprint with OpenSCAP customization', async ({
       })
       .click();
 
-    await frame.getByRole('button', { name: 'Kernel' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
-    await expect(frame.getByText('2 Added by OpenSCAP')).toBeVisible();
+    await expect(
+      frame.getByText('2 Added by OpenSCAP', { exact: true }),
+    ).toBeVisible();
     await expect(frame.getByText('audit_backlog_limit=8192')).toBeVisible();
     await expect(frame.getByText('audit=1')).toBeVisible();
-    await frame.getByRole('button', { name: 'Additional packages' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await expect(frame.getByRole('gridcell', { name: 'aide' })).toBeVisible();
     await expect(
       frame.getByRole('gridcell', { name: 'audit-libs' }),
@@ -175,7 +188,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
       frame.getByRole('gridcell', { name: 'nftables' }),
     ).toBeVisible();
     await expect(frame.getByRole('gridcell', { name: 'sudo' })).toBeVisible();
-    await frame.getByRole('button', { name: 'Systemd services' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(frame.getByText('12 Added by OpenSCAP')).toBeVisible();
     await frame.getByPlaceholder('Add masked service').fill('nftables');
     await frame.getByPlaceholder('Add masked service').press('Enter');
@@ -189,7 +202,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await expect(frame.getByText('autofs')).toBeVisible();
     await expect(frame.getByText('bluetooth')).toBeVisible();
     await expect(frame.getByText('nftables')).toBeVisible();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -205,19 +218,18 @@ test('Create a blueprint with OpenSCAP customization', async ({
   });
 
   await test.step('Import BP', async () => {
-    await importBlueprint(page, exportedBP);
+    await importBlueprint(frame, exportedBP);
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(page);
-    await page.getByRole('button', { name: 'Security' }).nth(1).click();
-    await frame.getByRole('textbox', { name: 'Type to filter' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Base settings' }).click();
+    await frame.getByRole('button', { name: 'View details' }).nth(2).click();
     await expect(
-      frame.getByText(
-        'CIS Red Hat Enterprise Linux 9 Benchmark for Level 2 - Server',
-      ),
+      frame.getByText('Red Hat Enterprise Linux 9 CIS'),
     ).toBeVisible();
 
-    await page.getByRole('button', { name: 'Cancel' }).click();
+    await frame.getByRole('button', { name: 'Cancel' }).click();
   });
 });

--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -19,6 +19,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
 } from '../helpers/wizardHelpers';
 
@@ -41,7 +42,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Packages.spec.ts
+++ b/playwright/Customizations/Packages.spec.ts
@@ -24,7 +24,10 @@ test('shows on-premise wildcard search instructions when running on-premise', as
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Navigate to packages step', async () => {

--- a/playwright/Customizations/Packages.spec.ts
+++ b/playwright/Customizations/Packages.spec.ts
@@ -8,7 +8,7 @@ import {
   ibFrame,
   navigateToLandingPage,
 } from '../helpers/navHelpers';
-import { registerLater } from '../helpers/wizardHelpers';
+import { openWizard, registerLater } from '../helpers/wizardHelpers';
 
 test('shows on-premise wildcard search instructions when running on-premise', async ({
   page,
@@ -24,10 +24,7 @@ test('shows on-premise wildcard search instructions when running on-premise', as
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Navigate to packages step', async () => {

--- a/playwright/Customizations/Packages.spec.ts
+++ b/playwright/Customizations/Packages.spec.ts
@@ -16,15 +16,22 @@ test('shows on-premise wildcard search instructions when running on-premise', as
   test.skip(isHosted(), 'Skip on-premise specific tests on hosted');
 
   await ensureAuthenticated(page);
-  await navigateToLandingPage(page);
+
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
+
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
 
   await test.step('Navigate to packages step', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
-    // Navigate to packages step
     await frame
-      .getByRole('button', { name: 'Additional packages', exact: false })
+      .getByRole('button', { name: 'Repositories and packages' })
       .click();
   });
 

--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -178,6 +178,7 @@ registrationModes.forEach(
         await test.step('Open Wizard', async () => {
           await frame
             .getByRole('button', { name: 'Create image blueprint' })
+            .first()
             .click();
         });
 

--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -22,7 +22,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
 } from '../helpers/wizardHelpers';
 
@@ -72,7 +71,7 @@ const registrationModes = [
       // Conditional setup based on hosted vs on-premise
       if (isHosted()) {
         // Hosted: Select an activation key from dropdown
-        await frame.getByRole('button', { name: 'Menu toggle' }).click();
+        await frame.getByPlaceholder('Select activation key').click();
         await frame.getByRole('option', { name: 'activation-key-' }).click();
       } else if (isRhel(getHostDistroKey())) {
         // On-premise RHEL: Fill activation key and organization ID input fields
@@ -170,13 +169,24 @@ registrationModes.forEach(
           await ensureAuthenticated(page);
         }
 
-        // Navigate to IB landing page and get the frame
-        await navigateToLandingPage(page);
+        await test.step('Navigate to IB landing page', async () => {
+          await navigateToLandingPage(page);
+        });
+
         const frame = ibFrame(page);
 
-        await test.step('Navigate to Registration step', async () => {
+        await test.step('Open Wizard', async () => {
+          await frame
+            .getByRole('button', { name: 'Create image blueprint' })
+            .click();
+        });
+
+        await test.step('Fill the BP details', async () => {
+          await fillInDetails(frame, blueprintName);
+        });
+
+        await test.step('Fill Image Output', async () => {
           await fillInImageOutput(frame);
-          await frame.getByRole('button', { name: 'Register' }).click();
         });
 
         await test.step(`Setup ${name} registration mode`, async () => {
@@ -187,16 +197,15 @@ registrationModes.forEach(
           if (name === 'automatic') {
             // View details button only exists on hosted (ActivationKeysList); on-prem uses ManualActivationKey
             if (isHosted()) {
-              await expect(
-                frame.getByRole('button', { name: 'View details' }),
-              ).toBeVisible();
+              const viewDetailsBtn = frame
+                .getByRole('button', { name: 'View details' })
+                .first();
+              await expect(viewDetailsBtn).toBeVisible();
               await expect(frame.getByText('activation-key-')).toBeHidden();
-              await frame.getByRole('button', { name: 'View details' }).click();
-              await expect(
-                frame.getByRole('button', { name: 'View details' }),
-              ).toBeVisible();
+              await viewDetailsBtn.click();
+              await expect(viewDetailsBtn).toBeVisible();
               await expect(frame.getByText('activation-key-')).toBeVisible();
-              await frame.getByRole('button', { name: 'Close' }).click();
+              await frame.getByLabel('Close').click();
             }
 
             // Test enabling/disabling predictive analytics
@@ -216,9 +225,7 @@ registrationModes.forEach(
             await rhcSwitch.click();
             await expect(rhcSwitch).not.toBeChecked();
             await expect(insightsSwitch).toBeChecked(); // does not influence insights toggle
-            await frame
-              .getByRole('button', { name: 'Review and finish' })
-              .click();
+            await frame.getByRole('button', { name: 'Review image' }).click();
             await expect(
               frame.getByText('Register the system later'),
             ).toBeHidden();
@@ -238,7 +245,7 @@ registrationModes.forEach(
             }
             await expect(insightsReviewStep).toBeVisible();
             await expect(rhcReviewStep).toBeHidden();
-            await frame.getByRole('button', { name: 'Register' }).click();
+            await frame.getByRole('button', { name: 'Base settings' }).click();
             // check if the state is the same after returning from review step
             await expect(rhcSwitch).not.toBeChecked();
             await expect(insightsSwitch).toBeChecked();
@@ -248,9 +255,7 @@ registrationModes.forEach(
             await insightsSwitch.click();
             await expect(insightsSwitch).not.toBeChecked();
             await expect(rhcSwitch).not.toBeChecked(); // to use rhc, insights must be enabled
-            await frame
-              .getByRole('button', { name: 'Review and finish' })
-              .click();
+            await frame.getByRole('button', { name: 'Review image' }).click();
             await expect(
               frame.getByText('Register the system later'),
             ).toBeHidden();
@@ -269,7 +274,7 @@ registrationModes.forEach(
             }
             await expect(insightsReviewStep).toBeHidden();
             await expect(rhcReviewStep).toBeHidden();
-            await frame.getByRole('button', { name: 'Register' }).click();
+            await frame.getByRole('button', { name: 'Base settings' }).click();
             // check if the state is the same after returning from review step
             await expect(insightsSwitch).not.toBeChecked();
             await expect(rhcSwitch).not.toBeChecked();
@@ -278,9 +283,7 @@ registrationModes.forEach(
             await rhcSwitch.click();
             await expect(rhcSwitch).toBeChecked();
             await expect(insightsSwitch).toBeChecked(); // turning on rhc turns on insights
-            await frame
-              .getByRole('button', { name: 'Review and finish' })
-              .click();
+            await frame.getByRole('button', { name: 'Review image' }).click();
             await expect(
               frame.getByText('Register the system later'),
             ).toBeHidden();
@@ -305,7 +308,7 @@ registrationModes.forEach(
             }
             await expect(insightsReviewStep).toBeVisible();
             await expect(rhcReviewStep).toBeVisible();
-            await frame.getByRole('button', { name: 'Register' }).click();
+            await frame.getByRole('button', { name: 'Base settings' }).click();
             // check if the state is the same after returning from review step
             await expect(rhcSwitch).toBeChecked();
             await expect(insightsSwitch).toBeChecked();
@@ -321,7 +324,7 @@ registrationModes.forEach(
             await registrationCommandInput.pressSequentially('invalid-command');
             await registrationCommandInput.blur();
             await expect(
-              frame.getByRole('button', { name: 'Review and finish' }),
+              frame.getByRole('button', { name: 'Review image' }),
             ).toBeDisabled();
             await expect(
               frame.getByText('Invalid or missing token'),
@@ -337,7 +340,7 @@ registrationModes.forEach(
               ),
             ).toBeVisible();
             await expect(
-              frame.getByRole('button', { name: 'Review and finish' }),
+              frame.getByRole('button', { name: 'Review image' }),
             ).toBeEnabled();
 
             // Test valid command with no expiration
@@ -360,17 +363,14 @@ registrationModes.forEach(
             ).toBeHidden();
 
             await frame
-              .getByRole('button', { name: 'Systemd services' })
+              .getByRole('button', { name: 'Advanced settings' })
               .click();
             await expect(frame.getByText('register-satellite')).toBeVisible();
           }
         });
 
-        await test.step('Fill the BP details', async () => {
-          await frame
-            .getByRole('button', { name: 'Review and finish' })
-            .click();
-          await fillInDetails(frame, blueprintName);
+        await test.step('Navigate to Review', async () => {
+          await frame.getByRole('button', { name: 'Review image' }).click();
         });
 
         await test.step('Verify Review step shows correct registration details', async () => {
@@ -384,7 +384,7 @@ registrationModes.forEach(
 
         await test.step('Edit blueprint and verify registration persisted', async () => {
           await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-          await frame.getByRole('button', { name: 'Register' }).click();
+          await frame.getByRole('button', { name: 'Base settings' }).click();
 
           // Verify the original registration mode is still selected
           if (name === 'automatic') {
@@ -405,9 +405,7 @@ registrationModes.forEach(
             ).toBeChecked();
           }
 
-          await frame
-            .getByRole('button', { name: 'Review and finish' })
-            .click();
+          await frame.getByRole('button', { name: 'Review image' }).click();
           await frame
             .getByRole('button', { name: 'Save changes to blueprint' })
             .click();
@@ -427,8 +425,10 @@ registrationModes.forEach(
         });
 
         await test.step('Verify import does not change registration settings', async () => {
-          await fillInImageOutputGuest(frame);
-          await frame.getByRole('button', { name: 'Register' }).click();
+          await fillInImageOutput(frame);
+          await frame
+            .getByRole('textbox', { name: 'Blueprint name' })
+            .fill('tmp');
           // Verify registration settings are preserved based on mode
           await expect(
             frame.getByRole('radio', {

--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -23,6 +23,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
 } from '../helpers/wizardHelpers';
 
 export const SATELLITE_COMMAND = `
@@ -176,10 +177,7 @@ registrationModes.forEach(
         const frame = ibFrame(page);
 
         await test.step('Open Wizard', async () => {
-          await frame
-            .getByRole('button', { name: 'Create image blueprint' })
-            .first()
-            .click();
+          await openWizard(frame);
         });
 
         await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -171,7 +171,6 @@ test('Create a blueprint with Repeatable build customization', async ({
       .click();
     // Wait for menu to appear, then close it and re-open it, PW selectors are not matching
     // the menu items for unknown reason on first open
-    await page.waitForTimeout(2000);
     await frame
       .getByRole('button', { name: /Select content template/i })
       .click();
@@ -179,7 +178,6 @@ test('Create a blueprint with Repeatable build customization', async ({
       .getByRole('button', { name: /Select content template/i })
       .click();
     await expect(frame.getByText(/Loading/i)).toBeHidden();
-    await page.waitForTimeout(2000);
     await frame.getByRole('menuitem').first().click();
     await frame.getByRole('button', { name: 'Review image' }).click();
     await expect(

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -24,6 +24,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
 } from '../helpers/wizardHelpers';
 
@@ -73,7 +74,7 @@ test('Create a blueprint with Repeatable build customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -22,7 +22,9 @@ import {
   createBlueprint,
   deleteBlueprint,
   exportBlueprint,
+  fillInDetails,
   importBlueprint,
+  registerLater,
 } from '../helpers/wizardHelpers';
 
 test('Create a blueprint with Repeatable build customization', async ({
@@ -64,15 +66,23 @@ test('Create a blueprint with Repeatable build customization', async ({
     timeout: 30000,
   });
 
-  // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
-  await enablePreview(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
-    await frame.getByRole('button', { name: 'Back' }).click();
-    await frame.getByRole('radio', { name: 'Register later' }).click();
+    await registerLater(frame);
   });
 
   await test.step('Check non-snapshot repository is disabled', async () => {
@@ -83,7 +93,9 @@ test('Create a blueprint with Repeatable build customization', async ({
     await frame
       .getByRole('textbox', { name: /date picker/i })
       .fill('2025-12-24');
-    await frame.getByRole('button', { name: /Repositories/i }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await expect(frame.getByText(/Loading/i)).toBeHidden();
 
     await frame
@@ -184,12 +196,6 @@ test('Create a blueprint with Repeatable build customization', async ({
     await frame
       .getByRole('textbox', { name: /date picker/i })
       .fill('2026-01-01');
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await frame
-      .getByRole('textbox', { name: 'Blueprint name' })
-      .fill(blueprintName);
     await frame.getByRole('button', { name: 'Review image' }).click();
   });
 

--- a/playwright/Customizations/Repositories.spec.ts
+++ b/playwright/Customizations/Repositories.spec.ts
@@ -18,6 +18,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../helpers/wizardHelpers';
 
@@ -62,7 +63,7 @@ test('Create blueprint with repository and test edit mode removal', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Repositories.spec.ts
+++ b/playwright/Customizations/Repositories.spec.ts
@@ -55,34 +55,45 @@ test('Create blueprint with repository and test edit mode removal', async ({
   cleanup.add(() => deleteBlueprint(page, blueprintName));
   cleanup.add(() => deleteRepositoryViaApi(page, repositoryUuid));
 
-  await navigateToLandingPage(page);
-  const frame = ibFrame(page);
-
-  await test.step('Fill in image output', async () => {
-    await fillInImageOutput(frame, 'qcow2', 'rhel10', 'x86_64');
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
   });
 
-  await test.step('Register later', async () => {
+  const frame = ibFrame(page);
+
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill in image output and registration', async () => {
+    await fillInImageOutput(frame, 'qcow2');
     await registerLater(frame);
   });
 
   await test.step('Select the repository', async () => {
-    await frame.getByRole('button', { name: 'Repositories' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
     await frame.getByRole('option', { name: repositoryName }).click();
   });
 
-  await test.step('Fill blueprint details and create', async () => {
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-    await fillInDetails(frame, blueprintName);
+  await test.step('Review and create blueprint', async () => {
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await createBlueprint(frame, blueprintName);
   });
 
   await test.step('Edit blueprint and verify repository is displayed', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Repositories' }).click();
+    await frame
+      .getByRole('button', { name: 'Repositories and packages' })
+      .click();
 
     await expect(
       frame.getByRole('gridcell', { name: repositoryName }),
@@ -113,7 +124,7 @@ test('Create blueprint with repository and test edit mode removal', async ({
   });
 
   await test.step('Save changes and verify repository is removed', async () => {
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -42,7 +42,10 @@ test('Create a blueprint with Systemd customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -324,6 +327,9 @@ test('Create a blueprint with Systemd customization', async ({
 
   await test.step('Review imported BP', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
 

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -19,6 +19,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -42,10 +43,7 @@ test('Create a blueprint with Systemd customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -18,7 +18,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -36,16 +35,27 @@ test('Create a blueprint with Systemd customization', async ({
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Systemd services' }).click();
   });
 
   await test.step('Enabled services: shows all chips when 8 or fewer', async () => {
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     const enabledInput = frame.getByPlaceholder('Add enabled service');
     for (const service of [
       'sshd.service',
@@ -246,9 +256,8 @@ test('Create a blueprint with Systemd customization', async ({
     ).toBeVisible();
   });
 
-  await test.step('Fill the BP details', async () => {
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-    await fillInDetails(frame, blueprintName);
+  await test.step('Navigate to review', async () => {
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -257,7 +266,7 @@ test('Create a blueprint with Systemd customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Systemd services' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     await frame
       .getByPlaceholder('Add disabled service')
@@ -286,7 +295,7 @@ test('Create a blueprint with Systemd customization', async ({
     await expect(frame.getByText('systemd-dis.service')).toBeHidden();
     await expect(frame.getByText('systemd-m.service')).toBeHidden();
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -314,8 +323,9 @@ test('Create a blueprint with Systemd customization', async ({
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Systemd services' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     await expect(frame.getByText('enabled-service')).toBeVisible();
     await expect(frame.getByText('disabled-service')).toBeVisible();

--- a/playwright/Customizations/TargetEnvironments/Azure.spec.ts
+++ b/playwright/Customizations/TargetEnvironments/Azure.spec.ts
@@ -28,12 +28,16 @@ test('Create a blueprint with Azure target', async ({ page, cleanup }) => {
   const frame = ibFrame(page);
 
   await test.step('Select Azure target and verify field behavior', async () => {
-    await page.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+
+    await fillInDetails(frame, blueprintName);
 
     await selectTarget(frame, 'azure');
 
-    const nextButton = frame.getByRole('button', { name: 'Next' });
-    await expect(nextButton).toBeDisabled();
+    const reviewImageButton = frame.getByRole('button', {
+      name: 'Review image',
+    });
+    await expect(reviewImageButton).toBeDisabled();
 
     const tenantInput = frame.getByRole('textbox', {
       name: /azure tenant guid/i,
@@ -58,14 +62,12 @@ test('Create a blueprint with Azure target', async ({ page, cleanup }) => {
     await subscriptionInput.fill(SUBSCRIPTION_ID);
     await resourceGroupInput.fill(RESOURCE_GROUP);
 
-    await expect(nextButton).toBeEnabled();
+    await expect(reviewImageButton).toBeEnabled();
   });
 
   await test.step('Navigate to review and create blueprint', async () => {
-    await frame.getByRole('button', { name: 'Next' }).click();
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Verify Azure details on review step', async () => {
@@ -81,10 +83,7 @@ test('Create a blueprint with Azure target', async ({ page, cleanup }) => {
 
   await test.step('Edit blueprint and verify Azure config persisted', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame
-      .getByLabel('Wizard steps')
-      .getByRole('button', { name: 'Image output' })
-      .click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
 
     const tenantInput = frame.getByRole('textbox', {
       name: /azure tenant guid/i,
@@ -113,8 +112,7 @@ test('Create a blueprint with Azure target', async ({ page, cleanup }) => {
       frame.getByRole('button', { name: /Generation 1/i }),
     ).toBeVisible();
 
-    await frame.getByRole('button', { name: 'Next', exact: true }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -122,17 +120,13 @@ test('Create a blueprint with Azure target', async ({ page, cleanup }) => {
 
   await test.step('Re-edit and verify V1 persisted', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame
-      .getByLabel('Wizard steps')
-      .getByRole('button', { name: 'Image output' })
-      .click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
 
     await expect(
       frame.getByRole('button', { name: /Generation 1/i }),
     ).toBeVisible();
 
-    await frame.getByRole('button', { name: 'Next', exact: true }).click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -153,7 +147,9 @@ test('Deselecting Azure removes its config from the blueprint', async ({
   const frame = ibFrame(page);
 
   await test.step('Select Azure and fill in fields', async () => {
-    await page.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+
+    await fillInDetails(frame, blueprintName);
 
     await selectTarget(frame, 'azure');
 
@@ -166,15 +162,10 @@ test('Deselecting Azure removes its config from the blueprint', async ({
     await frame
       .getByRole('textbox', { name: /resource group/i })
       .fill(RESOURCE_GROUP);
-
-    await frame.getByRole('button', { name: 'Next' }).click();
   });
 
   await test.step('Go back and deselect Azure', async () => {
-    await frame
-      .getByLabel('Wizard steps')
-      .getByRole('button', { name: 'Image output' })
-      .click();
+    await frame.getByRole('button', { name: 'Base settings' }).click();
 
     await selectTarget(frame, 'azure');
 
@@ -185,13 +176,11 @@ test('Deselecting Azure removes its config from the blueprint', async ({
 
   await test.step('Select Guest Image and continue', async () => {
     await frame.getByRole('checkbox', { name: /Virtualization/i }).click();
-    await frame.getByRole('button', { name: 'Next' }).click();
   });
 
   await test.step('Navigate to review and verify no Azure details', async () => {
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
 
     // Azure-specific details should not be present on the review step
     await expect(frame.getByText(TENANT_GUID)).toBeHidden();

--- a/playwright/Customizations/TargetEnvironments/Azure.spec.ts
+++ b/playwright/Customizations/TargetEnvironments/Azure.spec.ts
@@ -10,6 +10,7 @@ import {
   createBlueprint,
   deleteBlueprint,
   fillInDetails,
+  openWizard,
   registerLater,
 } from '../../helpers/wizardHelpers';
 
@@ -28,7 +29,7 @@ test('Create a blueprint with Azure target', async ({ page, cleanup }) => {
   const frame = ibFrame(page);
 
   await test.step('Select Azure target and verify field behavior', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
 
     await fillInDetails(frame, blueprintName);
 
@@ -147,7 +148,7 @@ test('Deselecting Azure removes its config from the blueprint', async ({
   const frame = ibFrame(page);
 
   await test.step('Select Azure and fill in fields', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await openWizard(frame);
 
     await fillInDetails(frame, blueprintName);
 

--- a/playwright/Customizations/Timezone.spec.ts
+++ b/playwright/Customizations/Timezone.spec.ts
@@ -18,7 +18,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -36,16 +35,27 @@ test('Create a blueprint with Timezone customization', async ({
   await ensureAuthenticated(page);
 
   // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Timezone' }).click();
   });
 
   await test.step('Select the Timezone', async () => {
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(
       frame.getByText('Select a timezone and define NTP servers'),
     ).toBeVisible();
@@ -158,11 +168,7 @@ test('Create a blueprint with Timezone customization', async ({
       .getByRole('button', { name: 'Remove 0.cz.pool.ntp.org' })
       .click();
     await expect(frame.getByText('0.cz.pool.ntp.org')).toBeHidden();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {
@@ -171,7 +177,7 @@ test('Create a blueprint with Timezone customization', async ({
 
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Timezone' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(frame.getByText('Canada/Saskatchewan')).toBeHidden();
     await expect(
       frame.getByText('Europe/Stockholm', { exact: true }),
@@ -183,7 +189,7 @@ test('Create a blueprint with Timezone customization', async ({
     await expect(frame.getByText('0.nl.pool.ntp.org')).toBeVisible();
     await expect(frame.getByText('0.de.pool.ntp.org')).toBeVisible();
     await expect(frame.getByText('0.cz.pool.ntp.org')).toBeHidden();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -211,8 +217,9 @@ test('Create a blueprint with Timezone customization', async ({
   });
 
   await test.step('Review imported BP', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Timezone' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(frame.getByText('Europe/Oslo', { exact: true })).toBeVisible();
     await expect(frame.getByText('0.nl.pool.ntp.org')).toBeVisible();
     await expect(frame.getByText('0.de.pool.ntp.org')).toBeVisible();

--- a/playwright/Customizations/Timezone.spec.ts
+++ b/playwright/Customizations/Timezone.spec.ts
@@ -19,6 +19,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -42,10 +43,7 @@ test('Create a blueprint with Timezone customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/Timezone.spec.ts
+++ b/playwright/Customizations/Timezone.spec.ts
@@ -42,7 +42,10 @@ test('Create a blueprint with Timezone customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -61,8 +64,8 @@ test('Create a blueprint with Timezone customization', async ({
     ).toBeVisible();
     await frame.getByTestId('timezone-toggle').click();
     await frame.getByLabel('Filter timezone').fill('Canada');
-    await frame.getByRole('menuitem', { name: 'Canada/Saskatchewan' }).click();
-    await frame.getByText('Canada/Saskatchewan', { exact: true }).click();
+    await frame.getByRole('menuitem', { name: 'Canada/Atlantic' }).click();
+    await frame.getByText('Canada/Atlantic', { exact: true }).click();
     await frame.getByLabel('Filter timezone').fill('Europe');
     await frame.getByRole('menuitem', { name: 'Europe/Stockholm' }).click();
   });
@@ -178,7 +181,7 @@ test('Create a blueprint with Timezone customization', async ({
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
-    await expect(frame.getByText('Canada/Saskatchewan')).toBeHidden();
+    await expect(frame.getByText('Canada/Atlantic')).toBeHidden();
     await expect(
       frame.getByText('Europe/Stockholm', { exact: true }),
     ).toBeVisible();
@@ -218,6 +221,9 @@ test('Create a blueprint with Timezone customization', async ({
 
   await test.step('Review imported BP', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(frame.getByText('Europe/Oslo', { exact: true })).toBeVisible();

--- a/playwright/Customizations/UsersAndGroups.spec.ts
+++ b/playwright/Customizations/UsersAndGroups.spec.ts
@@ -49,7 +49,10 @@ test('Create a blueprint with Users customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -535,6 +538,9 @@ test('Create a blueprint with Users customization', async ({
 
   await test.step('Verify imported users', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
@@ -573,7 +579,10 @@ test('Create a blueprint with Groups customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+    await frame
+      .getByRole('button', { name: 'Create image blueprint' })
+      .first()
+      .click();
   });
 
   await test.step('Fill the BP details', async () => {
@@ -722,6 +731,9 @@ test('Create a blueprint with Groups customization', async ({
 
   await test.step('Review imported groups', async () => {
     await fillInImageOutput(frame);
+    if (!isHosted()) {
+      await registerLater(frame);
+    }
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
 

--- a/playwright/Customizations/UsersAndGroups.spec.ts
+++ b/playwright/Customizations/UsersAndGroups.spec.ts
@@ -22,6 +22,7 @@ import {
   exportBlueprint,
   fillInDetails,
   importBlueprint,
+  openWizard,
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
@@ -49,10 +50,7 @@ test('Create a blueprint with Users customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {
@@ -579,10 +577,7 @@ test('Create a blueprint with Groups customization', async ({
   const frame = ibFrame(page);
 
   await test.step('Open Wizard', async () => {
-    await frame
-      .getByRole('button', { name: 'Create image blueprint' })
-      .first()
-      .click();
+    await openWizard(frame);
   });
 
   await test.step('Fill the BP details', async () => {

--- a/playwright/Customizations/UsersAndGroups.spec.ts
+++ b/playwright/Customizations/UsersAndGroups.spec.ts
@@ -21,7 +21,6 @@ import {
   deleteBlueprint,
   exportBlueprint,
   fillInDetails,
-  fillInImageOutputGuest,
   importBlueprint,
   registerLater,
   verifyExportedBlueprint,
@@ -43,17 +42,27 @@ test('Create a blueprint with Users customization', async ({
 
   await ensureAuthenticated(page);
 
-  // Navigate to IB landing page and get the frame
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to Groups and users step', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
   });
 
   await test.step('Test editable Group ID', async () => {
-    await frame.getByRole('button', { name: 'Groups and users' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     const gidInput = frame.getByRole('textbox', { name: 'Group ID' });
     await expect(gidInput).toBeVisible();
@@ -222,22 +231,13 @@ test('Create a blueprint with Users customization', async ({
     ).toBeVisible();
 
     // Test 4: Empty username with password filled
-    await expect(
-      frame.getByRole('heading', {
-        name: 'Danger alert: Errors found',
-      }),
-    ).toBeHidden();
     await usernameInputs.nth(4).fill('');
     await passwordInputs.nth(4).fill('password123');
-    // Click Next to trigger validation
-    await frame.getByRole('button', { name: 'Next' }).click();
+    // Next and Review image buttons should be disabled due to validation errors
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
     await expect(
-      frame.getByRole('heading', {
-        name: 'Danger alert: Errors found',
-      }),
-    ).toBeVisible();
-    // Go back to Groups and users step to continue with other tests
-    await frame.getByRole('button', { name: 'Groups and users' }).click();
+      frame.getByRole('button', { name: 'Review image' }),
+    ).toBeDisabled();
 
     // Test 5: Invalid group name with spaces
     await expect(
@@ -420,7 +420,7 @@ test('Create a blueprint with Users customization', async ({
         .nth(1),
     ).toBeVisible();
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
 
     const advancedSettingsCard = frame
       .locator('.pf-v6-c-card')
@@ -452,13 +452,12 @@ test('Create a blueprint with Users customization', async ({
   });
 
   await test.step('Create and save blueprint', async () => {
-    await fillInDetails(frame, blueprintName);
     await createBlueprint(frame, blueprintName);
   });
 
   await test.step('Edit blueprint and modify users', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Groups and users' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     // Modify existing user
     const passwordInputs = frame.getByRole('textbox', {
@@ -478,7 +477,7 @@ test('Create a blueprint with Users customization', async ({
     });
     await newPasswordInputs.last().fill('NewUserPass123');
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -487,7 +486,7 @@ test('Create a blueprint with Users customization', async ({
   await test.step('Verify blueprint was saved correctly', async () => {
     // Navigate back to the blueprint to verify it was saved
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Groups and users' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     // Verify all users are present and correct
     const usernameInputs = frame.getByRole('textbox', {
@@ -507,7 +506,7 @@ test('Create a blueprint with Users customization', async ({
     await expect(passwordInputs.nth(2)).toHaveValue('');
     await expect(passwordInputs.nth(3)).toHaveValue('');
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -535,8 +534,9 @@ test('Create a blueprint with Users customization', async ({
   });
 
   await test.step('Verify imported users', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Groups and users' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     // Verify users are preserved
     await expect(
@@ -566,16 +566,27 @@ test('Create a blueprint with Groups customization', async ({
 
   await ensureAuthenticated(page);
 
-  await navigateToLandingPage(page);
+  await test.step('Navigate to IB landing page', async () => {
+    await navigateToLandingPage(page);
+  });
+
   const frame = ibFrame(page);
 
-  await test.step('Navigate to Groups and users step', async () => {
+  await test.step('Open Wizard', async () => {
+    await frame.getByRole('button', { name: 'Create image blueprint' }).click();
+  });
+
+  await test.step('Fill the BP details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Fill Image Output and Registration', async () => {
     await fillInImageOutput(frame);
     await registerLater(frame);
-    await frame.getByRole('button', { name: 'Groups and users' }).click();
   });
 
   await test.step('Add groups', async () => {
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await frame.getByPlaceholder('Set group name').fill('developers');
     await expect(frame.getByPlaceholder('Set group ID')).toBeVisible();
 
@@ -660,7 +671,7 @@ test('Create a blueprint with Groups customization', async ({
   });
 
   await test.step('Verify groups in Review step', async () => {
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
 
     await expect(frame.getByText('developers')).toBeVisible();
     // TODO: for now we only verify groups that are added to users
@@ -669,21 +680,20 @@ test('Create a blueprint with Groups customization', async ({
     // await expect(frame.getByText('ops')).toBeVisible();
   });
 
-  await test.step('Fill details and create blueprint', async () => {
-    await fillInDetails(frame, blueprintName);
+  await test.step('Create and save blueprint', async () => {
     await createBlueprint(frame, blueprintName);
   });
 
   await test.step('Edit blueprint and verify groups persist', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
-    await frame.getByRole('button', { name: 'Groups and users' }).click();
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     const groupNameInputs = frame.getByPlaceholder('Set group name');
     await expect(groupNameInputs.nth(0)).toHaveValue('developers');
     await expect(groupNameInputs.nth(1)).toHaveValue('qa-team');
     await expect(groupNameInputs.nth(2)).toHaveValue('ops');
 
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
+    await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
       .click();
@@ -711,8 +721,9 @@ test('Create a blueprint with Groups customization', async ({
   });
 
   await test.step('Review imported groups', async () => {
-    await fillInImageOutputGuest(frame);
-    await frame.getByRole('button', { name: 'Groups and users' }).click();
+    await fillInImageOutput(frame);
+    await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     const groupNameInputs = frame.getByPlaceholder('Set group name');
     await expect(groupNameInputs.nth(0)).toHaveValue('developers');

--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -42,17 +42,17 @@ test('Import a blueprint with invalid customization', async ({
     await importBlueprint(frame, blueprintFile);
   });
 
-  await test.step('Navigate to optional steps in Wizard', async () => {
+  await test.step('Fill blueprint details', async () => {
+    await fillInDetails(frame, blueprintName);
+  });
+
+  await test.step('Select Virtualization and register later', async () => {
     await frame.getByRole('checkbox', { name: 'Virtualization' }).click();
-    await frame.getByRole('button', { name: 'Next' }).click();
     await registerLater(frame);
   });
 
-  await test.step('Select the File System Configuration step', async () => {
-    await frame
-      .getByLabel('Wizard steps')
-      .getByRole('button', { name: 'File system configuration' })
-      .click();
+  await test.step('Open Advanced settings and fix file system errors', async () => {
+    await frame.getByRole('button', { name: 'Advanced settings' }).click();
     await expect(
       frame.getByText(/Duplicate mount points/i).first(),
     ).toBeVisible();
@@ -68,12 +68,10 @@ test('Import a blueprint with invalid customization', async ({
     await expect(closeRootButton2).toBeDisabled();
   });
 
-  await test.step('Select the Timezone step', async () => {
-    await frame.getByRole('button', { name: 'error Timezone' }).click();
+  await test.step('Fix timezone and locale errors on Advanced settings', async () => {
     await expect(frame.getByText('Includes duplicate NTP')).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
     await frame.getByRole('button', { name: 'Remove ntp/' }).first().click();
-    await frame.getByRole('button', { name: 'Next' }).click();
 
     await expect(frame.getByText('Unknown languages: random:')).toBeVisible();
     await expect(frame.getByText('Duplicated languages: af_ZA.')).toBeVisible();
@@ -81,14 +79,22 @@ test('Import a blueprint with invalid customization', async ({
     await frame.getByRole('button', { name: 'Remove language' }).last().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
     await frame.getByRole('button', { name: 'Remove language' }).last().click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
   });
 
-  await test.step('Select the Firewall step', async () => {
-    await frame.getByRole('button', { name: 'error Firewall' }).click();
+  await test.step('Fix firewall errors on Advanced settings', async () => {
+    await frame
+      .getByRole('heading', { name: 'Firewall' })
+      .scrollIntoViewIfNeeded();
     await expect(frame.getByText('Includes duplicate ports:')).toBeVisible();
-    await expect(frame.getByText('Includes duplicate enabled')).toBeVisible();
-    await expect(frame.getByText('Includes duplicate disabled')).toBeVisible();
+    await expect(
+      frame.getByText(
+        'Includes duplicate enabled services: service1: error status',
+      ),
+    ).toBeVisible();
+    await expect(
+      frame.getByText('Includes duplicate disabled services: service2'),
+    ).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
     await frame
       .getByRole('button', { name: 'Remove 2020:port' })
@@ -104,13 +110,19 @@ test('Import a blueprint with invalid customization', async ({
       .getByRole('button', { name: 'Remove service2' })
       .first()
       .click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
   });
 
-  await test.step('Select the Systemd step', async () => {
-    await frame.getByRole('button', { name: 'error Systemd services' }).click();
-    await expect(frame.getByText('Includes duplicate enabled')).toBeVisible();
-    await expect(frame.getByText('Includes duplicate disabled')).toBeVisible();
+  await test.step('Fix systemd errors on Advanced settings', async () => {
+    await frame
+      .getByRole('heading', { name: 'Systemd services' })
+      .scrollIntoViewIfNeeded();
+    await expect(
+      frame.getByText('Includes duplicate enabled services: auditd'),
+    ).toBeVisible();
+    await expect(
+      frame.getByText('Includes duplicate disabled services: sssd'),
+    ).toBeVisible();
     await expect(frame.getByText('Includes duplicate masked')).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
     await frame.getByRole('button', { name: 'Remove auditd' }).first().click();
@@ -118,11 +130,8 @@ test('Import a blueprint with invalid customization', async ({
     await frame.getByRole('button', { name: 'Remove sssd' }).first().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
     await frame.getByRole('button', { name: 'Remove masked' }).first().click();
-    await frame.getByRole('button', { name: 'Review and finish' }).click();
-  });
-
-  await test.step('Fill the BP details', async () => {
-    await fillInDetails(frame, blueprintName);
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
+    await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
   await test.step('Create BP', async () => {

--- a/playwright/fixtures/ariaHiddenWorkaround.ts
+++ b/playwright/fixtures/ariaHiddenWorkaround.ts
@@ -1,0 +1,66 @@
+// PatternFly's Modal.toggleSiblingsFromScreenReaders sets aria-hidden="true"
+// on all direct children of document.body during componentDidUpdate. Popper-based
+// dropdowns (Select, Menu) portal their content to document.body as direct
+// children. When the Modal re-renders after a dropdown opens, the menu gets
+// aria-hidden="true", making it invisible to Playwright's getByRole.
+//
+// This fixture installs a MutationObserver that automatically strips
+// aria-hidden="true" from any body-level element that is or contains a
+// PatternFly menu (.pf-v6-c-menu).
+import { test as base } from '@playwright/test';
+
+export type AriaHiddenWorkaroundFixture = {
+  ariaHiddenWorkaround: void;
+};
+
+export const test = base.extend<AriaHiddenWorkaroundFixture>({
+  ariaHiddenWorkaround: [
+    async ({ page }, use) => {
+      await page.addInitScript(() => {
+        const strip = (el: Element) => {
+          if (
+            el.getAttribute('aria-hidden') === 'true' &&
+            (el.matches('.pf-v6-c-menu') || el.querySelector('.pf-v6-c-menu'))
+          ) {
+            el.removeAttribute('aria-hidden');
+          }
+        };
+
+        const observer = new MutationObserver((mutations) => {
+          for (const m of mutations) {
+            if (
+              m.type === 'attributes' &&
+              m.target.parentElement === document.body
+            ) {
+              strip(m.target as Element);
+            }
+            if (m.type === 'childList') {
+              for (const node of m.addedNodes) {
+                if (node instanceof Element) strip(node);
+              }
+            }
+          }
+        });
+
+        const init = () => {
+          observer.observe(document.body, {
+            attributes: true,
+            attributeFilter: ['aria-hidden'],
+            childList: true,
+            subtree: true,
+          });
+        };
+
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (document.body) {
+          init();
+        } else {
+          document.addEventListener('DOMContentLoaded', init);
+        }
+      });
+
+      await use(undefined);
+    },
+    { auto: true },
+  ],
+});

--- a/playwright/fixtures/customizations.ts
+++ b/playwright/fixtures/customizations.ts
@@ -1,9 +1,15 @@
 // This is a common fixture for the customizations tests
 import { mergeTests } from '@playwright/test';
 
+import { test as ariaHiddenTest } from './ariaHiddenWorkaround';
 import { blockAnalyticsTest } from './blockAnalytics';
 import { test as cleanupTest } from './cleanup';
 import { test as popupTest } from './popupHandler';
 
 // Combine the fixtures into one
-export const test = mergeTests(blockAnalyticsTest, cleanupTest, popupTest);
+export const test = mergeTests(
+  ariaHiddenTest,
+  blockAnalyticsTest,
+  cleanupTest,
+  popupTest,
+);

--- a/playwright/fixtures/data/exportBlueprintContents.ts
+++ b/playwright/fixtures/data/exportBlueprintContents.ts
@@ -1,3 +1,7 @@
+import { getDefaultTimezone } from '../../helpers/helpers';
+
+const tz = getDefaultTimezone();
+
 export const exportedDiskBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
@@ -31,7 +35,7 @@ fs_type = "xfs"
 mountpoint = "/var"
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8" ]`;
@@ -52,7 +56,7 @@ mountpoint = "/srv/data"
 minsize = 21474836480
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8" ]`;
@@ -62,7 +66,7 @@ export const exportedFirewallBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8" ]
@@ -82,7 +86,7 @@ export const exportedHostnameBP = (blueprintName: string): string => {
 hostname = "testsystemedited"
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8" ]`;
@@ -96,7 +100,7 @@ name = "kernel-debug"
 append = "rootwait console=tty0 console=ttyS0,115200n8 new=argument"
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8" ]`;
@@ -106,7 +110,7 @@ export const exportedLocaleBP = (blueprintName: string): string => {
   return `name = "${blueprintName}"
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8", "ru_RU.UTF-8", "en_GB.UTF-8", "fy_DE.UTF-8" ]
@@ -130,7 +134,7 @@ masked = [ "masked-service" ]
 disabled = [ "disabled-service" ]
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8" ]`;
@@ -169,7 +173,7 @@ name = "ops"
 gid = 1002
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8" ]`;
@@ -203,7 +207,7 @@ groups = []
 password = ""
 
 [customizations.timezone]
-timezone = "Etc/UTC"
+timezone = "${tz}"
 
 [customizations.locale]
 languages = [ "C.UTF-8" ]`;

--- a/playwright/helpers/helpers.ts
+++ b/playwright/helpers/helpers.ts
@@ -12,7 +12,7 @@ import {
 export const togglePreview = async (page: Page) => {
   const toggleSwitch = page.locator('#preview-toggle');
 
-  if (await toggleSwitch.isChecked()) {
+  if (!(await toggleSwitch.isChecked())) {
     await toggleSwitch.click();
   }
 
@@ -21,7 +21,10 @@ export const togglePreview = async (page: Page) => {
     await turnOnButton.click();
   }
 
-  await expect(toggleSwitch).not.toBeChecked();
+  await expect(toggleSwitch).toBeChecked();
+
+  // TODO: Temporary fix to wait for the preview to be turned on and the modal to load
+  await page.waitForTimeout(3000);
 };
 
 export const enablePreview = async (page: Page) => {

--- a/playwright/helpers/helpers.ts
+++ b/playwright/helpers/helpers.ts
@@ -118,6 +118,14 @@ export const getHostArch = (): string => {
   return execSync('uname -m').toString('utf-8').replace(/\s/g, '');
 };
 
+export const getDefaultTimezone = (): string => {
+  if (isHosted()) {
+    return 'Etc/UTC';
+  }
+  const distroKey = getHostDistroKey();
+  return distroKey === 'rhel-10' ? 'Etc/UTC' : 'America/New_York';
+};
+
 export const uploadCertificateFile = async (
   scope: Page | FrameLocator,
   uploadButton: Locator,

--- a/playwright/helpers/login.ts
+++ b/playwright/helpers/login.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { expect, type Page } from '@playwright/test';
 
-import { closePopupsIfExist, isHosted, togglePreview } from './helpers';
+import { closePopupsIfExist, isHosted } from './helpers';
 import { ibFrame } from './navHelpers';
 
 /**
@@ -145,10 +145,12 @@ const loginConsole = async (page: Page, user: string, password: string) => {
     }
     loginInputAttempts++;
     if (loginInputAttempts > 5) {
-      // Login page had some other issue, throw an error
-      throw new Error(
+      // this just helps us for test debugging
+      // eslint-disable-next-line no-console
+      console.warn(
         'Login page did not transition to password input after 5 attempts',
       );
+      break;
     }
   }
 
@@ -162,8 +164,6 @@ const loginConsole = async (page: Page, user: string, password: string) => {
 
   const allImagesHeading = page.getByRole('heading', { name: 'All images' });
   await expect(allImagesHeading).toBeVisible({ timeout: 30_000 });
-  await togglePreview(page);
-  await expect(allImagesHeading).toBeVisible();
 };
 
 export const storeStorageStateAndToken = async (page: Page) => {

--- a/playwright/helpers/navHelpers.ts
+++ b/playwright/helpers/navHelpers.ts
@@ -27,7 +27,6 @@ export const fillInImageOutput = async (
   distro?: 'rhel10' | 'rhel9' | 'rhel8',
   arch?: 'x86_64' | 'aarch64',
 ) => {
-  await page.getByRole('button', { name: 'Create image blueprint' }).click();
   if (!isHosted()) {
     // wait until the distro and architecture aligns with the host
     await expect(page.getByTestId('release_select')).toHaveText(
@@ -46,7 +45,6 @@ export const fillInImageOutput = async (
   } else {
     await page.getByRole('checkbox', { name: 'Virtualization' }).click();
   }
-  await page.getByRole('button', { name: 'Next' }).click();
 };
 
 /**

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -189,6 +189,15 @@ export const deleteBlueprintUI = async (page: Page, blueprintName: string) => {
 
       // Check if the blueprint is already on the landing page
       if (!(await frame.locator(`button[id="${blueprintName}"]`).isVisible())) {
+        if (
+          await frame
+            .getByRole('heading', { name: 'No blueprints' })
+            .isVisible()
+        ) {
+          // Empty state - the blueprint creation failed and no other is on the account -> fail gracefully
+          // Happens mostly on Cockpit - Search input is not visible in this state
+          return;
+        }
         await frame
           .getByRole('textbox', { name: 'Search input' })
           .fill(blueprintName);

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -75,7 +75,6 @@ export const registerLater = async (page: Page | FrameLocator) => {
  */
 export const registerAutomatically = async (page: Page | FrameLocator) => {
   if (isHosted()) {
-    await page.getByRole('button', { name: 'Register' }).click();
     await page
       .getByRole('radio', { name: 'Automatically register to Red Hat' })
       .click();
@@ -103,8 +102,6 @@ export const registerAutomatically = async (page: Page | FrameLocator) => {
  */
 export const registerWithActivationKey = async (page: Page | FrameLocator) => {
   if (isHosted()) {
-    await page.getByRole('button', { name: 'Register' }).click();
-
     // Ensure "Automatically register to Red Hat" is selected (should be default)
     await expect(
       page.getByRole('radio', { name: 'Automatically register to Red Hat' }),

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -40,10 +40,8 @@ export const createBlueprint = async (
 };
 
 /**
- * Fill in the "Details" step in the wizard
- * This method assumes that the "Details" step is ENABLED!
- * After filling the step, it will click the "Next" button
- * Description defaults to "Testing blueprint"
+ * Fill in name and description of the blueprint in the Base settings step.
+ * It starts with navigating to the Base settings step.
  * @param page - the page object
  * @param blueprintName - the name of the blueprint to create
  */
@@ -51,14 +49,13 @@ export const fillInDetails = async (
   page: Page | FrameLocator,
   blueprintName: string,
 ) => {
-  await page.getByRole('listitem').filter({ hasText: 'Details' }).click();
+  await page.getByRole('button', { name: 'Base settings' }).click();
   await page
     .getByRole('textbox', { name: 'Blueprint name' })
     .fill(blueprintName);
   await page
     .getByRole('textbox', { name: 'Blueprint description' })
     .fill('Testing blueprint');
-  await page.getByRole('button', { name: 'Next' }).click();
 };
 
 /**
@@ -67,7 +64,6 @@ export const fillInDetails = async (
  */
 export const registerLater = async (page: Page | FrameLocator) => {
   if (isHosted() || isRhel(getHostDistroKey())) {
-    await page.getByRole('button', { name: 'Register' }).click();
     await page.getByRole('radio', { name: 'Register later' }).click();
   }
 };
@@ -134,15 +130,6 @@ export const registerWithActivationKey = async (page: Page | FrameLocator) => {
       await rhcSwitch.click();
     }
   }
-};
-
-/**
- * Fill in the image output step in the wizard by selecting the Guest Image
- * @param page - the page object
- */
-export const fillInImageOutputGuest = async (page: Page | FrameLocator) => {
-  await page.getByRole('checkbox', { name: 'Virtualization' }).click();
-  await page.getByRole('button', { name: 'Next' }).click();
 };
 
 /**
@@ -288,6 +275,8 @@ export const importBlueprint = async (
   ).not.toBeEmpty();
   // Wait for the blueprint to finish parsing (including any async repo import API
   // calls) before clicking. The button is disabled until importedBlueprint is set.
+  // The import modal uses "Review and finish" (ImportBlueprintModal.tsx),
+  // not "Review image" like the v3 wizard.
   const reviewBtn = page.getByRole('button', { name: /review and finish/i });
   await expect(reviewBtn).toBeEnabled();
   await reviewBtn.click();

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -11,6 +11,13 @@ import { ibFrame, navigateToLandingPage } from './navHelpers';
 
 import isRhel from '../../src/Utilities/isRhel';
 
+export const openWizard = async (scope: Page | FrameLocator) => {
+  await scope
+    .getByRole('button', { name: 'Create image blueprint' })
+    .first()
+    .click();
+};
+
 /**
  * Clicks the create button, handles the modal, clicks the button again and selects the BP in the list
  * @param page - the page object

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -41,6 +41,8 @@ const onPremFlag = (flag: string): boolean => {
   switch (flag) {
     case 'image-builder.image-mode.enabled':
       return true;
+    case 'image-builder.wizard-revamp.enabled':
+      return true;
     default:
       return false;
   }


### PR DESCRIPTION
This PR:
- migrates entire Playwright testing suite to the new v3 Wizard :mage:
- includes a **temporary** fixture that should ease up issues with Patternfly Modal component race condition that sometimes sets aria to hidden on open dropdown menus in the Modal, making PW unable to locate them
- switches the Wizard on **Cockpit from v2 to v3**