### PR TITLE
Wizard: image-mode changes property name (HMS-10554)

### DIFF
--- a/playwright/Basic/imageMode.spec.ts
+++ b/playwright/Basic/imageMode.spec.ts
@@ -79,7 +79,7 @@ test('Image mode blueprint create, edit, export, import', async ({
     await expect(firstOption).toBeVisible({ timeout: 10000 });
     await firstOption.click();
 
-    await frame.getByRole('checkbox', { name: 'Virtualization' }).click();
+    await frame.getByRole('radio', { name: 'Virtualization' }).click();
   });
 
   await test.step('Fill in user', async () => {
@@ -117,7 +117,7 @@ test('Image mode blueprint create, edit, export, import', async ({
     ).toBeHidden();
 
     await expect(
-      frame.getByRole('checkbox', { name: 'Virtualization' }),
+      frame.getByRole('radio', { name: 'Virtualization' }),
     ).toBeChecked();
   });
 
@@ -162,7 +162,7 @@ test('Image mode blueprint create, edit, export, import', async ({
     await expect(importedImageMode).toHaveAttribute('aria-pressed', 'true');
 
     // Export doesn't include image_requests, so image types must be re-selected
-    await frame.getByRole('checkbox', { name: 'Virtualization' }).click();
+    await frame.getByRole('radio', { name: 'Virtualization' }).click();
 
     await expect(
       frame.getByRole('textbox', { name: 'blueprint user name' }),

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
@@ -8,13 +8,15 @@ import {
 } from '@patternfly/react-core';
 import { BuildIcon, RepositoryIcon } from '@patternfly/react-icons';
 
-import { RHEL_10 } from '@/constants';
+import { RHEL_10, X86_64 } from '@/constants';
 import { Distributions } from '@/store/api/backend';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
+  changeArchitecture,
   changeBlueprintMode,
   changeDistribution,
+  selectArchitecture,
   selectDistribution,
   selectIsImageMode,
 } from '@/store/slices/wizard';
@@ -26,8 +28,10 @@ const BlueprintMode = () => {
   const isOnPremise = useAppSelector(selectIsOnPremise);
   const isImageMode = useAppSelector(selectIsImageMode);
   const distribution = useAppSelector(selectDistribution);
+  const architecture = useAppSelector(selectArchitecture);
   const [defaultDistro, setDefaultDistro] = useState<Distributions>(RHEL_10);
   const previousDistro = useRef<Distributions>(RHEL_10);
+  const previousArch = useRef(architecture);
 
   useEffect(() => {
     if (!isOnPremise) return;
@@ -60,6 +64,9 @@ const BlueprintMode = () => {
                 isOnPremise ? defaultDistro : previousDistro.current,
               ),
             );
+            if (!isOnPremise) {
+              dispatch(changeArchitecture(previousArch.current));
+            }
           }}
           aria-describedby='blueprint-mode-description'
         />
@@ -71,9 +78,14 @@ const BlueprintMode = () => {
           onChange={() => {
             if (!isOnPremise) {
               previousDistro.current = distribution as Distributions;
+              previousArch.current = architecture;
             }
             dispatch(changeBlueprintMode('image'));
-            dispatch(changeDistribution('image-mode'));
+            if (isOnPremise) {
+              dispatch(changeDistribution('image-mode'));
+            } else {
+              dispatch(changeArchitecture(X86_64));
+            }
           }}
           aria-describedby='blueprint-mode-description'
         />

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -26,9 +26,12 @@ import {
   useGetDistributionsQuery,
   usePodmanImagesQuery,
 } from '@/store/api/backend';
+import { Distributions } from '@/store/api/backend/hosted';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
+  changeBootcDistributions,
+  changeDistribution,
   changeImageSource,
   ImageSource,
   selectArchitecture,
@@ -249,6 +252,12 @@ const BootcImageSourceSelect = () => {
     | BootcDistributionItem[]
     | undefined;
 
+  useEffect(() => {
+    if (bootcDistributions) {
+      dispatch(changeBootcDistributions(bootcDistributions));
+    }
+  }, [bootcDistributions, dispatch]);
+
   // Deduplicate by name — the API returns one entry per target type,
   // but the dropdown should show one entry per base image.
   const uniqueDistributions = bootcDistributions?.reduce<
@@ -260,12 +269,16 @@ const BootcImageSourceSelect = () => {
     return acc;
   }, []);
 
-  const selectedItem = uniqueDistributions?.find(
-    (d) => d.image_name === imageSource,
+  const selectedItem = bootcDistributions?.find(
+    (d) => d.reference === imageSource,
   );
 
   const onSelect = (_event?: React.MouseEvent, selection?: string | number) => {
     dispatch(changeImageSource(selection as string));
+    const selected = bootcDistributions?.find((d) => d.reference === selection);
+    if (selected) {
+      dispatch(changeDistribution(selected.distro as Distributions));
+    }
     setIsOpen(false);
   };
 
@@ -324,7 +337,7 @@ const BootcImageSourceSelect = () => {
         <SelectList>
           {uniqueDistributions && uniqueDistributions.length > 0 ? (
             uniqueDistributions.map((item) => (
-              <SelectOption key={item.image_name} value={item.image_name}>
+              <SelectOption key={item.reference} value={item.reference}>
                 {item.name}
               </SelectOption>
             ))

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -6,6 +6,7 @@ import {
   Content,
   EmptyState,
   FormGroup,
+  Radio,
   Spinner,
 } from '@patternfly/react-core';
 
@@ -22,6 +23,7 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices';
 import {
   addImageType,
+  changeImageTypes,
   changeRegistrationType,
   reinitializeAws,
   reinitializeAzure,
@@ -39,13 +41,6 @@ import Gcp from './Gcp';
 
 const TEXT_WRAP_WIDTH = '54rem';
 const EMPTY_ENVIRONMENTS: string[] = [];
-
-const bootcTypeToImageType: Record<string, string> = {
-  ec2: 'aws',
-  azure: 'azure',
-  gcp: 'gcp',
-  qcow2: 'guest-image',
-};
 
 const TargetEnvironment = () => {
   const arch = useAppSelector(selectArchitecture);
@@ -101,9 +96,7 @@ const TargetEnvironment = () => {
       skipArchitectures
         ? [
             ...new Set(
-              bootcDistributions
-                ?.map((d) => bootcTypeToImageType[d.type])
-                .filter(Boolean) ?? EMPTY_ENVIRONMENTS,
+              bootcDistributions?.map((d) => d.type) ?? EMPTY_ENVIRONMENTS,
             ),
           ]
         : archEnvironments,
@@ -125,6 +118,12 @@ const TargetEnvironment = () => {
       dispatch(changeRegistrationType('register-later'));
     }
   }, [restrictions.registration.shouldHide, dispatch]);
+
+  useEffect(() => {
+    if (isImageMode && environments.length > 1) {
+      dispatch(changeImageTypes([environments[0]]));
+    }
+  }, [isImageMode, environments, dispatch]);
 
   const isOnlyNetworkInstallerSelected =
     environments.length === 1 && environments.includes('network-installer');
@@ -151,6 +150,10 @@ const TargetEnvironment = () => {
     } else {
       dispatch(addImageType(environment));
     }
+  };
+
+  const handleSelectSingleEnvironment = (environment: ImageTypes) => {
+    dispatch(changeImageTypes([environment]));
   };
 
   if (isFetching) {
@@ -200,7 +203,9 @@ const TargetEnvironment = () => {
       fieldId='target-environments'
     >
       <Content component='p'>
-        Select one or more target environments for this image.
+        {isImageMode
+          ? 'Select a target environment for this image.'
+          : 'Select one or more target environments for this image.'}
       </Content>
 
       {publicClouds.length > 0 && (
@@ -211,57 +216,104 @@ const TargetEnvironment = () => {
           aria-label='Public cloud'
           fieldId='public-cloud-group'
         >
-          {publicClouds.includes('aws') && (
-            <Checkbox
-              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-              id='checkbox-aws'
-              name='Amazon Web Services'
-              label='Amazon Web Services'
-              aria-label='Amazon Web Services checkbox'
-              isChecked={environments.includes('aws')}
-              isDisabled={isOnlyNetworkInstallerSelected}
-              onChange={() => handleToggleEnvironment('aws')}
-              body={environments.includes('aws') ? <Aws /> : undefined}
-            />
-          )}
-          {publicClouds.includes('gcp') && (
-            <Checkbox
-              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-              id='checkbox-gcp'
-              name='Google Cloud Platform'
-              label='Google Cloud Platform'
-              aria-label='Google Cloud checkbox'
-              isChecked={environments.includes('gcp')}
-              isDisabled={isOnlyNetworkInstallerSelected}
-              onChange={() => handleToggleEnvironment('gcp')}
-              body={environments.includes('gcp') ? <Gcp /> : undefined}
-            />
-          )}
-          {publicClouds.includes('azure') && (
-            <Checkbox
-              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-              id='checkbox-azure'
-              name='Microsoft Azure'
-              label='Microsoft Azure'
-              aria-label='Microsoft Azure checkbox'
-              isChecked={environments.includes('azure')}
-              isDisabled={isOnlyNetworkInstallerSelected}
-              onChange={() => handleToggleEnvironment('azure')}
-              body={environments.includes('azure') ? <Azure /> : undefined}
-            />
-          )}
-          {publicClouds.includes('oci') && (
-            <Checkbox
-              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-              id='checkbox-oci'
-              name='Oracle Cloud Infrastructure'
-              label='Oracle Cloud Infrastructure'
-              aria-label='Oracle Cloud Infrastructure checkbox'
-              isChecked={environments.includes('oci')}
-              isDisabled={isOnlyNetworkInstallerSelected}
-              onChange={() => handleToggleEnvironment('oci')}
-            />
-          )}
+          {publicClouds.includes('aws') &&
+            (isImageMode ? (
+              <Radio
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='radio-aws'
+                name='target-environment'
+                label='Amazon Web Services'
+                aria-label='Amazon Web Services'
+                isChecked={environments.includes('aws')}
+                onChange={() => handleSelectSingleEnvironment('aws')}
+                body={environments.includes('aws') ? <Aws /> : undefined}
+              />
+            ) : (
+              <Checkbox
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='checkbox-aws'
+                name='Amazon Web Services'
+                label='Amazon Web Services'
+                aria-label='Amazon Web Services checkbox'
+                isChecked={environments.includes('aws')}
+                isDisabled={isOnlyNetworkInstallerSelected}
+                onChange={() => handleToggleEnvironment('aws')}
+                body={environments.includes('aws') ? <Aws /> : undefined}
+              />
+            ))}
+          {publicClouds.includes('gcp') &&
+            (isImageMode ? (
+              <Radio
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='radio-gcp'
+                name='target-environment'
+                label='Google Cloud Platform'
+                aria-label='Google Cloud Platform'
+                isChecked={environments.includes('gcp')}
+                onChange={() => handleSelectSingleEnvironment('gcp')}
+                body={environments.includes('gcp') ? <Gcp /> : undefined}
+              />
+            ) : (
+              <Checkbox
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='checkbox-gcp'
+                name='Google Cloud Platform'
+                label='Google Cloud Platform'
+                aria-label='Google Cloud checkbox'
+                isChecked={environments.includes('gcp')}
+                isDisabled={isOnlyNetworkInstallerSelected}
+                onChange={() => handleToggleEnvironment('gcp')}
+                body={environments.includes('gcp') ? <Gcp /> : undefined}
+              />
+            ))}
+          {publicClouds.includes('azure') &&
+            (isImageMode ? (
+              <Radio
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='radio-azure'
+                name='target-environment'
+                label='Microsoft Azure'
+                aria-label='Microsoft Azure'
+                isChecked={environments.includes('azure')}
+                onChange={() => handleSelectSingleEnvironment('azure')}
+                body={environments.includes('azure') ? <Azure /> : undefined}
+              />
+            ) : (
+              <Checkbox
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='checkbox-azure'
+                name='Microsoft Azure'
+                label='Microsoft Azure'
+                aria-label='Microsoft Azure checkbox'
+                isChecked={environments.includes('azure')}
+                isDisabled={isOnlyNetworkInstallerSelected}
+                onChange={() => handleToggleEnvironment('azure')}
+                body={environments.includes('azure') ? <Azure /> : undefined}
+              />
+            ))}
+          {publicClouds.includes('oci') &&
+            (isImageMode ? (
+              <Radio
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='radio-oci'
+                name='target-environment'
+                label='Oracle Cloud Infrastructure'
+                aria-label='Oracle Cloud Infrastructure'
+                isChecked={environments.includes('oci')}
+                onChange={() => handleSelectSingleEnvironment('oci')}
+              />
+            ) : (
+              <Checkbox
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='checkbox-oci'
+                name='Oracle Cloud Infrastructure'
+                label='Oracle Cloud Infrastructure'
+                aria-label='Oracle Cloud Infrastructure checkbox'
+                isChecked={environments.includes('oci')}
+                isDisabled={isOnlyNetworkInstallerSelected}
+                onChange={() => handleToggleEnvironment('oci')}
+              />
+            ))}
         </FormGroup>
       )}
 
@@ -273,59 +325,104 @@ const TargetEnvironment = () => {
           aria-label='Private cloud'
           fieldId='private-cloud-group'
         >
-          {privateClouds.includes('vsphere-ova') && (
-            <Checkbox
-              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-              id='vsphere-checkbox-ova'
-              isLabelWrapped
-              name='vsphere-checkbox-ova'
-              label='VMware vSphere - Open virtualization format (.ova)'
-              aria-label='VMware vSphere checkbox OVA'
-              description={
-                <Content
-                  component='small'
-                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
-                >
-                  An OVA file is a virtual appliance used by virtualization
-                  platforms such as VMware vSphere. It is a package that
-                  contains files used to describe a virtual machine, which
-                  includes a VMDK image, OVF descriptor file and a manifest
-                  file.
-                </Content>
-              }
-              isChecked={environments.includes('vsphere-ova')}
-              isDisabled={isOnlyNetworkInstallerSelected}
-              onChange={() => {
-                handleToggleEnvironment('vsphere-ova');
-              }}
-            />
-          )}
-          {privateClouds.includes('vsphere') && (
-            <Checkbox
-              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-              id='vsphere-checkbox-vmdk'
-              isLabelWrapped
-              name='vsphere-checkbox-vmdk'
-              label='VMware vSphere - Virtual disk (.vmdk)'
-              aria-label='VMware vSphere checkbox VMDK'
-              description={
-                <Content
-                  component='small'
-                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
-                >
-                  A VMDK file is a virtual disk that stores the contents of a
-                  virtual machine. This disk has to be imported into vSphere
-                  using govc import.vmdk, use the OVA version when using the
-                  vSphere UI.
-                </Content>
-              }
-              isChecked={environments.includes('vsphere')}
-              isDisabled={isOnlyNetworkInstallerSelected}
-              onChange={() => {
-                handleToggleEnvironment('vsphere');
-              }}
-            />
-          )}
+          {privateClouds.includes('vsphere-ova') &&
+            (isImageMode ? (
+              <Radio
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='radio-vsphere-ova'
+                name='target-environment'
+                label='VMware vSphere - Open virtualization format (.ova)'
+                aria-label='VMware vSphere OVA'
+                description={
+                  <Content
+                    component='small'
+                    style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                  >
+                    An OVA file is a virtual appliance used by virtualization
+                    platforms such as VMware vSphere. It is a package that
+                    contains files used to describe a virtual machine, which
+                    includes a VMDK image, OVF descriptor file and a manifest
+                    file.
+                  </Content>
+                }
+                isChecked={environments.includes('vsphere-ova')}
+                onChange={() => handleSelectSingleEnvironment('vsphere-ova')}
+              />
+            ) : (
+              <Checkbox
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='vsphere-checkbox-ova'
+                isLabelWrapped
+                name='vsphere-checkbox-ova'
+                label='VMware vSphere - Open virtualization format (.ova)'
+                aria-label='VMware vSphere checkbox OVA'
+                description={
+                  <Content
+                    component='small'
+                    style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                  >
+                    An OVA file is a virtual appliance used by virtualization
+                    platforms such as VMware vSphere. It is a package that
+                    contains files used to describe a virtual machine, which
+                    includes a VMDK image, OVF descriptor file and a manifest
+                    file.
+                  </Content>
+                }
+                isChecked={environments.includes('vsphere-ova')}
+                isDisabled={isOnlyNetworkInstallerSelected}
+                onChange={() => {
+                  handleToggleEnvironment('vsphere-ova');
+                }}
+              />
+            ))}
+          {privateClouds.includes('vsphere') &&
+            (isImageMode ? (
+              <Radio
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='radio-vsphere-vmdk'
+                name='target-environment'
+                label='VMware vSphere - Virtual disk (.vmdk)'
+                aria-label='VMware vSphere VMDK'
+                description={
+                  <Content
+                    component='small'
+                    style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                  >
+                    A VMDK file is a virtual disk that stores the contents of a
+                    virtual machine. This disk has to be imported into vSphere
+                    using govc import.vmdk, use the OVA version when using the
+                    vSphere UI.
+                  </Content>
+                }
+                isChecked={environments.includes('vsphere')}
+                onChange={() => handleSelectSingleEnvironment('vsphere')}
+              />
+            ) : (
+              <Checkbox
+                className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+                id='vsphere-checkbox-vmdk'
+                isLabelWrapped
+                name='vsphere-checkbox-vmdk'
+                label='VMware vSphere - Virtual disk (.vmdk)'
+                aria-label='VMware vSphere checkbox VMDK'
+                description={
+                  <Content
+                    component='small'
+                    style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                  >
+                    A VMDK file is a virtual disk that stores the contents of a
+                    virtual machine. This disk has to be imported into vSphere
+                    using govc import.vmdk, use the OVA version when using the
+                    vSphere UI.
+                  </Content>
+                }
+                isChecked={environments.includes('vsphere')}
+                isDisabled={isOnlyNetworkInstallerSelected}
+                onChange={() => {
+                  handleToggleEnvironment('vsphere');
+                }}
+              />
+            ))}
         </FormGroup>
       )}
 
@@ -340,123 +437,256 @@ const TargetEnvironment = () => {
         aria-label='Miscellaneous formats'
         fieldId='misc-formats-group'
       >
-        {miscFormats.includes('guest-image') && (
-          <Checkbox
-            className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-            id='checkbox-guest-image'
-            isLabelWrapped
-            name='Virtualization guest image'
-            label='Virtualization - Guest image (.qcow2)'
-            aria-label='Virtualization guest image checkbox'
-            description={
-              <Content component='small' style={{ maxWidth: TEXT_WRAP_WIDTH }}>
-                A deployment-ready virtual disk format used by virtualization
-                software like QEMU and KVM. It allows for efficient storage
-                usage by only writing the changes made to the disk image rather
-                than the entire image, ensuring the file only consumes physical
-                storage as data is written.
-              </Content>
-            }
-            isChecked={environments.includes('guest-image')}
-            isDisabled={isOnlyNetworkInstallerSelected}
-            onChange={() => {
-              handleToggleEnvironment('guest-image');
-            }}
-          />
-        )}
-        {miscFormats.includes('image-installer') && (
-          <Checkbox
-            className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-            id='checkbox-image-installer'
-            isLabelWrapped
-            name='Bare metal installer'
-            label='Bare metal - Installer (.iso)'
-            aria-label='Bare metal installer checkbox'
-            description={
-              <Content component='small' style={{ maxWidth: TEXT_WRAP_WIDTH }}>
-                This is a standard bootable image used to install RHEL directly
-                onto physical hardware or &ldquo;bare metal&rdquo; servers. It
-                contains the necessary installer and kernel to initialize a
-                system from scratch, ensuring the OS is configured correctly for
-                your specific hardware environment.
-              </Content>
-            }
-            isChecked={environments.includes('image-installer')}
-            isDisabled={isOnlyNetworkInstallerSelected}
-            onChange={() => {
-              handleToggleEnvironment('image-installer');
-            }}
-          />
-        )}
-        {miscFormats.includes('network-installer') && (
-          <Checkbox
-            className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-            id='checkbox-network-installer'
-            isLabelWrapped
-            name='Network - Installer'
-            label='Network - Installer (.iso)'
-            aria-label='Network installer checkbox'
-            description={
-              <Content component='small' style={{ maxWidth: TEXT_WRAP_WIDTH }}>
-                This is a lightweight image that differs from a standard
-                &quot;full&quot; ISO by requiring an active network connection
-                to pull the latest software directly from package repositories,
-                as no OS packages are stored locally on the image.
-              </Content>
-            }
-            isChecked={environments.includes('network-installer')}
-            isDisabled={isOtherEnvironmentSelected}
-            onChange={() => {
-              handleToggleEnvironment('network-installer');
-            }}
-          />
-        )}
-        {miscFormats.includes('pxe-tar-xz') && (
-          <Checkbox
-            className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-            id='checkbox-pxe-boot'
-            isLabelWrapped
-            name='PXE boot image'
-            label='Network - PXE boot (.tar.xz)'
-            aria-label='PXE boot image checkbox'
-            description={
-              <Content component='small' style={{ maxWidth: TEXT_WRAP_WIDTH }}>
-                A PXE boot image is a compressed archive containing the kernel,
-                initramfs, and root filesystem needed to boot a system over the
-                network using the Preboot Execution Environment (PXE) protocol.
-              </Content>
-            }
-            isChecked={environments.includes('pxe-tar-xz')}
-            isDisabled={isOnlyNetworkInstallerSelected}
-            onChange={() => {
-              handleToggleEnvironment('pxe-tar-xz');
-            }}
-          />
-        )}
-        {miscFormats.includes('wsl') && (
-          <Checkbox
-            className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
-            id='checkbox-wsl'
-            isLabelWrapped
-            name='WSL'
-            label='WSL - Windows Subsystem for Linux (.wsl)'
-            aria-label='Windows Subsystem for Linux checkbox'
-            description={
-              <Content component='small' style={{ maxWidth: TEXT_WRAP_WIDTH }}>
-                You can use RHEL on Microsoft&apos;s Windows Subsystem for Linux
-                (WSL) for development and learning use cases. Red Hat supports
-                WSL under the Validated Software Pattern and Third Party
-                Component Support Policy, which does not include production use
-                cases.
-              </Content>
-            }
-            isChecked={environments.includes('wsl')}
-            isDisabled={isOnlyNetworkInstallerSelected}
-            onChange={() => {
-              handleToggleEnvironment('wsl');
-            }}
-          />
-        )}
+        {miscFormats.includes('guest-image') &&
+          (isImageMode ? (
+            <Radio
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='radio-guest-image'
+              name='target-environment'
+              label='Virtualization - Guest image (.qcow2)'
+              aria-label='Virtualization guest image'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  A deployment-ready virtual disk format used by virtualization
+                  software like QEMU and KVM. It allows for efficient storage
+                  usage by only writing the changes made to the disk image
+                  rather than the entire image, ensuring the file only consumes
+                  physical storage as data is written.
+                </Content>
+              }
+              isChecked={environments.includes('guest-image')}
+              onChange={() => handleSelectSingleEnvironment('guest-image')}
+            />
+          ) : (
+            <Checkbox
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='checkbox-guest-image'
+              isLabelWrapped
+              name='Virtualization guest image'
+              label='Virtualization - Guest image (.qcow2)'
+              aria-label='Virtualization guest image checkbox'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  A deployment-ready virtual disk format used by virtualization
+                  software like QEMU and KVM. It allows for efficient storage
+                  usage by only writing the changes made to the disk image
+                  rather than the entire image, ensuring the file only consumes
+                  physical storage as data is written.
+                </Content>
+              }
+              isChecked={environments.includes('guest-image')}
+              isDisabled={isOnlyNetworkInstallerSelected}
+              onChange={() => {
+                handleToggleEnvironment('guest-image');
+              }}
+            />
+          ))}
+        {miscFormats.includes('image-installer') &&
+          (isImageMode ? (
+            <Radio
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='radio-image-installer'
+              name='target-environment'
+              label='Bare metal - Installer (.iso)'
+              aria-label='Bare metal installer'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  This is a standard bootable image used to install RHEL
+                  directly onto physical hardware or &ldquo;bare metal&rdquo;
+                  servers. It contains the necessary installer and kernel to
+                  initialize a system from scratch, ensuring the OS is
+                  configured correctly for your specific hardware environment.
+                </Content>
+              }
+              isChecked={environments.includes('image-installer')}
+              onChange={() => handleSelectSingleEnvironment('image-installer')}
+            />
+          ) : (
+            <Checkbox
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='checkbox-image-installer'
+              isLabelWrapped
+              name='Bare metal installer'
+              label='Bare metal - Installer (.iso)'
+              aria-label='Bare metal installer checkbox'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  This is a standard bootable image used to install RHEL
+                  directly onto physical hardware or &ldquo;bare metal&rdquo;
+                  servers. It contains the necessary installer and kernel to
+                  initialize a system from scratch, ensuring the OS is
+                  configured correctly for your specific hardware environment.
+                </Content>
+              }
+              isChecked={environments.includes('image-installer')}
+              isDisabled={isOnlyNetworkInstallerSelected}
+              onChange={() => {
+                handleToggleEnvironment('image-installer');
+              }}
+            />
+          ))}
+        {miscFormats.includes('network-installer') &&
+          (isImageMode ? (
+            <Radio
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='radio-network-installer'
+              name='target-environment'
+              label='Network - Installer (.iso)'
+              aria-label='Network installer'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  This is a lightweight image that differs from a standard
+                  &quot;full&quot; ISO by requiring an active network connection
+                  to pull the latest software directly from package
+                  repositories, as no OS packages are stored locally on the
+                  image.
+                </Content>
+              }
+              isChecked={environments.includes('network-installer')}
+              onChange={() =>
+                handleSelectSingleEnvironment('network-installer')
+              }
+            />
+          ) : (
+            <Checkbox
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='checkbox-network-installer'
+              isLabelWrapped
+              name='Network - Installer'
+              label='Network - Installer (.iso)'
+              aria-label='Network installer checkbox'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  This is a lightweight image that differs from a standard
+                  &quot;full&quot; ISO by requiring an active network connection
+                  to pull the latest software directly from package
+                  repositories, as no OS packages are stored locally on the
+                  image.
+                </Content>
+              }
+              isChecked={environments.includes('network-installer')}
+              isDisabled={isOtherEnvironmentSelected}
+              onChange={() => {
+                handleToggleEnvironment('network-installer');
+              }}
+            />
+          ))}
+        {miscFormats.includes('pxe-tar-xz') &&
+          (isImageMode ? (
+            <Radio
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='radio-pxe-boot'
+              name='target-environment'
+              label='Network - PXE boot (.tar.xz)'
+              aria-label='PXE boot image'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  A PXE boot image is a compressed archive containing the
+                  kernel, initramfs, and root filesystem needed to boot a system
+                  over the network using the Preboot Execution Environment (PXE)
+                  protocol.
+                </Content>
+              }
+              isChecked={environments.includes('pxe-tar-xz')}
+              onChange={() => handleSelectSingleEnvironment('pxe-tar-xz')}
+            />
+          ) : (
+            <Checkbox
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='checkbox-pxe-boot'
+              isLabelWrapped
+              name='PXE boot image'
+              label='Network - PXE boot (.tar.xz)'
+              aria-label='PXE boot image checkbox'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  A PXE boot image is a compressed archive containing the
+                  kernel, initramfs, and root filesystem needed to boot a system
+                  over the network using the Preboot Execution Environment (PXE)
+                  protocol.
+                </Content>
+              }
+              isChecked={environments.includes('pxe-tar-xz')}
+              isDisabled={isOnlyNetworkInstallerSelected}
+              onChange={() => {
+                handleToggleEnvironment('pxe-tar-xz');
+              }}
+            />
+          ))}
+        {miscFormats.includes('wsl') &&
+          (isImageMode ? (
+            <Radio
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='radio-wsl'
+              name='target-environment'
+              label='WSL - Windows Subsystem for Linux (.wsl)'
+              aria-label='Windows Subsystem for Linux'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  You can use RHEL on Microsoft&apos;s Windows Subsystem for
+                  Linux (WSL) for development and learning use cases. Red Hat
+                  supports WSL under the Validated Software Pattern and Third
+                  Party Component Support Policy, which does not include
+                  production use cases.
+                </Content>
+              }
+              isChecked={environments.includes('wsl')}
+              onChange={() => handleSelectSingleEnvironment('wsl')}
+            />
+          ) : (
+            <Checkbox
+              className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+              id='checkbox-wsl'
+              isLabelWrapped
+              name='WSL'
+              label='WSL - Windows Subsystem for Linux (.wsl)'
+              aria-label='Windows Subsystem for Linux checkbox'
+              description={
+                <Content
+                  component='small'
+                  style={{ maxWidth: TEXT_WRAP_WIDTH }}
+                >
+                  You can use RHEL on Microsoft&apos;s Windows Subsystem for
+                  Linux (WSL) for development and learning use cases. Red Hat
+                  supports WSL under the Validated Software Pattern and Third
+                  Party Component Support Policy, which does not include
+                  production use cases.
+                </Content>
+              }
+              isChecked={environments.includes('wsl')}
+              isDisabled={isOnlyNetworkInstallerSelected}
+              onChange={() => {
+                handleToggleEnvironment('wsl');
+              }}
+            />
+          ))}
       </FormGroup>
 
       {isOnlyNetworkInstallerSelected && (

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -59,6 +59,7 @@ import {
   selectBaseUrl,
   selectBlueprintDescription,
   selectBlueprintName,
+  selectBootcDistributions,
   selectCompliancePolicyID,
   selectComplianceProfileID,
   selectComplianceType,
@@ -114,7 +115,6 @@ import {
   FIRST_BOOT_SERVICE_DATA,
   FIRSTBOOT_PATH,
   FIRSTBOOT_SERVICE_PATH,
-  IMAGE_MODE,
   RHEL_10,
   RHEL_8,
   RHEL_9,
@@ -157,20 +157,31 @@ export const mapRequestFromState = (
   const isImageMode = selectIsImageMode(state);
   const imageSource = selectImageSource(state);
 
+  let bootcReference: string | undefined;
+  if (isImageMode && imageSource) {
+    const bootcDistributions = selectBootcDistributions(state);
+    const imageTypes = selectImageTypes(state);
+    if (bootcDistributions.length > 0 && imageTypes.length > 0) {
+      const match = bootcDistributions.find((d) => d.type === imageTypes[0]);
+      if (match) {
+        bootcReference = match.reference;
+      }
+    }
+    if (!bootcReference) {
+      bootcReference = imageSource;
+    }
+  }
+
   return {
     name: selectBlueprintName(state),
     metadata: selectMetadata(state),
     description: selectBlueprintDescription(state),
-    distribution:
-      // we want to make sure image-source is defined
-      // if it isn't, then keep the original distro
-      isImageMode && imageSource ? IMAGE_MODE : selectDistribution(state),
-    bootc:
-      isImageMode && imageSource
-        ? {
-            reference: imageSource,
-          }
-        : undefined,
+    distribution: selectDistribution(state),
+    bootc: bootcReference
+      ? {
+          reference: bootcReference,
+        }
+      : undefined,
     image_requests: imageRequests,
     customizations,
   };
@@ -590,12 +601,14 @@ export const mapRequestToState = (
   request: BlueprintResponse | ComposerBlueprintResponse,
 ): wizardState => {
   const wizardMode = 'edit';
-  const blueprintMode = isImageModeDistribution(request.distribution)
-    ? 'image'
-    : 'package';
+  const blueprintMode =
+    isImageModeDistribution(request.distribution) || request.bootc
+      ? 'image'
+      : 'package';
   return {
     wizardMode,
     blueprintMode,
+    bootcDistributions: [],
     blueprintId: request.id,
     env: {
       serverUrl: request.customizations.subscription?.['server-url'] || '',
@@ -688,9 +701,11 @@ export const mapExportRequestToState = (
 
   return {
     wizardMode,
-    blueprintMode: isImageModeDistribution(request.distribution)
-      ? 'image'
-      : 'package',
+    blueprintMode:
+      isImageModeDistribution(request.distribution) || request.bootc
+        ? 'image'
+        : 'package',
+    bootcDistributions: [],
     metadata: getMetadata(request.metadata),
     env: initialState.env,
     registration: initialState.registration,
@@ -1127,11 +1142,9 @@ const getModules = (state: RootState) => {
 const getTimezone = (state: RootState) => {
   const timezone = selectTimezone(state);
   const ntpservers = selectNtpServers(state);
-  const distribution = selectDistribution(state);
   const isImageMode = selectIsImageMode(state);
 
-  // timezone isn't supported by image-mode
-  if (isImageMode || isImageModeDistribution(distribution)) {
+  if (isImageMode) {
     return undefined;
   }
 
@@ -1185,11 +1198,9 @@ const getSubscription = (
 const getLocale = (state: RootState) => {
   const languages = selectLanguages(state);
   const keyboard = selectKeyboard(state);
-  const distribution = selectDistribution(state);
   const isImageMode = selectIsImageMode(state);
 
-  // locale isn't supported by image-mode
-  if (isImageMode || isImageModeDistribution(distribution)) {
+  if (isImageMode) {
     return undefined;
   }
 

--- a/src/Components/ImagesTable/Release.tsx
+++ b/src/Components/ImagesTable/Release.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Distributions } from '@/store/api/backend';
 
 type ReleaseProps = {
-  release: Distributions;
+  release: Distributions | 'image-mode';
 };
 
 const Release = ({ release }: ReleaseProps) => {

--- a/src/store/api/backend/hooks.tsx
+++ b/src/store/api/backend/hooks.tsx
@@ -7,11 +7,15 @@ import {
   selectComplianceProfileID,
   selectComplianceType,
   selectDistribution,
+  selectIsImageMode,
   selectIsOnPremise,
 } from '@/store/slices';
-import { isImageMode } from '@/store/typeGuards';
 
-import { imageBuilderApi, OpenScapProfile } from './hosted/imageBuilderApi';
+import {
+  Distributions,
+  imageBuilderApi,
+  OpenScapProfile,
+} from './hosted/imageBuilderApi';
 import { composerApi } from './onprem/composerApi';
 
 export const useSecuritySummary = () => {
@@ -21,6 +25,7 @@ export const useSecuritySummary = () => {
   const policyId = useAppSelector(selectCompliancePolicyID);
   const policyTitle = useAppSelector(selectCompliancePolicyTitle);
   const distribution = useAppSelector(selectDistribution);
+  const isImageMode = useAppSelector(selectIsImageMode);
 
   // `isOnPremise` is derived from `process.env.IS_ON_PREMISE`, which is
   // a build-time constant set by webpack. It will never change between
@@ -32,9 +37,9 @@ export const useSecuritySummary = () => {
     {
       // @ts-expect-error we skip this if it's not defined
       profile: profileId,
-      distribution: distribution,
+      distribution: distribution as Distributions,
     },
-    { skip: isImageMode(distribution) || !profileId },
+    { skip: isImageMode || !profileId },
   );
 
   const { data: complianceData } =
@@ -42,10 +47,10 @@ export const useSecuritySummary = () => {
       {
         // @ts-expect-error we skip this if it's not defined
         policy: policyId,
-        distribution: distribution,
+        distribution: distribution as Distributions,
       },
       {
-        skip: isImageMode(distribution) || isOnPremise || !policyId,
+        skip: isImageMode || isOnPremise || !policyId,
       },
     );
 

--- a/src/store/api/backend/hosted/imageBuilderApi.ts
+++ b/src/store/api/backend/hosted/imageBuilderApi.ts
@@ -186,7 +186,7 @@ export type GetDistributionsApiResponse =
    */ DistributionsResponse;
 export type GetDistributionsApiArg = {
   /** Kind of distributions to return. When set to 'bootc', returns bootc/image-mode
-    distributions (each with id, name, type, arch, and image). Defaults to classic distributions.
+    distributions (each with distro, name, type, arch, and reference). Defaults to classic distributions.
      */
   kind?: DistributionKind;
   /** Filter bootc distributions by distribution name. Only applies when kind=bootc.
@@ -352,13 +352,12 @@ export type DistributionItem = {
   name: string;
 };
 export type BootcDistributionItem = {
-  id: string;
   distro: string;
   name: string;
   type: string;
   arch: string;
-  /** part of the container image name used as the base for composing */
-  image_name: string;
+  /** Derived container image reference, only references listed in the bootc distributions list are allowed. */
+  reference: string;
 };
 export type DistributionsResponse = (
   | DistributionItem
@@ -439,8 +438,7 @@ export type Distributions =
   | "fedora-41"
   | "fedora-42"
   | "fedora-43"
-  | "fedora-44"
-  | "image-mode";
+  | "fedora-44";
 export type ListResponseMeta = {
   count: number;
 };
@@ -464,7 +462,7 @@ export type CreateBlueprintResponse = {
   id: string;
 };
 export type BootcBody = {
-  /** Image name from the bootc distributions list. Must match an image_name
+  /** Image name from the bootc distributions list. Must match a reference
     returned by GET /distributions?kind=bootc.
      */
   reference: string;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,6 +19,7 @@ import {
   selectArchitecture,
   selectDistribution,
   selectImageTypes,
+  selectIsImageMode,
   selectIsOnPremise,
   wizardModalSlice,
   wizardSlice,
@@ -62,6 +63,11 @@ startAppListening({
     const imageTypes = selectImageTypes(state);
     const architecture = action.payload;
 
+    // Image-mode gets allowed types from bootc distributions, not getArchitectures
+    if (selectIsImageMode(state)) {
+      return;
+    }
+
     // The response from the RTKQ getArchitectures hook
     const architecturesResponse = isOnPremise
       ? composerApi.endpoints.getArchitectures.select({
@@ -92,6 +98,11 @@ startAppListening({
     const distribution = action.payload;
     const imageTypes = selectImageTypes(state);
     const architecture = selectArchitecture(state);
+
+    // Image-mode gets allowed types from bootc distributions, not getArchitectures
+    if (selectIsImageMode(state)) {
+      return;
+    }
 
     // The response from the RTKQ getArchitectures hook
     const architecturesResponse = isOnPremise

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -23,6 +23,7 @@ import { generateDefaultName } from '@/Components/CreateImageWizard/utilities/us
 import { RHEL_10, UNIT_GIB, X86_64 } from '@/constants';
 import type { RootState } from '@/store';
 import type {
+  BootcDistributionItem,
   CustomRepository,
   Distributions,
   ImageRequest,
@@ -117,6 +118,7 @@ export type wizardState = {
   wizardMode: WizardModeOptions;
   blueprintMode: BlueprintModeOptions;
   imageSource?: ImageSource | undefined;
+  bootcDistributions: BootcDistributionItem[];
   architecture: ImageRequest['architecture'];
   distribution: Distributions | 'image-mode';
   imageTypes: ImageTypes[];
@@ -228,6 +230,7 @@ export const initialState: wizardState = {
   },
   wizardMode: 'create',
   blueprintMode: 'package',
+  bootcDistributions: [],
   architecture: X86_64,
   distribution: RHEL_10,
   imageTypes: [],
@@ -347,6 +350,10 @@ export const selectBlueprintMode = (state: RootState) => {
 
 export const selectImageSource = (state: RootState) => {
   return state.wizard.imageSource;
+};
+
+export const selectBootcDistributions = (state: RootState) => {
+  return state.wizard.bootcDistributions;
 };
 
 export const selectBlueprintId = (state: RootState) => {
@@ -782,6 +789,12 @@ export const wizardSlice = createSlice({
       action: PayloadAction<ImageSource | undefined>,
     ) => {
       state.imageSource = action.payload;
+    },
+    changeBootcDistributions: (
+      state,
+      action: PayloadAction<BootcDistributionItem[]>,
+    ) => {
+      state.bootcDistributions = action.payload;
     },
     changeArchitecture: (
       state,
@@ -1714,6 +1727,7 @@ export const {
   changeProxy,
   changeBlueprintMode,
   changeImageSource,
+  changeBootcDistributions,
   changeArchitecture,
   changeDistribution,
   addImageType,


### PR DESCRIPTION
In regards to new changes in CRC:
- the `image_name` prop was changed to `reference` 
- the distro now no longer expects `image-mode`, but the real distro.
- The bootc request also expects only one reference, so I constrained the target env in image mode only to radio buttons
- added a ref for the architecture so that when the user clicks between the package\image mode, they don't mess up