### PR TITLE
Wizard: Clear image targets when switching to image mode

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
@@ -16,6 +16,7 @@ import {
   changeArchitecture,
   changeBlueprintMode,
   changeDistribution,
+  changeImageTypes,
   selectArchitecture,
   selectDistribution,
   selectIsImageMode,
@@ -81,6 +82,7 @@ const BlueprintMode = () => {
               previousArch.current = architecture;
             }
             dispatch(changeBlueprintMode('image'));
+            dispatch(changeImageTypes([]));
             if (isOnPremise) {
               dispatch(changeDistribution('image-mode'));
             } else {


### PR DESCRIPTION
Some targets are not supported by the image mode, this clears the array when switching to the image mode to ensure no unsupported targets stay stale in the state.

Follow up to https://github.com/osbuild/image-builder-frontend/pull/4328