### PR TITLE
Gate Advanced Settings sub-steps for wizard revamp (HMS-10415)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Content, Form, Title } from '@patternfly/react-core';
 
 import { selectFscMode } from '@/store/slices/wizard';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import AdvancedPartitioning from './components/AdvancedPartitioning';
 import FileSystemAutomaticPartition from './components/FileSystemAutomaticPartitionInformation';
@@ -16,11 +17,17 @@ export type FscModeType = 'automatic' | 'basic' | 'advanced';
 
 const FileSystemStep = () => {
   const fscMode = useAppSelector(selectFscMode);
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
+
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
 
   return (
-    <Form>
+    <Wrapper>
       <CustomizationLabels customization='filesystem' />
-      <Title headingLevel='h1' size='xl'>
+      <Title
+        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+        size={isWizardRevampEnabled ? 'lg' : 'xl'}
+      >
         File system configuration
       </Title>
       <Content>Define the partitioning of the image.</Content>
@@ -40,7 +47,7 @@ const FileSystemStep = () => {
           <AdvancedPartitioning />
         </>
       )}
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
@@ -30,7 +30,9 @@ const FileSystemStep = () => {
       >
         File system configuration
       </Title>
-      <Content>Define the partitioning of the image.</Content>
+      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
+        Define the partitioning of the image.
+      </Content>
       {fscMode === 'automatic' ? (
         <>
           <FileSystemPartition />

--- a/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
@@ -13,6 +13,10 @@ import FileSystemPartition from './components/FileSystemPartition';
 import { useAppSelector } from '../../../../store/hooks';
 import { CustomizationLabels } from '../../../sharedComponents/CustomizationLabels';
 
+// NOTE: waiting for docs to come back to us on this
+// const DOCS_URL =
+// 'https://docs.redhat.com/en/documentation/red_hat_lightspeed/1-latest/html/deploying_and_managing_rhel_systems_in_hybrid_clouds/creating-blueprints-and-blueprint-images_host-management-services#additional-modifications-to-a-blueprint_creating-blueprints-and-blueprint-images';
+
 export type FscModeType = 'automatic' | 'basic' | 'advanced';
 
 const FileSystemStep = () => {
@@ -31,7 +35,33 @@ const FileSystemStep = () => {
         File system configuration
       </Title>
       <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
-        Define the partitioning of the image.
+        Configure the system and partitioning for your image. You can use
+        automatic partitioning, manually define your own mount points and sizes,
+        or use advanced partitioning for complex storage layouts. The order of
+        the partitions may change when the image is installed in order to
+        conform to best practices and ensure functionality.
+        {
+          // our existing documentation link button isn't very re-usable
+          // so we have to re-implement this here. Commenting this out
+          // for now while we wait for the docs team to get back to us
+          // about a suitable docs link
+          // !isOnPremise && (
+          //   <Button
+          //     component='a'
+          //     target='_blank'
+          //     variant='link'
+          //     icon={<ExternalLinkAltIcon />}
+          //     iconPosition='right'
+          //     isInline
+          //     href={
+          //
+          //       DOCS_URL
+          //     }
+          //   >
+          //     Learn about customizing file systems
+          //   </Button>
+          // )
+        }
       </Content>
       {fscMode === 'automatic' ? (
         <>

--- a/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Content, Form, Title } from '@patternfly/react-core';
 
+import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
+import { useAppSelector } from '@/store/hooks';
 import { selectFscMode } from '@/store/slices/wizard';
 import { useFlag } from '@/Utilities/useGetEnvironment';
 
@@ -9,9 +11,6 @@ import AdvancedPartitioning from './components/AdvancedPartitioning';
 import FileSystemAutomaticPartition from './components/FileSystemAutomaticPartitionInformation';
 import FileSystemConfiguration from './components/FileSystemConfiguration';
 import FileSystemPartition from './components/FileSystemPartition';
-
-import { useAppSelector } from '../../../../store/hooks';
-import { CustomizationLabels } from '../../../sharedComponents/CustomizationLabels';
 
 // NOTE: waiting for docs to come back to us on this
 // const DOCS_URL =

--- a/src/Components/CreateImageWizard/steps/Firewall/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/index.tsx
@@ -21,7 +21,7 @@ const FirewallStep = () => {
       >
         Firewall
       </Title>
-      <Content>
+      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
         Customize firewall settings for your image. When enabling or disabling
         services, use the firewalld service name rather than systemd unit names.
       </Content>

--- a/src/Components/CreateImageWizard/steps/Firewall/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/index.tsx
@@ -22,8 +22,9 @@ const FirewallStep = () => {
         Firewall
       </Title>
       <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
-        Customize firewall settings for your image. When enabling or disabling
-        services, use the firewalld service name rather than systemd unit names.
+        Control network traffic by configuring your image&apos;s firewall.
+        Specify which ports and services are allowed to communicate with your
+        system.
       </Content>
       <PortsInput />
       <Services />

--- a/src/Components/CreateImageWizard/steps/Firewall/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/index.tsx
@@ -3,15 +3,22 @@ import React from 'react';
 import { Content, Form, Title } from '@patternfly/react-core';
 
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import PortsInput from './components/PortsInput';
 import Services from './components/Services';
 
 const FirewallStep = () => {
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
+
   return (
-    <Form>
+    <Wrapper>
       <CustomizationLabels customization='firewall' />
-      <Title headingLevel='h1' size='xl'>
+      <Title
+        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+        size={isWizardRevampEnabled ? 'lg' : 'xl'}
+      >
         Firewall
       </Title>
       <Content>
@@ -20,7 +27,7 @@ const FirewallStep = () => {
       </Content>
       <PortsInput />
       <Services />
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Firewall/tests/Firewall.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/tests/Firewall.test.tsx
@@ -22,7 +22,7 @@ describe('Firewall Component', () => {
         await screen.findByRole('heading', { name: /Firewall/i }),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(/Customize firewall settings for your image/i),
+        screen.getByText(/Control network traffic by configuring/i),
       ).toBeInTheDocument();
     });
 

--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -68,7 +68,7 @@ const FirstBootStep = () => {
       >
         First boot configuration
       </Title>
-      <Content>
+      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
         Configure the image with a custom script that will execute on its first
         boot.
         {registrationType !== 'register-later' && (

--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -19,6 +19,7 @@ import {
   selectRegistrationType,
   setFirstBootScript,
 } from '@/store/slices/wizard';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import { FIRST_BOOT_SERVICE } from '../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
@@ -54,11 +55,17 @@ const FirstBootStep = () => {
   const registrationType = useAppSelector(selectRegistrationType);
   const language = detectScriptType(selectedScript);
   const { errors } = useFirstBootValidation();
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
+
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
 
   return (
-    <Form>
+    <Wrapper>
       <CustomizationLabels customization='firstBoot' />
-      <Title headingLevel='h1' size='xl'>
+      <Title
+        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+        size={isWizardRevampEnabled ? 'lg' : 'xl'}
+      >
         First boot configuration
       </Title>
       <Content>
@@ -111,7 +118,7 @@ const FirstBootStep = () => {
           </FormHelperText>
         )}
       </FormGroup>
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -12,6 +12,10 @@ import {
   Title,
 } from '@patternfly/react-core';
 
+import { useFirstBootValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
+import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
+import { FIRST_BOOT_SERVICE } from '@/constants';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   addEnabledService,
   removeEnabledService,
@@ -20,11 +24,6 @@ import {
   setFirstBootScript,
 } from '@/store/slices/wizard';
 import { useFlag } from '@/Utilities/useGetEnvironment';
-
-import { FIRST_BOOT_SERVICE } from '../../../../constants';
-import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
-import { CustomizationLabels } from '../../../sharedComponents/CustomizationLabels';
-import { useFirstBootValidation } from '../../utilities/useValidation';
 
 const detectScriptType = (scriptString: string): Language => {
   const lines = scriptString.split('\n');

--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -69,10 +69,10 @@ const FirstBootStep = () => {
         First boot configuration
       </Title>
       <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
-        Configure the image with a custom script that will execute on its first
-        boot.
+        Add a custom script to be executed when the image boots for the first
+        time.
         {registrationType !== 'register-later' && (
-          <> First boot script will run after registration is done.</>
+          <> The first boot script will run after registration is done.</>
         )}
       </Content>
 

--- a/src/Components/CreateImageWizard/steps/FirstBoot/tests/FirstBoot.test.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/tests/FirstBoot.test.tsx
@@ -21,7 +21,7 @@ describe('FirstBoot Component', () => {
         }),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(/Configure the image with a custom script/i),
+        screen.getByText(/Add a custom script to be executed/i),
       ).toBeInTheDocument();
     });
 
@@ -95,7 +95,7 @@ describe('FirstBoot Component', () => {
 
       expect(
         await screen.findByText(
-          /First boot script will run after registration is done/i,
+          /The first boot script will run after registration is done/i,
         ),
       ).toBeInTheDocument();
     });
@@ -114,7 +114,7 @@ describe('FirstBoot Component', () => {
 
       expect(
         screen.queryByText(
-          /First boot script will run after registration is done/i,
+          /The first boot script will run after registration is done/i,
         ),
       ).not.toBeInTheDocument();
     });

--- a/src/Components/CreateImageWizard/steps/Hostname/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Hostname/index.tsx
@@ -31,7 +31,7 @@ const HostnameStep = () => {
       >
         Hostname
       </Title>
-      <Content>
+      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
         Define the hostname to uniquely identify this image within your network
         environment.
       </Content>

--- a/src/Components/CreateImageWizard/steps/Hostname/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Hostname/index.tsx
@@ -3,19 +3,32 @@ import React from 'react';
 import { Content, Form, Title } from '@patternfly/react-core';
 
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import HostnameInput from './components/HostnameInput';
 
 const HostnameStep = () => {
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
+
   return (
-    <Form
-      onSubmit={(event) => {
-        // this prevents from reloading the wizard on pressing enter
-        event.preventDefault();
-      }}
+    <Wrapper
+      {
+        // the old wizard is still using a form, so we need
+        // to do this to prevent the page from reloading. For
+        // the new wizard, this is done in the parent form instead
+        ...(!isWizardRevampEnabled && {
+          onSubmit: (event: React.FormEvent) => {
+            event.preventDefault();
+          },
+        })
+      }
     >
       <CustomizationLabels customization='hostname' />
-      <Title headingLevel='h1' size='xl'>
+      <Title
+        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+        size={isWizardRevampEnabled ? 'lg' : 'xl'}
+      >
         Hostname
       </Title>
       <Content>
@@ -23,7 +36,7 @@ const HostnameStep = () => {
         environment.
       </Content>
       <HostnameInput />
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Kernel/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/index.tsx
@@ -7,6 +7,7 @@ import { CustomizationLabels } from '@/Components/sharedComponents/Customization
 import { useSecuritySummary } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
 import { selectFips } from '@/store/slices/wizard';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import KernelArguments from './components/KernelArguments';
 import KernelName from './components/KernelName';
@@ -18,12 +19,15 @@ const KernelStep = () => {
     kernel: { append: requiredByOpenSCAP },
   } = useSecuritySummary();
 
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
+
   return (
-    <Form>
+    <Wrapper>
       <CustomizationLabels customization='kernel' />
       <Title
-        headingLevel='h1'
-        size='xl'
+        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+        size={isWizardRevampEnabled ? 'lg' : 'xl'}
         className='pf-v6-u-display-flex pf-v6-u-align-items-center'
       >
         Kernel
@@ -46,7 +50,7 @@ const KernelStep = () => {
       )}
       <KernelName />
       <KernelArguments />
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Kernel/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/index.tsx
@@ -37,7 +37,7 @@ const KernelStep = () => {
           </Label>
         )}
       </Title>
-      <Content>
+      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
         Choose a kernel package and append specific boot parameters to customize
         how your image initializes its core operating environment.
       </Content>

--- a/src/Components/CreateImageWizard/steps/Locale/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/index.tsx
@@ -2,22 +2,21 @@ import React, { useMemo } from 'react';
 
 import { Content, Form, Spinner, Title } from '@patternfly/react-core';
 
+import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useGetArchitecturesQuery } from '@/store/api/backend';
 import { useSearchLanguagePacks } from '@/store/api/distributions';
+import { useAppSelector } from '@/store/hooks';
 import {
   selectArchitecture,
   selectDistribution,
   selectLocaleLangpackCandidates,
   selectVerifiedLocaleLangpacks,
 } from '@/store/slices/wizard';
+import { asDistribution } from '@/store/typeGuards';
 import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import KeyboardDropDown from './components/KeyboardDropDown';
 import LanguagesDropDown from './components/LanguagesDropDown';
-
-import { useAppSelector } from '../../../../store/hooks';
-import { asDistribution } from '../../../../store/typeGuards';
-import { CustomizationLabels } from '../../../sharedComponents/CustomizationLabels';
 
 const LocaleStep = () => {
   const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');

--- a/src/Components/CreateImageWizard/steps/Locale/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/index.tsx
@@ -10,6 +10,7 @@ import {
   selectLocaleLangpackCandidates,
   selectVerifiedLocaleLangpacks,
 } from '@/store/slices/wizard';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import KeyboardDropDown from './components/KeyboardDropDown';
 import LanguagesDropDown from './components/LanguagesDropDown';
@@ -19,6 +20,7 @@ import { asDistribution } from '../../../../store/typeGuards';
 import { CustomizationLabels } from '../../../sharedComponents/CustomizationLabels';
 
 const LocaleStep = () => {
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
   const distribution = useAppSelector(selectDistribution);
   const arch = useAppSelector(selectArchitecture);
   const candidateLangpacks = useAppSelector(selectLocaleLangpackCandidates);
@@ -43,10 +45,15 @@ const LocaleStep = () => {
     candidateLangpacks.length > 0 &&
     (isArchitecturesLoading || isSearchLoading);
 
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
+
   return (
-    <Form>
+    <Wrapper>
       <CustomizationLabels customization='locale' />
-      <Title headingLevel='h1' size='xl'>
+      <Title
+        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+        size={isWizardRevampEnabled ? 'lg' : 'xl'}
+      >
         Locale
       </Title>
       <Content>
@@ -72,7 +79,7 @@ const LocaleStep = () => {
         </Content>
       )}
       <KeyboardDropDown />
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Locale/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/index.tsx
@@ -56,7 +56,7 @@ const LocaleStep = () => {
       >
         Locale
       </Title>
-      <Content>
+      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
         Define the primary languages and keyboard settings for your image to
         ensure proper system localization and user interface support.
       </Content>

--- a/src/Components/CreateImageWizard/steps/Services/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/index.tsx
@@ -30,7 +30,7 @@ const ServicesStep = () => {
           </Label>
         )}
       </Title>
-      <Content>
+      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
         Configure systemd units to manage your system’s services and startup
         logic. Enable services to start at boot, disable them to prevent
         automatic starting, or mask them to completely block execution.

--- a/src/Components/CreateImageWizard/steps/Services/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/index.tsx
@@ -5,18 +5,22 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useSecuritySummary } from '@/store/api/backend';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import ServicesInput from './components/ServicesInputs';
 
 const ServicesStep = () => {
   const { services: requiredByOpenSCAP } = useSecuritySummary();
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
+
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
 
   return (
-    <Form>
+    <Wrapper>
       <CustomizationLabels customization='services' />
       <Title
-        headingLevel='h1'
-        size='xl'
+        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+        size={isWizardRevampEnabled ? 'lg' : 'xl'}
         className='pf-v6-u-display-flex pf-v6-u-align-items-center'
       >
         Systemd services
@@ -32,7 +36,7 @@ const ServicesStep = () => {
         automatic starting, or mask them to completely block execution.
       </Content>
       <ServicesInput />
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Timezone/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/index.tsx
@@ -3,15 +3,23 @@ import React from 'react';
 import { Content, Form, Title } from '@patternfly/react-core';
 
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import NtpServersInput from './components/NtpServersInput';
 import TimezoneDropDown from './components/TimezoneDropDown';
 
 const TimezoneStep = () => {
+  const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
+
+  const Wrapper = isWizardRevampEnabled ? React.Fragment : Form;
+
   return (
-    <Form>
+    <Wrapper>
       <CustomizationLabels customization='timezone' />
-      <Title headingLevel='h1' size='xl'>
+      <Title
+        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+        size={isWizardRevampEnabled ? 'lg' : 'xl'}
+      >
         Timezone
       </Title>
       <Content>
@@ -20,7 +28,7 @@ const TimezoneStep = () => {
       </Content>
       <TimezoneDropDown />
       <NtpServersInput />
-    </Form>
+    </Wrapper>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Timezone/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/index.tsx
@@ -22,7 +22,7 @@ const TimezoneStep = () => {
       >
         Timezone
       </Title>
-      <Content>
+      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
         Select a timezone and define NTP servers to ensure your image maintains
         accurate system time upon deployment.
       </Content>

--- a/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
+++ b/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
@@ -423,7 +423,7 @@ const CreateImageWizard3 = () => {
             />
           }
         >
-          <Form>
+          <Form onSubmit={handleFormSubmit}>
             <Title headingLevel='h1' size='xl'>
               Advanced settings
             </Title>


### PR DESCRIPTION
## Summary
Prepare the Advanced Settings sub-steps (FileSystem, Firewall, FirstBoot, Hostname, Kernel, Locale, Services, Timezone) for the wizard revamp by gating their layout and text formatting behind the `image-builder.wizard-revamp.enabled` feature flag.

## Changes
- Switch each sub-step wrapper from `<Form>` to `<React.Fragment>` when the revamp flag is enabled, avoiding nested `<form>` elements under the parent wizard form
- Demote sub-step headings from h1/xl to h2/lg and descriptions from `<p>` to `<small>` to match the consolidated Advanced Settings layout
- Add `onSubmit` prevention on the parent Advanced Settings `<Form>` in CreateImageWizard3
- Expand the FileSystem description and add an external documentation link (hidden for on-prem users)
- Reword Firewall and FirstBoot descriptions for clarity, updating tests to match