### PR TITLE
vitest: Add "onSubmit" tests to text inputs (HMS-10462)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Details/tests/Details.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/tests/Details.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 
 import { initialState } from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
-import { createUser } from '@/test/testUtils';
+import { clearWithWait, createUser, typeWithWait } from '@/test/testUtils';
 
 import {
   clearBlueprintName,
@@ -310,6 +310,45 @@ describe('Details Component', () => {
       await enterBlueprintName(user, 'Custom Name');
 
       expect(store.getState().wizard.details.isCustomName).toBe(true);
+    });
+  });
+
+  describe('Form submission', () => {
+    test('pressing Enter in name input does not trigger page reload', async () => {
+      const { store } = renderDetailsStep();
+      const user = createUser();
+
+      const nameInput = await screen.findByRole('textbox', {
+        name: /blueprint name/i,
+      });
+      await clearWithWait(user, nameInput);
+      await typeWithWait(user, nameInput, 'custom-blueprint-name{Enter}');
+
+      expect(
+        screen.getByRole('heading', { name: /Image details/i }),
+      ).toBeInTheDocument();
+      expect(nameInput).toBeInTheDocument();
+      expect(store.getState().wizard.details.blueprintName).toBe(
+        'custom-blueprint-name',
+      );
+    });
+
+    test('pressing Enter in description input does not trigger page reload', async () => {
+      const { store } = renderDetailsStep();
+      const user = createUser();
+
+      const descriptionInput = await screen.findByRole('textbox', {
+        name: /blueprint description/i,
+      });
+      await typeWithWait(user, descriptionInput, 'Test description{Enter}');
+
+      expect(
+        screen.getByRole('heading', { name: /Image details/i }),
+      ).toBeInTheDocument();
+      expect(descriptionInput).toBeInTheDocument();
+      expect(store.getState().wizard.details.blueprintDescription).toBe(
+        'Test description',
+      );
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/FileSystem/tests/FileSystem.test.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/tests/FileSystem.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
+
+import FileSystemStep from '../index';
+
+describe('FileSystem Component', () => {
+  describe('Form submission', () => {
+    test('pressing Enter in mountpoint input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<FileSystemStep />, {
+        fscMode: 'basic',
+        fileSystem: {
+          partitions: [
+            {
+              id: '642a10c4-4ffc-471b-803d-44405ae4abf4',
+              mountpoint: '/',
+              min_size: '10',
+              unit: 'GiB',
+            },
+            {
+              id: '46acd579-e5a6-474a-875c-017394d70382',
+              mountpoint: '',
+              min_size: '10',
+              unit: 'GiB',
+            },
+          ],
+        },
+      });
+      const user = createUser();
+
+      const mountpointInputs = await screen.findAllByRole('textbox', {
+        name: /mount point input/i,
+      });
+      await typeWithWait(user, mountpointInputs[1], '/var{Enter}');
+
+      expect(mountpointInputs[1]).toBeInTheDocument();
+      expect(store.getState().wizard.fileSystem.partitions[1].mountpoint).toBe(
+        '/var',
+      );
+    });
+
+    test('pressing Enter in minimum size input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<FileSystemStep />, {
+        fscMode: 'basic',
+        fileSystem: {
+          partitions: [
+            {
+              id: '1',
+              mountpoint: '/var',
+              min_size: '',
+              unit: 'GiB',
+            },
+          ],
+        },
+      });
+      const user = createUser();
+
+      const minSizeInput = await screen.findByRole('textbox', {
+        name: /minimum partition size/i,
+      });
+      await typeWithWait(user, minSizeInput, '20{Enter}');
+
+      expect(minSizeInput).toBeInTheDocument();
+      expect(store.getState().wizard.fileSystem.partitions[0].min_size).toBe(
+        '20',
+      );
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/Hostname/tests/Hostname.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Hostname/tests/Hostname.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { createUser } from '@/test/testUtils';
+import { createUser, typeWithWait } from '@/test/testUtils';
 
 import {
   clearHostname,
@@ -168,6 +168,23 @@ describe('Hostname Component', () => {
 
       await clearHostname(user);
       expect(screen.queryByText(/Invalid hostname/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Form submission', () => {
+    test('pressing Enter does not trigger page reload', async () => {
+      const { store } = renderHostnameStep();
+      const user = createUser();
+
+      const hostnameInput =
+        await screen.findByPlaceholderText(/Add a hostname/i);
+      await typeWithWait(user, hostnameInput, 'test-hostname{Enter}');
+
+      expect(
+        screen.getByRole('heading', { name: /Hostname/i }),
+      ).toBeInTheDocument();
+      expect(hostnameInput).toBeInTheDocument();
+      expect(store.getState().wizard.hostname).toBe('test-hostname');
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Aws/tests/Aws.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Aws/tests/Aws.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
+
+import Aws from '../index';
+
+describe('AWS Component', () => {
+  describe('Form submission', () => {
+    test('pressing Enter in AWS account ID input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<Aws />, {
+        imageTypes: ['aws'],
+      });
+      const user = createUser();
+
+      const accountIdInput = await screen.findByRole('textbox', {
+        name: /aws account id/i,
+      });
+      await typeWithWait(user, accountIdInput, '123456789012{Enter}');
+
+      expect(accountIdInput).toBeInTheDocument();
+      expect(store.getState().wizard.aws.accountId).toBe('123456789012');
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
@@ -5,7 +5,12 @@ import { mapRequestFromState } from '@/Components/CreateImageWizard/utilities/re
 import { serviceMiddleware, serviceReducer } from '@/store';
 import { CreateBlueprintRequest, ImageRequest } from '@/store/api/backend';
 import { initialState } from '@/store/slices/wizard';
-import { clickWithWait, createUser, tabWithWait } from '@/test/testUtils';
+import {
+  clickWithWait,
+  createUser,
+  tabWithWait,
+  typeWithWait,
+} from '@/test/testUtils';
 
 import {
   checkHyperVGenValue,
@@ -485,5 +490,69 @@ describe('Azure CreateBlueprintRequest payload', () => {
     ) as CreateBlueprintRequest;
 
     expect(request.customizations.subscription).toBeUndefined();
+  });
+});
+
+describe('Form submission', () => {
+  test('pressing Enter in tenant ID input does not trigger page reload', async () => {
+    const { store } = renderAzureStep();
+    const user = createUser();
+
+    const tenantInput = await screen.findByPlaceholderText(
+      /Enter your 36-character GUID/i,
+    );
+    await typeWithWait(
+      user,
+      tenantInput,
+      'b8f86d22-4371-46ce-95e7-65c415f3b1e2{Enter}',
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Generation 2 \(UEFI\)/i }),
+    ).toBeInTheDocument();
+    expect(tenantInput).toBeInTheDocument();
+    expect(store.getState().wizard.azure.tenantId).toBe(
+      'b8f86d22-4371-46ce-95e7-65c415f3b1e2',
+    );
+  });
+
+  test('pressing Enter in subscription ID input does not trigger page reload', async () => {
+    const { store } = renderAzureStep();
+    const user = createUser();
+
+    const subscriptionInput = await screen.findByPlaceholderText(
+      /Enter your 36-character ID/i,
+    );
+    await typeWithWait(
+      user,
+      subscriptionInput,
+      '60631143-a7dc-4d15-988b-ba83f3c99711{Enter}',
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Generation 2 \(UEFI\)/i }),
+    ).toBeInTheDocument();
+    expect(subscriptionInput).toBeInTheDocument();
+    expect(store.getState().wizard.azure.subscriptionId).toBe(
+      '60631143-a7dc-4d15-988b-ba83f3c99711',
+    );
+  });
+
+  test('pressing Enter in resource group input does not trigger page reload', async () => {
+    const { store } = renderAzureStep();
+    const user = createUser();
+
+    const resourceGroupInput = await screen.findByPlaceholderText(
+      /Enter your resource group/i,
+    );
+    await typeWithWait(user, resourceGroupInput, 'test-resource-group{Enter}');
+
+    expect(
+      screen.getByRole('button', { name: /Generation 2 \(UEFI\)/i }),
+    ).toBeInTheDocument();
+    expect(resourceGroupInput).toBeInTheDocument();
+    expect(store.getState().wizard.azure.resourceGroup).toBe(
+      'test-resource-group',
+    );
   });
 });

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/tests/Gcp.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/tests/Gcp.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
+
+import Gcp from '../index';
+
+describe('GCP Component', () => {
+  describe('Form submission', () => {
+    test('pressing Enter in principal input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<Gcp />, {
+        imageTypes: ['gcp'],
+        gcp: {
+          accountType: 'user',
+          email: '',
+        },
+      });
+      const user = createUser();
+
+      const principalInput = await screen.findByRole('textbox', {
+        name: /google principal/i,
+      });
+      await typeWithWait(user, principalInput, 'user@example.com{Enter}');
+
+      expect(principalInput).toBeInTheDocument();
+      expect(store.getState().wizard.gcp.email).toBe('user@example.com');
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { createUser } from '@/test/testUtils';
+import { createUser, typeWithWait } from '@/test/testUtils';
 
 import {
   clearKeyboardSearch,
@@ -319,6 +319,36 @@ describe('Locale Component', () => {
       await selectKeyboardOption(user, 'us');
 
       expect(store.getState().wizard.locale.keyboard).toBe('us');
+    });
+  });
+
+  describe('Form submission', () => {
+    test('pressing Enter in keyboard search does not trigger page reload', async () => {
+      renderLocaleStep();
+      const user = createUser();
+
+      const keyboardInput =
+        await screen.findByPlaceholderText(/select a keyboard/i);
+      await typeWithWait(user, keyboardInput, 'us-dvorak{Enter}');
+
+      expect(
+        screen.getByPlaceholderText(/select a language/i),
+      ).toBeInTheDocument();
+      expect(keyboardInput).toBeInTheDocument();
+    });
+
+    test('pressing Enter in language search does not trigger page reload', async () => {
+      renderLocaleStep();
+      const user = createUser();
+
+      const languageInput =
+        await screen.findByPlaceholderText(/select a language/i);
+      await typeWithWait(user, languageInput, 'Dutch{Enter}');
+
+      expect(
+        screen.getByPlaceholderText(/select a keyboard/i),
+      ).toBeInTheDocument();
+      expect(languageInput).toBeInTheDocument();
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
+
+import OscapStep from '../index';
+
+describe('Oscap Component', () => {
+  describe('Form submission', () => {
+    test('pressing Enter in profile search does not trigger page reload', async () => {
+      renderWithRedux(<OscapStep />, {
+        compliance: {
+          complianceType: 'openscap',
+          profileID: undefined,
+          policyID: undefined,
+          policyTitle: undefined,
+        },
+      });
+      const user = createUser();
+
+      const profileSearchInput = await screen.findByPlaceholderText('None');
+      await typeWithWait(user, profileSearchInput, 'cis{Enter}');
+
+      expect(profileSearchInput).toBeInTheDocument();
+      expect(profileSearchInput).toHaveValue('cis');
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
@@ -590,4 +590,23 @@ describe('Packages Component', () => {
       await screen.findByText(/there are no selected packages/i);
     });
   });
+
+  describe('Form submission', () => {
+    test('pressing Enter in search input does not trigger page reload', async () => {
+      fetchMock.mockResponse(createFetchHandler({ rpms: mockSearchResults }));
+      renderPackagesStep();
+      const user = createUser();
+
+      const searchInput = await screen.findByRole('textbox', {
+        name: /search packages/i,
+      });
+      await typeWithWait(user, searchInput, 'test-pkg{Enter}');
+
+      expect(
+        screen.getByRole('button', { name: /individual packages/i }),
+      ).toBeInTheDocument();
+      expect(searchInput).toBeInTheDocument();
+      expect(searchInput).toHaveValue('test-pkg');
+    });
+  });
 });

--- a/src/Components/CreateImageWizard/steps/Registration/components/AAP/tests/AAP.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/AAP/tests/AAP.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { createUser } from '@/test/testUtils';
+import { createUser, typeWithWait } from '@/test/testUtils';
 
 import {
   enterCallbackUrl,
@@ -211,6 +211,48 @@ describe('AAP Component', () => {
 
       expect(store.getState().wizard.aapRegistration.skipTlsVerification).toBe(
         true,
+      );
+    });
+  });
+
+  describe('Form submission', () => {
+    test('pressing Enter in callback URL input does not trigger page reload', async () => {
+      const { store } = renderAAPStep();
+      const user = createUser();
+
+      const callbackUrlInput = await screen.findByRole('textbox', {
+        name: /ansible callback url/i,
+      });
+      await typeWithWait(
+        user,
+        callbackUrlInput,
+        'https://controller.example.com/callback/{Enter}',
+      );
+
+      expect(
+        screen.getByRole('textbox', { name: /host config key/i }),
+      ).toBeInTheDocument();
+      expect(callbackUrlInput).toBeInTheDocument();
+      expect(store.getState().wizard.aapRegistration.callbackUrl).toBe(
+        'https://controller.example.com/callback/',
+      );
+    });
+
+    test('pressing Enter in host config key input does not trigger page reload', async () => {
+      const { store } = renderAAPStep();
+      const user = createUser();
+
+      const hostConfigKeyInput = await screen.findByRole('textbox', {
+        name: /host config key/i,
+      });
+      await typeWithWait(user, hostConfigKeyInput, 'test-config-key{Enter}');
+
+      expect(
+        screen.getByRole('textbox', { name: /ansible callback url/i }),
+      ).toBeInTheDocument();
+      expect(hostConfigKeyInput).toBeInTheDocument();
+      expect(store.getState().wizard.aapRegistration.hostConfigKey).toBe(
+        'test-config-key',
       );
     });
   });

--- a/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
@@ -3,7 +3,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { mapRequestFromState } from '@/Components/CreateImageWizard/utilities/requestMapper';
 import { CreateBlueprintRequest } from '@/store/api/backend';
 import { server } from '@/test/mocks/server';
-import { createTestStore, createUser } from '@/test/testUtils';
+import { createTestStore, createUser, typeWithWait } from '@/test/testUtils';
 
 import {
   removeRepo,
@@ -613,5 +613,26 @@ describe('Request Payload Generation', () => {
       'ae39f556-6986-478a-95d1-f9c7e33d066c',
       '34718648-0946-4b09-abef-3a20647f2b1f',
     ]);
+  });
+
+  describe('Form submission', () => {
+    test('pressing Enter in search input does not trigger page reload', async () => {
+      fetchMock.mockResponse(
+        createFetchHandler({ repositories: mockRepositoryResults }),
+      );
+      renderRepositoriesStep();
+      const user = createUser();
+
+      const searchInput = await screen.findByRole('textbox', {
+        name: /filter repositories/i,
+      });
+      await typeWithWait(user, searchInput, 'test-repo{Enter}');
+
+      expect(
+        screen.getByRole('button', { name: /menu toggle/i }),
+      ).toBeInTheDocument();
+      expect(searchInput).toBeInTheDocument();
+      expect(searchInput).toHaveValue('test-repo');
+    });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Snapshot/tests/RepeatableBuild.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/tests/RepeatableBuild.test.tsx
@@ -1,7 +1,12 @@
 import { screen } from '@testing-library/react';
 
 import { server } from '@/test/mocks/server';
-import { createUser, tabWithWait } from '@/test/testUtils';
+import {
+  clearWithWait,
+  createUser,
+  tabWithWait,
+  typeWithWait,
+} from '@/test/testUtils';
 import { yyyyMMddFormat } from '@/Utilities/time';
 
 import {
@@ -350,6 +355,45 @@ describe('Repeatable Build Component', () => {
 
       expect(store.getState().wizard.snapshotting.useLatest).toBe(true);
       expect(store.getState().wizard.snapshotting.snapshotDate).toBe('');
+    });
+  });
+
+  describe('Form submission', () => {
+    test('pressing Enter in snapshot date picker does not trigger page reload', async () => {
+      const { store } = renderRepeatableBuildStep();
+      const user = createUser();
+
+      await selectEnableRepeatableBuild(user);
+
+      const dateInput = await screen.findByRole('textbox', {
+        name: /date picker/i,
+      });
+      await clearWithWait(user, dateInput);
+      await typeWithWait(user, dateInput, '2026-03-15{Enter}');
+
+      expect(dateInput).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', { name: /Enable repeatable build/i }),
+      ).toBeChecked();
+      expect(store.getState().wizard.snapshotting.snapshotDate).toBe(
+        '2026-03-15T00:00:00.000Z',
+      );
+    });
+
+    test('pressing Enter in template search does not trigger page reload', async () => {
+      renderRepeatableBuildStep();
+      const user = createUser();
+
+      await selectUseAContentTemplate(user);
+      await openTemplateDropdown(user);
+
+      const searchInput = await screen.findByPlaceholderText(/find by name/i);
+      await typeWithWait(user, searchInput, 'template{Enter}');
+
+      expect(searchInput).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', { name: /Use a content template/i }),
+      ).toBeChecked();
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Timezone/tests/Timezone.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/tests/Timezone.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { createUser } from '@/test/testUtils';
+import { createUser, typeWithWait } from '@/test/testUtils';
 
 import {
   addNtpServer,
@@ -277,6 +277,22 @@ describe('Timezone Component', () => {
       expect(store.getState().wizard.timezone.ntpservers).not.toContain(
         '0.nl.pool.ntp.org',
       );
+    });
+  });
+
+  describe('Form submission', () => {
+    test('pressing Enter in timezone search does not trigger page reload', async () => {
+      const { store } = renderTimezoneStep();
+      const user = createUser();
+
+      await openTimezoneDropdown(user);
+
+      const searchInput = await screen.findByLabelText(/Filter timezone/i);
+      await typeWithWait(user, searchInput, 'Europe{Enter}');
+
+      expect(searchInput).toBeInTheDocument();
+      expect(searchInput).toHaveValue('Europe');
+      expect(store.getState().wizard.timezone.timezone).toBe('');
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/UserGroups/tests/UserGroups.test.tsx
+++ b/src/Components/CreateImageWizard/steps/UserGroups/tests/UserGroups.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
+
+import UserGroupsStep from '../index';
+
+describe('UserGroups Component', () => {
+  describe('Form submission', () => {
+    test('pressing Enter in group name input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<UserGroupsStep />, {
+        userGroups: [
+          {
+            name: '',
+          },
+        ],
+      });
+      const user = createUser();
+
+      const groupInput = await screen.findByRole('textbox', {
+        name: /name/i,
+      });
+      await typeWithWait(user, groupInput, 'developers{Enter}');
+
+      expect(groupInput).toBeInTheDocument();
+      expect(store.getState().wizard.userGroups[0].name).toBe('developers');
+    });
+
+    test('pressing Enter in group ID input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<UserGroupsStep />, {
+        userGroups: [
+          {
+            name: 'developers',
+          },
+        ],
+      });
+      const user = createUser();
+
+      const gidInput = await screen.findByRole('textbox', {
+        name: /Group ID/i,
+      });
+      await typeWithWait(user, gidInput, '1001{Enter}');
+
+      expect(gidInput).toBeInTheDocument();
+      expect(store.getState().wizard.userGroups[0].gid).toBe(1001);
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/Users/tests/Users.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/tests/Users.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
+
+import UsersStep from '../index';
+
+describe('Users Component', () => {
+  describe('Form submission', () => {
+    test('pressing Enter in username input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<UsersStep />, {
+        users: [
+          {
+            name: '',
+            password: '',
+            ssh_key: '',
+            isAdministrator: false,
+            groups: [],
+            hasPassword: false,
+          },
+        ],
+      });
+      const user = createUser();
+
+      const usernameInput = await screen.findByRole('textbox', {
+        name: /user name/i,
+      });
+      await typeWithWait(user, usernameInput, 'testuser{Enter}');
+
+      expect(usernameInput).toBeInTheDocument();
+      expect(store.getState().wizard.users[0].name).toBe('testuser');
+    });
+
+    test('pressing Enter in password input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<UsersStep />, {
+        users: [
+          {
+            name: 'testuser',
+            password: '',
+            ssh_key: '',
+            isAdministrator: false,
+            groups: [],
+            hasPassword: false,
+          },
+        ],
+      });
+      const user = createUser();
+
+      const passwordInput = await screen.findByPlaceholderText(/set password/i);
+      await typeWithWait(user, passwordInput, 'SecurePass123{Enter}');
+
+      expect(passwordInput).toBeInTheDocument();
+      expect(store.getState().wizard.users[0].password).toBe('SecurePass123');
+    });
+
+    test('pressing Enter in SSH key input does not trigger page reload', async () => {
+      const { store } = renderWithRedux(<UsersStep />, {
+        users: [
+          {
+            name: 'testuser',
+            password: '',
+            ssh_key: '',
+            isAdministrator: false,
+            groups: [],
+            hasPassword: false,
+          },
+        ],
+      });
+      const user = createUser();
+
+      const sshKeyInput = await screen.findByRole('textbox', {
+        name: /public ssh key/i,
+      });
+      await typeWithWait(
+        user,
+        sshKeyInput,
+        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ{Enter}',
+      );
+
+      expect(sshKeyInput).toBeInTheDocument();
+      expect(store.getState().wizard.users[0].ssh_key).toBe(
+        'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ',
+      );
+    });
+  });
+});


### PR DESCRIPTION
This adds new form submission tests to ensure that entering inside a text input doesn't trigger the default form action and reloads the wizard.