### PR TITLE
Wizard/FSC: Move volume group to expandable and fix step spacing (HMS-9395)

### DIFF
--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -70,7 +70,7 @@ test('Create a blueprint with Disk customization', async ({
     ).toBeVisible();
     await expect(
       frame.getByRole('button', {
-        name: /add lvm volume group/i,
+        name: /Volume Group Manager/i,
       }),
     ).toBeVisible();
   });
@@ -86,7 +86,7 @@ test('Create a blueprint with Disk customization', async ({
     await frame.getByRole('button', { name: 'GiB' }).nth(1).click();
     await frame.getByRole('option', { name: 'MiB' }).click();
 
-    await frame.getByRole('button', { name: 'Add LVM volume group' }).click();
+    await frame.getByRole('button', { name: 'Volume Group Manager' }).click();
     await expect(
       frame
         .getByRole('row')

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/AdvancedPartitioning.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/AdvancedPartitioning.tsx
@@ -63,35 +63,6 @@ const AdvancedPartitioning = () => {
     );
   };
 
-  const handleAddVolumeGroup = () => {
-    const vgId = uuidv4();
-    const lvId = uuidv4();
-    const mountpoint = getNextAvailableMountpoint(
-      filesystemPartitions,
-      diskPartitions,
-      inImageMode,
-    );
-    dispatch(
-      addDiskPartition({
-        id: vgId,
-        name: '',
-        min_size: '1',
-        unit: 'GiB',
-        type: 'lvm',
-        logical_volumes: [
-          {
-            id: lvId,
-            name: '',
-            mountpoint,
-            min_size: '1',
-            unit: 'GiB',
-            fs_type: 'xfs',
-          },
-        ],
-      }),
-    );
-  };
-
   const handleDiskMinsizeChange = (_e: React.FormEvent, value: string) => {
     dispatch(changeDiskMinsize(value));
   };
@@ -167,18 +138,6 @@ const AdvancedPartitioning = () => {
       <VolumeGroups
         volumeGroups={diskPartitions.filter((p) => p.type === 'lvm')}
       />
-      {!diskPartitions.find((p) => p.type === 'lvm') && (
-        <Content>
-          <Button
-            className='pf-v6-u-text-align-left'
-            variant='link'
-            icon={<AddCircleOIcon />}
-            onClick={handleAddVolumeGroup}
-          >
-            Add LVM volume group
-          </Button>
-        </Content>
-      )}
     </>
   );
 };

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/DiskRow.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/DiskRow.tsx
@@ -39,25 +39,25 @@ const DiskRow = ({ partition }: DiskRowPropTypes) => {
   return (
     <Tr id={partition.id}>
       {partition.type !== 'plain' && (
-        <Td className='pf-m-width-20'>
+        <Td width={30}>
           <PartitionName partition={partition} customization={customization} />
         </Td>
       )}
-      <Td width={20}>
+      <Td width={30}>
         <Mountpoint partition={partition} customization={customization} />
       </Td>
-      <Td width={20}>
+      <Td width={10}>
         <PartitionType partition={partition} customization={customization} />
       </Td>
-      <Td width={20}>
+      <Td width={15}>
         <MinimumSize partition={partition} customization={customization} />
       </Td>
-      <Td width={10}>
+      <Td width={15}>
         <SizeUnit partition={partition} customization={customization} />
       </Td>
-      <Td width={10}>
+      <Td isActionCell>
         <Button
-          variant='link'
+          variant='plain'
           icon={<MinusCircleIcon />}
           onClick={() => handleRemovePartition(partition.id)}
           // there needs to be at least one logical volume in a volume group

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemPartition.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemPartition.tsx
@@ -67,7 +67,10 @@ const FileSystemPartition = () => {
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
-      style={{ width: '100%' }}
+      style={{
+        minWidth: '90%',
+        maxWidth: '90%',
+      }}
     >
       {fscModeOptions.find((opt) => opt.value === fscMode)?.label}
     </MenuToggle>

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
@@ -31,7 +31,12 @@ const FileSystemTable = ({ partitions, mode }: FileSystemTableTypes) => {
   );
 
   return (
-    <Table aria-label='File system table' variant='compact' borders={false}>
+    <Table
+      aria-label='File system table'
+      variant='compact'
+      borders={false}
+      style={{ backgroundColor: 'transparent' }}
+    >
       <Thead>
         <Tr>
           {mode === 'disk-lvm' && <Th>Name</Th>}

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
@@ -30,7 +30,7 @@ const Row = ({ partition, isRemovingDisabled }: RowPropTypes) => {
 
   return (
     <Tr id={partition.id}>
-      <Td width={30}>
+      <Td width={40}>
         <Mountpoint partition={partition} customization={customization} />
       </Td>
       <Td width={20}>
@@ -47,7 +47,7 @@ const Row = ({ partition, isRemovingDisabled }: RowPropTypes) => {
       <Td width={20}>
         <SizeUnit partition={partition} customization={customization} />
       </Td>
-      <Td width={10}>
+      <Td isActionCell>
         <Button
           variant='plain'
           icon={<MinusCircleIcon />}

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
@@ -118,28 +118,34 @@ const VolumeGroups = ({ volumeGroups }: VolumeGroupsType) => {
     >
       {vg ? (
         <>
-          <FormGroup label='Volume group name'>
-            <ValidatedInputAndTextArea
-              ariaLabel='Volume group name input'
-              value={vg.name || ''}
-              onChange={(_event, name) =>
-                dispatch(changeDiskPartitionName({ id: vg.id, name: name }))
-              }
-              placeholder='Add volume group name'
-              stepValidation={stepValidation}
-              fieldName={`name-${vg.id}`}
-            />
-          </FormGroup>
-          <FormGroup label='Minimum volume group size'>
-            <Flex>
-              <FlexItem spacer={{ default: 'spacerNone' }}>
-                <MinimumSize partition={vg} customization='disk' />
-              </FlexItem>
-              <FlexItem>
-                <SizeUnit partition={vg} customization='disk' />
-              </FlexItem>
-            </Flex>
-          </FormGroup>
+          <Flex gap={{ default: 'gapXl' }}>
+            <FlexItem>
+              <FormGroup label='Volume group name'>
+                <ValidatedInputAndTextArea
+                  ariaLabel='Volume group name input'
+                  value={vg.name || ''}
+                  onChange={(_event, name) =>
+                    dispatch(changeDiskPartitionName({ id: vg.id, name: name }))
+                  }
+                  placeholder='Add volume group name'
+                  stepValidation={stepValidation}
+                  fieldName={`name-${vg.id}`}
+                />
+              </FormGroup>
+            </FlexItem>
+            <FlexItem>
+              <FormGroup label='Minimum volume group size'>
+                <Flex>
+                  <FlexItem spacer={{ default: 'spacerXs' }}>
+                    <MinimumSize partition={vg} customization='disk' />
+                  </FlexItem>
+                  <FlexItem>
+                    <SizeUnit partition={vg} customization='disk' />
+                  </FlexItem>
+                </Flex>
+              </FormGroup>
+            </FlexItem>
+          </Flex>
           {vg.logical_volumes.length > 0 && (
             <FileSystemTable partitions={vg.logical_volumes} mode='disk-lvm' />
           )}

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
@@ -8,7 +8,7 @@ import {
   FlexItem,
   FormGroup,
 } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { AddCircleOIcon } from '@patternfly/react-icons';
 import { v4 as uuidv4 } from 'uuid';
 
 import { VolumeGroup } from '@/store/api/backend';
@@ -147,7 +147,7 @@ const VolumeGroups = ({ volumeGroups }: VolumeGroupsType) => {
             <Button
               className='pf-v6-u-text-align-left'
               variant='link'
-              icon={<PlusCircleIcon />}
+              icon={<AddCircleOIcon />}
               onClick={() => handleAddLogicalVolume(vg.id)}
             >
               Add logical volume

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
@@ -114,11 +114,11 @@ const VolumeGroups = ({ volumeGroups }: VolumeGroupsType) => {
       onToggle={onToggle}
       isExpanded={isExpanded}
       displaySize='lg'
-      isWidthLimited
+      className='pf-v6-u-mt-lg'
     >
       {vg ? (
         <>
-          <Flex gap={{ default: 'gapXl' }}>
+          <Flex gap={{ default: 'gapXl' }} className='pf-v6-u-pb-md'>
             <FlexItem>
               <FormGroup label='Volume group name'>
                 <ValidatedInputAndTextArea

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
@@ -1,20 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
   Button,
-  Card,
-  CardBody,
-  CardHeader,
   Content,
+  ExpandableSection,
   Flex,
   FlexItem,
   FormGroup,
 } from '@patternfly/react-core';
-import { PlusCircleIcon, TimesIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 import { v4 as uuidv4 } from 'uuid';
 
 import { VolumeGroup } from '@/store/api/backend';
 import {
+  addDiskPartition,
   addLogicalVolumeToVolumeGroup,
   changeDiskPartitionName,
   removeDiskPartition,
@@ -33,8 +32,12 @@ import { ValidatedInputAndTextArea } from '../../../ValidatedInput';
 import { DiskPartition, DiskPartitionBase } from '../fscTypes';
 import { getNextAvailableMountpoint } from '../fscUtilities';
 
+type VolumeGroupType =
+  | Extract<DiskPartition, VolumeGroup & DiskPartitionBase>
+  | undefined;
+
 type VolumeGroupsType = {
-  volumeGroups: Extract<DiskPartition, VolumeGroup & DiskPartitionBase>[];
+  volumeGroups: VolumeGroupType[];
 };
 
 const VolumeGroups = ({ volumeGroups }: VolumeGroupsType) => {
@@ -43,6 +46,45 @@ const VolumeGroups = ({ volumeGroups }: VolumeGroupsType) => {
   const filesystemPartitions = useAppSelector(selectFilesystemPartitions);
   const diskPartitions = useAppSelector(selectDiskPartitions);
   const inImageMode = useAppSelector(selectIsImageMode);
+
+  // Only one volume group is supported
+  const vg = volumeGroups[0];
+  const [isExpanded, setIsExpanded] = useState(!!vg);
+
+  const onToggle = (_event: React.MouseEvent, isExpanded: boolean) => {
+    setIsExpanded(isExpanded);
+
+    if (isExpanded && !vg) {
+      const vgId = uuidv4();
+      const lvId = uuidv4();
+      const mountpoint = getNextAvailableMountpoint(
+        filesystemPartitions,
+        diskPartitions,
+        inImageMode,
+      );
+      dispatch(
+        addDiskPartition({
+          id: vgId,
+          name: '',
+          min_size: '1',
+          unit: 'GiB',
+          type: 'lvm',
+          logical_volumes: [
+            {
+              id: lvId,
+              name: '',
+              mountpoint,
+              min_size: '1',
+              unit: 'GiB',
+              fs_type: 'xfs',
+            },
+          ],
+        }),
+      );
+    } else if (!isExpanded && vg) {
+      dispatch(removeDiskPartition(vg.id));
+    }
+  };
 
   const handleAddLogicalVolume = (vgId: string) => {
     const id = uuidv4();
@@ -66,59 +108,55 @@ const VolumeGroups = ({ volumeGroups }: VolumeGroupsType) => {
     );
   };
 
-  return volumeGroups.map((vg) => (
-    <Card key={vg.id}>
-      <CardHeader
-        actions={{
-          actions: (
-            <Button
-              variant='plain'
-              aria-label='Remove volume group button'
-              icon={<TimesIcon />}
-              onClick={() => dispatch(removeDiskPartition(vg.id))}
+  return (
+    <ExpandableSection
+      toggleText='Volume Group Manager'
+      onToggle={onToggle}
+      isExpanded={isExpanded}
+      displaySize='lg'
+      isWidthLimited
+    >
+      {vg ? (
+        <>
+          <FormGroup label='Volume group name'>
+            <ValidatedInputAndTextArea
+              ariaLabel='Volume group name input'
+              value={vg.name || ''}
+              onChange={(_event, name) =>
+                dispatch(changeDiskPartitionName({ id: vg.id, name: name }))
+              }
+              placeholder='Add volume group name'
+              stepValidation={stepValidation}
+              fieldName={`name-${vg.id}`}
             />
-          ),
-        }}
-      />
-      <CardBody>
-        <FormGroup label='Volume group name'>
-          <ValidatedInputAndTextArea
-            ariaLabel='Volume group name input'
-            value={vg.name || ''}
-            onChange={(event, name) =>
-              dispatch(changeDiskPartitionName({ id: vg.id, name: name }))
-            }
-            placeholder='Add volume group name'
-            stepValidation={stepValidation}
-            fieldName={`name-${vg.id}`}
-          />
-        </FormGroup>
-        <FormGroup label='Minimum volume group size'>
-          <Flex>
-            <FlexItem spacer={{ default: 'spacerNone' }}>
-              <MinimumSize partition={vg} customization='disk' />
-            </FlexItem>
-            <FlexItem>
-              <SizeUnit partition={vg} customization='disk' />
-            </FlexItem>
-          </Flex>
-        </FormGroup>
-        {vg.logical_volumes.length > 0 && (
-          <FileSystemTable partitions={vg.logical_volumes} mode='disk-lvm' />
-        )}
-        <Content>
-          <Button
-            className='pf-v6-u-text-align-left'
-            variant='link'
-            icon={<PlusCircleIcon />}
-            onClick={() => handleAddLogicalVolume(vg.id)}
-          >
-            Add logical volume
-          </Button>
-        </Content>
-      </CardBody>
-    </Card>
-  ));
+          </FormGroup>
+          <FormGroup label='Minimum volume group size'>
+            <Flex>
+              <FlexItem spacer={{ default: 'spacerNone' }}>
+                <MinimumSize partition={vg} customization='disk' />
+              </FlexItem>
+              <FlexItem>
+                <SizeUnit partition={vg} customization='disk' />
+              </FlexItem>
+            </Flex>
+          </FormGroup>
+          {vg.logical_volumes.length > 0 && (
+            <FileSystemTable partitions={vg.logical_volumes} mode='disk-lvm' />
+          )}
+          <Content>
+            <Button
+              className='pf-v6-u-text-align-left'
+              variant='link'
+              icon={<PlusCircleIcon />}
+              onClick={() => handleAddLogicalVolume(vg.id)}
+            >
+              Add logical volume
+            </Button>
+          </Content>
+        </>
+      ) : null}
+    </ExpandableSection>
+  );
 };
 
 export default VolumeGroups;

--- a/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
@@ -28,48 +28,52 @@ const FileSystemStep = () => {
   return (
     <Wrapper>
       <CustomizationLabels customization='filesystem' />
-      <Title
-        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
-        size={isWizardRevampEnabled ? 'lg' : 'xl'}
-      >
-        File system configuration
-      </Title>
-      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
-        Configure the system and partitioning for your image. You can use
-        automatic partitioning, manually define your own mount points and sizes,
-        or use advanced partitioning for complex storage layouts. The order of
-        the partitions may change when the image is installed in order to
-        conform to best practices and ensure functionality.
-        {!isOnPremise && (
-          <Button
-            component='a'
-            target='_blank'
-            rel='noreferrer noopener'
-            variant='link'
-            icon={<ExternalLinkAltIcon />}
-            iconPosition='right'
-            isInline
-            href={DOCS_URL}
-          >
-            Learn about customizing file systems
-          </Button>
+      <Content>
+        <Title
+          headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+          size={isWizardRevampEnabled ? 'lg' : 'xl'}
+        >
+          File system configuration
+        </Title>
+        <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
+          Configure the system and partitioning for your image. You can use
+          automatic partitioning, manually define your own mount points and
+          sizes, or use advanced partitioning for complex storage layouts. The
+          order of the partitions may change when the image is installed in
+          order to conform to best practices and ensure functionality.
+          {!isOnPremise && (
+            <Button
+              component='a'
+              target='_blank'
+              rel='noreferrer noopener'
+              variant='link'
+              icon={<ExternalLinkAltIcon />}
+              iconPosition='right'
+              isInline
+              href={DOCS_URL}
+            >
+              Learn about customizing file systems
+            </Button>
+          )}
+        </Content>
+        {fscMode === 'automatic' ? (
+          <>
+            <FileSystemPartition />
+          </>
+        ) : fscMode === 'basic' ? (
+          <>
+            <FileSystemPartition />
+            <br />
+            <FileSystemConfiguration />
+          </>
+        ) : (
+          <>
+            <FileSystemPartition />
+            <br />
+            <AdvancedPartitioning />
+          </>
         )}
       </Content>
-      {fscMode === 'automatic' ? (
-        <>
-          <FileSystemPartition />
-        </>
-      ) : fscMode === 'basic' ? (
-        <>
-          <FileSystemPartition />
-          <FileSystemConfiguration />
-        </>
-      ) : (
-        <>
-          <FileSystemPartition />
-          <AdvancedPartitioning />
-        </>
-      )}
     </Wrapper>
   );
 };


### PR DESCRIPTION
This updates the spacing on the step and moves the content of the volume group card to an expandable. The "Add LVM volume group" and remove group buttons were replaced by the mechanic of opening/closing the expandable as discussed with the UX team.

Rebased on https://github.com/osbuild/image-builder-frontend/pull/4340