### PR TITLE
Wizard/Azure: Update Hyper-V generation option labels (HMS-10573)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/components/AzureHyperVSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/components/AzureHyperVSelect.tsx
@@ -40,6 +40,10 @@ const AzureHyperVSelect = () => {
       ref={toggleRef}
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
+      style={{
+        minWidth: '50%',
+        maxWidth: '50%',
+      }}
     >
       {HYPER_V_GENERATIONS.find((gen) => gen.value === hyperVGeneration)?.label}
     </MenuToggle>

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/components/AzureHyperVSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/components/AzureHyperVSelect.tsx
@@ -22,9 +22,6 @@ const AzureHyperVSelect = () => {
   const hyperVGeneration = useAppSelector(selectAzureHyperVGeneration);
   const [isOpen, setIsOpen] = useState(false);
 
-  const shortGenerationName =
-    hyperVGeneration === 'V1' ? 'Generation 1 (BIOS)' : 'Generation 2 (UEFI)';
-
   const handleSelect = (
     _event?: React.MouseEvent,
     selection?: string | number,
@@ -44,7 +41,7 @@ const AzureHyperVSelect = () => {
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
     >
-      {shortGenerationName}
+      {HYPER_V_GENERATIONS.find((gen) => gen.value === hyperVGeneration)?.label}
     </MenuToggle>
   );
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/constants.ts
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/constants.ts
@@ -2,6 +2,6 @@ export const AZURE_AUTH_URL =
   'https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow';
 
 export const HYPER_V_GENERATIONS = [
-  { value: 'V1', label: 'Hyper-V generation 1 (BIOS)' },
-  { value: 'V2', label: 'Hyper-V generation 2 (UEFI)' },
+  { value: 'V1', label: 'Generation 1 (BIOS)' },
+  { value: 'V2', label: 'Generation 2 (UEFI)' },
 ];

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
@@ -80,12 +80,12 @@ describe('Azure Component', () => {
 
       expect(
         await screen.findByRole('option', {
-          name: /Hyper-V generation 1 \(BIOS\)/i,
+          name: /Generation 1 \(BIOS\)/i,
         }),
       ).toBeInTheDocument();
       expect(
         await screen.findByRole('option', {
-          name: /Hyper-V generation 2 \(UEFI\)/i,
+          name: /Generation 2 \(UEFI\)/i,
         }),
       ).toBeInTheDocument();
     });
@@ -279,7 +279,7 @@ describe('Azure Component', () => {
       await clickWithWait(
         user,
         await screen.findByRole('option', {
-          name: /Hyper-V generation 1 \(BIOS\)/i,
+          name: /Generation 1 \(BIOS\)/i,
         }),
       );
 


### PR DESCRIPTION
This updates the labels of the options to not include "Hyper-V" again and update width.