### PR TITLE
Wizard: Remove "Create image wizard" title (HMS-10574)

### DIFF
--- a/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
+++ b/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
@@ -315,7 +315,6 @@ const CreateImageWizard3 = () => {
     >
       <Wizard
         onClose={handleClose}
-        title='Create image wizard'
         isVisitRequired
         startIndex={startIndex}
         header={


### PR DESCRIPTION
When hovering over the Wizard a title "Create image wizard" would render in a tooltip at any point. This removes it.

Before:
<img width="548" height="197" alt="image" src="https://github.com/user-attachments/assets/e99371de-586c-4e93-bcaf-532b8d983b60" />

After:
<img width="455" height="187" alt="image" src="https://github.com/user-attachments/assets/80e4e805-7205-4c50-8c18-e1b7e057a0e5" />
