### PR TITLE
Wizard: Resolve auto-scrolling issues (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
@@ -37,7 +37,6 @@ const Registration = ({ onErrorChange }: RegistrationProps) => {
           }}
           id='register-system-now'
           name='registration-type'
-          autoFocus
           body={
             <>
               <Content className='pf-v6-u-pb-sm'>


### PR DESCRIPTION
The `autoFocus` in the registration step made the wizard scroll down to registration both when switching between steps and on state changes. This resolves the issue and makes the Wizard start at the top of the step.