### PR TITLE
playwright: use API for repository setup in RepeatableBuild test

### DIFF
--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -119,7 +119,7 @@ test('Create a blueprint with Repeatable build customization', async ({
       frame.getByText(
         /This repository doesn't have snapshots enabled, so it cannot be selected./i,
       ),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
   });
 
   await test.step('Check Repeatable build step behaviour with no repos', async () => {

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -89,9 +89,10 @@ test('Create a blueprint with Repeatable build customization', async ({
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
-    await expect(frame.getByRole('grid').first().getByRole('row')).toHaveCount(
-      3,
-    ); // one base distro repo + header
+    const reposTable = frame.getByRole('grid').filter({
+      has: frame.getByRole('columnheader', { name: 'Snapshot date' }),
+    });
+    await expect(reposTable.getByRole('row')).toHaveCount(3); // two base distro repos + header
     await expect(
       frame.getByRole('option', { name: repositoryName }),
     ).toBeVisible();
@@ -140,10 +141,17 @@ test('Create a blueprint with Repeatable build customization', async ({
     await frame
       .getByRole('button', { name: /Select content template/i })
       .click();
-    // Wait for menu to appear (any item, including the loading spinner item),
-    // then wait for the spinner to disappear before clicking.
-    await expect(frame.getByRole('menuitem').first()).toBeVisible();
-    await expect(frame.getByRole('progressbar')).toBeHidden();
+    // Wait for menu to appear, then close it and re-open it, PW selectors are not matching
+    // the menu items for unknown reason on first open
+    await page.waitForTimeout(2000);
+    await frame
+      .getByRole('button', { name: /Select content template/i })
+      .click();
+    await frame
+      .getByRole('button', { name: /Select content template/i })
+      .click();
+    await expect(frame.getByText(/Loading/i)).toBeHidden();
+    await page.waitForTimeout(2000);
     await frame.getByRole('menuitem').first().click();
     await frame.getByRole('button', { name: 'Review image' }).click();
     await expect(

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -9,6 +9,7 @@ import {
   createRepositoryViaApi,
   deleteRepositoryByUrlViaApi,
   deleteRepositoryViaApi,
+  waitUntilRepositoryIsSearchable,
 } from '../helpers/apiHelpers';
 import { enablePreview, isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
@@ -50,6 +51,8 @@ test('Create a blueprint with Repeatable build customization', async ({
       snapshot: false,
     });
     repositoryUuid = repository.uuid;
+
+    await waitUntilRepositoryIsSearchable(page, repositoryName);
   });
 
   // Register cleanup after resources are created

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -4,11 +4,12 @@ import * as path from 'path';
 import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-  deleteRepository,
-  navigateToRepositories,
-} from '../BootTests/Content/helpers';
 import { test } from '../fixtures/customizations';
+import {
+  createRepositoryViaApi,
+  deleteRepositoryByUrlViaApi,
+  deleteRepositoryViaApi,
+} from '../helpers/apiHelpers';
 import { enablePreview, isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
 import {
@@ -35,33 +36,29 @@ test('Create a blueprint with Repeatable build customization', async ({
   const repositoryUrl =
     'https://jlsherrill.fedorapeople.org/fake-repos/really-empty/';
 
-  // Delete the blueprint after the run fixture
-  cleanup.add(() => deleteBlueprint(page, blueprintName));
-  cleanup.add(() => deleteRepository(page, repositoryName));
-
   await ensureAuthenticated(page);
+
+  // Ensure URL exclusivity by deleting any existing repository with this URL
+  await deleteRepositoryByUrlViaApi(page, repositoryUrl);
+
+  let repositoryUuid: string;
+
+  await test.step('Create a custom repository via API', async () => {
+    const repository = await createRepositoryViaApi(page, {
+      name: repositoryName,
+      url: repositoryUrl,
+      snapshot: false,
+    });
+    repositoryUuid = repository.uuid;
+  });
+
+  // Register cleanup after resources are created
+  cleanup.add(() => deleteBlueprint(page, blueprintName));
+  cleanup.add(() => deleteRepositoryViaApi(page, repositoryUuid));
 
   await enablePreview(page);
   await expect(page.getByRole('heading', { name: 'All images' })).toBeVisible({
     timeout: 30000,
-  });
-
-  // Here we want to be sure that the repository is deleted due to URL exclusivity per repository
-  await deleteRepository(page, repositoryUrl);
-
-  await test.step('Create a custom repository', async () => {
-    await navigateToRepositories(page);
-    await page.getByRole('button', { name: 'Add repositories' }).click();
-    await page.getByRole('textbox', { name: 'Name' }).fill(repositoryName);
-    await page.getByRole('radio', { name: 'Introspect only' }).click();
-    await page.getByRole('textbox', { name: 'URL' }).fill(repositoryUrl);
-    await page.getByRole('button', { name: 'Save' }).click();
-    await page
-      .getByRole('textbox', { name: 'Name/URL filter' })
-      .fill(repositoryName);
-    await expect(
-      page.getByRole('gridcell', { name: repositoryName }),
-    ).toBeVisible();
   });
 
   // Navigate to IB landing page and get the frame
@@ -85,6 +82,7 @@ test('Create a blueprint with Repeatable build customization', async ({
       .fill('2025-12-24');
     await frame.getByRole('button', { name: /Repositories/i }).click();
     await expect(frame.getByText(/Loading/i)).toBeHidden();
+
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -89,16 +89,32 @@ test('Create a blueprint with Repeatable build customization', async ({
     await frame
       .getByRole('textbox', { name: 'Filter repositories' })
       .fill(repositoryName);
+    const searchInput = frame.getByRole('textbox', {
+      name: 'Filter repositories',
+    });
+    const repoOption = frame.getByRole('option', { name: repositoryName });
+
+    // The repo may not be indexed for filtered queries yet. If the
+    // search shows "No repositories found", refresh and retry.
+    await searchInput.fill(repositoryName);
+    const noResults = frame.getByRole('option', {
+      name: `No repositories found for "${repositoryName}"`,
+    });
+    if (await noResults.isVisible({ timeout: 5000 }).catch(() => false)) {
+      await searchInput.clear();
+      await frame.getByRole('button', { name: 'Refresh repositories' }).click();
+      await expect(
+        frame.getByRole('button', { name: 'Refreshing repositories' }),
+      ).toBeHidden();
+      await searchInput.fill(repositoryName);
+    }
+
     const reposTable = frame.getByRole('grid').filter({
       has: frame.getByRole('columnheader', { name: 'Snapshot date' }),
     });
     await expect(reposTable.getByRole('row')).toHaveCount(3); // two base distro repos + header
-    await expect(
-      frame.getByRole('option', { name: repositoryName }),
-    ).toBeVisible();
-    await expect(
-      frame.getByRole('option', { name: repositoryName }),
-    ).toBeDisabled();
+    await expect(repoOption).toBeVisible();
+    await expect(repoOption).toBeDisabled();
     await expect(
       frame.getByText(
         /This repository doesn't have snapshots enabled, so it cannot be selected./i,

--- a/playwright/helpers/apiHelpers.ts
+++ b/playwright/helpers/apiHelpers.ts
@@ -138,6 +138,39 @@ export const deleteRepositoryViaApi = async (
   }
 };
 
+// Polls the content-sources API until the repository appears in search
+// results. Call this after creating a repo to give the backend time to
+// index it before the UI tries to find it.
+export const waitUntilRepositoryIsSearchable = async (
+  page: Page,
+  repositoryName: string,
+  { intervalMs = 2_000, timeoutMs = 30_000 } = {},
+): Promise<void> => {
+  const headers = await getAuthHeaders(page);
+  const endpoint = `/api/content-sources/v1/repositories/?search=${encodeURIComponent(repositoryName)}`;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const response = await page.context().request.get(endpoint, { headers });
+
+    if (response.status() === 200) {
+      const body = await response.json();
+      const found = body.data?.some(
+        (repo: { name: string }) => repo.name === repositoryName,
+      );
+      if (found) {
+        return;
+      }
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(
+    `Repository "${repositoryName}" was not searchable after ${timeoutMs}ms`,
+  );
+};
+
 export const deleteRepositoryByUrlViaApi = async (
   page: Page,
   url: string,


### PR DESCRIPTION
## Summary
Replace UI-based repository creation and deletion in the RepeatableBuild Playwright test with direct API calls to reduce flakiness. The previous approach navigated to the content-sources application, handled zero-state pages, filled forms, and waited for UI elements — each step a potential failure point.

## Changes
- Replace UI repository creation (navigateToRepositories + form fill) with `createRepositoryViaApi`
- Replace UI repository deletion (navigateToRepositories + search + kebab + confirm dialog) with `deleteRepositoryViaApi` (cleanup) and `deleteRepositoryByUrlViaApi` (URL exclusivity pre-check)
- Move `ensureAuthenticated` before API calls so auth headers are available
- Move cleanup registration after resource creation so the repository UUID is captured