### PR TITLE
Wizard/Timezone: SPUR fixes (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Timezone/components/TimezoneDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/components/TimezoneDropDown.tsx
@@ -144,9 +144,7 @@ const TimezoneDropDown = () => {
         onOpenChangeKeys={['Escape']}
       />
       <HelperText className='pf-v6-u-pt-sm'>
-        <HelperTextItem>
-          Network time servers for system clock synchronization
-        </HelperTextItem>
+        <HelperTextItem>Search by city and continent.</HelperTextItem>
       </HelperText>
       {errorText && (
         <HelperText>

--- a/src/Components/CreateImageWizard/steps/Timezone/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/index.tsx
@@ -20,7 +20,7 @@ const TimezoneStep = () => {
         headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
         size={isWizardRevampEnabled ? 'lg' : 'xl'}
       >
-        Timezone
+        Time
       </Title>
       <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
         Select a timezone and define NTP servers to ensure your image maintains

--- a/src/Components/CreateImageWizard/steps/Timezone/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/index.tsx
@@ -16,18 +16,21 @@ const TimezoneStep = () => {
   return (
     <Wrapper>
       <CustomizationLabels customization='timezone' />
-      <Title
-        headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
-        size={isWizardRevampEnabled ? 'lg' : 'xl'}
-      >
-        Time
-      </Title>
-      <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
-        Select a timezone and define NTP servers to ensure your image maintains
-        accurate system time upon deployment.
+      <Content>
+        <Title
+          headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
+          size={isWizardRevampEnabled ? 'lg' : 'xl'}
+        >
+          Time
+        </Title>
+        <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
+          Select a timezone and define NTP servers to ensure your image
+          maintains accurate system time upon deployment.
+        </Content>
+        <TimezoneDropDown />
+        <br />
+        <NtpServersInput />
       </Content>
-      <TimezoneDropDown />
-      <NtpServersInput />
     </Wrapper>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Timezone/tests/Timezone.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/tests/Timezone.test.tsx
@@ -30,7 +30,7 @@ describe('Timezone Component', () => {
       renderTimezoneStep();
 
       expect(
-        await screen.findByRole('heading', { name: /Timezone/i }),
+        await screen.findByRole('heading', { name: 'Time' }),
       ).toBeInTheDocument();
       expect(
         screen.getByText(/Select a timezone and define NTP servers/i),

--- a/src/Components/CreateImageWizard/steps/Timezone/tests/Timezone.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/tests/Timezone.test.tsx
@@ -52,9 +52,7 @@ describe('Timezone Component', () => {
       renderTimezoneStep();
 
       expect(
-        await screen.findByText(
-          /Network time servers for system clock synchronization/i,
-        ),
+        await screen.findByText(/Search by city and continent./i),
       ).toBeInTheDocument();
     });
 

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -170,7 +170,7 @@ describe('Import modal', () => {
     expect(sizeValue).toBeInTheDocument();
 
     // Timezone
-    await screen.findByRole('heading', { name: /Timezone/ });
+    await screen.findByRole('heading', { name: 'Time' });
     expect(
       await screen.findByRole('button', { name: 'US/Eastern' }),
     ).toBeInTheDocument();


### PR DESCRIPTION
This:
- renames the section to "Time" so there are not two "Timezone" headings right after each other.
- updates spacing between the title and the step content
- updates helper text below the timezone dropdown