### PR TITLE
Wizard/Image output: SPUR updates (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
@@ -97,7 +97,7 @@ const BlueprintMode = () => {
         className='pf-v6-u-pt-sm pf-v6-u-text-color-subtle'
       >
         {!isImageMode &&
-          'RHEL in package mode is a system managed by individually installing and updating software packages'}
+          'RHEL in package mode is a system managed by individually installing and updating software packages.'}
         {isImageMode &&
           'RHEL image mode treats the entire operating system as a single, immutable container image that is updated atomically'}
       </Content>

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ReleaseSelect.tsx
@@ -2,9 +2,6 @@ import React, { ReactElement, useState } from 'react';
 
 import {
   FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
   MenuToggle,
   MenuToggleElement,
   Select,
@@ -179,13 +176,6 @@ const ReleaseSelect = () => {
             )}
         </SelectList>
       </Select>
-      <FormHelperText>
-        <HelperText>
-          <HelperTextItem id='release-select-helper'>
-            The latest version is selected by default.
-          </HelperTextItem>
-        </HelperText>
-      </FormHelperText>
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ReleaseSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ReleaseSelect.test.tsx
@@ -43,19 +43,6 @@ describe('ReleaseSelect', () => {
       expect(screen.getByText('Release')).toBeInTheDocument();
       expect(screen.getByText('*')).toBeInTheDocument();
     });
-
-    test('shows helper text', () => {
-      renderReleaseSelect();
-
-      expect(
-        screen.getByText(/latest version is selected by default/i),
-      ).toBeInTheDocument();
-
-      const toggle = screen.getByTestId('release_select');
-      expect(toggle).toHaveAccessibleDescription(
-        /latest version is selected by default/i,
-      );
-    });
   });
 
   describe('Dropdown behavior', () => {


### PR DESCRIPTION
This:
- adds a dot at the end of the helper text for mode
- removes the helper text from release select