### PR TITLE
Wizard/OpenSCAP: Show error only when the packages are installed

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -372,8 +372,12 @@ const OscapContent = () => {
             </Alert>
           )}
 
-        {isError && (
-          <Alert title='Error fetching the profiles' variant='danger' isInline>
+        {isError && onPremOpenSCAPAvailable && (
+          <Alert
+            title='Error fetching the OpenSCAP profiles'
+            variant='danger'
+            isInline
+          >
             Cannot get the list of profiles
           </Alert>
         )}


### PR DESCRIPTION
The error that profiles can't be fetched is rendered even when the OpenSCAP packages are not installed. Let's hide it and show it only when the packages are already available and something goes wrong.