### PR TITLE
Wizard: add default value to Image Source dropdown in image mode (HMS-10561)

### DIFF
--- a/playwright/Basic/imageMode.spec.ts
+++ b/playwright/Basic/imageMode.spec.ts
@@ -69,7 +69,7 @@ test('Image mode blueprint create, edit, export, import', async ({
     await imageModeToggle.click();
 
     const imageSourceDropdown = frame.getByRole('button', {
-      name: /Select a bootc image/,
+      name: /Red Hat Enterprise Linux|RHEL/i,
     });
     await expect(imageSourceDropdown).toBeVisible({ timeout: 10000 });
     await expect(imageSourceDropdown).toBeEnabled({ timeout: 5000 });
@@ -113,8 +113,8 @@ test('Image mode blueprint create, edit, export, import', async ({
     await expect(imageModeButton).toHaveAttribute('aria-pressed', 'true');
 
     await expect(
-      frame.getByRole('button', { name: /Select a bootc image/ }),
-    ).toBeHidden();
+      frame.getByRole('button', { name: /Red Hat Enterprise Linux|RHEL/i }),
+    ).toBeVisible();
 
     await expect(
       frame.getByRole('radio', { name: 'Virtualization' }),

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
@@ -8,7 +8,7 @@ import {
 } from '@patternfly/react-core';
 import { BuildIcon, RepositoryIcon } from '@patternfly/react-icons';
 
-import { RHEL_10, X86_64 } from '@/constants';
+import { RHEL_10, RHEL_10_IMAGE_MODE_IMAGE, X86_64 } from '@/constants';
 import { Distributions } from '@/store/api/backend';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
@@ -16,6 +16,7 @@ import {
   changeArchitecture,
   changeBlueprintMode,
   changeDistribution,
+  changeImageSource,
   changeImageTypes,
   selectArchitecture,
   selectDistribution,
@@ -65,6 +66,8 @@ const BlueprintMode = () => {
                 isOnPremise ? defaultDistro : previousDistro.current,
               ),
             );
+            // Image source is only relevant in image mode
+            dispatch(changeImageSource(undefined));
             if (!isOnPremise) {
               dispatch(changeArchitecture(previousArch.current));
             }
@@ -87,6 +90,7 @@ const BlueprintMode = () => {
               dispatch(changeDistribution('image-mode'));
             } else {
               dispatch(changeArchitecture(X86_64));
+              dispatch(changeImageSource(RHEL_10_IMAGE_MODE_IMAGE));
             }
           }}
           aria-describedby='blueprint-mode-description'

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -258,6 +258,22 @@ const BootcImageSourceSelect = () => {
     }
   }, [bootcDistributions, dispatch]);
 
+  useEffect(() => {
+    if (!bootcDistributions || bootcDistributions.length === 0) return;
+
+    const hasSelected = imageSource
+      ? bootcDistributions.some((d) => d.reference === imageSource)
+      : false;
+    if (hasSelected) return;
+
+    const defaultItem =
+      bootcDistributions.find((d) => d.distro.startsWith('rhel-10')) ??
+      bootcDistributions[0];
+
+    dispatch(changeImageSource(defaultItem.reference));
+    dispatch(changeDistribution(defaultItem.distro as Distributions));
+  }, [bootcDistributions, dispatch, imageSource]);
+
   // Deduplicate by name — the API returns one entry per target type,
   // but the dropdown should show one entry per base image.
   const uniqueDistributions = bootcDistributions?.reduce<

--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -3,14 +3,17 @@ import React, { useEffect } from 'react';
 import { Content, Form, FormGroup, Title } from '@patternfly/react-core';
 
 import DocumentationButton from '@/Components/sharedComponents/DocumentationButton';
+import { RHEL_10_IMAGE_MODE_IMAGE } from '@/constants';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
   changeArchitecture,
   changeBlueprintName,
+  changeImageSource,
   selectArchitecture,
   selectBlueprintName,
   selectDistribution,
+  selectImageSource,
   selectIsCustomName,
   selectIsImageMode,
 } from '@/store/slices/wizard';
@@ -34,6 +37,7 @@ const ImageOutputStep = () => {
   const arch = useAppSelector(selectArchitecture);
   const isCustomName = useAppSelector(selectIsCustomName);
   const isOnPremise = useAppSelector(selectIsOnPremise);
+  const imageSource = useAppSelector(selectImageSource);
   const isImageModeEnabled = useFlag('image-builder.image-mode.enabled');
   const isWizardRevampEnabled = useFlag('image-builder.wizard-revamp.enabled');
   const isHostedImageMode = isImageMode && !isOnPremise;
@@ -52,6 +56,12 @@ const ImageOutputStep = () => {
       dispatch(changeArchitecture('x86_64'));
     }
   }, [dispatch, isHostedImageMode]);
+
+  useEffect(() => {
+    if (!isHostedImageMode) return;
+    if (imageSource) return;
+    dispatch(changeImageSource(RHEL_10_IMAGE_MODE_IMAGE));
+  }, [dispatch, imageSource, isHostedImageMode]);
 
   return (
     <Wrapper>


### PR DESCRIPTION
There used to be a placeholder text "Select bootc distribution" in the Image Source dropdown, now there is a default RHEL 10 value.