### PR TITLE
Many: Dark mode future proofing (HMS-10510)

### DIFF
--- a/src/Components/Blueprints/BuildImagesButton.tsx
+++ b/src/Components/Blueprints/BuildImagesButton.tsx
@@ -120,7 +120,8 @@ export const BuildImagesButton = ({ children }: BuildImagesButtonPropTypes) => {
                     <Spinner
                       style={
                         {
-                          '--pf-v6-c-spinner--Color': '#fff',
+                          '--pf-v6-c-spinner--Color':
+                            'var(--pf-t--global--text--color--on-brand--default)',
                         } as React.CSSProperties
                       }
                       isInline

--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -1,17 +1,3 @@
-.pf-c-popover[data-popper-reference-hidden="true"] {
-    font-weight: initial;
-    visibility: initial;
-    pointer-events: initial;
-}
-
-.pf-c-form {
-    --pf-c-form--GridGap: var(--pf6-global--spacer--md);
-}
-
-.pf-c-form__group-label {
-    --pf-c-form__group-label--PaddingBottom: var(--pf-v6-global--spacer--xs);
-}
-
 .provider-icon {
     width: 3.5em;
     height: 3.5em;
@@ -29,14 +15,6 @@ ul.pf-m-plain {
     list-style: none;
     padding-left: 0;
     margin-left: 0;
-}
-
-.not-available {
-    color: #6a6e73;
-}
-
-.panel-border {
-    --pf-v6-c-panel--before--BorderColor: #BEE1F4;
 }
 
 // Targets the alert within the Reviewsteps > content dropdown

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -215,7 +215,10 @@ export const CreateSaveButton = ({
             <FlexItem>
               <Spinner
                 style={
-                  { '--pf-v6-c-spinner--Color': '#fff' } as React.CSSProperties
+                  {
+                    '--pf-v6-c-spinner--Color':
+                      'var(--pf-t--global--text--color--on-brand--default)',
+                  } as React.CSSProperties
                 }
                 isInline
                 size='md'

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -154,7 +154,10 @@ export const EditSaveButton = ({
           <FlexItem>
             <Spinner
               style={
-                { '--pf-v6-c-spinner--Color': '#fff' } as React.CSSProperties
+                {
+                  '--pf-v6-c-spinner--Color':
+                    'var(--pf-t--global--text--color--on-brand--default)',
+                } as React.CSSProperties
               }
               isInline
               size='md'

--- a/src/Components/ImagesTable/ImageBuildStatus.scss
+++ b/src/Components/ImagesTable/ImageBuildStatus.scss
@@ -1,6 +1,6 @@
 .failure-button {
-  color: var(--pf-global--Color--100);
+  color: var(--pf-t--global--text--color--regular);
   text-decoration: underline;
   text-decoration-style: dotted;
-  text-decoration-color: grey;
+  text-decoration-color: var(--pf-t--global--border--color--default);
 }

--- a/src/Components/LandingPage/LandingPage.scss
+++ b/src/Components/LandingPage/LandingPage.scss
@@ -1,13 +1,5 @@
-.pf-c-form__group-label-help {
-    color: var(--pf-v6-global--icon--Color--light);
-}
-
-.pf-c-form__group-label-help:active {
-    color: var(--pf-v6-global--icon--Color--dark);
-}
-
 .expand-section {
-    background-color: var(--pf-v6-global--palette--white);
+    background-color: var(--pf-t--global--background--color--primary--default);
 }
 
 .sidebar-panel {

--- a/src/Components/LandingPage/Quickstarts.tsx
+++ b/src/Components/LandingPage/Quickstarts.tsx
@@ -13,7 +13,7 @@ export const Quickstarts = () => {
 
   return (
     <ExpandableSection
-      className='pf-m-light pf-v6-u-mb-xl expand-section'
+      className='pf-v6-u-mb-xl expand-section'
       toggleText='Help get started with new features'
       onToggle={(_event, val) => setShowHint(val)}
       isExpanded={showHint}


### PR DESCRIPTION
Replace hardcoded colors and legacy PatternFly tokens with PF6 semantic dark-mode-aware tokens. These changes are not visually noticeable but future-proof the codebase by using theme-aware tokens that will automatically adapt if PatternFly updates its dark mode palette.

- LandingPage.scss: Replace --pf-v6-global--palette--white with semantic background token --pf-t--global--background--color--primary--default
- ImageBuildStatus.scss: Replace legacy --pf-global--Color--100 and hardcoded 'grey' with PF6 text and border tokens
- BuildImagesButton.tsx, CreateDropdown.tsx, EditDropdown.tsx: Replace hardcoded '#fff' spinner color with var(--pf-t--global--text--color--on-brand--default)
- CreateImageWizard.scss: Remove dead legacy .pf-c-* selectors (PF4/PF5 class prefixes) and unused .not-available/.panel-border classes with hardcoded hex colors
- LandingPage.scss: Remove dead legacy .pf-c-form__group-label-help selectors
- Quickstarts.tsx: Remove obsolete pf-m-light modifier class