### PR TITLE
on-prem: fix compose status retrieval to handle missing files (HMS-10350)

### DIFF
--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -8,12 +8,14 @@ import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 import {
   getBlueprintsPath,
   readComposes,
+  safeReadJsonFile,
   toComposerComposeRequest,
 } from './helpers';
 
 import {
   ComposeBlueprintApiArg,
   ComposeBlueprintApiResponse,
+  ComposeRequest,
   ComposeResponse,
   ComposesResponseItem,
   GetBlueprintComposesApiArg,
@@ -153,12 +155,15 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
 
       const entries = Object.entries(info.entries || {});
       for (const bpEntry of entries) {
-        const request = await cockpit
-          .file(path.join(blueprintsDir, bpEntry[0], queryArgs.composeId))
-          .read();
+        const request = await safeReadJsonFile<ComposeRequest>(
+          path.join(blueprintsDir, bpEntry[0], queryArgs.composeId),
+        );
+        if (!request) {
+          continue;
+        }
         return {
           image_status: data.image_status,
-          request: JSON.parse(request),
+          request,
         };
       }
 

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -2,4 +2,5 @@ export { lookupDatastreamDistro } from './dataStreamLookup';
 export { getBlueprintsPath } from './getBlueprintsPath';
 export { getCloudConfigs } from './getCloudConfigs';
 export { readComposes } from './readComposes';
+export { safeReadJsonFile } from './safeReadJsonFile';
 export { toComposerComposeRequest } from './toComposerComposeRequest';

--- a/src/store/api/backend/onprem/composerApi/helpers/readComposes.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/readComposes.ts
@@ -1,11 +1,14 @@
 import path from 'path';
 
-import cockpit from 'cockpit';
 import { fsinfo } from 'cockpit/fsinfo';
 
-import type { ComposesResponseItem } from '@/store/api/backend/hosted';
+import type {
+  ComposeRequest,
+  ComposesResponseItem,
+} from '@/store/api/backend/hosted';
 
 import { getBlueprintsPath } from './getBlueprintsPath';
+import { safeReadJsonFile } from './safeReadJsonFile';
 
 export const readComposes = async (
   bpID: string,
@@ -24,15 +27,18 @@ export const readComposes = async (
     if (entry[0] === `${bpID}.json`) {
       continue;
     }
-    const composeReq = await cockpit
-      .file(path.join(blueprintsDir, bpID, entry[0]))
-      .read();
+    const request = await safeReadJsonFile<ComposeRequest>(
+      path.join(blueprintsDir, bpID, entry[0]),
+    );
+    if (!request) {
+      continue;
+    }
 
     composes = [
       ...composes,
       {
         id: entry[0],
-        request: JSON.parse(composeReq),
+        request,
         created_at: new Date(entry[1].mtime * 1000).toString(),
         blueprint_id: bpID,
       },

--- a/src/store/api/backend/onprem/composerApi/helpers/safeReadJsonFile.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/safeReadJsonFile.ts
@@ -1,0 +1,14 @@
+import cockpit from 'cockpit';
+
+export const safeReadJsonFile = async <T>(
+  filePath: string,
+): Promise<T | null> => {
+  try {
+    const content = await cockpit.file(filePath).read();
+    return JSON.parse(content) as T;
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn(`Failed to read JSON file: ${filePath}`, error);
+    return null;
+  }
+};

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/readComposes.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/readComposes.test.ts
@@ -1,0 +1,133 @@
+import { fsinfo } from 'cockpit/fsinfo';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getBlueprintsPath } from '../getBlueprintsPath';
+import { readComposes } from '../readComposes';
+import { safeReadJsonFile } from '../safeReadJsonFile';
+
+vi.mock('cockpit/fsinfo', () => ({
+  fsinfo: vi.fn(),
+}));
+
+vi.mock('../getBlueprintsPath', () => ({
+  getBlueprintsPath: vi.fn(),
+}));
+
+vi.mock('../safeReadJsonFile', () => ({
+  safeReadJsonFile: vi.fn(),
+}));
+
+const mockRequest = (distro: string) => ({
+  distribution: distro,
+  image_requests: [],
+});
+
+describe('readComposes', () => {
+  const bpID = 'my-blueprint';
+  const blueprintsDir = '/var/lib/image-builder/blueprints';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.mocked(getBlueprintsPath).mockResolvedValue(blueprintsDir);
+  });
+
+  it('returns all composes when all files are readable', async () => {
+    vi.mocked(fsinfo).mockResolvedValue({
+      entries: {
+        [`${bpID}.json`]: { mtime: 1000 },
+        'compose-1': { mtime: 2000 },
+        'compose-2': { mtime: 3000 },
+      },
+    } as never);
+
+    vi.mocked(safeReadJsonFile)
+      .mockResolvedValueOnce(mockRequest('rhel-9'))
+      .mockResolvedValueOnce(mockRequest('centos-9'));
+
+    const result = await readComposes(bpID);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: 'compose-1',
+      request: mockRequest('rhel-9'),
+      created_at: new Date(2000 * 1000).toString(),
+      blueprint_id: bpID,
+    });
+    expect(result[1]).toEqual({
+      id: 'compose-2',
+      request: mockRequest('centos-9'),
+      created_at: new Date(3000 * 1000).toString(),
+      blueprint_id: bpID,
+    });
+  });
+
+  it('skips unreadable files and returns the rest', async () => {
+    vi.mocked(fsinfo).mockResolvedValue({
+      entries: {
+        [`${bpID}.json`]: { mtime: 1000 },
+        'compose-1': { mtime: 2000 },
+        'compose-2': { mtime: 3000 },
+        'compose-3': { mtime: 4000 },
+      },
+    } as never);
+
+    vi.mocked(safeReadJsonFile)
+      .mockResolvedValueOnce(mockRequest('rhel-9'))
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(mockRequest('centos-9'));
+
+    const result = await readComposes(bpID);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      id: 'compose-1',
+      request: mockRequest('rhel-9'),
+      created_at: new Date(2000 * 1000).toString(),
+      blueprint_id: bpID,
+    });
+    expect(result[1]).toEqual({
+      id: 'compose-3',
+      request: mockRequest('centos-9'),
+      created_at: new Date(4000 * 1000).toString(),
+      blueprint_id: bpID,
+    });
+  });
+
+  it('returns empty array when all compose files are unreadable', async () => {
+    vi.mocked(fsinfo).mockResolvedValue({
+      entries: {
+        [`${bpID}.json`]: { mtime: 1000 },
+        'compose-1': { mtime: 2000 },
+        'compose-2': { mtime: 3000 },
+      },
+    } as never);
+
+    vi.mocked(safeReadJsonFile)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    const result = await readComposes(bpID);
+
+    expect(result).toEqual([]);
+  });
+
+  it('skips the blueprint JSON file', async () => {
+    vi.mocked(fsinfo).mockResolvedValue({
+      entries: {
+        [`${bpID}.json`]: { mtime: 1000 },
+        'compose-1': { mtime: 2000 },
+      },
+    } as never);
+
+    vi.mocked(safeReadJsonFile).mockResolvedValueOnce(mockRequest('rhel-9'));
+
+    const result = await readComposes(bpID);
+
+    expect(result).toHaveLength(1);
+    expect(safeReadJsonFile).toHaveBeenCalledTimes(1);
+    expect(safeReadJsonFile).toHaveBeenCalledWith(
+      `${blueprintsDir}/${bpID}/compose-1`,
+    );
+  });
+});

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/safeReadJsonFile.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/safeReadJsonFile.test.ts
@@ -1,0 +1,63 @@
+import cockpit from 'cockpit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { safeReadJsonFile } from '../safeReadJsonFile';
+
+vi.mock('cockpit', () => ({
+  default: {
+    file: vi.fn(),
+  },
+}));
+
+type TestData = {
+  name: string;
+  value: number;
+};
+
+describe('safeReadJsonFile', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('returns parsed JSON when file read succeeds', async () => {
+    const mockData: TestData = { name: 'test', value: 42 };
+    vi.mocked(cockpit.file).mockReturnValue({
+      read: vi.fn().mockResolvedValue(JSON.stringify(mockData)),
+    } as never);
+
+    const result = await safeReadJsonFile<TestData>('/path/to/file.json');
+
+    expect(result).toEqual(mockData);
+    expect(cockpit.file).toHaveBeenCalledWith('/path/to/file.json');
+  });
+
+  it('returns null when cockpit.file().read() throws', async () => {
+    vi.mocked(cockpit.file).mockReturnValue({
+      read: vi.fn().mockRejectedValue(new Error('File not found')),
+    } as never);
+
+    const result = await safeReadJsonFile<TestData>('/nonexistent/file.json');
+
+    expect(result).toBeNull();
+    // eslint-disable-next-line no-console
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to read JSON file: /nonexistent/file.json',
+      expect.any(Error),
+    );
+  });
+
+  it('returns null when JSON.parse fails', async () => {
+    vi.mocked(cockpit.file).mockReturnValue({
+      read: vi.fn().mockResolvedValue('not valid json{{{'),
+    } as never);
+
+    const result = await safeReadJsonFile<TestData>('/path/to/corrupt.json');
+
+    expect(result).toBeNull();
+    // eslint-disable-next-line no-console
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to read JSON file: /path/to/corrupt.json',
+      expect.any(Error),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
`getComposeStatus` and `readComposes` crashed when a compose file was missing or corrupt on disk, because `cockpit.file().read()` was called without error handling. This also meant `getComposeStatus` only ever checked the first blueprint directory.

## Changes
- Extract `safeReadJsonFile<T>` helper that wraps cockpit file reads in try-catch, returning `null` on error with a `console.warn` for debugging
- Fix `getComposeStatus` to search all blueprint directories instead of returning on the first iteration
- Fix `readComposes` to skip unreadable compose files instead of aborting the entire listing
- Add unit tests for both `safeReadJsonFile` (3 tests) and `readComposes` skip-and-continue behavior (4 tests)

Closes #4200 