### PR TITLE
Wizard/Kernel: Update kernel name default option (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Kernel/components/KernelName.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/components/KernelName.tsx
@@ -12,7 +12,7 @@ import {
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { changeKernelName, selectKernel } from '@/store/slices/wizard';
 
-const NONE_OPTION = 'None';
+const NONE_OPTION = 'Default';
 const kernelOptions = ['kernel', 'kernel-debug'];
 
 const KernelName = () => {
@@ -54,9 +54,11 @@ const KernelName = () => {
         shouldFocusFirstItemOnOpen={false}
       >
         <SelectList>
-          <SelectOption key={NONE_OPTION} value={NONE_OPTION}>
-            {NONE_OPTION}
-          </SelectOption>
+          {kernel && (
+            <SelectOption key={NONE_OPTION} value={NONE_OPTION}>
+              {NONE_OPTION}
+            </SelectOption>
+          )}
           {kernelOptions.map((option) => (
             <SelectOption key={option} value={option}>
               {option}

--- a/src/Components/CreateImageWizard/steps/Kernel/components/KernelName.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/components/KernelName.tsx
@@ -37,7 +37,17 @@ const KernelName = () => {
   };
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onToggleClick}
+      isExpanded={isOpen}
+      style={
+        {
+          minWidth: '50%',
+          maxWidth: '100%',
+        } as React.CSSProperties
+      }
+    >
       {kernel || 'Select default kernel'}
     </MenuToggle>
   );

--- a/src/Components/CreateImageWizard/steps/Kernel/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/tests/helpers.tsx
@@ -30,7 +30,7 @@ export const clearKernelName = async (user: UserEventInstance) => {
     name: /kernel/i,
   });
   await clickWithWait(user, toggle);
-  await selectKernelOption(user, 'None');
+  await selectKernelOption(user, 'Default');
 };
 
 export const selectKernelOption = async (


### PR DESCRIPTION
Rename the default kernel name option as "None" doesn't make sense in context of the kernel. The default option renders only if any kernel is selected.

Also updates dropdown width.