### PR TITLE
Wizard: exclude EUS repos from repo search

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/Packages.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { excludeEUSReposFilter } from '@/Components/CreateImageWizard/steps/Repositories/components/Repositories';
+import { excludeEUSReposFilter } from '@/Components/CreateImageWizard/steps/Repositories/repositoriesUtilities';
 import {
   AMPLITUDE_MODULE_NAME,
   ContentOrigin,

--- a/src/Components/CreateImageWizard/steps/Repositories/components/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/Repositories.tsx
@@ -61,14 +61,12 @@ import UploadRepositoryLabel from './UploadRepositoryLabel';
 import {
   convertSchemaToIBCustomRepo,
   convertSchemaToIBPayloadRepo,
+  excludeEUSReposFilter,
   getReadableArchitecture,
   getReadableVersions,
   isEPELUrl,
   isRepoDisabled,
 } from '../repositoriesUtilities';
-
-// Until IB has full support for extended release repositories, filter them out
-export const excludeEUSReposFilter = { extendedRelease: 'none' };
 
 const Repositories = () => {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/Repositories/components/RepositorySearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/RepositorySearch.tsx
@@ -35,7 +35,11 @@ import CommunityRepositoryLabel from './CommunityRepositoryLabel';
 import CustomEpelWarning from './CustomEpelWarning';
 import UploadRepositoryLabel from './UploadRepositoryLabel';
 
-import { isEPELUrl, isRepoDisabled } from '../repositoriesUtilities';
+import {
+  excludeEUSReposFilter,
+  isEPELUrl,
+  isRepoDisabled,
+} from '../repositoriesUtilities';
 
 type RepositorySearchProps = {
   onSelectRepository: (repo: ApiRepositoryResponseRead) => void;
@@ -76,6 +80,7 @@ const RepositorySearch = ({
       {
         availableForArch: arch,
         availableForVersion: version,
+        ...excludeEUSReposFilter,
         contentType: 'rpm',
         origin: originParam,
         limit: 50,

--- a/src/Components/CreateImageWizard/steps/Repositories/repositoriesUtilities.ts
+++ b/src/Components/CreateImageWizard/steps/Repositories/repositoriesUtilities.ts
@@ -207,3 +207,6 @@ export const isRepoDisabled = (
 
   return [false, ''];
 };
+
+// Until IB has full support for extended release repositories, filter them out
+export const excludeEUSReposFilter = { extendedRelease: 'none' };


### PR DESCRIPTION
This filters out the EUS repos in the `RepositorySearch` component since these aren't fully supported by IB yet. Also adds the helper for filtering out EUS repos to the `repositoriesUtilities` to avoid circular dependencies.