### PR TITLE
Wizard: Add 'No additional policy or profile' radio and remove 'None' from dropdowns (HMS-10579)

### DIFF
--- a/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
@@ -104,7 +104,7 @@ test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
     await frame
       .getByRole('radio', { name: 'Use a custom compliance policy' })
       .click();
-    await frame.getByRole('button', { name: 'None' }).click();
+    await frame.getByRole('button', { name: 'Select a policy' }).click();
     await frame.getByRole('option', { name: policyName }).click();
     await expect(frame.getByRole('button', { name: policyName })).toBeVisible();
     await frame.getByRole('button', { name: 'Review image' }).click();

--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -155,7 +155,7 @@ test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
     await frame
       .getByRole('radio', { name: 'Use a custom compliance policy' })
       .click();
-    await frame.getByRole('button', { name: 'None' }).click();
+    await frame.getByRole('button', { name: 'Select a policy' }).click();
     await expect(frame.getByRole('option').first()).toBeVisible();
     const searchInput = frame.getByRole('textbox', { name: /filter/i });
     await expect(searchInput).toBeVisible();

--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -68,7 +68,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
   await test.step('Select a CIS profile then switch to None', async () => {
     await frame
       .getByRole('radio', { name: 'Use a default OpenSCAP profile' })
-      .check();
+      .click();
     await frame.getByRole('textbox', { name: 'Type to filter' }).fill('cis');
     await frame
       .getByRole('option', {
@@ -76,8 +76,9 @@ test('Create a blueprint with OpenSCAP customization', async ({
       })
       .click();
 
-    await frame.getByRole('textbox', { name: 'Type to filter' }).click();
-    await frame.getByRole('option', { name: /^None$/ }).click();
+    await frame
+      .getByRole('radio', { name: 'No additional policy or profile' })
+      .click();
   });
 
   await test.step('Verify Packages show no OpenSCAP additions', async () => {
@@ -92,7 +93,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await frame.getByRole('button', { name: 'Base settings' }).click();
     await frame
       .getByRole('radio', { name: 'Use a default OpenSCAP profile' })
-      .check();
+      .click();
 
     await frame.getByRole('textbox', { name: 'Type to filter' }).fill('cis');
     await frame

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -53,7 +53,7 @@ const ComplianceSelectOption = ({
   ): ComplianceSelectOptionValueType => ({
     policyID,
     title,
-    toString: () => title || 'None',
+    toString: () => title || 'Untitled policy',
   });
 
   return (
@@ -209,15 +209,7 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
       ];
     }
 
-    const res = [
-      <SelectOption
-        key='compliance-none-option'
-        value={{ toString: () => 'None', compareTo: () => false }}
-        isSelected={!policyID}
-      >
-        None
-      </SelectOption>,
-    ];
+    const res = [];
     for (const p of policies.data) {
       // there is a mismatch between API type and real data
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -251,7 +243,7 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
           <Spinner size='sm' /> Applying policy...
         </>
       ) : (
-        policyTitle || 'None'
+        policyTitle || 'Select a policy'
       )}
     </MenuToggle>
   );

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -291,7 +291,7 @@ const ProfileSelector = ({
           onChange={onTextInputChange}
           onKeyDown={onKeyDown}
           autoComplete='off'
-          placeholder='None'
+          placeholder='Select a profile'
           isExpanded={isOpen}
         />
 
@@ -330,28 +330,18 @@ const ProfileSelector = ({
             </SelectOption>
           )}
           {selectOptions.length > 0 &&
-            [
+            selectOptions.map(({ id, name }) => (
               <SelectOption
-                key='oscap-none-option'
-                value={{ toString: () => 'None', compareTo: () => false }}
-                isSelected={!profileID}
+                key={id}
+                value={{
+                  profileID: id,
+                  toString: () => name,
+                }}
+                isSelected={profileID === id}
               >
-                None
-              </SelectOption>,
-            ].concat(
-              selectOptions.map(({ id, name }) => (
-                <SelectOption
-                  key={id}
-                  value={{
-                    profileID: id,
-                    toString: () => name,
-                  }}
-                  isSelected={profileID === id}
-                >
-                  {name}
-                </SelectOption>
-              )),
-            )}
+                {name}
+              </SelectOption>
+            ))}
           {isSuccess && selectOptions.length === 0 && (
             <SelectOption isDisabled>
               {`No results found for "${filterValue}"`}

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -128,8 +128,8 @@ const OscapContent = () => {
     dispatch(changeFips(checked));
   };
 
-  const handleTypeChange = (complianceType: string) => {
-    dispatch(changeComplianceType(complianceType as ComplianceType));
+  const handleTypeChange = (complianceType: ComplianceType) => {
+    dispatch(changeComplianceType(complianceType));
 
     // Avoid showing profile information when switching between types by
     // clearing the compliance data.
@@ -166,7 +166,7 @@ const OscapContent = () => {
     },
     {
       skip:
-        complianceType === 'openscap' ||
+        complianceType !== 'compliance' ||
         isOnPremise ||
         restrictions.openscap.shouldHide,
     },
@@ -223,13 +223,22 @@ const OscapContent = () => {
             <OscapOnPremWarning />
           ) : (
             <FormGroup>
+              <Content className='pf-v6-u-pb-sm'>
+                <Radio
+                  id='security-type-none'
+                  name='security-type'
+                  label='No additional policy or profile'
+                  isChecked={complianceType === 'none'}
+                  onChange={() => handleTypeChange('none')}
+                />
+              </Content>
               {!isOnPremise && (
                 <>
                   <Content className='pf-v6-u-pb-sm'>
                     <Radio
                       id='security-type-compliance'
                       name='security-type'
-                      label='Use a custom Compliance policy'
+                      label='Use a custom compliance policy'
                       isChecked={complianceType === 'compliance'}
                       onChange={() => handleTypeChange('compliance')}
                     />

--- a/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
@@ -19,11 +19,95 @@ describe('Oscap Component', () => {
       });
       const user = createUser();
 
-      const profileSearchInput = await screen.findByPlaceholderText('None');
+      const profileSearchInput =
+        await screen.findByPlaceholderText('Select a profile');
       await typeWithWait(user, profileSearchInput, 'cis{Enter}');
 
       expect(profileSearchInput).toBeInTheDocument();
       expect(profileSearchInput).toHaveValue('cis');
+    });
+  });
+
+  describe('Compliance type radio buttons', () => {
+    test('"No additional policy or profile" is selected by default', async () => {
+      renderWithRedux(<OscapStep />);
+
+      const noneRadio = await screen.findByRole('radio', {
+        name: /No additional policy or profile/i,
+      });
+      expect(noneRadio).toBeChecked();
+
+      const complianceRadio = screen.getByRole('radio', {
+        name: /Use a custom compliance policy/i,
+      });
+      expect(complianceRadio).not.toBeChecked();
+
+      const openscapRadio = screen.getByRole('radio', {
+        name: /Use a default OpenSCAP profile/i,
+      });
+      expect(openscapRadio).not.toBeChecked();
+    });
+
+    test('switching to compliance enables the policy selector', async () => {
+      renderWithRedux(<OscapStep />);
+      const user = createUser();
+
+      const complianceRadio = await screen.findByRole('radio', {
+        name: /Use a custom compliance policy/i,
+      });
+      await user.click(complianceRadio);
+
+      expect(complianceRadio).toBeChecked();
+      expect(
+        screen.getByRole('radio', {
+          name: /No additional policy or profile/i,
+        }),
+      ).not.toBeChecked();
+    });
+
+    test('switching to openscap enables the profile selector', async () => {
+      renderWithRedux(<OscapStep />);
+      const user = createUser();
+
+      const openscapRadio = await screen.findByRole('radio', {
+        name: /Use a default OpenSCAP profile/i,
+      });
+      await user.click(openscapRadio);
+
+      expect(openscapRadio).toBeChecked();
+      expect(
+        screen.getByRole('radio', {
+          name: /No additional policy or profile/i,
+        }),
+      ).not.toBeChecked();
+
+      expect(
+        screen.getByPlaceholderText('Select a profile'),
+      ).toBeInTheDocument();
+    });
+
+    test('switching back to none from openscap deselects profile', async () => {
+      renderWithRedux(<OscapStep />, {
+        compliance: {
+          complianceType: 'openscap',
+          profileID: undefined,
+          policyID: undefined,
+          policyTitle: undefined,
+        },
+      });
+      const user = createUser();
+
+      const noneRadio = await screen.findByRole('radio', {
+        name: /No additional policy or profile/i,
+      });
+      await user.click(noneRadio);
+
+      expect(noneRadio).toBeChecked();
+      expect(
+        screen.getByRole('radio', {
+          name: /Use a default OpenSCAP profile/i,
+        }),
+      ).not.toBeChecked();
     });
   });
 });

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -60,7 +60,7 @@ export type RegistrationType =
 
 export type PartitioningModeType = ('raw' | 'lvm' | 'auto-lvm') | undefined;
 
-export type ComplianceType = 'openscap' | 'compliance';
+export type ComplianceType = 'none' | 'openscap' | 'compliance';
 
 export type UserWithAdditionalInfo = {
   [K in keyof User]-?: NonNullable<User[K]>;
@@ -269,7 +269,7 @@ export const initialState: wizardState = {
     },
   },
   compliance: {
-    complianceType: 'openscap',
+    complianceType: 'none',
     policyID: undefined,
     profileID: undefined,
     policyTitle: undefined,


### PR DESCRIPTION
Add a radio button to explicitly opt out of compliance, replacing the
'None' option that was previously embedded in both the policy and
profile dropdowns. Default compliance type is now 'none'.

JIRA : HMS-10579

