### PR TITLE
Wizard: Fix activation key on re-open (HMS-10612)

### DIFF
--- a/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
+++ b/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 import {
   Bullseye,
@@ -99,6 +99,7 @@ const CreateImageWizard3 = () => {
   const isImageMode = useAppSelector(selectIsImageMode);
   const imageSource = useAppSelector(selectImageSource);
   const [searchParams, setSearchParams] = useSearchParams();
+  const hasInitialized = useRef(false);
 
   const { data: blueprintDetails, isSuccess } = useGetBlueprintQuery(
     { id: blueprintId || '' },
@@ -169,7 +170,10 @@ const CreateImageWizard3 = () => {
     }
 
     if (mode === 'create' && showWizardModal) {
-      dispatch(initializeWizard());
+      if (!hasInitialized.current) {
+        dispatch(initializeWizard());
+        hasInitialized.current = true;
+      }
       if (searchParams.get('release') === 'rhel8') {
         dispatch(changeDistribution(RHEL_8));
       }


### PR DESCRIPTION
This fixes missing activation key when the Wizard was opened, closed and re-opened. `initializeWizard()` was called every time and overwriting the activation key with an empty value. The ref should ensure the initialisation runs only when the modal is first opened.