### PR TITLE
Wizard/ Oscap: Lock FIPS toggle when enabled by compliance profile (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -33,6 +33,7 @@ import {
   useGetOscapCustomizationsQuery,
   useGetOscapProfilesQuery,
 } from '@/store/api/backend';
+import { useSecuritySummary } from '@/store/api/backend/hooks';
 import { usePoliciesQuery } from '@/store/api/compliance';
 import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
@@ -120,6 +121,8 @@ const OscapContent = () => {
     // dependency array. eslint's exhaustive-deps rule does not support this use.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const { fipsRequired } = useSecuritySummary();
 
   const handleFipsToggle = (checked: boolean) => {
     dispatch(changeFips(checked));
@@ -381,13 +384,17 @@ const OscapContent = () => {
             id='fips-enabled-switch'
             label='Enable FIPS mode'
             isChecked={fips.enabled}
+            isDisabled={fipsRequired}
             onChange={(_event, checked) => handleFipsToggle(checked)}
             hasCheckIcon
           />
           <FormHelperText>
             <HelperText>
-              Enable FIPS 140-2 compliant cryptographic algorithms. This setting
-              is applied at build time and persists on boot.
+              <HelperTextItem>
+                {fipsRequired
+                  ? 'FIPS mode is required by the selected compliance profile and cannot be disabled.'
+                  : 'Enable FIPS 140-2 compliant cryptographic algorithms. This setting is applied at build time and persists on boot.'}
+              </HelperTextItem>
             </HelperText>
           </FormHelperText>
         </FormGroup>

--- a/src/Components/CreateImageWizard/steps/Review/components/Security/tests/Security.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Security/tests/Security.test.tsx
@@ -11,6 +11,7 @@ describe('Security', () => {
   test('does not render the security card when nothing is configured', () => {
     const mockSecuritySummary = {
       title: undefined,
+      fipsRequired: false,
       packages: [],
       services: { enabled: [], disabled: [], masked: [], total: 0 },
       kernel: { append: [] },
@@ -63,6 +64,7 @@ describe('Security', () => {
     test('displays OpenSCAP profile when compliance type is openscap', () => {
       const mockSummaryWithCIS = {
         title: 'CIS Red Hat Enterprise Linux 9 Benchmark',
+        fipsRequired: false,
         packages: [],
         services: { enabled: [], disabled: [], masked: [], total: 0 },
         kernel: { append: [] },
@@ -93,6 +95,7 @@ describe('Security', () => {
     test('displays Compliance policy when compliance type is compliance', () => {
       const mockComplianceSummary = {
         title: 'My Compliance Policy',
+        fipsRequired: false,
         packages: [],
         services: { enabled: [], disabled: [], masked: [], total: 0 },
         kernel: { append: [] },

--- a/src/store/api/backend/hooks.tsx
+++ b/src/store/api/backend/hooks.tsx
@@ -76,9 +76,15 @@ export const useSecuritySummary = () => {
     return profile?.profile_name ?? profileId;
   }, [data?.openscap, complianceType, policyTitle, profileId]);
 
+  const fipsRequired = useMemo(
+    () => data?.fips?.enabled ?? false,
+    [data?.fips?.enabled],
+  );
+
   return useMemo(
     () => ({
       title,
+      fipsRequired,
       packages: data?.packages ?? [],
       services: {
         enabled,
@@ -90,6 +96,6 @@ export const useSecuritySummary = () => {
         append: data?.kernel?.append?.split(' ').filter(Boolean) ?? [],
       },
     }),
-    [data, title, enabled, disabled, masked],
+    [data, title, fipsRequired, enabled, disabled, masked],
   );
 };


### PR DESCRIPTION
Some compliance policies and OpenSCAP profiles (e.g., STIG) require
FIPS to be enabled. When selecting such a profile, the FIPS toggle is
now automatically turned on and locked, preventing the user from
disabling it. Clearing the profile selection or switching compliance
types unlocks the toggle.

Added `enabledByProfile` to the FIPS state to track whether FIPS was
set by a profile. When locked, the helper text explains that FIPS is
required by the selected profile.
JIRA: HMS-10579