### PR TITLE
Wizard: visually split required and optional packages

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-table';
 import { orderBy } from 'lodash';
 
+import { useSecuritySummary } from '@/store/api/backend';
 import { ApiRepositoryCollectionResponseRead } from '@/store/api/contentSources';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -48,6 +49,11 @@ const PackagesTable = ({
   const recommendedRepositories = useAppSelector(selectRecommendedRepositories);
   const packages = useAppSelector(selectPackages);
   const groups = useAppSelector(selectGroups);
+  const { packages: requiredPkgNames } = useSecuritySummary();
+  const requiredSet = useMemo(
+    () => new Set(requiredPkgNames),
+    [requiredPkgNames],
+  );
 
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 
@@ -199,29 +205,41 @@ const PackagesTable = ({
       )),
     );
 
+    // Render required (oscap) packages first, then user-added packages
+    const orderedPackages = [
+      ...sortedPackages.filter((pkg) => requiredSet.has(pkg.name)),
+      ...sortedPackages.filter((pkg) => !requiredSet.has(pkg.name)),
+    ];
+
     rows = rows.concat(
-      sortedPackages.map((pkg) => (
-        <Tbody
-          key={`${pkg.name}-${pkg.stream || 'default'}-${pkg.module_name || pkg.name}`}
-        >
-          <Tr data-testid='package-row'>
-            <Td>&nbsp;</Td>
-            <Td>{pkg.name}</Td>
-            <Td>{pkg.stream ? pkg.stream : 'N/A'}</Td>
-            <Td>
-              <RetirementDate date={pkg.end_date} />
-            </Td>
-            <Td>
-              <RemovePackageButton
-                item={pkg}
-                onRemove={(item) =>
-                  handleRemovePackage(item as IBPackageWithRepositoryInfo)
-                }
-              />
-            </Td>
-          </Tr>
-        </Tbody>
-      )),
+      orderedPackages.map((pkg) => {
+        const isRequired = requiredSet.has(pkg.name);
+        return (
+          <Tbody
+            key={`${pkg.name}-${pkg.stream || 'default'}-${pkg.module_name || pkg.name}`}
+          >
+            <Tr
+              data-testid={isRequired ? 'required-package-row' : 'package-row'}
+            >
+              <Td>&nbsp;</Td>
+              <Td>{pkg.name}</Td>
+              <Td>{pkg.stream ? pkg.stream : 'N/A'}</Td>
+              <Td>
+                <RetirementDate date={pkg.end_date} />
+              </Td>
+              <Td>
+                <RemovePackageButton
+                  item={pkg}
+                  isRequired={isRequired}
+                  onRemove={(item) =>
+                    handleRemovePackage(item as IBPackageWithRepositoryInfo)
+                  }
+                />
+              </Td>
+            </Tr>
+          </Tbody>
+        );
+      }),
     );
     return rows;
   };
@@ -240,6 +258,7 @@ const PackagesTable = ({
     expandedGroups,
     sortedPackages,
     sortedGroups,
+    requiredSet,
   ]);
 
   return (

--- a/src/Components/CreateImageWizard/steps/Packages/components/RemovePackageButton.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/RemovePackageButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Button } from '@patternfly/react-core';
-import { MinusCircleIcon } from '@patternfly/react-icons';
+import { Button, Tooltip } from '@patternfly/react-core';
+import { LockIcon, MinusCircleIcon } from '@patternfly/react-icons';
 
 import {
   GroupWithRepositoryInfo,
@@ -10,23 +10,43 @@ import {
 
 type RemovePackageButtonProps = {
   item: IBPackageWithRepositoryInfo | GroupWithRepositoryInfo;
+  isRequired?: boolean;
   onRemove: (
     item: IBPackageWithRepositoryInfo | GroupWithRepositoryInfo,
   ) => void;
 };
 
-const RemovePackageButton = ({ item, onRemove }: RemovePackageButtonProps) => {
+const RemovePackageButton = ({
+  item,
+  isRequired,
+  onRemove,
+}: RemovePackageButtonProps) => {
   const packageType = 'package_list' in item ? 'package group' : 'package';
 
-  return (
+  const button = (
     <Button
+      isDisabled={!!isRequired}
       variant='plain'
-      icon={<MinusCircleIcon />}
-      aria-label={`Remove ${packageType}`}
+      icon={isRequired ? <LockIcon /> : <MinusCircleIcon />}
+      aria-label={
+        isRequired
+          ? `Required ${packageType}, cannot be removed`
+          : `Remove ${packageType}`
+      }
       onClick={() => onRemove(item)}
       isInline
       hasNoPadding
     />
+  );
+
+  if (!isRequired) {
+    return button;
+  }
+
+  return (
+    <Tooltip content='Required by the selected OpenSCAP profile'>
+      <span>{button}</span>
+    </Tooltip>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
@@ -642,4 +642,137 @@ describe('Packages Component', () => {
       expect(searchInput).toHaveValue('test-pkg');
     });
   });
+
+  describe('Required packages (OpenSCAP)', () => {
+    const oscapCustomizationsResponse = {
+      openscap: {
+        profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+        profile_name: 'CIS Workstation L1',
+        profile_description: 'Test profile',
+      },
+      packages: ['aide', 'neovim'],
+    };
+
+    const renderWithOscapPackages = () => {
+      fetchMock.mockResponse(
+        createFetchHandler({ oscap: oscapCustomizationsResponse }),
+      );
+
+      return renderPackagesStep({
+        compliance: {
+          complianceType: 'openscap',
+          profileID: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+          policyID: undefined,
+          policyTitle: undefined,
+        },
+        packages: [
+          {
+            name: 'aide',
+            summary: 'Required by chosen OpenSCAP profile',
+            repository: 'distro',
+          },
+          {
+            name: 'neovim',
+            summary: 'Required by chosen OpenSCAP profile',
+            repository: 'distro',
+          },
+          {
+            name: 'zsh',
+            summary: 'User selected package',
+            repository: 'distro',
+          },
+          {
+            name: 'curl',
+            summary: 'User selected package',
+            repository: 'distro',
+          },
+        ],
+      });
+    };
+
+    test('required packages appear before user-added packages', async () => {
+      renderWithOscapPackages();
+
+      await screen.findAllByTestId('required-package-row');
+
+      // Query all rows together via the table to verify DOM order
+      const table = screen.getByTestId('packages-table');
+      const allRows = within(table).getAllByRole('row');
+      // Filter to data rows (skip the header row)
+      const dataRows = allRows.filter(
+        (row) =>
+          row.getAttribute('data-testid') === 'required-package-row' ||
+          row.getAttribute('data-testid') === 'package-row',
+      );
+
+      expect(dataRows).toHaveLength(4);
+      // Required packages first (alphabetical)
+      expect(dataRows[0]).toHaveTextContent('aide');
+      expect(dataRows[0]).toHaveAttribute(
+        'data-testid',
+        'required-package-row',
+      );
+      expect(dataRows[1]).toHaveTextContent('neovim');
+      expect(dataRows[1]).toHaveAttribute(
+        'data-testid',
+        'required-package-row',
+      );
+      // User packages after (alphabetical)
+      expect(dataRows[2]).toHaveTextContent('curl');
+      expect(dataRows[2]).toHaveAttribute('data-testid', 'package-row');
+      expect(dataRows[3]).toHaveTextContent('zsh');
+      expect(dataRows[3]).toHaveAttribute('data-testid', 'package-row');
+    });
+
+    test('required packages have a disabled button with lock icon', async () => {
+      renderWithOscapPackages();
+
+      const requiredRows = await screen.findAllByTestId('required-package-row');
+
+      // Required rows should have a disabled button
+      for (const row of requiredRows) {
+        const button = within(row).getByRole('button', {
+          name: /cannot be removed/i,
+        });
+        expect(button).toBeDisabled();
+      }
+
+      // User rows should have enabled remove buttons
+      const userRows = await screen.findAllByTestId('package-row');
+      for (const row of userRows) {
+        const button = within(row).getByRole('button', { name: /remove/i });
+        expect(button).toBeEnabled();
+      }
+    });
+
+    test('without oscap profile, all packages have remove buttons', async () => {
+      renderPackagesStep({
+        packages: [
+          {
+            name: 'zsh',
+            summary: 'User selected package',
+            repository: 'distro',
+          },
+          {
+            name: 'curl',
+            summary: 'User selected package',
+            repository: 'distro',
+          },
+        ],
+      });
+
+      const rows = await screen.findAllByTestId('package-row');
+      expect(rows).toHaveLength(2);
+
+      // No required package rows should exist
+      expect(screen.queryAllByTestId('required-package-row')).toHaveLength(0);
+
+      // All rows should have enabled remove buttons
+      for (const row of rows) {
+        const button = within(row).getByRole('button', { name: /remove/i });
+        expect(button).toBeInTheDocument();
+        expect(button).toBeEnabled();
+      }
+    });
+  });
 });

--- a/src/Components/CreateImageWizard/steps/Packages/tests/mocks/handlers.ts
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { GetOscapCustomizationsApiResponse } from '@/store/api/backend';
 import {
   ApiSearchPackageGroupResponse,
   ApiSearchRpmResponse,
@@ -6,6 +7,7 @@ import {
   composeHandlers,
   createArchitecturesHandler,
   createGroupsHandler,
+  createOscapHandler,
   createRecommendationsHandler,
   createRepositoriesHandler,
   createRpmHandler,
@@ -21,6 +23,7 @@ export { fetchMock };
 type FetchHandlerOverrides = {
   rpms?: ApiSearchRpmResponse[];
   groups?: ApiSearchPackageGroupResponse[];
+  oscap?: GetOscapCustomizationsApiResponse;
 };
 
 export const createFetchHandler = (
@@ -33,6 +36,9 @@ export const createFetchHandler = (
     createRepositoriesHandler(),
     createTemplatesHandler(),
     createRecommendationsHandler(),
+    createOscapHandler(
+      overrides.oscap ? { customizations: overrides.oscap } : {},
+    ),
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Repositories/components/RemoveRepositoryButton.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/RemoveRepositoryButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { Button, Tooltip } from '@patternfly/react-core';
-import { MinusCircleIcon } from '@patternfly/react-icons';
+import { LockIcon, MinusCircleIcon } from '@patternfly/react-icons';
 
 import { ApiRepositoryResponseRead } from '@/store/api/contentSources';
 
@@ -22,7 +22,7 @@ const RemoveRepositoryButton = ({
     <Button
       isDisabled={isDisabled}
       variant='plain'
-      icon={<MinusCircleIcon />}
+      icon={isDisabled ? <LockIcon /> : <MinusCircleIcon />}
       aria-label='Remove repository'
       onClick={() => onRemove(repo)}
       isInline

--- a/src/test/testUtils/fetchMock.ts
+++ b/src/test/testUtils/fetchMock.ts
@@ -1,6 +1,10 @@
 import createFetchMock from 'vitest-fetch-mock';
 
-import { Architectures, BlueprintsResponse } from '@/store/api/backend';
+import {
+  Architectures,
+  BlueprintsResponse,
+  GetOscapCustomizationsApiResponse,
+} from '@/store/api/backend';
 import {
   ApiRepositoryResponseRead,
   ApiSearchPackageGroupResponse,
@@ -207,6 +211,28 @@ export const createArchitecturesHandler = (
       if (distro in architectures) {
         return JSON.stringify(architectures[distro]);
       }
+    }
+    return null;
+  };
+};
+
+// Oscap customizations handler
+export type OscapHandlerOptions = {
+  customizations?: GetOscapCustomizationsApiResponse;
+};
+
+export const createOscapHandler = (
+  options: OscapHandlerOptions = {},
+): FetchHandler => {
+  const { customizations } = options;
+
+  return ({ url, method }: FetchRequest) => {
+    if (
+      url.includes('/oscap/') &&
+      url.endsWith('/customizations') &&
+      method === 'GET'
+    ) {
+      return JSON.stringify(customizations ?? {});
     }
     return null;
   };

--- a/src/test/testUtils/index.ts
+++ b/src/test/testUtils/index.ts
@@ -26,6 +26,7 @@ export {
   createArchitecturesHandler,
   createBlueprintsHandler,
   createGroupsHandler,
+  createOscapHandler,
   createRecommendationsHandler,
   createRepositoriesHandler,
   createRpmHandler,
@@ -34,6 +35,7 @@ export {
   type ArchitecturesHandlerOptions,
   type BlueprintsHandlerOptions,
   type GroupsHandlerOptions,
+  type OscapHandlerOptions,
   type RpmHandlerOptions,
 } from './fetchMock';
 


### PR DESCRIPTION
## Summary
OpenSCAP-required packages are now visually distinguished from user-added packages in the packages table, making it clear which packages cannot be removed.

## Changes
- Required packages render at the top of the table with a disabled remove button, tooltip, and lock icon; user-added packages appear below with the standard remove button
- `RemovePackageButton` extended with an `isRequired` prop that disables the button and swaps to a lock icon, matching the existing `RemoveRepositoryButton` pattern
- `RemoveRepositoryButton` updated to also show a lock icon when disabled for visual consistency across wizard steps
- Added shared `createOscapHandler` test utility for mocking OpenSCAP customizations API responses
- Three new tests covering DOM ordering, disabled button state, and fallback behavior without an OpenSCAP profile