### PR TITLE
Wizard: add installer to image mode (HMS-10601)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -24,6 +24,7 @@ import { selectIsOnPremise } from '@/store/slices';
 import {
   addImageType,
   changeImageTypes,
+  changeIsoPayloadReference,
   changeRegistrationType,
   reinitializeAws,
   reinitializeAzure,
@@ -33,6 +34,7 @@ import {
   selectDistribution,
   selectImageTypes,
   selectIsImageMode,
+  selectIsoPayloadReference,
 } from '@/store/slices/wizard';
 import { useFlag } from '@/Utilities/useGetEnvironment';
 
@@ -123,6 +125,31 @@ const TargetEnvironment = () => {
       dispatch(changeImageTypes([environments[0]]));
     }
   }, [isImageMode, environments, dispatch]);
+
+  const isoPayloadReference = useAppSelector(selectIsoPayloadReference);
+  useEffect(() => {
+    if (!isImageMode || !environments.includes('bootable-container-iso')) {
+      return;
+    }
+    const entry = bootcDistributions?.find(
+      (d) => d.type === 'bootable-container-iso' && d.distro === distribution,
+    );
+    const refs = entry?.iso_payload_references;
+    if (!refs || refs.length === 0) {
+      return;
+    }
+    if (isoPayloadReference && refs.includes(isoPayloadReference)) {
+      return;
+    }
+    dispatch(changeIsoPayloadReference(refs[0]));
+  }, [
+    isImageMode,
+    environments,
+    bootcDistributions,
+    distribution,
+    isoPayloadReference,
+    dispatch,
+  ]);
 
   const isOnlyNetworkInstallerSelected =
     environments.length === 1 && environments.includes('network-installer');
@@ -536,6 +563,25 @@ const TargetEnvironment = () => {
               }}
             />
           ))}
+        {miscFormats.includes('bootable-container-iso') && isImageMode && (
+          <Radio
+            className='pf-v6-u-mb-sm pf-v6-u-ml-lg'
+            id='radio-bootable-container-iso'
+            name='target-environment'
+            label='Container installer (.iso)'
+            aria-label='Container installer'
+            description={
+              <Content component='small' style={{ maxWidth: TEXT_WRAP_WIDTH }}>
+                Install a bootable container to bare metal or virtual machines
+                using the guided Anaconda installer.
+              </Content>
+            }
+            isChecked={environments.includes('bootable-container-iso')}
+            onChange={() =>
+              handleSelectSingleEnvironment('bootable-container-iso')
+            }
+          />
+        )}
         {miscFormats.includes('network-installer') &&
           (isImageMode ? (
             <Radio

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/components/MiscFormats.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/components/MiscFormats.tsx
@@ -7,7 +7,7 @@ import { MiscFormatType } from '@/Hooks/Utilities/useTargetEnvironmentCategories
 import { ReviewGroup } from '../../shared';
 
 const MISC_FORMATS: Record<MiscFormatType, string> = {
-  'bootable-container-iso': '',
+  'bootable-container-iso': 'Container installer (.iso)',
   'guest-image': 'Virtualization (.qcow2)',
   'image-installer': 'Baremetal (.iso)',
   'pxe-tar-xz': 'Network - PXE Boot',

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -81,6 +81,7 @@ import {
   selectImageSource,
   selectImageTypes,
   selectIsImageMode,
+  selectIsoPayloadReference,
   selectKernel,
   selectKeyboard,
   selectLanguages,
@@ -159,9 +160,9 @@ export const mapRequestFromState = (
   const imageSource = selectImageSource(state);
 
   let bootcReference: string | undefined;
+  const imageTypes = selectImageTypes(state);
   if (isImageMode && imageSource) {
     const bootcDistributions = selectBootcDistributions(state);
-    const imageTypes = selectImageTypes(state);
     const selectedDistro = bootcDistributions.find(
       (d) => d.reference === imageSource,
     );
@@ -178,16 +179,23 @@ export const mapRequestFromState = (
     }
   }
 
+  const isoPayloadRef = selectIsoPayloadReference(state);
+  const bootcBody =
+    bootcReference !== undefined
+      ? {
+          reference: bootcReference,
+          ...(imageTypes[0] === 'bootable-container-iso' && isoPayloadRef
+            ? { iso_payload_reference: isoPayloadRef }
+            : {}),
+        }
+      : undefined;
+
   return {
     name: selectBlueprintName(state),
     metadata: selectMetadata(state),
     description: selectBlueprintDescription(state),
     distribution: selectDistribution(state),
-    bootc: bootcReference
-      ? {
-          reference: bootcReference,
-        }
-      : undefined,
+    bootc: bootcBody,
     image_requests: imageRequests,
     customizations,
   };
@@ -540,6 +548,7 @@ function commonRequestToState(
     architecture: arch,
     distribution: getLatestRelease(request.distribution),
     imageSource: 'bootc' in request ? request.bootc?.reference : undefined,
+    isoPayloadReference: request.bootc?.iso_payload_reference,
     imageTypes: request.image_requests.map((image) => image.image_type),
     azure: azureTargetOptions(azureUploadOptions),
     gcp: gcpTargetOptions(gcpUploadOptions),
@@ -854,6 +863,8 @@ const uploadTypeByTargetEnv = (
     case 'guest-image':
       return 'aws.s3';
     case 'image-installer':
+      return 'aws.s3';
+    case 'bootable-container-iso':
       return 'aws.s3';
     case 'network-installer':
       return 'aws.s3';

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -46,7 +46,7 @@ export const AwsS3Instance = ({
   const fileExtensions: { [key in ImageTypes]: string } = {
     aws: '',
     azure: '',
-    'bootable-container-iso': '',
+    'bootable-container-iso': '.iso',
     'edge-commit': '',
     'edge-installer': '',
     gcp: '',
@@ -115,6 +115,7 @@ const VM_IMPORTABLE_IMAGE_TYPES: ImageTypes[] = ['guest-image'];
 
 // Image types that can be used as installation media in cockpit-machines
 const VM_INSTALLABLE_IMAGE_TYPES: ImageTypes[] = [
+  'bootable-container-iso',
   'image-installer',
   'network-installer',
 ];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,7 +70,7 @@ export const AARCH64 = 'aarch64';
 export const targetOptions: { [key in ImageTypes]: string } = {
   aws: 'Amazon Web Services',
   azure: 'Microsoft Azure',
-  'bootable-container-iso': '',
+  'bootable-container-iso': 'Container installer',
   'edge-commit': 'Edge Commit',
   'edge-installer': 'Edge Installer',
   gcp: 'Google Cloud',
@@ -91,7 +91,7 @@ export const targetOptions: { [key in ImageTypes]: string } = {
 export const simpleTargetNames: { [key in ImageTypes]: string } = {
   aws: 'AWS',
   azure: 'Microsoft Azure',
-  'bootable-container-iso': '',
+  'bootable-container-iso': 'Container installer',
   'edge-commit': 'Edge Commit',
   'edge-installer': 'Edge Installer',
   gcp: 'Google Cloud',

--- a/src/store/api/distributions/constants.ts
+++ b/src/store/api/distributions/constants.ts
@@ -45,6 +45,12 @@ export const DISTRO_DETAILS: Record<string, ImageTypeInfo> = {
       ...ALL_CUSTOMIZATIONS.filter((c) => c !== 'filesystem'),
     ],
   },
+  'bootable-container-iso': {
+    name: 'bootable-container-iso',
+    supported_blueprint_options: [
+      ...ALL_CUSTOMIZATIONS.filter((c) => c !== 'filesystem'),
+    ],
+  },
   vsphere: {
     name: 'vsphere',
     supported_blueprint_options: [...ALL_CUSTOMIZATIONS],

--- a/src/store/api/distributions/tests/distributionDetailsApi.test.ts
+++ b/src/store/api/distributions/tests/distributionDetailsApi.test.ts
@@ -142,6 +142,7 @@ describe('DISTRO_DETAILS structure', () => {
       'gcp',
       'guest-image',
       'image-installer',
+      'bootable-container-iso',
       'vsphere',
       'vsphere-ova',
       'wsl',

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -118,6 +118,8 @@ export type wizardState = {
   wizardMode: WizardModeOptions;
   blueprintMode: BlueprintModeOptions;
   imageSource?: ImageSource | undefined;
+  /** Embedded OS image ref for bootable-container-iso (installer ref is the bootc `reference` for that target). */
+  isoPayloadReference?: string | undefined;
   bootcDistributions: BootcDistributionItem[];
   architecture: ImageRequest['architecture'];
   distribution: Distributions | 'image-mode';
@@ -351,6 +353,10 @@ export const selectBlueprintMode = (state: RootState) => {
 
 export const selectImageSource = (state: RootState) => {
   return state.wizard.imageSource;
+};
+
+export const selectIsoPayloadReference = (state: RootState) => {
+  return state.wizard.isoPayloadReference;
 };
 
 export const selectBootcDistributions = (state: RootState) => {
@@ -795,6 +801,12 @@ export const wizardSlice = createSlice({
     ) => {
       state.imageSource = action.payload;
     },
+    changeIsoPayloadReference: (
+      state,
+      action: PayloadAction<string | undefined>,
+    ) => {
+      state.isoPayloadReference = action.payload;
+    },
     changeBootcDistributions: (
       state,
       action: PayloadAction<BootcDistributionItem[]>,
@@ -831,6 +843,11 @@ export const wizardSlice = createSlice({
     },
     changeImageTypes: (state, action: PayloadAction<ImageTypes[]>) => {
       state.imageTypes = action.payload;
+      // isoPayloadReference is only relevant for bootable-container-iso,
+      // clear it when that image type is no longer selected
+      if (!action.payload.includes('bootable-container-iso')) {
+        state.isoPayloadReference = undefined;
+      }
     },
     changeAwsAccountId: (state, action: PayloadAction<string>) => {
       state.aws.accountId = action.payload;
@@ -1748,6 +1765,7 @@ export const {
   changeProxy,
   changeBlueprintMode,
   changeImageSource,
+  changeIsoPayloadReference,
   changeBootcDistributions,
   changeArchitecture,
   changeDistribution,

--- a/src/store/slices/wizard/tests/wizardSlice.test.ts
+++ b/src/store/slices/wizard/tests/wizardSlice.test.ts
@@ -215,6 +215,21 @@ describe('wizardSlice core reducers', () => {
 
         expect(result.imageTypes).toEqual([]);
       });
+
+      it('should clear isoPayloadReference when bootable-container-iso is not selected', () => {
+        const stateWithIso: wizardState = {
+          ...initialState,
+          imageTypes: ['bootable-container-iso'],
+          isoPayloadReference: 'registry.example.org/payload:latest',
+        };
+
+        const result = wizardReducer(
+          stateWithIso,
+          changeImageTypes(['guest-image']),
+        );
+
+        expect(result.isoPayloadReference).toBeUndefined();
+      });
     });
   });
 });


### PR DESCRIPTION
The new installer for image mode just dropped!
I have two things that I'd like opinions on :arrow_down: 
<img width="1542" height="877" alt="image" src="https://github.com/user-attachments/assets/378183c7-1d81-4b68-8999-64026bfe5c89" />
