### PR TITLE
Wizard/Image output: Replace arch for image mode with disabled select (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ArchSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ArchSelect.tsx
@@ -15,7 +15,11 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import { changeArchitecture, selectArchitecture } from '@/store/slices/wizard';
 
-const ArchSelect = () => {
+type ArchSelectProps = {
+  isDisabled?: boolean;
+};
+
+const ArchSelect = ({ isDisabled = false }: ArchSelectProps) => {
   const arch = useAppSelector(selectArchitecture);
   const dispatch = useAppDispatch();
   const isOnPremise = useAppSelector(selectIsOnPremise);
@@ -57,6 +61,7 @@ const ArchSelect = () => {
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
+      isDisabled={isDisabled}
       style={
         {
           minWidth: '8rem',

--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { Content, Form, FormGroup, Title } from '@patternfly/react-core';
+import { Content, Form, Title } from '@patternfly/react-core';
 
 import DocumentationButton from '@/Components/sharedComponents/DocumentationButton';
 import { RHEL_10_IMAGE_MODE_IMAGE } from '@/constants';
@@ -92,11 +92,7 @@ const ImageOutputStep = () => {
           <ReleaseLifecycle />
         </>
       )}
-      {isHostedImageMode ? (
-        <FormGroup label='Architecture'>x86_64</FormGroup>
-      ) : (
-        <ArchSelect />
-      )}
+      <ArchSelect isDisabled={isHostedImageMode} />
       <TargetEnvironment />
     </Wrapper>
   );


### PR DESCRIPTION
The arch was previously just a simple text for image mode, now it uses the `<ArchSelect>` component and disables it.