### PR TITLE
Wizard: prevent removal of required packages via search

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -25,7 +25,11 @@ import { OptimizeIcon, SearchIcon, TimesIcon } from '@patternfly/react-icons';
 import { orderBy } from 'lodash';
 
 import { EPEL_10_REPO_DEFINITION } from '@/constants';
-import { Module, useGetArchitecturesQuery } from '@/store/api/backend';
+import {
+  Module,
+  useGetArchitecturesQuery,
+  useSecuritySummary,
+} from '@/store/api/backend';
 import {
   ApiRepositoryCollectionResponseRead,
   useGetTemplateQuery,
@@ -114,6 +118,15 @@ const PackageSearch = ({
   const template = useAppSelector(selectTemplate);
   const snapshotDate = useAppSelector(selectSnapshotDate);
   const wizardMode = useAppSelector(selectWizardMode);
+
+  const { packages: requiredPackages } = useSecuritySummary();
+  const requiredSet = useMemo(
+    () => new Set(requiredPackages),
+    [requiredPackages],
+  );
+
+  const isRequiredAndSelected = (pkg: IBPackageWithRepositoryInfo) =>
+    requiredSet.has(pkg.name) && packages.some((p) => p.name === pkg.name);
 
   const [searchTerm, setSearchTerm] = useState('');
   const [isSearchingOtherRepos, setIsSearchingOtherRepos] = useState(false);
@@ -597,10 +610,13 @@ const PackageSearch = ({
       modules.some((module: Module) => module.name === pkg.module_name) &&
       !modules.some((m: Module) => m.stream === pkg.stream);
 
+    const isRequired = isRequiredAndSelected(pkg);
+
     return (
       isModuleDisabledByPackage ||
       isPackageDisabledByModule ||
-      isModuleStreamConflict
+      isModuleStreamConflict ||
+      isRequired
     );
   };
 
@@ -717,7 +733,7 @@ const PackageSearch = ({
             );
           }
         }
-      } else {
+      } else if (!isRequiredAndSelected(pkg)) {
         dispatch(removePackage(pkg.name));
         if (pkg.type === 'module' && pkg.module_name) {
           dispatch(removeModule(pkg.module_name));

--- a/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
 import { server } from '@/test/mocks/server';
 import {
@@ -24,6 +24,9 @@ import {
   mockEpelSearch,
   mockGroupSearchResults,
   mockModuleSearchResults,
+  mockOscapCustomizations,
+  mockOscapProfile,
+  mockOscapSearchResults,
   mockSearchResults,
 } from './mocks';
 
@@ -644,24 +647,15 @@ describe('Packages Component', () => {
   });
 
   describe('Required packages (OpenSCAP)', () => {
-    const oscapCustomizationsResponse = {
-      openscap: {
-        profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
-        profile_name: 'CIS Workstation L1',
-        profile_description: 'Test profile',
-      },
-      packages: ['aide', 'neovim'],
-    };
-
     const renderWithOscapPackages = () => {
       fetchMock.mockResponse(
-        createFetchHandler({ oscap: oscapCustomizationsResponse }),
+        createFetchHandler({ oscap: mockOscapCustomizations }),
       );
 
       return renderPackagesStep({
         compliance: {
           complianceType: 'openscap',
-          profileID: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+          profileID: mockOscapProfile,
           policyID: undefined,
           policyTitle: undefined,
         },
@@ -773,6 +767,196 @@ describe('Packages Component', () => {
         expect(button).toBeInTheDocument();
         expect(button).toBeEnabled();
       }
+    });
+
+    test('required packages cannot be removed via search dropdown', async () => {
+      fetchMock.mockResponse(
+        createFetchHandler({
+          rpms: mockOscapSearchResults,
+          oscap: mockOscapCustomizations,
+        }),
+      );
+
+      const { store } = renderPackagesStep({
+        compliance: {
+          complianceType: 'openscap',
+          profileID: mockOscapProfile,
+          policyID: undefined,
+          policyTitle: undefined,
+        },
+        packages: [
+          {
+            name: 'aide',
+            summary: 'Advanced Intrusion Detection Environment',
+            repository: 'distro',
+          },
+        ],
+      });
+
+      const user = createUser();
+
+      // Verify the required package is in state
+      expect(store.getState().wizard.packages).toHaveLength(1);
+      expect(store.getState().wizard.packages[0].name).toBe('aide');
+
+      // Search for the required package
+      await typeIntoSearchBox(user, 'aide');
+
+      // The search result for 'aide' should be disabled since it's required
+      const aideOption = await screen.findByRole('option', { name: /aide/i });
+      expect(aideOption).toBeDisabled();
+
+      // Non-required package should not be disabled
+      const testLibOption = await screen.findByRole('option', {
+        name: /test-lib/i,
+      });
+      expect(testLibOption).not.toBeDisabled();
+
+      // Clicking the disabled option should not remove the package
+      await clickWithWait(user, aideOption);
+
+      // Package should still be in state
+      expect(store.getState().wizard.packages).toHaveLength(1);
+      expect(store.getState().wizard.packages[0].name).toBe('aide');
+    });
+
+    test('onSelect guard prevents removal of required packages even when click bypasses disabled state', async () => {
+      fetchMock.mockResponse(
+        createFetchHandler({
+          rpms: mockOscapSearchResults,
+          oscap: mockOscapCustomizations,
+        }),
+      );
+
+      const { store } = renderPackagesStep({
+        compliance: {
+          complianceType: 'openscap',
+          profileID: mockOscapProfile,
+          policyID: undefined,
+          policyTitle: undefined,
+        },
+        packages: [
+          {
+            name: 'aide',
+            summary: 'Advanced Intrusion Detection Environment',
+            repository: 'distro',
+          },
+        ],
+      });
+
+      const user = createUser();
+
+      expect(store.getState().wizard.packages).toHaveLength(1);
+
+      await typeIntoSearchBox(user, 'aide');
+
+      const aideOption = await screen.findByRole('option', { name: /aide/i });
+
+      // fireEvent is used intentionally here instead of userEvent.
+      // userEvent respects the native `disabled` attribute set by PatternFly
+      // and won't dispatch the click, so the onSelect guard at line 742 of
+      // PackageSearch.tsx would never be exercised. fireEvent bypasses
+      // disabled checks, letting us verify the guard blocks removePackage
+      // dispatch as a defense-in-depth measure.
+      fireEvent.click(aideOption);
+
+      // The onSelect guard should prevent the package from being removed
+      expect(store.getState().wizard.packages).toHaveLength(1);
+      expect(store.getState().wizard.packages[0].name).toBe('aide');
+    });
+
+    test('without compliance, search results are not disabled and packages can be toggled freely', async () => {
+      fetchMock.mockResponse(createFetchHandler({ rpms: mockSearchResults }));
+
+      const { store } = renderPackagesStep({
+        packages: [
+          {
+            name: 'test-lib',
+            summary: 'test-lib package summary',
+            repository: 'distro',
+          },
+        ],
+      });
+
+      const user = createUser();
+
+      // Verify the package is in state
+      expect(store.getState().wizard.packages).toHaveLength(1);
+      expect(store.getState().wizard.packages[0].name).toBe('test-lib');
+
+      // Search for the already-selected package
+      await typeIntoSearchBox(user, 'test');
+
+      // All search options should be enabled (no compliance = no protection)
+      const testLibOption = await screen.findByRole('option', {
+        name: /test-lib/i,
+      });
+      expect(testLibOption).not.toBeDisabled();
+
+      const testPkgOption = await screen.findByRole('option', {
+        name: /testPkg/i,
+      });
+      expect(testPkgOption).not.toBeDisabled();
+
+      // Clicking the selected package should remove it
+      await clickWithWait(user, testLibOption);
+      expect(store.getState().wizard.packages).toHaveLength(0);
+
+      // Re-search and re-add the package
+      await clearSearchInput(user);
+      await typeIntoSearchBox(user, 'test');
+
+      const testLibOptionAgain = await screen.findByRole('option', {
+        name: /test-lib/i,
+      });
+      await clickWithWait(user, testLibOptionAgain);
+      expect(store.getState().wizard.packages).toHaveLength(1);
+      expect(store.getState().wizard.packages[0].name).toBe('test-lib');
+    });
+
+    test('required package not yet selected can still be added via search', async () => {
+      fetchMock.mockResponse(
+        createFetchHandler({
+          rpms: mockOscapSearchResults,
+          oscap: mockOscapCustomizations,
+        }),
+      );
+
+      const { store } = renderPackagesStep({
+        compliance: {
+          complianceType: 'openscap',
+          profileID: mockOscapProfile,
+          policyID: undefined,
+          policyTitle: undefined,
+        },
+        // aide is required but NOT in the initial packages list
+        packages: [],
+      });
+
+      const user = createUser();
+
+      // Search for the required package
+      await typeIntoSearchBox(user, 'aide');
+
+      // aide is required but not yet selected, so it should NOT be disabled
+      const aideOption = await screen.findByRole('option', { name: /aide/i });
+      expect(aideOption).not.toBeDisabled();
+
+      // Select it — should be addable
+      await clickWithWait(user, aideOption);
+
+      // Verify it was added to Redux state
+      expect(store.getState().wizard.packages).toHaveLength(1);
+      expect(store.getState().wizard.packages[0].name).toBe('aide');
+
+      // Re-open search and verify it's now disabled (required AND selected)
+      await clearSearchInput(user);
+      await typeIntoSearchBox(user, 'aide');
+
+      const aideOptionAgain = await screen.findByRole('option', {
+        name: /aide/i,
+      });
+      expect(aideOptionAgain).toBeDisabled();
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Packages/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/mocks/fixtures.ts
@@ -1,4 +1,7 @@
-import type { Architectures } from '@/store/api/backend';
+import type {
+  Architectures,
+  GetOscapCustomizationsApiResponse,
+} from '@/store/api/backend';
 import type {
   ApiSearchPackageGroupResponse,
   ApiSearchRpmResponse,
@@ -42,6 +45,25 @@ export const mockGroupSearchResults: ApiSearchPackageGroupResponse[] = [
     package_group_name: 'Grouper group',
     package_list: ['fish1', 'fish2'],
   },
+];
+
+export const mockOscapProfile =
+  'xccdf_org.ssgproject.content_profile_cis_workstation_l1';
+
+export const mockOscapCustomizations: GetOscapCustomizationsApiResponse = {
+  openscap: {
+    profile_id: mockOscapProfile,
+    profile_name:
+      'CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Workstation',
+    profile_description: 'Mock OpenSCAP profile for testing',
+  },
+  packages: ['aide', 'neovim'],
+};
+
+export const mockOscapSearchResults: ApiSearchRpmResponse[] = [
+  { package_name: 'aide', summary: 'Advanced Intrusion Detection Environment' },
+  { package_name: 'neovim', summary: 'Vim-fork focused on extensibility' },
+  { package_name: 'test-lib', summary: 'test-lib package summary' },
 ];
 
 export const mockArchitectures: Record<string, Architectures> = {

--- a/src/Components/CreateImageWizard/steps/Packages/tests/mocks/handlers.ts
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { GetOscapCustomizationsApiResponse } from '@/store/api/backend';
+import type { GetOscapCustomizationsApiResponse } from '@/store/api/backend';
 import {
   ApiSearchPackageGroupResponse,
   ApiSearchRpmResponse,
@@ -29,7 +29,7 @@ type FetchHandlerOverrides = {
 export const createFetchHandler = (
   overrides: FetchHandlerOverrides = {},
 ): FetchHandler => {
-  return composeHandlers(
+  const handlers = [
     createRpmHandler({ rpms: overrides.rpms }),
     createGroupsHandler({ groups: overrides.groups }),
     createArchitecturesHandler({ architectures: mockArchitectures }),
@@ -39,7 +39,9 @@ export const createFetchHandler = (
     createOscapHandler(
       overrides.oscap ? { customizations: overrides.oscap } : {},
     ),
-  );
+  ];
+
+  return composeHandlers(...handlers);
 };
 
 export const createDefaultFetchHandler = createFetchHandler();


### PR DESCRIPTION
## Summary
Packages required by the selected OpenSCAP compliance profile can currently be deselected via the search dropdown, bypassing the protections already in place on the packages table. This adds a three-layer guard to PackageSearch to prevent that.

## Changes
- Add `isRequiredAndSelected` helper using `useSecuritySummary` to identify packages that are both required by the OpenSCAP profile and currently selected
- Disable the `SelectOption` for required-and-selected packages, with a description explaining why
- Guard the `onSelect` handler to block `removePackage` dispatch as defense-in-depth
- Add tests covering the disabled state, the dispatch guard (via `fireEvent` to bypass native disabled), and the positive case where a required-but-unselected package can still be added
- Extract shared OSCAP mock fixtures to `fixtures.ts` for reuse across tests