### PR TITLE
Wizard: Rename "Image details" to "Details" (HMS-10579)

### DIFF
--- a/playwright/Cockpit/cockpit.spec.ts
+++ b/playwright/Cockpit/cockpit.spec.ts
@@ -99,9 +99,7 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
     await frame.getByRole('button', { name: 'Back', exact: true }).click();
 
     await frame.getByRole('button', { name: 'Base settings' }).click();
-    await expect(
-      frame.getByRole('heading', { name: 'Image details' }),
-    ).toBeVisible();
+    await expect(frame.getByRole('heading', { name: 'Details' })).toBeVisible();
     await frame
       .getByRole('textbox', { name: 'blueprint name' })
       .fill(blueprintName);

--- a/src/Components/CreateImageWizard/steps/Details/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/index.tsx
@@ -47,7 +47,7 @@ const DetailsStep = () => {
           headingLevel={isWizardRevampEnabled ? 'h2' : 'h1'}
           size={isWizardRevampEnabled ? 'lg' : 'xl'}
         >
-          Image details
+          Details
         </Title>
         <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
           Enter a name and description to identify your deployment-ready image.

--- a/src/Components/CreateImageWizard/steps/Details/tests/Details.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/tests/Details.test.tsx
@@ -43,7 +43,7 @@ describe('Details Component', () => {
       renderDetailsStep();
 
       expect(
-        await screen.findByRole('heading', { name: /Image details/i }),
+        await screen.findByRole('heading', { name: /Details/i }),
       ).toBeInTheDocument();
       expect(
         screen.getByText(
@@ -325,7 +325,7 @@ describe('Details Component', () => {
       await typeWithWait(user, nameInput, 'custom-blueprint-name{Enter}');
 
       expect(
-        screen.getByRole('heading', { name: /Image details/i }),
+        screen.getByRole('heading', { name: /Details/i }),
       ).toBeInTheDocument();
       expect(nameInput).toBeInTheDocument();
       expect(store.getState().wizard.details.blueprintName).toBe(
@@ -343,7 +343,7 @@ describe('Details Component', () => {
       await typeWithWait(user, descriptionInput, 'Test description{Enter}');
 
       expect(
-        screen.getByRole('heading', { name: /Image details/i }),
+        screen.getByRole('heading', { name: /Details/i }),
       ).toBeInTheDocument();
       expect(descriptionInput).toBeInTheDocument();
       expect(store.getState().wizard.details.blueprintDescription).toBe(


### PR DESCRIPTION
This changes the heading to remove at least one instance of the word "image" on the first step.

"image" or "images" is repeated a lot, but reviewing copy of the entire step will take a bit more effort. This should make reasonable visual impact for now.