### PR TITLE
types: Add types for styles (HMS-10744)

### DIFF
--- a/src/types/styles.d.ts
+++ b/src/types/styles.d.ts
@@ -1,0 +1,9 @@
+declare module '*.scss' {
+  const content: Record<string, string>;
+  export default content;
+}
+
+declare module '*.css' {
+  const content: Record<string, string>;
+  export default content;
+}

--- a/src/types/styles.d.ts
+++ b/src/types/styles.d.ts
@@ -1,0 +1,9 @@
+declare module '*.scss' {
+  const classes: { [key: string]: string };
+  export default classes;
+}
+
+declare module '*.css' {
+  const classes: { [key: string]: string };
+  export default classes;
+}


### PR DESCRIPTION
This adds missing declarations for scss/css imports. Typescript throws an error on stylesheet imports without them, because it doesn't know how to handle the style files.

JIRA: [HMS-10744](https://issues.redhat.com/browse/HMS-10744)

[HMS-10744]: https://redhat.atlassian.net/browse/HMS-10744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ