### PR TITLE
Wizard: save bootc reference across edits of bp

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -185,7 +185,9 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
 
   // IMPORTANT: Ensure the wizard starts with a fresh initial state
   useEffect(() => {
-    dispatch(initializeWizard());
+    if (!isEdit) {
+      dispatch(initializeWizard());
+    }
     if (searchParams.get('release') === 'rhel8') {
       dispatch(changeDistribution(RHEL_8));
     }

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -94,17 +94,13 @@ const TargetEnvironment = () => {
   const isFetching = isArchFetching || isBootcFetching;
   const isError = isArchError || isBootcError;
 
-  const supportedEnvironments = useMemo(
-    () =>
-      skipArchitectures
-        ? [
-            ...new Set(
-              bootcDistributions?.map((d) => d.type) ?? EMPTY_ENVIRONMENTS,
-            ),
-          ]
-        : archEnvironments,
-    [skipArchitectures, bootcDistributions, archEnvironments],
-  );
+  const supportedEnvironments = useMemo(() => {
+    if (!skipArchitectures) return archEnvironments;
+
+    return [
+      ...new Set(bootcDistributions?.map((d) => d.type) ?? EMPTY_ENVIRONMENTS),
+    ];
+  }, [skipArchitectures, bootcDistributions, archEnvironments]);
 
   const dispatch = useAppDispatch();
   const prefetchActivationKeys = rhsmApi.usePrefetch('listActivationKeys');

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -162,8 +162,13 @@ export const mapRequestFromState = (
   if (isImageMode && imageSource) {
     const bootcDistributions = selectBootcDistributions(state);
     const imageTypes = selectImageTypes(state);
-    if (bootcDistributions.length > 0 && imageTypes.length > 0) {
-      const match = bootcDistributions.find((d) => d.type === imageTypes[0]);
+    const selectedDistro = bootcDistributions.find(
+      (d) => d.reference === imageSource,
+    );
+    if (selectedDistro && imageTypes.length > 0) {
+      const match = bootcDistributions.find(
+        (d) => d.name === selectedDistro.name && d.type === imageTypes[0],
+      );
       if (match) {
         bootcReference = match.reference;
       }


### PR DESCRIPTION
The bootc reference was being wiped when editing the bp, now the state stays the same across edits. 