### PR TITLE
Wizard: add error banner to users in image mode (HMS-10639)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -459,8 +459,9 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                   return true;
                 }}
                 disableNext={
-                  usersValidation.disabledNext ||
-                  userGroupsValidation.disabledNext
+                  usersStepAttemptedNext &&
+                  (usersValidation.disabledNext ||
+                    userGroupsValidation.disabledNext)
                 }
                 isOnPremise={isOnPremise}
               />

--- a/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
@@ -32,19 +32,17 @@ const UserInfo = ({ attemptedNext = false }: UserInfoProps) => {
       : users;
 
   const stepValidation = useUsersValidation();
-  const hasErrors = !!stepValidation.disabledNext;
-  const showAlert = attemptedNext && hasErrors;
 
   const onAddUserClick = () => {
     dispatch(addUser());
   };
   return (
     <>
-      {showAlert && (
+      {attemptedNext && stepValidation.stepError && (
         <Alert
           variant='danger'
           isInline
-          title='Errors found'
+          title={stepValidation.stepError}
           className='pf-v6-u-mt-lg'
         />
       )}

--- a/src/Components/CreateImageWizard/steps/Users/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/index.tsx
@@ -25,6 +25,14 @@ const UsersStep = ({ attemptedNext }: UsersStepProps) => {
       <Content>
         <Title headingLevel='h2' size='lg'>
           Users
+          {blueprintMode === 'image' && (
+            <span
+              className='pf-v6-u-text-color-status-danger'
+              aria-hidden='true'
+            >
+              {' *'}
+            </span>
+          )}
         </Title>
         <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
           Create user accounts to manage access to your image. All usernames

--- a/src/Components/CreateImageWizard/steps/Users/tests/Users.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/tests/Users.test.tsx
@@ -84,4 +84,76 @@ describe('Users Component', () => {
       );
     });
   });
+
+  describe('Image mode validation', () => {
+    test('shows error alert when image mode is selected with no users', () => {
+      renderWithRedux(<UsersStep attemptedNext={true} />, {
+        blueprintMode: 'image',
+        users: [],
+      });
+
+      expect(
+        screen.getByText(
+          'At least one user is required in image mode to be able to log in.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('shows error alert when image mode is selected with empty username', () => {
+      renderWithRedux(<UsersStep attemptedNext={true} />, {
+        blueprintMode: 'image',
+        users: [
+          {
+            name: '',
+            password: '',
+            ssh_key: '',
+            isAdministrator: false,
+            groups: [],
+            hasPassword: false,
+          },
+        ],
+      });
+
+      expect(
+        screen.getByText(
+          'At least one user is required in image mode to be able to log in.',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('does not show image mode error when a user is defined', () => {
+      renderWithRedux(<UsersStep attemptedNext={true} />, {
+        blueprintMode: 'image',
+        users: [
+          {
+            name: 'testuser',
+            password: '',
+            ssh_key: '',
+            isAdministrator: false,
+            groups: [],
+            hasPassword: false,
+          },
+        ],
+      });
+
+      expect(
+        screen.queryByText(
+          'At least one user is required in image mode to be able to log in.',
+        ),
+      ).not.toBeInTheDocument();
+    });
+
+    test('does not show error alert in package mode with no users', () => {
+      renderWithRedux(<UsersStep attemptedNext={true} />, {
+        blueprintMode: 'package',
+        users: [],
+      });
+
+      expect(
+        screen.queryByText(
+          'At least one user is required in image mode to be able to log in.',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -115,6 +115,7 @@ export type UsersStepValidation = {
     [key: string]: { [key: string]: string };
   };
   disabledNext: boolean;
+  stepError?: string;
 };
 
 export function useIsBlueprintValid(): boolean {
@@ -843,11 +844,11 @@ export function useUsersValidation(): UsersStepValidation {
   ) {
     if (blueprintMode === 'image') {
       return {
-        // the User step is required in image mode
-        // blocking Next without a render error is sufficient
         errors: {},
         warnings: {},
         disabledNext: true,
+        stepError:
+          'At least one user is required in image mode to be able to log in.',
       };
     }
 

--- a/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
+++ b/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import {
   Bullseye,
@@ -148,6 +148,9 @@ const CreateImageWizard3 = () => {
   const usersHaveErrors =
     usersValidation.disabledNext || userGroupsValidation.disabledNext;
 
+  const [baseSettingsAttemptedNext, setBaseSettingsAttemptedNext] =
+    useState(false);
+
   const baseSettingsHasErrors =
     targetEnvironments.length === 0 ||
     (isImageMode && !imageSource) ||
@@ -157,7 +160,9 @@ const CreateImageWizard3 = () => {
     detailsValidation.disabledNext ||
     registrationValidation.disabledNext ||
     snapshotValidation.disabledNext ||
-    (restrictions.users.required && usersHaveErrors);
+    (baseSettingsAttemptedNext &&
+      restrictions.users.required &&
+      usersHaveErrors);
 
   const advancedSettingsHasErrors =
     filesystemValidation.disabledNext ||
@@ -331,9 +336,17 @@ const CreateImageWizard3 = () => {
     _steps: WizardStepType[],
     goToStepByIndex: (index: number) => void,
   ) => {
-    const status = (step.id !== activeStep.id && step.status) || 'default';
-
     const isBaseSettingsStep = step.id === 'base-settings-step';
+    const showBaseSettingsUserError =
+      isBaseSettingsStep &&
+      baseSettingsAttemptedNext &&
+      restrictions.users.required &&
+      usersHaveErrors;
+    const status =
+      showBaseSettingsUserError ||
+      (step.id !== activeStep.id && step.status === 'error')
+        ? 'error'
+        : 'default';
     const hasVisitedBaseSettings = _steps.find(
       (s) => s.id === 'base-settings-step',
     )?.isVisited;
@@ -409,6 +422,13 @@ const CreateImageWizard3 = () => {
             <CustomWizardFooter
               disableBack={true}
               disableNext={baseSettingsHasErrors}
+              beforeNext={() => {
+                if (restrictions.users.required && usersHaveErrors) {
+                  setBaseSettingsAttemptedNext(true);
+                  return false;
+                }
+                return true;
+              }}
               isOnPremise={isOnPremise}
             />
           }
@@ -437,7 +457,12 @@ const CreateImageWizard3 = () => {
                 restrictions.openscap.shouldHide && restrictions.fips.shouldHide
               ) && <OscapStep key='oscap' />,
               restrictions.users.required && <UserGroupsStep key='groups' />,
-              restrictions.users.required && <UsersStep key='users' />,
+              restrictions.users.required && (
+                <UsersStep
+                  key='users'
+                  attemptedNext={baseSettingsAttemptedNext}
+                />
+              ),
             ]
               .filter(Boolean)
               .flatMap((component, index, array) =>


### PR DESCRIPTION
At least one user is necessary in Image mode, this commit adds a banner with that alert if a user tries to continue through the wizard without any user set.

I didn't want to have an error shown immediately as a user would click "Image mode". So now, the User step is marked as required with an asterix and if someone tries to click "Next" without one, only then will the alert banner appear:
<img width="1588" height="928" alt="spacing" src="https://github.com/user-attachments/assets/7ad653cd-c9f7-4c85-b120-d3f87fecfeea" />
