### PR TITLE
ImagesTable: Show image/package mode labels in service frontend

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -633,16 +633,15 @@ const Row = ({
               >
                 {compose.image_name || compose.id}
               </Button>{' '}
-              {isOnPremise &&
-                (bootcCompose?.request.bootc ? (
-                  <Label isCompact color='yellow'>
-                    Image mode
-                  </Label>
-                ) : (
-                  <Label isCompact color='teal'>
-                    Package mode
-                  </Label>
-                ))}
+              {bootcCompose?.request.bootc ? (
+                <Label isCompact color='yellow'>
+                  Image mode
+                </Label>
+              ) : (
+                <Label isCompact color='teal'>
+                  Package mode
+                </Label>
+              )}
             </>
           ) : (
             <span> {compose.image_name || compose.id}</span>

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -69,9 +69,11 @@ describe('Images Table', () => {
     // The image-mode entry is at the end of mockComposes (page 3).
     // Navigate forward twice to reach it.
     const pagination = await screen.findByTestId('images-pagination-top');
-    const nextButtons = await within(pagination).findAllByRole('button');
-    await user.click(nextButtons[nextButtons.length - 1]);
-    await user.click(nextButtons[nextButtons.length - 1]);
+    const nextPage = within(pagination).getByRole('button', {
+      name: 'Go to next page',
+    });
+    await user.click(nextPage);
+    await user.click(nextPage);
 
     const table = await screen.findByTestId('images-table');
 
@@ -88,6 +90,45 @@ describe('Images Table', () => {
     const cells = within(imageModeRow).getAllByRole('cell');
     const osCell = cells[3];
     expect(osCell).toHaveTextContent('RHEL 9.7');
+  });
+
+  test('displays Package mode and Image mode labels for blueprint-linked composes', async () => {
+    await renderCustomRoutesWithReduxRouter();
+
+    await screen.findByTestId('images-table');
+
+    // The blueprint-linked composes are on page 2 of mockComposes.
+    const pagination = await screen.findByTestId('images-pagination-top');
+    const nextPage = within(pagination).getByRole('button', {
+      name: 'Go to next page',
+    });
+    await user.click(nextPage);
+
+    const table = await screen.findByTestId('images-table');
+
+    const packageModeRow = await waitFor(() => {
+      const rows = within(table).getAllByRole('row');
+      const dataRows = rows.slice(1);
+      const row = dataRows.find((r) =>
+        within(r).queryByText('package-mode-bp-image'),
+      );
+      if (!row) throw new Error('Package mode row not found');
+      return row;
+    });
+    expect(
+      within(packageModeRow).getByText('Package mode'),
+    ).toBeInTheDocument();
+
+    const imageModeRow = await waitFor(() => {
+      const rows = within(table).getAllByRole('row');
+      const dataRows = rows.slice(1);
+      const row = dataRows.find((r) =>
+        within(r).queryByText('image-mode-bp-image'),
+      );
+      if (!row) throw new Error('Image mode row not found');
+      return row;
+    });
+    expect(within(imageModeRow).getByText('Image mode')).toBeInTheDocument();
   });
 
   test('check download compose request action', async () => {
@@ -222,8 +263,10 @@ describe('Images Table', () => {
 
     // Go to next page on the table
     const pagination = await screen.findByTestId('images-pagination-top');
-    const pageButtons = await within(pagination).findAllByRole('button');
-    await user.click(pageButtons[pageButtons.length - 1]);
+    const nextPage = within(pagination).getByRole('button', {
+      name: 'Go to next page',
+    });
+    await user.click(nextPage);
     await screen.findAllByText(/9e7d0d51-7106-42ab-98f2-f89872a9d599/i);
 
     rows = [];

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -399,6 +399,51 @@ export const mockComposes: ComposesResponseItem[] = [
     },
   },
   {
+    id: 'bp-package-mode-compose',
+    image_name: 'package-mode-bp-image',
+    created_at: '2024-02-01T10:00:00Z',
+    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc',
+    blueprint_version: 1,
+    request: {
+      distribution: RHEL_9,
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'aws',
+          upload_request: {
+            type: 'aws',
+            options: {
+              share_with_accounts: ['123123123123'],
+            },
+          },
+        },
+      ],
+    },
+  },
+  {
+    id: 'bp-image-mode-compose',
+    image_name: 'image-mode-bp-image',
+    created_at: '2024-02-01T10:00:00Z',
+    blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc',
+    blueprint_version: 1,
+    request: {
+      distribution: RHEL_9,
+      bootc: {
+        reference: 'registry.redhat.io/rhel9/rhel-bootc:9.7',
+      },
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'guest-image',
+          upload_request: {
+            type: 'aws.s3',
+            options: {},
+          },
+        },
+      ],
+    },
+  },
+  {
     id: '63e42aaf-b543-41c6-899f-3de1e61838dc',
     image_name: 'dark-chocolate-v2',
     created_at: '2023-09-08T14:38:00.000Z',
@@ -418,7 +463,6 @@ export const mockComposes: ComposesResponseItem[] = [
       ],
     },
   },
-  // Cockpit-only: bootc field and 'local' upload type are not in the hosted API types yet
   {
     id: 'image-mode-bootc-rhel9',
     image_name: 'image-mode-rhel9',
@@ -1018,7 +1062,6 @@ export const mockStatus = (composeId: string): ComposeStatus => {
         ],
       },
     },
-    // Cockpit-only: bootc field and 'local' upload type are not in the hosted API types yet
     'image-mode-bootc-rhel9': {
       image_status: {
         status: 'success',
@@ -1040,6 +1083,62 @@ export const mockStatus = (composeId: string): ComposeStatus => {
             image_type: 'guest-image',
             upload_request: {
               type: 'local',
+              options: {},
+            },
+          },
+        ],
+      },
+    } as unknown as ComposeStatus,
+    'bp-package-mode-compose': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            ami: 'ami-0217b81d9be50e44d',
+            region: 'us-east-1',
+          },
+          status: 'success',
+          type: 'aws',
+        },
+      },
+      request: {
+        distribution: RHEL_9,
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'aws',
+            upload_request: {
+              type: 'aws',
+              options: {
+                share_with_accounts: ['123123123123'],
+              },
+            },
+          },
+        ],
+      },
+    },
+    'bp-image-mode-compose': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://s3.amazonaws.com/bp-image-mode-compose-disk.qcow2',
+          },
+          status: 'success',
+          type: 'aws.s3',
+        },
+      },
+      request: {
+        distribution: RHEL_9,
+        bootc: {
+          reference: 'registry.redhat.io/rhel9/rhel-bootc:9.7',
+        },
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'guest-image',
+            upload_request: {
+              type: 'aws.s3',
               options: {},
             },
           },


### PR DESCRIPTION
Due to a lack of image mode support in the service, these labels were gated to be shown in Cockpit only so far.
Enable them for visual consistency between Cockpit and the Service.

<img width="1837" height="660" alt="image" src="https://github.com/user-attachments/assets/5577420a-091a-479b-9bdf-2c5fb9467d85" />
