### PR TITLE
ImagesTable: Show OS label for hosted bootc images

### DIFF
--- a/src/Components/ImagesTable/Release.tsx
+++ b/src/Components/ImagesTable/Release.tsx
@@ -58,6 +58,7 @@ const Release = ({ release }: ReleaseProps) => {
     'fedora-42': 'Fedora 42',
     'fedora-43': 'Fedora 43',
     'fedora-44': 'Fedora 44',
+    hummingbird: 'Fedora Hummingbird',
   };
 
   return <p>{releaseDisplayValue[release]}</p>;

--- a/src/Utilities/distributionToOSShortId.ts
+++ b/src/Utilities/distributionToOSShortId.ts
@@ -66,7 +66,20 @@ type BootcVersionInfo = {
   minor: string | undefined;
 };
 
-const parseBootcReference = (ref: string): BootcVersionInfo | undefined => {
+type BootcReferenceInfo =
+  | {
+      type: 'rhel';
+      major: string;
+      minor: string | undefined;
+    }
+  | {
+      type: 'hummingbird';
+    };
+
+// Cockpit / on-prem references: registry.redhat.io/rhel<N>/rhel-bootc:<version>
+const parseCockpitBootcReference = (
+  ref: string,
+): BootcVersionInfo | undefined => {
   const rhelPathMatch = ref.match(/\/rhel(\d+)\//);
   if (!rhelPathMatch) {
     return undefined;
@@ -91,29 +104,75 @@ const parseBootcReference = (ref: string): BootcVersionInfo | undefined => {
   return { major: pathMajor, minor: undefined };
 };
 
+// Hosted service references: .../image-builder-bootc-foundry/<name>-<target>:<tag>
+const parseHostedBootcReference = (
+  ref: string,
+): BootcReferenceInfo | undefined => {
+  const foundryMatch = ref.match(
+    /\/image-builder-bootc-foundry\/([^:]+?)(?::[^/]*)?$/,
+  );
+  if (!foundryMatch) {
+    return undefined;
+  }
+  const imageName = foundryMatch[1];
+
+  if (imageName.startsWith('hummingbird')) {
+    return { type: 'hummingbird' };
+  }
+
+  const rhelMatch = imageName.match(/^rhel-(\d+)/);
+  if (rhelMatch) {
+    return { type: 'rhel', major: rhelMatch[1], minor: undefined };
+  }
+
+  return undefined;
+};
+
 /**
- * Maps a bootc image reference (e.g. from image mode builds) to a libosinfo shortID.
- * Used when building Launch/Install URLs for cockpit-machines when distribution is not set.
- * Parses the image tag to return major.minor when available.
+ * Maps a bootc image reference to a libosinfo shortID.
+ * Supports both Cockpit references (registry.redhat.io/rhel<N>/rhel-bootc:<version>)
+ * and hosted service references (.../image-builder-bootc-foundry/<name>-<target>:<tag>).
  *
- * @param ref - The bootc image reference (e.g. 'registry.redhat.io/rhel9/rhel-bootc:9.7')
- * @returns The libosinfo shortID (e.g. 'rhel9.7', 'rhel10.1', 'rhel9.0') or undefined if not mappable
+ * @param ref - The bootc image reference
+ * @returns The libosinfo shortID (e.g. 'rhel9.7', 'rhel10.0') or undefined if not mappable
  */
 export const bootcReferenceToOSShortId = (ref: string): string | undefined => {
-  const info = parseBootcReference(ref);
-  if (!info) return undefined;
-  return `rhel${info.major}.${info.minor ?? '0'}`;
+  const cockpitInfo = parseCockpitBootcReference(ref);
+  if (cockpitInfo) {
+    return `rhel${cockpitInfo.major}.${cockpitInfo.minor ?? '0'}`;
+  }
+
+  const hostedInfo = parseHostedBootcReference(ref);
+  if (hostedInfo && hostedInfo.type === 'rhel') {
+    return `rhel${hostedInfo.major}.0`;
+  }
+
+  return undefined;
 };
 
 /**
  * Maps a bootc image reference to a display label for the OS column.
- * Parses the image tag to show major and minor version when available.
+ * Supports both Cockpit references (registry.redhat.io/rhel<N>/rhel-bootc:<version>)
+ * and hosted service references (.../image-builder-bootc-foundry/<name>-<target>:<tag>).
  *
- * @param ref - The bootc image reference (e.g. 'registry.redhat.io/rhel10/rhel-bootc:10.1')
- * @returns Display label (e.g. 'RHEL 10.1', 'RHEL 9') or 'Image mode' if not recognized
+ * @param ref - The bootc image reference
+ * @returns Display label (e.g. 'RHEL 10.1', 'Fedora Hummingbird') or 'Image mode' if not recognized
  */
 export const bootcReferenceToOSDisplayLabel = (ref: string): string => {
-  const info = parseBootcReference(ref);
-  if (!info) return 'Image mode';
-  return info.minor ? `RHEL ${info.major}.${info.minor}` : `RHEL ${info.major}`;
+  const cockpitInfo = parseCockpitBootcReference(ref);
+  if (cockpitInfo) {
+    return cockpitInfo.minor
+      ? `RHEL ${cockpitInfo.major}.${cockpitInfo.minor}`
+      : `RHEL ${cockpitInfo.major}`;
+  }
+
+  const hostedInfo = parseHostedBootcReference(ref);
+  if (hostedInfo) {
+    if (hostedInfo.type === 'hummingbird') {
+      return 'Fedora Hummingbird';
+    }
+    return `RHEL ${hostedInfo.major}`;
+  }
+
+  return 'Image mode';
 };

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -66,12 +66,13 @@ describe('Images Table', () => {
 
     await screen.findByTestId('images-table');
 
-    // The image-mode entry is at the end of mockComposes (page 3).
-    // Navigate forward twice to reach it.
+    // The image-mode entry is on page 2 of mockComposes.
+    // Navigate forward once to reach it.
     const pagination = await screen.findByTestId('images-pagination-top');
-    const nextButtons = await within(pagination).findAllByRole('button');
-    await user.click(nextButtons[nextButtons.length - 1]);
-    await user.click(nextButtons[nextButtons.length - 1]);
+    const nextButton = await within(pagination).findByRole('button', {
+      name: /go to next page/i,
+    });
+    await user.click(nextButton);
 
     const table = await screen.findByTestId('images-table');
 

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -439,6 +439,52 @@ export const mockComposes: ComposesResponseItem[] = [
       ],
     },
   } as unknown as ComposesResponseItem,
+  {
+    id: 'image-mode-bootc-rhel10-hosted',
+    image_name: 'image-mode-rhel10-hosted',
+    created_at: '2025-06-01T10:00:00Z',
+    request: {
+      distribution: 'rhel-10.1',
+      bootc: {
+        reference:
+          'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest',
+      },
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'aws',
+          upload_request: {
+            type: 'aws',
+            options: {
+              share_with_accounts: ['123123123123'],
+            },
+          },
+        },
+      ],
+    },
+  } as unknown as ComposesResponseItem,
+  {
+    id: 'image-mode-bootc-hummingbird',
+    image_name: 'image-mode-hummingbird',
+    created_at: '2025-06-01T11:00:00Z',
+    request: {
+      distribution: 'hummingbird',
+      bootc: {
+        reference:
+          'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/hummingbird-qcow2:latest',
+      },
+      image_requests: [
+        {
+          architecture: 'x86_64',
+          image_type: 'guest-image',
+          upload_request: {
+            type: 'aws.s3',
+            options: {},
+          },
+        },
+      ],
+    },
+  } as unknown as ComposesResponseItem,
 ];
 
 export const mockComposeImageModeRhel9 = mockComposes.find(
@@ -1040,6 +1086,67 @@ export const mockStatus = (composeId: string): ComposeStatus => {
             image_type: 'guest-image',
             upload_request: {
               type: 'local',
+              options: {},
+            },
+          },
+        ],
+      },
+    } as unknown as ComposeStatus,
+    'image-mode-bootc-rhel10-hosted': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            ami: 'ami-0217b81d9be50e44b',
+            region: 'us-east-1',
+          },
+          status: 'success',
+          type: 'aws',
+        },
+      },
+      request: {
+        distribution: 'rhel-10.1',
+        bootc: {
+          reference:
+            'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/rhel-10-ec2:latest',
+        },
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'aws',
+            upload_request: {
+              type: 'aws',
+              options: {
+                share_with_accounts: ['123123123123'],
+              },
+            },
+          },
+        ],
+      },
+    } as unknown as ComposeStatus,
+    'image-mode-bootc-hummingbird': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://image-builder-s3-bucket.s3.amazonaws.com/hummingbird-qcow2',
+          },
+          status: 'success',
+          type: 'aws.s3',
+        },
+      },
+      request: {
+        distribution: 'hummingbird',
+        bootc: {
+          reference:
+            'quay.io/redhat-services-prod/insights-management-tenant/image-builder-bootc-foundry/hummingbird-qcow2:latest',
+        },
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'guest-image',
+            upload_request: {
+              type: 'aws.s3',
               options: {},
             },
           },


### PR DESCRIPTION
The OS column previously showed "Image mode" for all bootc composes from the hosted service because the reference parser only recognized the official `registry.redhat.io` references we use on premises. This commit adds a second parser for the hosted `quay.io/…/image-builder-bootc-foundry` pattern so RHEL 10 and Fedora Hummingbird builds display meaningful OS labels in the service.

<img width="1260" height="516" alt="image" src="https://github.com/user-attachments/assets/e9bf9fa2-12d0-416b-9c58-0c02f8a1f025" />
