### PR TITLE
ImagesTable: show distro for image mode in hosted

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -274,16 +274,19 @@ const BootcImageSourceSelect = () => {
     dispatch(changeDistribution(defaultItem.distro as Distributions));
   }, [bootcDistributions, dispatch, imageSource]);
 
-  // Deduplicate by name — the API returns one entry per target type,
+  // Filter out minor versions (e.g. rhel-10.1, etc.), the backend returns
+  // both major and minor versions, we want to show only major versions
+  // for now.
+  // Then, deduplicate by name — the API returns one entry per target type,
   // but the dropdown should show one entry per base image.
-  const uniqueDistributions = bootcDistributions?.reduce<
-    BootcDistributionItem[]
-  >((acc, item) => {
-    if (!acc.some((d) => d.name === item.name)) {
-      acc.push(item);
-    }
-    return acc;
-  }, []);
+  const uniqueDistributions = bootcDistributions
+    ?.filter((d) => !d.name.includes('.'))
+    .reduce<BootcDistributionItem[]>((acc, item) => {
+      if (!acc.some((d) => d.name === item.name)) {
+        acc.push(item);
+      }
+      return acc;
+    }, []);
 
   const selectedItem = bootcDistributions?.find(
     (d) => d.reference === imageSource,

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -655,14 +655,15 @@ const Row = ({
           {timestampToDisplayString(compose.created_at)}
         </Td>
         <Td dataLabel='Release'>
-          {bootcCompose?.request.bootc?.reference ? (
-            <p>
-              {bootcReferenceToOSDisplayLabel(
-                bootcCompose.request.bootc.reference,
-              )}
-            </p>
-          ) : (
+          {compose.request.distribution ? (
             <Release release={compose.request.distribution} />
+          ) : (
+            <p>
+              {bootcCompose?.request.bootc?.reference &&
+                bootcReferenceToOSDisplayLabel(
+                  bootcCompose.request.bootc.reference,
+                )}
+            </p>
           )}
         </Td>
         <Td dataLabel='Target'>

--- a/src/Components/ImagesTable/Release.tsx
+++ b/src/Components/ImagesTable/Release.tsx
@@ -58,6 +58,7 @@ const Release = ({ release }: ReleaseProps) => {
     'fedora-42': 'Fedora 42',
     'fedora-43': 'Fedora 43',
     'fedora-44': 'Fedora 44',
+    hummingbird: 'Fedora Hummingbird',
   };
 
   return <p>{releaseDisplayValue[release]}</p>;


### PR DESCRIPTION
I'm not sure if #4417 isn't too heavy, I think this fixes everything in a simpler way. Might be missing something.

<img width="692" height="206" alt="image" src="https://github.com/user-attachments/assets/30ab5a6d-cb8a-4216-9d71-adedb8b52eec" />

Note that ondrejs-image-mode-image was created before the second commit that normalizes the distro on only major versions.

**ImagesTable: Show distro version for hosted image mode**

For bootc we parse the bootc ref to get the distro version. However, the
reference is different between hosted and onprem and the parser cannot
work with the hosted version, so it always falls back to showing "Image
Mode".

I discovered that we actually have the distro version filled in the the
compose request, so we don't need to parse the bootc ref. Thus, we can
fix this by simply switching the condition - firstly, let's try to get
the name from the compose request, and if it's not there, fall back to
the old parsing.

---

**ImageSourceSelect: filter out minor versions of RHEL**

Package mode prefers major versions, so let's do the same for image
mode. This will actually fix the images table - it will show RHEL 10
like it does for package mode instead of showing RHEL 10.1.

---