### PR TITLE
Wizard: Add tooltip to disabled network installer checkbox (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -563,7 +563,9 @@ const TargetEnvironment = () => {
               label={createLabelWithTooltip(
                 'Network',
                 'Installer (.iso)',
-                'This is a lightweight image that differs from a standard "full" ISO by requiring an active network connection to pull the latest software directly from package repositories, as no OS packages are stored locally on the image.',
+                isOtherEnvironmentSelected
+                  ? 'Network installer cannot be combined with other image types'
+                  : 'This is a lightweight image that differs from a standard "full" ISO by requiring an active network connection to pull the latest software directly from package repositories, as no OS packages are stored locally on the image.',
               )}
               aria-label='Network installer checkbox'
               isChecked={environments.includes('network-installer')}


### PR DESCRIPTION
When other image types are selected, the network installer checkbox is disabled without explanation. Add a tooltip explaining that it cannot be combined with other image types.

<img width="519" height="195" alt="Screenshot 2026-05-18 at 12 33 20" src="https://github.com/user-attachments/assets/bb04366a-cb2d-47d7-b565-a10208ca0eb1" />
JIRA: (HMS-10579)