### PR TITLE
Wizard/FSC: Bump default root partition size to 10 GiB in advanced mode

### DIFF
--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -988,7 +988,7 @@ export const wizardSlice = createSlice({
                 id: uuidv4(),
                 mountpoint: '/',
                 fs_type: 'xfs',
-                min_size: '1',
+                min_size: '10',
                 unit: 'GiB',
                 type: 'plain',
               },


### PR DESCRIPTION
We want consistent defaults between basic and advanced partitioning, but also avoid failing builds because of a root partition that is too small.