### PR TITLE
fix: Allow repo dropdown to open on input when empty

### DIFF
--- a/src/Components/CreateImageWizard/steps/Repositories/components/RepositorySearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/RepositorySearch.tsx
@@ -85,12 +85,12 @@ const RepositorySearch = ({
         search: debouncedFilterValue,
       },
       {
-        skip: !debouncedFilterValue,
+        skip: !isOpen,
       },
     );
 
   const onInputClick = () => {
-    if (!isOpen && inputValue) {
+    if (!isOpen) {
       setIsOpen(true);
     }
   };
@@ -181,12 +181,8 @@ const RepositorySearch = ({
       shouldFocusFirstItemOnOpen={false}
     >
       <SelectList>
-        {!debouncedFilterValue ? (
-          <SelectOption isDisabled>
-            Start typing to search repositories
-          </SelectOption>
-        ) : isFetching ? (
-          <SelectOption isDisabled>Searching repositories...</SelectOption>
+        {isFetching ? (
+          <SelectOption isDisabled>Loading repositories...</SelectOption>
         ) : repositories.length > 0 ? (
           repositories.map((repo) => {
             const isSelected = selectedRepoIds.has(repo.uuid || '');
@@ -224,10 +220,12 @@ const RepositorySearch = ({
               </SelectOption>
             );
           })
-        ) : (
+        ) : debouncedFilterValue ? (
           <SelectOption isDisabled>
             No repositories found for &quot;{debouncedFilterValue}&quot;
           </SelectOption>
+        ) : (
+          <SelectOption isDisabled>No repositories available</SelectOption>
         )}
       </SelectList>
     </Select>

--- a/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
@@ -83,11 +83,110 @@ describe('Repositories Component', () => {
 
       expect(
         await screen.findByRole('option', {
-          name: /searching repositories/i,
+          name: /loading repositories/i,
         }),
       ).toBeInTheDocument();
 
       resolveSearch(JSON.stringify({ data: [], meta: { count: 0 } }));
+    });
+
+    test('shows unfiltered repositories when dropdown opens', async () => {
+      fetchMock.mockResponse(
+        createFetchHandler({ repositories: mockRepositoryResults }),
+      );
+      renderRepositoriesStep();
+      const user = createUser();
+
+      // Open dropdown by clicking toggle
+      const toggle = await screen.findByRole('button', {
+        name: /menu toggle/i,
+      });
+      await user.click(toggle);
+
+      // Should show repositories without typing
+      expect(
+        await screen.findByRole('option', { name: /01-test-valid-repo/i }),
+      ).toBeInTheDocument();
+      expect(
+        await screen.findByRole('option', {
+          name: /04-test-another-valid-repo/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    test('shows appropriate empty state message based on filter state', async () => {
+      fetchMock.mockResponse(createFetchHandler({ repositories: [] }));
+      renderRepositoriesStep();
+      const user = createUser();
+
+      // Open dropdown - should show "No repositories available"
+      const toggle = await screen.findByRole('button', {
+        name: /menu toggle/i,
+      });
+      await user.click(toggle);
+
+      expect(
+        await screen.findByRole('option', {
+          name: /no repositories available/i,
+        }),
+      ).toBeInTheDocument();
+
+      // Type to search - should show "No repositories found for..."
+      const searchInput = await screen.findByRole('textbox', {
+        name: /filter repositories/i,
+      });
+      await user.type(searchInput, 'nonexistent');
+
+      expect(
+        await screen.findByRole('option', {
+          name: /no repositories found for "nonexistent"/i,
+        }),
+      ).toBeInTheDocument();
+
+      // Initial empty-state message should no longer be rendered
+      expect(
+        screen.queryByRole('option', {
+          name: /no repositories available/i,
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    test('uses different limit for filtered vs unfiltered results', async () => {
+      const requestLog: string[] = [];
+
+      fetchMock.mockResponse((req) => {
+        requestLog.push(req.url);
+        return createDefaultFetchHandler(req);
+      });
+
+      renderRepositoriesStep();
+      const user = createUser();
+
+      // Open dropdown without search
+      const toggle = await screen.findByRole('button', {
+        name: /menu toggle/i,
+      });
+      await user.click(toggle);
+
+      await screen.findByRole('option', { name: /no repositories available/i });
+
+      // Type to search - should use limit=50
+      const searchInput = await screen.findByRole('textbox', {
+        name: /filter repositories/i,
+      });
+      await user.type(searchInput, 'test');
+
+      await screen.findByRole('option', {
+        name: /no repositories found for "test"/i,
+      });
+
+      const filteredRequest = requestLog.find(
+        (url) =>
+          url.includes('/repositories') &&
+          url.includes('search=test') &&
+          !url.includes('uuid='),
+      );
+      expect(filteredRequest).toContain('limit=50');
     });
 
     test('shows "no results" for failed search', async () => {


### PR DESCRIPTION
Removes inputValue condition from onInputClick so the dropdown opens when clicking the search box, even when empty, allowing users to see unfiltered repositories immediately.

Fixes HMS-10642