### PR TITLE
playwright: Safeguard target selecting in OpenSCAP test

### DIFF
--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -12,7 +12,6 @@ import {
   ibFrame,
   navigateToLandingPage,
 } from '../helpers/navHelpers';
-import { selectDistro } from '../helpers/targetChooser';
 import {
   createBlueprint,
   deleteBlueprint,
@@ -50,10 +49,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
   });
 
   await test.step('WSL + Installer shows WSL is not supported', async () => {
-    await selectDistro(frame, 'rhel9');
-    await frame
-      .getByRole('checkbox', { name: 'Windows Subsystem for Linux' })
-      .click();
+    await fillInImageOutput(frame, 'wsl', 'rhel9');
     await frame.getByRole('checkbox', { name: 'Bare metal installer' }).click();
     await registerLater(frame);
 

--- a/playwright/helpers/targetChooser.ts
+++ b/playwright/helpers/targetChooser.ts
@@ -19,7 +19,9 @@ export const selectTarget = async (
       await page.getByRole('checkbox', { name: 'Bare metal' }).click();
       break;
     case 'wsl':
-      await page.getByRole('checkbox', { name: 'WSL' }).click();
+      await page
+        .getByRole('checkbox', { name: 'Windows Subsystem for Linux' })
+        .click();
       break;
     case 'ova':
       await page
@@ -48,7 +50,7 @@ export const selectDistro = async (
    * @param page - the page object
    * @param distro - the distro to select (rhel10, rhel9, rhel8)
    */
-  await page.getByRole('button', { name: 'Red Hat Enterprise Linux' }).click();
+  await page.getByRole('button', { name: /Red Hat Enterprise Linux/ }).click();
   switch (distro) {
     case 'rhel10':
       await page


### PR DESCRIPTION
This replaces direct use of `selectDistro` with its safeguarded alternative `fillInImageOutput` to resolve issue with playwright trying to check selectors that didn't render yet.