### PR TITLE
Wizard: Rename "Enable repeatable build" -> "Repeatable build"

### DIFF
--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -103,7 +103,7 @@ test('Create a blueprint with Repeatable build customization', async ({
   await test.step('Check Repeatable build step behaviour with no repos', async () => {
     await frame.getByRole('button', { name: 'Review image' }).click();
     await expect(
-      frame.getByRole('heading', { name: 'Enable repeatable build' }),
+      frame.getByRole('heading', { name: 'Repeatable build' }),
     ).toBeVisible();
     await expect(frame.getByText('Dec 24, 2025')).toBeVisible();
   });
@@ -127,7 +127,7 @@ test('Create a blueprint with Repeatable build customization', async ({
         .click();
       await frame.getByRole('button', { name: 'Review image' }).click();
       await expect(
-        frame.getByRole('heading', { name: 'Enable repeatable build' }),
+        frame.getByRole('heading', { name: 'Repeatable build' }),
       ).toBeVisible();
       await expect(frame.getByText('Dec 24, 2025')).toBeVisible();
       await expect(frame.getByText('EPEL 10 Everything x86_64')).toBeVisible();
@@ -152,7 +152,7 @@ test('Create a blueprint with Repeatable build customization', async ({
     await frame.getByRole('menuitem').first().click();
     await frame.getByRole('button', { name: 'Review image' }).click();
     await expect(
-      frame.getByRole('heading', { name: 'Enable repeatable build' }),
+      frame.getByRole('heading', { name: 'Repeatable build' }),
     ).toBeVisible();
   });
 

--- a/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/index.tsx
@@ -27,7 +27,7 @@ const RepeatableBuild = ({ restrictions }: ReviewCardProps) => {
   return (
     <Card>
       <ReviewCardHeader
-        title='Enable repeatable build'
+        title='Repeatable build'
         stepId={
           isWizardRevampEnabled
             ? 'base-settings-step'

--- a/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/tests/RepeatableBuild.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/tests/RepeatableBuild.test.tsx
@@ -22,8 +22,8 @@ describe('RepeatableBuild', () => {
       },
     );
 
-    expect(screen.getByText('Enable repeatable build')).toBeInTheDocument();
-    expect(screen.getByText('Repeatable build')).toBeInTheDocument();
+    const repeatableBuildTexts = screen.getAllByText('Repeatable build');
+    expect(repeatableBuildTexts).toHaveLength(2); // Card title and review group heading
     expect(screen.getByText('Enabled')).toBeInTheDocument();
   });
 

--- a/src/Components/CreateImageWizard/steps/Snapshot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/index.tsx
@@ -23,7 +23,7 @@ const RepeatableBuildStep = () => {
           size={isWizardRevampEnabled ? 'lg' : 'xl'}
           id='repeatable-build-section'
         >
-          Enable repeatable build
+          Repeatable build
         </Title>
         <Content component={isWizardRevampEnabled ? 'small' : 'p'}>
           Create images that can be reproduced consistently with the same

--- a/src/Components/CreateImageWizard/steps/Snapshot/tests/RepeatableBuild.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/tests/RepeatableBuild.test.tsx
@@ -60,7 +60,7 @@ describe('Repeatable Build Component', () => {
 
       expect(
         await screen.findByRole('heading', {
-          name: /Enable repeatable build/i,
+          name: /Repeatable build/i,
         }),
       ).toBeInTheDocument();
       expect(


### PR DESCRIPTION
This updates the heading.

On the step
<img width="805" height="288" alt="image" src="https://github.com/user-attachments/assets/0e951bc0-6821-4c95-9677-88e805d53eb2" />

In the review
<img width="789" height="192" alt="image" src="https://github.com/user-attachments/assets/a11a94ab-084d-4593-8586-ec6775f92d66" />
