### PR TITLE
Wizard: hide all customizations for bootable-container-iso

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/index.tsx
@@ -63,11 +63,13 @@ const ReviewStep = () => {
         restrictions={restrictions}
         oscapPackages={security.packages}
       />
-      <AdvancedSettingsOverview
-        restrictions={restrictions}
-        oscapKernelArgs={security.kernel.append}
-        oscapServices={security.services}
-      />
+      {Object.values(restrictions).some((r) => !r.shouldHide) && (
+        <AdvancedSettingsOverview
+          restrictions={restrictions}
+          oscapKernelArgs={security.kernel.append}
+          oscapServices={security.services}
+        />
+      )}
     </Form>
   );
 };

--- a/src/store/api/distributions/constants.ts
+++ b/src/store/api/distributions/constants.ts
@@ -47,9 +47,7 @@ export const DISTRO_DETAILS: Record<string, ImageTypeInfo> = {
   },
   'bootable-container-iso': {
     name: 'bootable-container-iso',
-    supported_blueprint_options: [
-      ...ALL_CUSTOMIZATIONS.filter((c) => c !== 'filesystem'),
-    ],
+    supported_blueprint_options: [],
   },
   vsphere: {
     name: 'vsphere',

--- a/src/store/api/distributions/hooks.tsx
+++ b/src/store/api/distributions/hooks.tsx
@@ -57,10 +57,6 @@ export const isCustomizationSupported = (
   imageType: ImageTypeInfo | undefined,
   ctx: SupportContext,
 ) => {
-  if (ctx.isImageMode) {
-    return ['filesystem', 'users'].includes(customization);
-  }
-
   if (
     ctx.isOnPremise &&
     // on-premise doesn't allow first boot & repository
@@ -68,6 +64,14 @@ export const isCustomizationSupported = (
     ['repositories', 'firstBoot'].includes(customization)
   ) {
     return false;
+  }
+
+  let supportedOptions = imageType?.supported_blueprint_options;
+  if (ctx.isImageMode) {
+    // Image mode at most supports filesystem and users, and might not support any customization.
+    supportedOptions = supportedOptions?.filter((c) =>
+      ['filesystem', 'users'].includes(c),
+    ) ?? ['filesystem', 'users'];
   }
 
   // only rhel distros support registration
@@ -78,7 +82,6 @@ export const isCustomizationSupported = (
     return false;
   }
 
-  const supportedOptions = imageType?.supported_blueprint_options;
   return !supportedOptions || supportedOptions.includes(customization);
 };
 
@@ -137,16 +140,11 @@ export const useCustomizationRestrictions = ({
   const isOnPremise = useAppSelector(selectIsOnPremise);
   const isImageMode = useAppSelector(selectIsImageMode);
 
-  const { data } = api.useGetDistributionDetailsQuery(
-    {
-      distro: distro,
-      architecture: [arch],
-      imageType: selectedImageTypes,
-    },
-    {
-      skip: isImageMode,
-    },
-  );
+  const { data } = api.useGetDistributionDetailsQuery({
+    distro: distro,
+    architecture: [arch],
+    imageType: selectedImageTypes,
+  });
 
   const restrictions = useMemo(() => {
     const imageTypes = extractImageTypes({

--- a/src/store/api/distributions/tests/distributionDetailsApi.test.ts
+++ b/src/store/api/distributions/tests/distributionDetailsApi.test.ts
@@ -96,6 +96,19 @@ describe('DISTRO_DETAILS configuration', () => {
       expect(wslSupported).toHaveLength(ALL_CUSTOMIZATIONS.length - 3);
     });
   });
+
+  describe('bootable-container-iso restrictions', () => {
+    it('should allow no customizations', () => {
+      const isoSupported =
+        DISTRO_DETAILS['bootable-container-iso'].supported_blueprint_options;
+
+      // Verify it's an array (not an object due to accidental object spread)
+      expect(Array.isArray(isoSupported)).toBe(true);
+
+      // Should be empty
+      expect(isoSupported).toHaveLength(0);
+    });
+  });
 });
 
 describe('ALL_CUSTOMIZATIONS', () => {


### PR DESCRIPTION
This enables the mocked distribution details for image mode. At most filesystem and users is allowed, but any image type can choose to support less. In the case of the bootable container iso, no customizations should be supported.