### PR TITLE
Wizard: Match GCP principal input width to account type select (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/index.tsx
@@ -92,6 +92,7 @@ const Gcp = () => {
       <FormGroup
         label={accountType === 'domain' ? 'Domain' : 'Principal'}
         isRequired
+        style={{ maxWidth: '50%' }}
       >
         <ValidatedInput
           aria-label='google principal'


### PR DESCRIPTION
The principal/domain input field was wider than the account type dropdown. Constrain its width to 50% to align with the select.
<img width="1335" height="527" alt="Screenshot 2026-05-10 at 19 39 56" src="https://github.com/user-attachments/assets/ac43eaa7-e300-4215-832a-ff085927a259" />


JIRA: HMS-10579