### PR TITLE
Wizard/Packages: Fix recommendations tracking

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -702,7 +702,7 @@ const PackageSearch = ({
     isOpen,
     hasTrackedOpen,
     hasTrackedRecommendations,
-    transformedRecommendations.length,
+    transformedRecommendations,
   ]);
 
   const sortedPackages = useMemo(() => {


### PR DESCRIPTION
There's and issue where "Recommended Package Added" event fired without "Package Recommendations Shown" in edit mode.

This fixes the issue by updating the dependency of the "shown" event from `transformedRecommendations.length` to `transformedRecommendations`. This way the useEffect isn't ignored when the API returns a different set of recommendations with the same count of pkgs as the previous one (which can easily happen as the rec limit is set to 5).