### PR TITLE
Wizard: Replace typeahead profile selector with simple dropdown (HMS-10638)

### DIFF
--- a/playwright/Customizations/FipsMode.spec.ts
+++ b/playwright/Customizations/FipsMode.spec.ts
@@ -71,9 +71,7 @@ test('FIPS switch toggles and persists through save', async ({
       .getByRole('radio', { name: 'Use a default OpenSCAP profile' })
       .check();
 
-    const typeToFilter = frame.getByRole('textbox', { name: 'Type to filter' });
-
-    await typeToFilter.fill('stig');
+    await frame.getByTestId('profileSelect').click();
     await frame
       .getByRole('option', {
         name: /Red Hat STIG for Red Hat Enterprise Linux 10/i,

--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -56,16 +56,14 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await expect(
       frame.getByText('WSL: customization is not supported'),
     ).toBeVisible();
-    await expect(
-      frame.getByRole('textbox', { name: 'Type to filter' }),
-    ).toBeEnabled();
   });
 
   await test.step('Select a CIS profile then switch to None', async () => {
     await frame
       .getByRole('radio', { name: 'Use a default OpenSCAP profile' })
       .click();
-    await frame.getByRole('textbox', { name: 'Type to filter' }).fill('cis');
+    await expect(frame.getByTestId('profileSelect')).toBeEnabled();
+    await frame.getByTestId('profileSelect').click();
     await frame
       .getByRole('option', {
         name: 'CIS Red Hat Enterprise Linux 9 Benchmark for Level 1 - Server',
@@ -91,7 +89,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
       .getByRole('radio', { name: 'Use a default OpenSCAP profile' })
       .click();
 
-    await frame.getByRole('textbox', { name: 'Type to filter' }).fill('cis');
+    await frame.getByTestId('profileSelect').click();
     await frame
       .getByRole('option', {
         name: 'CIS Red Hat Enterprise Linux 9 Benchmark for Level 1 - Server',
@@ -143,14 +141,11 @@ test('Create a blueprint with OpenSCAP customization', async ({
   await test.step('Edit BP', async () => {
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
     await frame.getByRole('button', { name: 'Base settings' }).click();
-    await frame.getByRole('textbox', { name: 'Type to filter' }).click();
-    await expect(
-      frame.getByText(
-        'CIS Red Hat Enterprise Linux 9 Benchmark for Level 1 - Server',
-      ),
-    ).toBeVisible();
-    await frame.getByRole('textbox', { name: 'Type to filter' }).clear();
-    await frame.getByRole('textbox', { name: 'Type to filter' }).fill('cis');
+    await expect(frame.getByTestId('profileSelect')).toContainText(
+      'CIS Red Hat Enterprise Linux 9 Benchmark for Level 1 - Server',
+      { timeout: 60000 },
+    );
+    await frame.getByTestId('profileSelect').click();
     await frame
       .getByRole('option', {
         name: 'CIS Red Hat Enterprise Linux 9 Benchmark for Level 2 - Server',

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -228,6 +228,7 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
     <MenuToggle
       ouiaId='compliancePolicySelect'
       ref={toggleRef}
+      isPlaceholder={!policyTitle && !isApplying}
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
       isDisabled={isDisabled || isFetchingPolicies || isApplying}

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -232,6 +232,7 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
     <MenuToggle
       ouiaId='compliancePolicySelect'
       ref={toggleRef}
+      isPlaceholder={!policyTitle && !isApplying}
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}
       isDisabled={isDisabled || isFetchingPolicies || isApplying}

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 import {
-  Button,
   FormGroup,
   MenuToggle,
   MenuToggleElement,
@@ -9,11 +8,7 @@ import {
   SelectList,
   SelectOption,
   Spinner,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
 } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
 
 import {
   DistributionProfileItem,
@@ -31,7 +26,6 @@ import {
   changeFscMode,
   clearKernelAppend,
   selectComplianceProfileID,
-  selectComplianceType,
   selectDistribution,
   setOscapProfile,
 } from '@/store/slices/wizard';
@@ -68,21 +62,13 @@ const ProfileSelector = ({
   );
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState<string>('');
-  const [filterValue, setFilterValue] = useState<string>('');
-  const [selectOptions, setSelectOptions] = useState<
-    {
-      id: DistributionProfileItem;
-      name: string | undefined;
-    }[]
-  >([]);
+  const [isApplying, setIsApplying] = useState(false);
   const [profileDetails, setProfileDetails] = useState<
     {
       id: DistributionProfileItem;
       name: string | undefined;
     }[]
   >([]);
-  const complianceType = useAppSelector(selectComplianceType);
   const prefetchProfile = useBackendPrefetch('getOscapCustomizations');
   const {
     clearCompliancePackages,
@@ -102,14 +88,6 @@ const ProfileSelector = ({
   );
 
   const [trigger] = useLazyGetOscapCustomizationsQuery();
-
-  useEffect(() => {
-    if (!profileID) {
-      setInputValue('');
-      setFilterValue('');
-      setIsOpen(false);
-    }
-  }, [profileID]);
 
   // prefetch the profiles customizations for on-prem
   // and save the results to the cache, since the request
@@ -148,33 +126,16 @@ const ProfileSelector = ({
 
       const resolvedProfiles = await Promise.all(promises);
       setProfileDetails(resolvedProfiles);
-      setSelectOptions(resolvedProfiles);
     };
 
     fetchProfileDetails();
   }, [profiles, release, trigger]);
 
-  useEffect(() => {
-    if (!filterValue) {
-      setSelectOptions(profileDetails);
-      return;
-    }
-    const trimmedFilter = filterValue.toLowerCase().trim();
-    const filtered = profileDetails.filter(({ name }) =>
-      name?.toLowerCase().includes(trimmedFilter),
-    );
-
-    setSelectOptions(filtered);
-    if (!isOpen && filtered.length > 0) {
-      setIsOpen(true);
-    }
-  }, [filterValue, profileDetails, isOpen]);
-
-  const handleToggle = () => {
-    if (!isOpen && complianceType === 'openscap') {
+  const handleToggle = (nextIsOpen: boolean) => {
+    if (nextIsOpen) {
       refetch();
     }
-    setIsOpen(!isOpen);
+    setIsOpen(nextIsOpen);
   };
 
   const handleClear = () => {
@@ -184,53 +145,13 @@ const ProfileSelector = ({
     handleServices(undefined);
     dispatch(clearKernelAppend());
     dispatch(changeFips(false));
-    setInputValue('');
-    setFilterValue('');
-  };
-
-  const onInputClick = () => {
-    if (!isOpen) {
-      setIsOpen(true);
-    } else if (!inputValue) {
-      setIsOpen(false);
-    }
-  };
-
-  const onTextInputChange = (_event: React.FormEvent, value: string) => {
-    setInputValue(value);
-    setFilterValue(value);
-
-    if (value !== profileID) {
-      dispatch(setOscapProfile(undefined));
-    }
-  };
-
-  const onKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-
-      if (!isOpen) {
-        setIsOpen(true);
-      } else if (selectOptions.length === 1) {
-        const singleProfile = selectOptions[0];
-        const selection: OScapSelectOptionValueType = {
-          profileID: singleProfile.id,
-          toString: () => singleProfile.name || '',
-        };
-
-        setInputValue(singleProfile.name || '');
-        setFilterValue('');
-        applyChanges(selection);
-        setIsOpen(false);
-      }
-    }
   };
 
   const applyChanges = (selection: OScapSelectOptionValueType) => {
     if (selection.profileID === undefined) {
-      // handle user has selected 'None' case
       handleClear();
     } else {
+      setIsApplying(true);
       const oldOscapPackages = currentProfileData?.packages || [];
       trigger(
         {
@@ -253,7 +174,8 @@ const ProfileSelector = ({
           handleKernelAppend(response.kernel?.append);
           dispatch(setOscapProfile(selection.profileID));
           dispatch(changeFips(response.fips?.enabled || false));
-        });
+        })
+        .finally(() => setIsApplying(false));
     }
   };
 
@@ -263,49 +185,56 @@ const ProfileSelector = ({
   ) => {
     if (selection === undefined) return;
 
-    setInputValue((selection as OScapSelectOptionValueType['profileID']) || '');
-    setFilterValue('');
     applyChanges(selection as unknown as OScapSelectOptionValueType);
     setIsOpen(false);
+  };
+
+  const selectedProfileName = profileID
+    ? profileDetails.find(({ id }) => id === profileID)?.name || profileID
+    : undefined;
+
+  const profileOptions = () => {
+    if (isFetching) {
+      return [
+        <SelectOption key='oscap-loader' value='loader'>
+          <Spinner size='lg' />
+        </SelectOption>,
+      ];
+    }
+
+    const res = profileDetails.map(({ id, name }) => (
+      <SelectOption
+        key={id}
+        value={{
+          profileID: id,
+          toString: () => name,
+        }}
+        isSelected={profileID === id}
+      >
+        {name}
+      </SelectOption>
+    ));
+    return res;
   };
 
   const toggleOpenSCAP = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       data-testid='profileSelect'
       ref={toggleRef}
-      variant='typeahead'
-      onClick={() => setIsOpen(!isOpen)}
+      isPlaceholder={!selectedProfileName && !isApplying}
+      onClick={() => handleToggle(!isOpen)}
       isExpanded={isOpen}
-      isDisabled={isDisabled || !isSuccess}
+      isDisabled={isDisabled || !isSuccess || isApplying}
       isFullWidth
+      style={{ maxWidth: 'none' }}
     >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={
-            profileID
-              ? profileDetails.find(({ id }) => id === profileID)?.name ||
-                profileID
-              : inputValue
-          }
-          onClick={onInputClick}
-          onChange={onTextInputChange}
-          onKeyDown={onKeyDown}
-          autoComplete='off'
-          placeholder='Select a profile'
-          isExpanded={isOpen}
-        />
-
-        {profileID && (
-          <TextInputGroupUtilities>
-            <Button
-              icon={<TimesIcon />}
-              variant='plain'
-              onClick={handleClear}
-              aria-label='Clear input'
-            />
-          </TextInputGroupUtilities>
-        )}
-      </TextInputGroup>
+      {isApplying ? (
+        <>
+          <Spinner size='sm' /> Applying profile...
+        </>
+      ) : (
+        selectedProfileName || 'Select a profile'
+      )}
     </MenuToggle>
   );
 
@@ -319,35 +248,8 @@ const ProfileSelector = ({
         onOpenChange={handleToggle}
         toggle={toggleOpenSCAP}
         shouldFocusFirstItemOnOpen={false}
-        popperProps={{
-          maxWidth: '50vw',
-        }}
       >
-        <SelectList>
-          {isFetching && (
-            <SelectOption value='loader'>
-              <Spinner size='lg' />
-            </SelectOption>
-          )}
-          {selectOptions.length > 0 &&
-            selectOptions.map(({ id, name }) => (
-              <SelectOption
-                key={id}
-                value={{
-                  profileID: id,
-                  toString: () => name,
-                }}
-                isSelected={profileID === id}
-              >
-                {name}
-              </SelectOption>
-            ))}
-          {isSuccess && selectOptions.length === 0 && (
-            <SelectOption isDisabled>
-              {`No results found for "${filterValue}"`}
-            </SelectOption>
-          )}
-        </SelectList>
+        <SelectList>{profileOptions()}</SelectList>
       </Select>
     </FormGroup>
   );

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
 import {
-  Button,
   FormGroup,
   MenuToggle,
   MenuToggleElement,
@@ -9,11 +8,7 @@ import {
   SelectList,
   SelectOption,
   Spinner,
-  TextInputGroup,
-  TextInputGroupMain,
-  TextInputGroupUtilities,
 } from '@patternfly/react-core';
-import { TimesIcon } from '@patternfly/react-icons';
 
 import {
   DistributionProfileItem,
@@ -32,7 +27,6 @@ import {
   clearKernelAppend,
   removeBetaFromRelease,
   selectComplianceProfileID,
-  selectComplianceType,
   selectDistribution,
   setOscapProfile,
 } from '@/store/slices/wizard';
@@ -64,21 +58,13 @@ const ProfileSelector = ({
   const release = removeBetaFromRelease(useAppSelector(selectDistribution));
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
-  const [inputValue, setInputValue] = useState<string>('');
-  const [filterValue, setFilterValue] = useState<string>('');
-  const [selectOptions, setSelectOptions] = useState<
-    {
-      id: DistributionProfileItem;
-      name: string | undefined;
-    }[]
-  >([]);
+  const [isApplying, setIsApplying] = useState(false);
   const [profileDetails, setProfileDetails] = useState<
     {
       id: DistributionProfileItem;
       name: string | undefined;
     }[]
   >([]);
-  const complianceType = useAppSelector(selectComplianceType);
   const prefetchProfile = useBackendPrefetch('getOscapCustomizations');
   const {
     clearCompliancePackages,
@@ -98,14 +84,6 @@ const ProfileSelector = ({
   );
 
   const [trigger] = useLazyGetOscapCustomizationsQuery();
-
-  useEffect(() => {
-    if (!profileID) {
-      setInputValue('');
-      setFilterValue('');
-      setIsOpen(false);
-    }
-  }, [profileID]);
 
   // prefetch the profiles customizations for on-prem
   // and save the results to the cache, since the request
@@ -144,33 +122,16 @@ const ProfileSelector = ({
 
       const resolvedProfiles = await Promise.all(promises);
       setProfileDetails(resolvedProfiles);
-      setSelectOptions(resolvedProfiles);
     };
 
     fetchProfileDetails();
   }, [profiles, release, trigger]);
 
-  useEffect(() => {
-    if (!filterValue) {
-      setSelectOptions(profileDetails);
-      return;
-    }
-    const trimmedFilter = filterValue.toLowerCase().trim();
-    const filtered = profileDetails.filter(({ name }) =>
-      name?.toLowerCase().includes(trimmedFilter),
-    );
-
-    setSelectOptions(filtered);
-    if (!isOpen && filtered.length > 0) {
-      setIsOpen(true);
-    }
-  }, [filterValue, profileDetails, isOpen]);
-
-  const handleToggle = () => {
-    if (!isOpen && complianceType === 'openscap') {
+  const handleToggle = (nextIsOpen: boolean) => {
+    if (nextIsOpen) {
       refetch();
     }
-    setIsOpen(!isOpen);
+    setIsOpen(nextIsOpen);
   };
 
   const handleClear = () => {
@@ -180,53 +141,13 @@ const ProfileSelector = ({
     handleServices(undefined);
     dispatch(clearKernelAppend());
     dispatch(changeFips(false));
-    setInputValue('');
-    setFilterValue('');
-  };
-
-  const onInputClick = () => {
-    if (!isOpen) {
-      setIsOpen(true);
-    } else if (!inputValue) {
-      setIsOpen(false);
-    }
-  };
-
-  const onTextInputChange = (_event: React.FormEvent, value: string) => {
-    setInputValue(value);
-    setFilterValue(value);
-
-    if (value !== profileID) {
-      dispatch(setOscapProfile(undefined));
-    }
-  };
-
-  const onKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter') {
-      event.preventDefault();
-
-      if (!isOpen) {
-        setIsOpen(true);
-      } else if (selectOptions.length === 1) {
-        const singleProfile = selectOptions[0];
-        const selection: OScapSelectOptionValueType = {
-          profileID: singleProfile.id,
-          toString: () => singleProfile.name || '',
-        };
-
-        setInputValue(singleProfile.name || '');
-        setFilterValue('');
-        applyChanges(selection);
-        setIsOpen(false);
-      }
-    }
   };
 
   const applyChanges = (selection: OScapSelectOptionValueType) => {
     if (selection.profileID === undefined) {
-      // handle user has selected 'None' case
       handleClear();
     } else {
+      setIsApplying(true);
       const oldOscapPackages = currentProfileData?.packages || [];
       trigger(
         {
@@ -249,7 +170,8 @@ const ProfileSelector = ({
           handleKernelAppend(response.kernel?.append);
           dispatch(setOscapProfile(selection.profileID));
           dispatch(changeFips(response.fips?.enabled || false));
-        });
+        })
+        .finally(() => setIsApplying(false));
     }
   };
 
@@ -259,49 +181,56 @@ const ProfileSelector = ({
   ) => {
     if (selection === undefined) return;
 
-    setInputValue((selection as OScapSelectOptionValueType['profileID']) || '');
-    setFilterValue('');
     applyChanges(selection as unknown as OScapSelectOptionValueType);
     setIsOpen(false);
+  };
+
+  const selectedProfileName = profileID
+    ? profileDetails.find(({ id }) => id === profileID)?.name || profileID
+    : undefined;
+
+  const profileOptions = () => {
+    if (isFetching) {
+      return [
+        <SelectOption key='oscap-loader' value='loader'>
+          <Spinner size='lg' />
+        </SelectOption>,
+      ];
+    }
+
+    const res = profileDetails.map(({ id, name }) => (
+      <SelectOption
+        key={id}
+        value={{
+          profileID: id,
+          toString: () => name,
+        }}
+        isSelected={profileID === id}
+      >
+        {name}
+      </SelectOption>
+    ));
+    return res;
   };
 
   const toggleOpenSCAP = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
       data-testid='profileSelect'
       ref={toggleRef}
-      variant='typeahead'
-      onClick={() => setIsOpen(!isOpen)}
+      isPlaceholder={!selectedProfileName && !isApplying}
+      onClick={() => handleToggle(!isOpen)}
       isExpanded={isOpen}
-      isDisabled={isDisabled || !isSuccess}
+      isDisabled={isDisabled || !isSuccess || isApplying}
       isFullWidth
+      style={{ maxWidth: 'none' }}
     >
-      <TextInputGroup isPlain>
-        <TextInputGroupMain
-          value={
-            profileID
-              ? profileDetails.find(({ id }) => id === profileID)?.name ||
-                profileID
-              : inputValue
-          }
-          onClick={onInputClick}
-          onChange={onTextInputChange}
-          onKeyDown={onKeyDown}
-          autoComplete='off'
-          placeholder='Select a profile'
-          isExpanded={isOpen}
-        />
-
-        {profileID && (
-          <TextInputGroupUtilities>
-            <Button
-              icon={<TimesIcon />}
-              variant='plain'
-              onClick={handleClear}
-              aria-label='Clear input'
-            />
-          </TextInputGroupUtilities>
-        )}
-      </TextInputGroup>
+      {isApplying ? (
+        <>
+          <Spinner size='sm' /> Applying profile...
+        </>
+      ) : (
+        selectedProfileName || 'Select a profile'
+      )}
     </MenuToggle>
   );
 
@@ -315,35 +244,8 @@ const ProfileSelector = ({
         onOpenChange={handleToggle}
         toggle={toggleOpenSCAP}
         shouldFocusFirstItemOnOpen={false}
-        popperProps={{
-          maxWidth: '50vw',
-        }}
       >
-        <SelectList>
-          {isFetching && (
-            <SelectOption value='loader'>
-              <Spinner size='lg' />
-            </SelectOption>
-          )}
-          {selectOptions.length > 0 &&
-            selectOptions.map(({ id, name }) => (
-              <SelectOption
-                key={id}
-                value={{
-                  profileID: id,
-                  toString: () => name,
-                }}
-                isSelected={profileID === id}
-              >
-                {name}
-              </SelectOption>
-            ))}
-          {isSuccess && selectOptions.length === 0 && (
-            <SelectOption isDisabled>
-              {`No results found for "${filterValue}"`}
-            </SelectOption>
-          )}
-        </SelectList>
+        <SelectList>{profileOptions()}</SelectList>
       </Select>
     </FormGroup>
   );

--- a/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
@@ -2,19 +2,15 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
-import {
-  clickWithWait,
-  createUser,
-  renderWithRedux,
-  typeWithWait,
-} from '@/test/testUtils';
+import { clickWithWait, createUser, renderWithRedux } from '@/test/testUtils';
 
 import OscapStep from '../index';
 
 describe('Oscap Component', () => {
-  describe('Form submission', () => {
-    test('pressing Enter in profile search does not trigger page reload', async () => {
+  describe('Profile selector', () => {
+    test('profile dropdown opens and closes on toggle click', async () => {
       renderWithRedux(<OscapStep />, {
+        imageTypes: ['guest-image'],
         compliance: {
           complianceType: 'openscap',
           profileID: undefined,
@@ -24,12 +20,16 @@ describe('Oscap Component', () => {
       });
       const user = createUser();
 
-      const profileSearchInput =
-        await screen.findByPlaceholderText('Select a profile');
-      await typeWithWait(user, profileSearchInput, 'cis{Enter}');
+      const openscapRadio = await screen.findByRole('radio', {
+        name: /Use a default OpenSCAP profile/i,
+      });
+      await user.click(openscapRadio);
 
-      expect(profileSearchInput).toBeInTheDocument();
-      expect(profileSearchInput).toHaveValue('cis');
+      const profileSelect = await screen.findByTestId('profileSelect');
+      expect(profileSelect).toHaveTextContent('Select a profile');
+
+      await user.click(profileSelect);
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
   });
 
@@ -71,7 +71,7 @@ describe('Oscap Component', () => {
     });
 
     test('switching to openscap enables the profile selector', async () => {
-      renderWithRedux(<OscapStep />);
+      renderWithRedux(<OscapStep />, { imageTypes: ['guest-image'] });
       const user = createUser();
 
       const openscapRadio = await screen.findByRole('radio', {
@@ -86,13 +86,12 @@ describe('Oscap Component', () => {
         }),
       ).not.toBeChecked();
 
-      expect(
-        screen.getByPlaceholderText('Select a profile'),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId('profileSelect')).toBeInTheDocument();
     });
 
     test('switching back to none from openscap deselects profile', async () => {
       renderWithRedux(<OscapStep />, {
+        imageTypes: ['guest-image'],
         compliance: {
           complianceType: 'openscap',
           profileID: undefined,

--- a/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
-import {
-  clickWithWait,
-  createUser,
-  renderWithRedux,
-  typeWithWait,
-} from '@/test/testUtils';
+import { initialState } from '@/store/slices/wizard';
+import { clickWithWait, createUser, renderWithRedux } from '@/test/testUtils';
 
 import OscapStep from '../index';
 
 describe('Oscap Component', () => {
-  describe('Form submission', () => {
-    test('pressing Enter in profile search does not trigger page reload', async () => {
+  describe('Profile selector', () => {
+    test('profile dropdown opens and closes on toggle click', async () => {
       renderWithRedux(<OscapStep />, {
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         compliance: {
           type: 'openscap',
           profileID: undefined,
@@ -25,12 +25,16 @@ describe('Oscap Component', () => {
       });
       const user = createUser();
 
-      const profileSearchInput =
-        await screen.findByPlaceholderText('Select a profile');
-      await typeWithWait(user, profileSearchInput, 'cis{Enter}');
+      const openscapRadio = await screen.findByRole('radio', {
+        name: /Use a default OpenSCAP profile/i,
+      });
+      await clickWithWait(user, openscapRadio);
 
-      expect(profileSearchInput).toBeInTheDocument();
-      expect(profileSearchInput).toHaveValue('cis');
+      const profileSelect = await screen.findByTestId('profileSelect');
+      expect(profileSelect).toHaveTextContent('Select a profile');
+
+      await clickWithWait(user, profileSelect);
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
     });
   });
 
@@ -72,7 +76,9 @@ describe('Oscap Component', () => {
     });
 
     test('switching to openscap enables the profile selector', async () => {
-      renderWithRedux(<OscapStep />);
+      renderWithRedux(<OscapStep />, {
+        output: { ...initialState.output, imageTypes: ['guest-image'] },
+      });
       const user = createUser();
 
       const openscapRadio = await screen.findByRole('radio', {
@@ -87,13 +93,15 @@ describe('Oscap Component', () => {
         }),
       ).not.toBeChecked();
 
-      expect(
-        screen.getByPlaceholderText('Select a profile'),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId('profileSelect')).toBeInTheDocument();
     });
 
     test('switching back to none from openscap deselects profile', async () => {
       renderWithRedux(<OscapStep />, {
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         compliance: {
           type: 'openscap',
           profileID: undefined,

--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -60,11 +60,7 @@ const selectSimplifiedOscapProfile = async () => {
   });
   await user.click(openscapRadio);
   const openScapSelect = await screen.findByTestId('profileSelect');
-  const typeahead = await within(openScapSelect).findByRole('textbox', {
-    name: /type to filter/i,
-  });
-  await waitFor(() => user.click(typeahead));
-  await waitFor(() => user.type(typeahead, 'simplified'));
+  await waitFor(() => user.click(openScapSelect));
 
   const simplifiedProfile = await screen.findByRole('option', {
     name: /simplified profile/i,

--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -10,7 +10,7 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
-import { clickWithWait, typeWithWait } from '@/test/testUtils';
+import { clickWithWait } from '@/test/testUtils';
 
 import {
   CREATE_BLUEPRINT,
@@ -62,11 +62,7 @@ const selectSimplifiedOscapProfile = async () => {
   });
   await clickWithWait(user, openscapRadio);
   const openScapSelect = await screen.findByTestId('profileSelect');
-  const typeahead = await within(openScapSelect).findByRole('textbox', {
-    name: /type to filter/i,
-  });
-  await clickWithWait(user, typeahead);
-  await typeWithWait(user, typeahead, 'simplified');
+  await clickWithWait(user, openScapSelect);
 
   const simplifiedProfile = await screen.findByRole('option', {
     name: /simplified profile/i,


### PR DESCRIPTION
The ProfileSelector used a typeahead variant with text filtering,
which caused the placeholder text to appear white in dark mode.
PatternFly's MenuToggle typeahead variant uses a separate CSS variable
for its input placeholder that doesn't inherit the dark mode color.

Replace with a simple button-based dropdown matching the PolicySelector
pattern. This also adds an applying state with a spinner, and adds
isPlaceholder to the PolicySelector toggle for consistency.

<img width="1335" height="531" alt="Screenshot 2026-05-20 at 14 40 34" src="https://github.com/user-attachments/assets/3b3cd1fc-b532-45d1-ae9c-ce6c8e2b602c" />



JIRA: HMS-10638 HMS-10657