### PR TITLE
Wizard: remove error from pristine state of sattelite registration

### DIFF
--- a/src/Components/CreateImageWizard/ValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInput.tsx
@@ -75,13 +75,11 @@ export const ValidatedInputAndTextArea = ({
   );
 
   const handleBlur = () => {
-    if (value) {
-      setIsPristine(false);
-    }
+    setIsPristine(false);
   };
 
   useEffect(() => {
-    if (errorMessage) {
+    if (errorMessage && value) {
       setIsPristine(false);
     }
     if (isDisabled) {


### PR DESCRIPTION
Before, the satellite registration threw an error immediately after the user picked the radio button for it, now it only throws that error if the user tries to put in a value and deletes it.
<img width="1544" height="890" alt="sattelite" src="https://github.com/user-attachments/assets/1e0e0745-f9f9-4a8d-bd9a-02b1d98bdafa" />
