### PR TITLE
Wizard: fix validation in AAP step

### DIFF
--- a/playwright/Customizations/AAP.spec.ts
+++ b/playwright/Customizations/AAP.spec.ts
@@ -147,12 +147,12 @@ test('Create a blueprint with AAP registration customization', async ({
       .getByRole('textbox', { name: 'ansible callback url' })
       .fill(validHttpCallbackUrl);
 
-    // TLS confirmation checkbox should NOT appear for HTTP URLs
+    // TLS confirmation checkbox should be disabled for HTTP URLs
     await expect(
       frame.getByRole('checkbox', {
         name: 'Insecure',
       }),
-    ).toBeHidden();
+    ).toBeDisabled();
     await expect(
       frame.getByRole('textbox', { name: 'File upload' }),
     ).toBeVisible();

--- a/src/Components/CreateImageWizard/steps/Registration/components/AAP/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/AAP/index.tsx
@@ -12,9 +12,11 @@ import {
 } from '@patternfly/react-core';
 
 import ExternalLinkButton from '@/Components/CreateImageWizard/utilities/ExternalLinkButton';
-import { useAAPValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
+import {
+  type StepValidation,
+  useAAPValidation,
+} from '@/Components/CreateImageWizard/utilities/useValidation';
 import { ValidatedInputAndTextArea } from '@/Components/CreateImageWizard/ValidatedInput';
-import { validateMultipleCertificates } from '@/Components/CreateImageWizard/validators';
 import { AAP_DOCS_URL } from '@/constants';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -28,6 +30,29 @@ import {
   selectAapTlsConfirmation,
 } from '@/store/slices/wizard';
 
+const emptyValidation: StepValidation = { errors: {}, disabledNext: false };
+
+// clear hostConfigKey when the user leaves the step if the callback URL is still empty.
+function useClearHostConfigKeyOnUnmount(
+  callbackUrl: string | undefined,
+  hostConfigKey: string | undefined,
+  dispatch: ReturnType<typeof useAppDispatch>,
+) {
+  const callbackUrlRef = React.useRef(callbackUrl);
+  const hostConfigKeyRef = React.useRef(hostConfigKey);
+  React.useEffect(() => {
+    callbackUrlRef.current = callbackUrl;
+    hostConfigKeyRef.current = hostConfigKey;
+  }, [callbackUrl, hostConfigKey]);
+  React.useEffect(() => {
+    return () => {
+      if (!callbackUrlRef.current && hostConfigKeyRef.current) {
+        dispatch(changeAapHostConfigKey(undefined));
+      }
+    };
+  }, [dispatch]);
+}
+
 const AAPRegistration = () => {
   const dispatch = useAppDispatch();
   const callbackUrl = useAppSelector(selectAapCallbackUrl);
@@ -39,20 +64,39 @@ const AAPRegistration = () => {
   const [isRejected, setIsRejected] = React.useState(false);
   const stepValidation = useAAPValidation();
 
-  const isHttpsUrl = callbackUrl?.toLowerCase().startsWith('https://') || false;
+  useClearHostConfigKeyOnUnmount(callbackUrl, hostConfigKey, dispatch);
+
+  const [callbackUrlBlurred, setCallbackUrlBlurred] = React.useState(false);
+  const callbackUrlValidation = React.useMemo(
+    (): StepValidation =>
+      callbackUrlBlurred && stepValidation.errors.callbackUrl
+        ? {
+            errors: { callbackUrl: stepValidation.errors.callbackUrl },
+            disabledNext: stepValidation.disabledNext,
+          }
+        : emptyValidation,
+    [callbackUrlBlurred, stepValidation],
+  );
+
+  const isHttpsUrl = callbackUrl?.toLowerCase().startsWith('https:') || false;
+  const isHttpUrl =
+    (callbackUrl?.toLowerCase().startsWith('http:') && !isHttpsUrl) || false;
   const shouldShowCaInput = !isHttpsUrl || !tlsConfirmation;
 
-  const validated =
-    'certificate' in stepValidation.errors
+  const hasCertContent =
+    !!tlsCertificateAuthority && tlsCertificateAuthority.trim() !== '';
+
+  const validated: 'default' | 'success' | 'error' = hasCertContent
+    ? stepValidation.errors.certificate
       ? 'error'
-      : tlsCertificateAuthority &&
-          validateMultipleCertificates(tlsCertificateAuthority)
-            .validCertificates.length > 0
-        ? 'success'
-        : 'default';
+      : 'success'
+    : 'default';
 
   const handleCallbackUrlChange = (value: string) => {
     dispatch(changeAapCallbackUrl(value));
+    if (tlsConfirmation && !value.toLowerCase().startsWith('https:')) {
+      dispatch(changeAapTlsConfirmation(false));
+    }
   };
 
   const handleHostConfigKeyChange = (value: string) => {
@@ -92,14 +136,16 @@ const AAPRegistration = () => {
         isRequired
         className='pf-v6-u-w-50'
       >
-        <ValidatedInputAndTextArea
-          value={callbackUrl || ''}
-          onChange={(_event, value) => handleCallbackUrlChange(value.trim())}
-          ariaLabel='ansible callback url'
-          isRequired
-          stepValidation={stepValidation}
-          fieldName='callbackUrl'
-        />
+        <div onBlur={() => setCallbackUrlBlurred(true)}>
+          <ValidatedInputAndTextArea
+            value={callbackUrl || ''}
+            onChange={(_event, value) => handleCallbackUrlChange(value.trim())}
+            ariaLabel='ansible callback url'
+            isRequired
+            stepValidation={callbackUrlValidation}
+            fieldName='callbackUrl'
+          />
+        </div>
         <FormHelperText>
           <HelperText>
             <HelperTextItem>
@@ -141,7 +187,33 @@ const AAPRegistration = () => {
       </FormGroup>
 
       {shouldShowCaInput && (
-        <FormGroup label='Certificate authority (CA) for Ansible Controller'>
+        <FormGroup
+          label='Certificate authority (CA) for Ansible Controller'
+          isRequired={isHttpUrl}
+        >
+          <FormHelperText>
+            <HelperText>
+              <HelperTextItem>
+                {isHttpUrl ? (
+                  'Upload a CA certificate for the Ansible Controller'
+                ) : (
+                  <>
+                    Upload a CA certificate, or check &quot;Insecure&quot; to
+                    skip TLS verification{' '}
+                    <span
+                      style={{
+                        color:
+                          'var(--pf-t--global--color--status--danger--default)',
+                        fontSize: 'var(--pf-t--global--font--size--lg)',
+                      }}
+                    >
+                      *
+                    </span>
+                  </>
+                )}
+              </HelperTextItem>
+            </HelperText>
+          </FormHelperText>
           <FileUpload
             id='aap-certificate-upload'
             type='text'
@@ -199,25 +271,20 @@ const AAPRegistration = () => {
           </FormHelperText>
         </FormGroup>
       )}
-      {isHttpsUrl && (
-        <FormGroup>
-          <Checkbox
-            id='tls-confirmation-checkbox'
-            label='Insecure'
-            isChecked={tlsConfirmation || false}
-            onChange={(_event, checked) => handleTlsConfirmationChange(checked)}
-          />
-          {stepValidation.errors['tlsConfirmation'] && (
-            <FormHelperText>
-              <HelperText>
-                <HelperTextItem variant='error'>
-                  {stepValidation.errors['tlsConfirmation']}
-                </HelperTextItem>
-              </HelperText>
-            </FormHelperText>
-          )}
-        </FormGroup>
-      )}
+      <FormGroup>
+        <Checkbox
+          id='tls-confirmation-checkbox'
+          label='Insecure'
+          description={
+            isHttpUrl
+              ? 'Not available for HTTP URLs — a CA certificate is required'
+              : 'Skip TLS certificate verification for HTTPS connections'
+          }
+          isChecked={tlsConfirmation || false}
+          isDisabled={isHttpUrl}
+          onChange={(_event, checked) => handleTlsConfirmationChange(checked)}
+        />
+      </FormGroup>
     </Form>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Registration/components/AAP/tests/AAP.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/AAP/tests/AAP.test.tsx
@@ -36,26 +36,46 @@ describe('AAP Component', () => {
       expect(input).toHaveValue('https://controller.example.com/callback/');
     });
 
-    test('shows insecure checkbox for HTTPS URLs', async () => {
+    test('insecure checkbox is always visible', async () => {
       renderAAPStep();
-      const user = createUser();
-
-      await enterCallbackUrl(user, 'https://controller.example.com/callback/');
 
       expect(
         await screen.findByRole('checkbox', { name: /insecure/i }),
       ).toBeInTheDocument();
     });
 
-    test('does not show insecure checkbox for HTTP URLs', async () => {
+    test('insecure checkbox is enabled with HTTPS description for HTTPS URLs', async () => {
+      renderAAPStep();
+      const user = createUser();
+
+      await enterCallbackUrl(user, 'https://controller.example.com/callback/');
+
+      const checkbox = await screen.findByRole('checkbox', {
+        name: /insecure/i,
+      });
+      expect(checkbox).toBeEnabled();
+      expect(
+        screen.getByText(
+          /Skip TLS certificate verification for HTTPS connections/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('insecure checkbox is disabled with HTTP description for HTTP URLs', async () => {
       renderAAPStep();
       const user = createUser();
 
       await enterCallbackUrl(user, 'http://controller.example.com/callback/');
 
+      const checkbox = await screen.findByRole('checkbox', {
+        name: /insecure/i,
+      });
+      expect(checkbox).toBeDisabled();
       expect(
-        screen.queryByRole('checkbox', { name: /insecure/i }),
-      ).not.toBeInTheDocument();
+        screen.getByText(
+          /Not available for HTTP URLs — a CA certificate is required/i,
+        ),
+      ).toBeInTheDocument();
     });
   });
 
@@ -64,6 +84,7 @@ describe('AAP Component', () => {
       renderAAPStep();
       const user = createUser();
 
+      await enterCallbackUrl(user, 'https://controller.example.com/callback/');
       await enterHostConfigKey(user, 'my-host-config-key');
 
       const input = await screen.findByRole('textbox', {
@@ -71,27 +92,44 @@ describe('AAP Component', () => {
       });
       expect(input).toHaveValue('my-host-config-key');
     });
+
+    test('host config key is cleared on unmount when callback URL is empty', async () => {
+      const { store, unmount } = renderAAPStep({
+        aapRegistration: {
+          enabled: true,
+          callbackUrl: '',
+          hostConfigKey: 'orphaned-key',
+          tlsCertificateAuthority: '',
+          skipTlsVerification: false,
+        },
+      });
+
+      const input = await screen.findByRole('textbox', {
+        name: /host config key/i,
+      });
+      expect(input).toHaveValue('orphaned-key');
+
+      unmount();
+      expect(
+        store.getState().wizard.aapRegistration.hostConfigKey,
+      ).toBeUndefined();
+    });
   });
 
   describe('TLS Configuration', () => {
-    test('certificate input is visible by default for HTTPS URLs', async () => {
+    test('certificate input is visible by default', async () => {
       renderAAPStep();
-      const user = createUser();
-
-      await enterCallbackUrl(user, 'https://controller.example.com/callback/');
 
       expect(
         await screen.findByText(/Certificate authority/i),
       ).toBeInTheDocument();
     });
 
-    test('certificate input is hidden when insecure checkbox is checked', async () => {
+    test('certificate input is hidden when insecure checkbox is checked for HTTPS URLs', async () => {
       renderAAPStep();
       const user = createUser();
 
       await enterCallbackUrl(user, 'https://controller.example.com/callback/');
-      await screen.findByRole('checkbox', { name: /insecure/i });
-
       await toggleInsecureCheckbox(user);
 
       expect(
@@ -104,11 +142,51 @@ describe('AAP Component', () => {
       const user = createUser();
 
       await enterCallbackUrl(user, 'https://controller.example.com/callback/');
-      await screen.findByRole('checkbox', { name: /insecure/i });
-
       await toggleInsecureCheckbox(user);
       await toggleInsecureCheckbox(user);
 
+      expect(
+        await screen.findByText(/Certificate authority/i),
+      ).toBeInTheDocument();
+    });
+
+    test('shows info hint about CA and Insecure options', async () => {
+      renderAAPStep();
+
+      expect(
+        await screen.findByText(
+          /upload a CA certificate, or check "Insecure" to skip TLS verification/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('shows HTTP-specific CA helper text for HTTP URLs', async () => {
+      renderAAPStep();
+      const user = createUser();
+
+      await enterCallbackUrl(user, 'http://controller.example.com/callback/');
+
+      expect(
+        await screen.findByText(
+          /Upload a CA certificate for the Ansible Controller/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('TLS confirmation is cleared when switching from HTTPS to HTTP', async () => {
+      renderAAPStep();
+      const user = createUser();
+
+      await enterCallbackUrl(user, 'https://controller.example.com/callback/');
+      await toggleInsecureCheckbox(user);
+
+      const checkbox = screen.getByRole('checkbox', { name: /insecure/i });
+      expect(checkbox).toBeChecked();
+
+      await enterCallbackUrl(user, 'http://controller.example.com/callback/');
+
+      expect(checkbox).not.toBeChecked();
+      expect(checkbox).toBeDisabled();
       expect(
         await screen.findByText(/Certificate authority/i),
       ).toBeInTheDocument();
@@ -137,7 +215,7 @@ describe('AAP Component', () => {
       renderAAPStep({
         aapRegistration: {
           enabled: true,
-          callbackUrl: '',
+          callbackUrl: 'https://controller.example.com/callback/',
           hostConfigKey: 'existing-key',
           tlsCertificateAuthority: '',
           skipTlsVerification: false,
@@ -184,6 +262,7 @@ describe('AAP Component', () => {
       const { store } = renderAAPStep();
       const user = createUser();
 
+      await enterCallbackUrl(user, 'https://controller.example.com/callback/');
       await enterHostConfigKey(user, 'my-host-config-key');
 
       expect(store.getState().wizard.aapRegistration.hostConfigKey).toBe(
@@ -242,6 +321,7 @@ describe('AAP Component', () => {
       const { store } = renderAAPStep();
       const user = createUser();
 
+      await enterCallbackUrl(user, 'https://controller.example.com/callback/');
       const hostConfigKeyInput = await screen.findByRole('textbox', {
         name: /host config key/i,
       });

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -303,13 +303,11 @@ export function useAAPValidation(): StepValidation {
   if (!callbackUrl && !hostConfigKey && !tlsCertificateAuthority) {
     return { errors: {}, disabledNext: false };
   }
-  if (!callbackUrl || callbackUrl.trim() === '') {
-    errors.callbackUrl = 'Ansible Callback URL is required';
-  } else if (!isValidUrl(callbackUrl)) {
+  if (callbackUrl && !isValidUrl(callbackUrl)) {
     errors.callbackUrl = 'Callback URL must be a valid URL';
   }
 
-  if (!hostConfigKey || hostConfigKey.trim() === '') {
+  if (hostConfigKey !== undefined && hostConfigKey.trim() === '') {
     errors.hostConfigKey = 'Host Config Key is required';
   }
 
@@ -322,29 +320,27 @@ export function useAAPValidation(): StepValidation {
     }
   }
 
-  if (callbackUrl && callbackUrl.trim() !== '') {
-    const isHttpsUrl = callbackUrl.toLowerCase().startsWith('https://');
+  const urlIsValid = !!callbackUrl && isValidUrl(callbackUrl);
+  const hasHostConfigKey = !!hostConfigKey && hostConfigKey.trim() !== '';
+  const hasValidCert =
+    !!tlsCertificateAuthority &&
+    tlsCertificateAuthority.trim() !== '' &&
+    !errors.certificate;
 
-    // If URL is HTTP, require TLS certificate
-    if (
-      !isHttpsUrl &&
-      (!tlsCertificateAuthority || tlsCertificateAuthority.trim() === '')
-    ) {
-      errors.certificate = 'HTTP URL requires a custom TLS certificate';
-      return { errors, disabledNext: true };
+  let disabledNext =
+    Object.keys(errors).length > 0 || !urlIsValid || !hasHostConfigKey;
+
+  if (urlIsValid) {
+    const isHttpsUrl = callbackUrl.toLowerCase().startsWith('https:');
+    if (!isHttpsUrl && !hasValidCert) {
+      disabledNext = true;
     }
-
-    // For HTTPS URL, if the TLS confirmation is not checked, require certificate
-    if (
-      !tlsConfirmation &&
-      (!tlsCertificateAuthority || tlsCertificateAuthority.trim() === '')
-    ) {
-      errors.certificate =
-        'HTTPS URL requires either a custom TLS certificate or confirmation that no custom certificate is needed';
+    if (isHttpsUrl && !tlsConfirmation && !hasValidCert) {
+      disabledNext = true;
     }
   }
 
-  return { errors, disabledNext: Object.keys(errors).length > 0 };
+  return { errors, disabledNext };
 }
 
 const validatePartitionSize = (

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -919,7 +919,10 @@ export const wizardSlice = createSlice({
       state.aapRegistration.callbackUrl = action.payload;
     },
 
-    changeAapHostConfigKey: (state, action: PayloadAction<string>) => {
+    changeAapHostConfigKey: (
+      state,
+      action: PayloadAction<string | undefined>,
+    ) => {
       state.aapRegistration.hostConfigKey = action.payload;
     },
     changeAapTlsCertificateAuthority: (


### PR DESCRIPTION
The default state consisted of various errors, now the behavior is more controlled
<img width="1506" height="878" alt="aap" src="https://github.com/user-attachments/assets/662537f0-efae-4a97-b6c0-4a999355641f" />
