### PR TITLE
deps: Remove `classnames`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@scalprum/react-core": "0.11.1",
         "@sentry/webpack-plugin": "5.2.1",
         "@unleash/proxy-client-react": "5.0.1",
-        "classnames": "2.5.1",
         "jwt-decode": "4.0.0",
         "lodash": "4.18.1",
         "react": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@scalprum/react-core": "0.11.1",
     "@sentry/webpack-plugin": "5.2.1",
     "@unleash/proxy-client-react": "5.0.1",
-    "classnames": "2.5.1",
     "jwt-decode": "4.0.0",
     "lodash": "4.18.1",
     "react": "18.3.1",


### PR DESCRIPTION
I believe this dep isn't needed and it was also last updated 2 years ago. Might as well drop it.