### PR TITLE
Wizard/Packages: Fix recommendationsShown flag in analytics event

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -685,7 +685,7 @@ const PackageSearch = ({
           module: AMPLITUDE_MODULE_NAME,
           isPreview: isBeta(),
           selectedPackages: packages.map((pkg) => pkg.name),
-          recommendationsShown: false,
+          recommendationsShown: transformedRecommendations.length > 0,
         },
       );
       setHasTrackedOpen(true);


### PR DESCRIPTION
## Summary
- Fixes the `recommendationsShown` property in the "Package Search Dropdown Opened" analytics event (HMS-9397)
- Was hardcoded to `false`; now checks `transformedRecommendations.length > 0` so it correctly reflects cached recommendations on dropdown re-opens

## Test plan
- [ ] Open the packages step, open the search dropdown — `recommendationsShown` should be `false` (recommendations not yet loaded)
- [ ] Close and re-open the dropdown — `recommendationsShown` should be `true` (recommendations cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)