### PR TITLE
Wizard: Filter out empty users from review step (HMS-10691)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Users.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Users.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { Flex, Truncate } from '@patternfly/react-core';
 
 import { useAppSelector } from '@/store/hooks';
-import { selectUsers } from '@/store/slices';
+import { selectNonEmptyUsers } from '@/store/slices/wizard';
 
 import { FlexColumn, ReviewGroup, StatusItem } from '../../shared';
 import { Hideable } from '../../types';
 
 export const Users = ({ shouldHide }: Hideable) => {
-  const users = useAppSelector(selectUsers);
+  const users = useAppSelector(selectNonEmptyUsers);
 
   if (shouldHide || users.length === 0) {
     return null;

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -726,6 +726,51 @@ echo 'Hello there, General Kenobi!'`;
       expect(screen.queryByText('Users')).not.toBeInTheDocument();
     });
 
+    test('does not render users section when only empty users exist', () => {
+      renderWithRedux(
+        <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['guest-image'],
+          users: [
+            {
+              name: '',
+              password: '',
+              hasPassword: false,
+              ssh_key: '',
+              groups: [],
+              isAdministrator: false,
+            },
+          ],
+        },
+      );
+
+      expect(screen.queryByText('Users')).not.toBeInTheDocument();
+    });
+
+    test('filters out empty users and renders only non-empty ones', () => {
+      renderWithRedux(
+        <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['guest-image'],
+          users: [
+            {
+              name: '',
+              password: '',
+              hasPassword: false,
+              ssh_key: '',
+              groups: [],
+              isAdministrator: false,
+            },
+            adminUser,
+          ],
+        },
+      );
+
+      expect(screen.getByText('Users')).toBeInTheDocument();
+      expect(screen.getByText('admin')).toBeInTheDocument();
+      expect(screen.getAllByText('*****')).toHaveLength(1);
+    });
+
     test('displays users heading when users are configured', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -559,6 +559,16 @@ export const selectUsers = (state: RootState) => {
   return state.wizard.users;
 };
 
+export const selectNonEmptyUsers = (state: RootState) => {
+  return state.wizard.users.filter(
+    (user) =>
+      user.name.trim() ||
+      user.password.trim() ||
+      user.ssh_key.trim() ||
+      user.hasPassword,
+  );
+};
+
 export const selectUserGroups = (state: RootState) => {
   return state.wizard.userGroups;
 };


### PR DESCRIPTION
When a user was added and then removed, an empty user object remained in the Redux store. 
The review step displayed it because it only checked users.length === 0, showing a blank row with no meaningful data.

Filter out users that have no name, password, SSH key, or stored password before rendering the review section.

ISSUE IN GITHUB: 4423
JIRA: 4423
