### PR TITLE
CIWatch: Improve boot test agent messages

### DIFF
--- a/.github/workflows/boot-tests-nightly.yml
+++ b/.github/workflows/boot-tests-nightly.yml
@@ -139,7 +139,13 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ matrix.channel.id }}
-            text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *SUCCESS* :partymeow:"
+            attachments:
+              - color: "#2EB67D"
+                blocks:
+                  - type: section
+                    text:
+                      type: mrkdwn
+                      text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *SUCCESS* :partymeow:"
 
       - name: Notify Slack on failure
         id: slack-failure
@@ -150,7 +156,13 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             channel: ${{ matrix.channel.id }}
-            text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *FAILED* :big-sad:"
+            attachments:
+              - color: "#E01E5A"
+                blocks:
+                  - type: section
+                    text:
+                      type: mrkdwn
+                      text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *FAILED* :big-sad:"
 
       - name: Save Slack message ts
         if: ${{ (needs.boot-tests.result == 'failure' || github.event.inputs.run_id != '') && github.run_attempt == '1' }}
@@ -188,7 +200,13 @@ jobs:
           payload: |
             channel: ${{ matrix.channel.id }}
             ts: ${{ steps.slack-ts.outputs.ts }}
-            text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: ~*FAILED*~ *PASSED on retry* (attempt ${{ github.run_attempt }}) :partymeow:"
+            attachments:
+              - color: "#2EB67D"
+                blocks:
+                  - type: section
+                    text:
+                      type: mrkdwn
+                      text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: ~*FAILED*~ *PASSED on retry* (attempt ${{ github.run_attempt }}) :partymeow:"
 
   # Analyze test failures with Claude Code (via Vertex AI) — only on first attempt
   # SECURITY: This job only has Vertex AI secrets — no Slack tokens, no other credentials.
@@ -227,6 +245,20 @@ jobs:
           path: playwright-report/
           run-id: ${{ github.event.inputs.run_id || github.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Download boot-tests job log
+        run: |
+          JOB_ID=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.name == "boot-tests") | .id')
+          if [ -n "$JOB_ID" ]; then
+            gh api "repos/${{ github.repository }}/actions/jobs/${JOB_ID}/logs" > ci-logs.txt
+          else
+            echo "Could not find boot-tests job" > ci-logs.txt
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.inputs.run_id || github.run_id }}
         continue-on-error: true
 
       - name: Install Claude Code
@@ -341,8 +373,19 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: ${{ steps.analysis-payload.outputs.json }}
 
-      - name: Update original message with analysis indicator
-        if: ${{ steps.analysis-payload.outputs.json }}
+      - name: Read classification
+        id: classification
+        if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'success' }}
+        run: |
+          CLASSIFICATION=$(cat boot-test-reports/classification.txt 2>/dev/null || echo "UNKNOWN")
+          CLASSIFICATION=$(echo "$CLASSIFICATION" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
+          echo "value=$CLASSIFICATION" >> "$GITHUB_OUTPUT"
+          if [ "$CLASSIFICATION" = "FLAKE" ] || [ "$CLASSIFICATION" = "INFRASTRUCTURE" ]; then
+            echo "retriable=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update original message — rerun in progress
+        if: ${{ steps.classification.outputs.retriable && steps.slack-ts.outputs.ts }}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           method: chat.update
@@ -350,7 +393,13 @@ jobs:
           payload: |
             channel: ${{ matrix.channel.id }}
             ts: ${{ steps.slack-ts.outputs.ts }}
-            text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *FAILED* :big-sad: — :memo::arrow_down:"
+            attachments:
+              - color: "#1445f7"
+                blocks:
+                  - type: section
+                    text:
+                      type: mrkdwn
+                      text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *FAILED* :big-sad: :arrows_counterclockwise:"
 
       - name: Notify analysis failure
         if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'failure' && steps.slack-ts.outputs.ts }}
@@ -364,19 +413,14 @@ jobs:
             text: ":warning: Automated analysis failed — could not classify this failure. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/|View run>"
 
       # Only rerun from one matrix instance to avoid duplicate reruns
-      - name: Rerun if flake
-        if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'success' && github.event.inputs.run_id == '' && (matrix.channel.name == 'main' || matrix.channel.name == 'manual') }}
+      - name: Rerun if retriable
+        if: ${{ steps.classification.outputs.retriable && github.event.inputs.run_id == '' && (matrix.channel.name == 'main' || matrix.channel.name == 'manual') }}
         run: |
-          CLASSIFICATION=$(cat boot-test-reports/classification.txt 2>/dev/null || echo "UNKNOWN")
-          CLASSIFICATION=$(echo "$CLASSIFICATION" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
-          if [ "$CLASSIFICATION" = "FLAKE" ]; then
-            echo "Classified as FLAKE — rerunning failed jobs (attempt ${{ github.run_attempt }})"
-            gh run rerun ${{ github.run_id }} --failed --repo ${{ github.repository }}
-          else
-            echo "Classified as $CLASSIFICATION — not rerunning"
-          fi
+          echo "Classified as $CLASSIFICATION — rerunning failed jobs (attempt ${{ github.run_attempt }})"
+          gh run rerun ${{ github.run_id }} --failed --repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLASSIFICATION: ${{ steps.classification.outputs.value }}
 
       # --- Attempt 2+: post a short thread reply ---
       - name: Post retry failure to Slack
@@ -389,3 +433,20 @@ jobs:
             channel: ${{ matrix.channel.id }}
             thread_ts: ${{ steps.slack-ts.outputs.ts }}
             text: ":x: Retry attempt ${{ github.run_attempt }} also failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/|View run>"
+
+      - name: Revert original message on retry failure
+        if: ${{ github.run_attempt != '1' && steps.slack-ts.outputs.ts }}
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ matrix.channel.id }}
+            ts: ${{ steps.slack-ts.outputs.ts }}
+            attachments:
+              - color: "#E01E5A"
+                blocks:
+                  - type: section
+                    text:
+                      type: mrkdwn
+                      text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *FAILED* :big-sad:"

--- a/.github/workflows/boot-tests-nightly.yml
+++ b/.github/workflows/boot-tests-nightly.yml
@@ -93,84 +93,83 @@ jobs:
           path: test-results.json
           retention-days: 10
 
-  # Post success/failure notifications to Slack
-  # Isolated from Claude analysis — secrets here are NOT accessible to the analyze-failures job
-  notify-slack:
+  # Compute which Slack channels to notify based on trigger type.
+  # Scheduled runs notify both channels; manual runs with slack_channel_id notify only that channel.
+  prepare-channels:
     runs-on: ubuntu-latest
-    needs: boot-tests
-    if: >-
-      always() &&
-      (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.slack_channel_id != ''))
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.slack_channel_id != '')
     permissions: {}
     outputs:
-      slack-ts: ${{ steps.slack-ts.outputs.ts }}
+      channels: ${{ steps.set.outputs.channels }}
+    steps:
+      - name: Build channel list
+        id: set
+        run: |
+          if [ -n "$MANUAL" ]; then
+            echo 'channels=[{"id":"'"$MANUAL"'","name":"manual"}]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'channels=[{"id":"'"$MAIN"'","name":"main"},{"id":"'"$FRONTEND"'","name":"frontend"}]' >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          MANUAL: ${{ github.event.inputs.slack_channel_id }}
+          MAIN: ${{ vars.SLACK_CHANNEL_ID }}
+          FRONTEND: ${{ vars.SLACK_FRONTEND_CHANNEL_ID }}
+
+  # Post success/failure notifications to Slack.
+  # Isolated from Claude analysis — secrets here are NOT accessible to the analyze-failures job.
+  # Uses a matrix to post to all target channels without duplicating steps.
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs: [boot-tests, prepare-channels]
+    if: >-
+      always() &&
+      needs.prepare-channels.result == 'success'
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: ${{ fromJSON(needs.prepare-channels.outputs.channels) }}
 
     steps:
       - name: Notify Slack on success
-        uses: slackapi/slack-github-action@v2.1.1
         if: ${{ needs.boot-tests.result == 'success' }}
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ github.event.inputs.slack_channel_id || vars.SLACK_CHANNEL_ID }}
-            text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *SUCCESS* :partymeow:"
-
-      - name: Notify Slack on success (Frontend)
         uses: slackapi/slack-github-action@v2.1.1
-        if: ${{ needs.boot-tests.result == 'success' && github.event.inputs.slack_channel_id == '' }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ vars.SLACK_FRONTEND_CHANNEL_ID }}
+            channel: ${{ matrix.channel.id }}
             text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *SUCCESS* :partymeow:"
 
       - name: Notify Slack on failure
         id: slack-failure
-        uses: slackapi/slack-github-action@v2.1.1
         if: ${{ (needs.boot-tests.result == 'failure' || github.event.inputs.run_id != '') && github.run_attempt == '1' }}
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ github.event.inputs.slack_channel_id || vars.SLACK_CHANNEL_ID }}
-            text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *FAILED* :big-sad:"
-
-      - name: Notify Slack on failure (Frontend)
-        id: slack-failure-frontend
         uses: slackapi/slack-github-action@v2.1.1
-        if: ${{ (needs.boot-tests.result == 'failure' || github.event.inputs.run_id != '') && github.run_attempt == '1' && github.event.inputs.slack_channel_id == '' }}
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ vars.SLACK_FRONTEND_CHANNEL_ID }}
+            channel: ${{ matrix.channel.id }}
             text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *FAILED* :big-sad:"
 
-      # Save the Slack message timestamps so later rerun attempts can thread replies
       - name: Save Slack message ts
         if: ${{ (needs.boot-tests.result == 'failure' || github.event.inputs.run_id != '') && github.run_attempt == '1' }}
-        run: |
-          echo "${{ steps.slack-failure.outputs.ts }}" > slack-ts.txt
-          echo "${{ steps.slack-failure-frontend.outputs.ts }}" > slack-ts-frontend.txt
+        run: echo "${{ steps.slack-failure.outputs.ts }}" > slack-ts.txt
 
       - name: Upload Slack ts artifact
         if: ${{ (needs.boot-tests.result == 'failure' || github.event.inputs.run_id != '') && github.run_attempt == '1' }}
         uses: actions/upload-artifact@v4
         with:
-          name: slack-ts
-          path: |
-            slack-ts.txt
-            slack-ts-frontend.txt
+          name: slack-ts-${{ matrix.channel.name }}
+          path: slack-ts.txt
           overwrite: true
 
-      # On rerun attempts, retrieve the original message ts (needed for both failure threading and success updates)
+      # On rerun attempts, retrieve the original message ts
       - name: Download Slack ts artifact
         if: ${{ github.run_attempt != '1' }}
         uses: actions/download-artifact@v4
         with:
-          name: slack-ts
+          name: slack-ts-${{ matrix.channel.name }}
         continue-on-error: true
 
       - name: Read Slack message ts
@@ -179,11 +178,7 @@ jobs:
           if [ -f slack-ts.txt ]; then
             echo "ts=$(cat slack-ts.txt)" >> "$GITHUB_OUTPUT"
           fi
-          if [ -f slack-ts-frontend.txt ]; then
-            echo "ts_frontend=$(cat slack-ts-frontend.txt)" >> "$GITHUB_OUTPUT"
-          fi
 
-      # If a retry succeeded, update the original failure messages
       - name: Update original message on retry success
         if: ${{ needs.boot-tests.result == 'success' && github.run_attempt != '1' && steps.slack-ts.outputs.ts }}
         uses: slackapi/slack-github-action@v2.1.1
@@ -191,19 +186,8 @@ jobs:
           method: chat.update
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ github.event.inputs.slack_channel_id || vars.SLACK_CHANNEL_ID }}
+            channel: ${{ matrix.channel.id }}
             ts: ${{ steps.slack-ts.outputs.ts }}
-            text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: ~*FAILED*~ *PASSED on retry* (attempt ${{ github.run_attempt }}) :partymeow:"
-
-      - name: Update original message on retry success (Frontend)
-        if: ${{ needs.boot-tests.result == 'success' && github.run_attempt != '1' && steps.slack-ts.outputs.ts_frontend }}
-        uses: slackapi/slack-github-action@v2.1.1
-        with:
-          method: chat.update
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            channel: ${{ vars.SLACK_FRONTEND_CHANNEL_ID }}
-            ts: ${{ steps.slack-ts.outputs.ts_frontend }}
             text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: ~*FAILED*~ *PASSED on retry* (attempt ${{ github.run_attempt }}) :partymeow:"
 
   # Analyze test failures with Claude Code (via Vertex AI) — only on first attempt
@@ -280,20 +264,25 @@ jobs:
 
   # Post Claude's analysis to Slack and rerun flaky tests (attempt 1),
   # or post a short "retry also failed" thread reply (attempt 2+).
+  # Uses the same channel matrix as notify-slack to avoid step duplication.
   # NOTE: When dispatched with run_id only (no slack_channel_id), this job is
   # intentionally skipped — analyze-failures still runs and uploads reports as
   # artifacts, but nothing posts them. Use this mode to re-analyze a past run
   # and download the results manually.
   post-analysis:
     runs-on: ubuntu-latest
-    needs: [boot-tests, analyze-failures, notify-slack]
+    needs: [boot-tests, analyze-failures, notify-slack, prepare-channels]
     if: >-
       always() &&
+      needs.prepare-channels.result == 'success' &&
       (needs.boot-tests.result == 'failure' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_id != '')) &&
-      (needs.analyze-failures.result == 'success' || needs.analyze-failures.result == 'skipped' || needs.analyze-failures.result == 'failure') &&
-      (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.slack_channel_id != ''))
+      (needs.analyze-failures.result == 'success' || needs.analyze-failures.result == 'skipped' || needs.analyze-failures.result == 'failure')
     permissions:
       actions: write
+    strategy:
+      fail-fast: false
+      matrix:
+        channel: ${{ fromJSON(needs.prepare-channels.outputs.channels) }}
 
     steps:
       # --- Attempt 1: post Claude's analysis and rerun if flake ---
@@ -304,9 +293,22 @@ jobs:
           name: reports
           path: boot-test-reports/
 
+      - name: Download Slack ts artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: slack-ts-${{ matrix.channel.name }}
+        continue-on-error: true
+
+      - name: Read Slack message ts
+        id: slack-ts
+        run: |
+          if [ -f slack-ts.txt ]; then
+            echo "ts=$(cat slack-ts.txt)" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build analysis payload
         id: analysis-payload
-        if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'success' && needs.notify-slack.outputs.slack-ts }}
+        if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'success' && steps.slack-ts.outputs.ts }}
         run: |
           if [ ! -f boot-test-reports/latest.md ]; then
             echo "::warning::Claude did not produce boot-test-reports/latest.md"
@@ -328,8 +330,8 @@ jobs:
             echo "PAYLOAD_EOF"
           } >> "$GITHUB_OUTPUT"
         env:
-          SLACK_CHANNEL_ID: ${{ github.event.inputs.slack_channel_id || vars.SLACK_CHANNEL_ID }}
-          THREAD_TS: ${{ needs.notify-slack.outputs.slack-ts }}
+          SLACK_CHANNEL_ID: ${{ matrix.channel.id }}
+          THREAD_TS: ${{ steps.slack-ts.outputs.ts }}
 
       - name: Post analysis to Slack
         if: ${{ steps.analysis-payload.outputs.json }}
@@ -339,19 +341,31 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: ${{ steps.analysis-payload.outputs.json }}
 
+      - name: Update original message with analysis indicator
+        if: ${{ steps.analysis-payload.outputs.json }}
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ matrix.channel.id }}
+            ts: ${{ steps.slack-ts.outputs.ts }}
+            text: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/ | :stars: Nightly boot test run>: *FAILED* :big-sad: — :memo::arrow_down:"
+
       - name: Notify analysis failure
-        if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'failure' && needs.notify-slack.outputs.slack-ts }}
+        if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'failure' && steps.slack-ts.outputs.ts }}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ github.event.inputs.slack_channel_id || vars.SLACK_CHANNEL_ID }}
-            thread_ts: ${{ needs.notify-slack.outputs.slack-ts }}
+            channel: ${{ matrix.channel.id }}
+            thread_ts: ${{ steps.slack-ts.outputs.ts }}
             text: ":warning: Automated analysis failed — could not classify this failure. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/|View run>"
 
+      # Only rerun from one matrix instance to avoid duplicate reruns
       - name: Rerun if flake
-        if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'success' && github.event.inputs.run_id == '' }}
+        if: ${{ github.run_attempt == '1' && needs.analyze-failures.result == 'success' && github.event.inputs.run_id == '' && (matrix.channel.name == 'main' || matrix.channel.name == 'manual') }}
         run: |
           CLASSIFICATION=$(cat boot-test-reports/classification.txt 2>/dev/null || echo "UNKNOWN")
           CLASSIFICATION=$(echo "$CLASSIFICATION" | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
@@ -366,12 +380,12 @@ jobs:
 
       # --- Attempt 2+: post a short thread reply ---
       - name: Post retry failure to Slack
-        if: ${{ github.run_attempt != '1' && needs.notify-slack.outputs.slack-ts }}
+        if: ${{ github.run_attempt != '1' && steps.slack-ts.outputs.ts }}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
-            channel: ${{ github.event.inputs.slack_channel_id || vars.SLACK_CHANNEL_ID }}
-            thread_ts: ${{ needs.notify-slack.outputs.slack-ts }}
+            channel: ${{ matrix.channel.id }}
+            thread_ts: ${{ steps.slack-ts.outputs.ts }}
             text: ":x: Retry attempt ${{ github.run_attempt }} also failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/|View run>"

--- a/boot-test-instructions.md
+++ b/boot-test-instructions.md
@@ -24,12 +24,16 @@ You have access to:
 - The checked-out repository source code (read-only)
 - `test-results.json` in the working directory (Playwright JSON reporter output), OR
   `playwright-report/` directory (HTML report fallback for older runs)
+- `ci-logs.txt` in the working directory — full GitHub Actions log from the boot-tests job.
+  Check this if test results are missing or incomplete (runner errors, infra failures).
 - The GitHub Actions run URL is appended to this prompt — include it in your report
 
 ## Workflow
 
 1. **Read the test results.** Check for `test-results.json` first — if it exists,
    use it as your primary source. Fall back to `playwright-report/` if not found.
+   If neither exists, read `ci-logs.txt` to determine what went wrong at the
+   runner/infrastructure level.
 2. **If all tests passed** — write a green report and stop.
 3. **If tests failed:**
    a. For each failed test:
@@ -45,6 +49,7 @@ You have access to:
       - **FLAKE** — non-deterministic (timing, network, resource contention)
       - **EXTERNAL** — a dependency or service covered by integration tests changed behavior
       - **BUG** — genuine issue in our code or tests
+      - **INFRASTRUCTURE** — runner or CI environment failure (Docker, npm install, server startup, OOM, network)
 4. **Produce the final report:**
    - Write the classification to `boot-test-reports/classification.txt` (just the word: FLAKE, EXTERNAL, or BUG).
    - Write the full analysis to `boot-test-reports/latest.md`, following the template below.
@@ -89,10 +94,11 @@ Both failures are timing-related flakes under load, no code changes involved. Sa
 - Extract the Currents run URL from `ci-logs.txt` (look for `https://app.currents.dev/run/...`) and include it next to the GH Run link. If not found, omit it.
 - Every failed test in the report MUST include the error message.
 - Keep headers/labels terse. Give detailed analysis in the probable cause section.
-- Write the classification (FLAKE, EXTERNAL, or BUG) to `boot-test-reports/classification.txt`.
+- Write the classification (FLAKE, EXTERNAL, BUG, or INFRASTRUCTURE) to `boot-test-reports/classification.txt`.
 - Write the full report to `boot-test-reports/latest.md`.
 - Keep the Failed tests section very brief
 - For FLAKE classification use :large_yellow_circle: emoji
 - For BUG classification use :red_circle: emoji
 - For EXTERNAL classification use :large_orange_circle: emoji
+- For INFRASTRUCTURE classification use :swanson_computer: emoji
 

--- a/boot-test-instructions.md
+++ b/boot-test-instructions.md
@@ -56,27 +56,41 @@ Keep headers/labels terse but give detailed analysis in the probable cause.
 The GH Run link MUST be present.
 If a rerun was triggered by the workflow, add a line about it at the end.
 
+IMPORTANT: The report is posted to Slack, so you MUST use Slack mrkdwn syntax:
+- Bold: `*bold*` (single asterisks, NOT double `**`)
+- Links: `<url|text>` (NOT `[text](url)`)
+- Code: `` `code` `` (backticks work the same)
+
 ```
-**Boot Test Report — 2026-03-26**
-:warning: **FLAKE** | 2 test(s) failed
+*Boot Test Report — 2026-03-26*
+:large_yellow_circle: *FLAKE* | 2 test(s) failed
+:github-664: <https://github.com/org/repo/actions/runs/12345|Run link>
+~--------------------------------------------~
+:x: *Failed tests:*
 
-[GH Run](https://github.com/org/repo/actions/runs/12345)
+• *Image Builder > Create blueprint* — timed out clicking a "Create Blueprint" button; likely slow API response under load
+Error: `TimeoutError: locator.click: Timeout 30000ms exceeded`
 
-**Failed tests:**
-
-• Image Builder > Create blueprint — `TimeoutError: locator.click: Timeout 30000ms exceeded`
-  Likely a timing issue — the "Create" button renders after an async API call to image-builder service. Under load the response takes >30s. This test has failed 3 times this week with the same timeout, confirming flakiness rather than a real regression.
-
-• Wizard > Select AWS target — `Error: expect(locator).toBeVisible() — element not found`
-  The AWS target card depends on a feature flag fetched from chrome-service. Probably a race condition where the wizard renders before the feature flags response arrives. No code changes to this area in recent commits.
+• *Wizard > Select AWS target* — element not found; likely race condition with feature flag fetch
+Error: `Error: expect(locator).toBeVisible() — element not found`
+~--------------------------------------------~
+:large_blue_circle: *Summary:*
+Both failures are timing-related flakes under load, no code changes involved. Safe to ignore if rerun passes.
 
 :arrows_counterclockwise: Rerun of failed jobs triggered automatically.
+~--------------------------------------------~
 ```
 
 ## Rules — DO NOT SKIP
 
+- The report MUST use Slack mrkdwn syntax (NOT Markdown). `*bold*` not `**bold**`, `<url|text>` not `[text](url)`.
 - The report MUST contain a link to the GitHub Actions run.
 - Every failed test in the report MUST include the error message.
 - Keep headers/labels terse. Give detailed analysis in the probable cause section.
 - Write the classification (FLAKE, EXTERNAL, or BUG) to `boot-test-reports/classification.txt`.
 - Write the full report to `boot-test-reports/latest.md`.
+- Keep the Failed tests section very brief
+- For FLAKE classification use :large_yellow_circle: emoji
+- For BUG classification use :red_circle: emoji
+- For EXTERNAL classification use :large_orange_circle: emoji
+

--- a/boot-test-instructions.md
+++ b/boot-test-instructions.md
@@ -65,6 +65,7 @@ IMPORTANT: The report is posted to Slack, so you MUST use Slack mrkdwn syntax:
 *Boot Test Report — 2026-03-26*
 :large_yellow_circle: *FLAKE* | 2 test(s) failed
 :github-664: <https://github.com/org/repo/actions/runs/12345|Run link>
+:playwright: <https://app.currents.dev/run/666bfb835a936797|Currents link>
 ~--------------------------------------------~
 :x: *Failed tests:*
 
@@ -85,6 +86,7 @@ Both failures are timing-related flakes under load, no code changes involved. Sa
 
 - The report MUST use Slack mrkdwn syntax (NOT Markdown). `*bold*` not `**bold**`, `<url|text>` not `[text](url)`.
 - The report MUST contain a link to the GitHub Actions run.
+- Extract the Currents run URL from `ci-logs.txt` (look for `https://app.currents.dev/run/...`) and include it next to the GH Run link. If not found, omit it.
 - Every failed test in the report MUST include the error message.
 - Keep headers/labels terse. Give detailed analysis in the probable cause section.
 - Write the classification (FLAKE, EXTERNAL, or BUG) to `boot-test-reports/classification.txt`.


### PR DESCRIPTION
**Changes**:

- Re-introduced color indication of the result in the original message
- Added a indication of triggering a retry
- Fixed the markdown formatting
- Added `INFRASTRUCTURE` classification for infra issues
- Added access to GH job logs themselves instead of just using the PW report
- Reworked the action to be a matrix job - removed some redundancy
- Analysis is now sent to both channels

---

**Before**:
<img width="956" height="408" alt="image" src="https://github.com/user-attachments/assets/1e5bf500-9c60-46a7-a4b8-72c4bc1f498c" />

**After**:
<img width="959" height="461" alt="image" src="https://github.com/user-attachments/assets/8b271312-43eb-49f6-8d68-7f1229bee39e" />

