### PR TITLE
playwright: fix tmt

### DIFF
--- a/schutzbot/playwright_tests.sh
+++ b/schutzbot/playwright_tests.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
-TMT_SOURCE_DIR=${TMT_SOURCE_DIR:-}
 PW_WORKERS=4
-if [ -n "$TMT_SOURCE_DIR" ]; then
+if [ -n "${TMT_TREE:-}" ]; then
     # Move to the directory with sources
-    cd "${TMT_SOURCE_DIR}/cockpit-image-builder"
+    cd "${TMT_TREE}"
     npm ci
 elif [ "${CI:-}" != "true" ]; then
-    # packit drops us into the schutzbot directory
     cd ../
     npm ci
     # halve the workers on schutzbot to increase reliability


### PR DESCRIPTION
The testing-farm tests have started failing with this error message
`./playwright_tests.sh: line 8: cd:
/var/ARTIFACTS/work-main3voo2o5b/plans/all/main/discover/default-0/source/cockpit-image-builder:
No such file or directory Shared connection to 3.145.30.21 closed.`

I am not sure what changed or where (Packit? TMT?) but after reading the
TMT docs it seems like we should be using TMT_TREE instead of
TMT_SOURCE_DIR.

TMT_SOURCE_DIR seems to be intended for use with dist-git style repositories:
https://tmt.readthedocs.io/en/1.71.0/spec/plans.html#dist-git-source

TMT_TREE seems to be what we want:
https://tmt.readthedocs.io/en/1.71.0/glossary.html#term-work-tree

“Copy of the user tree stored under plan-workdir/tree. Path to this
directory is available in the TMT_TREE environment variable, e.g.
/var/tmp/tmt/run-123/plans/core/tree. See Work Tree for details.”

I also think this comment: `# packit drops us into the schutzbot
directory` must be stale – Packit kicks off the testing-farm tests so
this shouldn’t be in the elif clause. Removed it.