### PR TITLE
Move useSearchLanguagePacks hook to contentSources (HMS-107670)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Locale/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/index.tsx
@@ -4,7 +4,7 @@ import { Content, Form, Spinner, Title } from '@patternfly/react-core';
 
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useGetArchitecturesQuery } from '@/store/api/backend';
-import { useSearchLanguagePacks } from '@/store/api/distributions';
+import { useSearchLanguagePacks } from '@/store/api/contentSources';
 import { useAppSelector } from '@/store/hooks';
 import {
   selectArchitecture,

--- a/src/store/api/contentSources/hooks.tsx
+++ b/src/store/api/contentSources/hooks.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react';
+
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import {
+  selectArchitecture,
+  selectDistribution,
+  selectIsOnPremise,
+  selectLocaleLangpackCandidates,
+  setVerifiedLocaleLangpacks,
+} from '@/store/slices';
+import { asDistribution } from '@/store/typeGuards';
+
+import { contentSourcesApi as hostedApi } from './hosted';
+import { contentSourcesApi as onPremApi } from './onprem';
+
+const extractPackageNames = (data: { package_name?: string }[]): string[] =>
+  Array.from(
+    new Set(data.flatMap((d) => (d.package_name ? [d.package_name] : []))),
+  );
+
+export const useSearchLanguagePacks = (distroUrls: string[]) => {
+  const isOnPremise = useAppSelector(selectIsOnPremise);
+  const dispatch = useAppDispatch();
+  const distribution = useAppSelector(selectDistribution);
+  const arch = useAppSelector(selectArchitecture);
+  const candidateLangpacks = useAppSelector(selectLocaleLangpackCandidates);
+
+  // `isOnPremise` is derived from `process.env.IS_ON_PREMISE`, which is
+  // a build-time constant set by webpack. It will never change between
+  // renders, so this conditional does not violate the Rules of Hooks —
+  // the same branch is always taken for the lifetime of the application.
+  // We also access `.endpoints` directly to avoid circular dependencies.
+  const { endpoints } = isOnPremise ? onPremApi : hostedApi;
+  const [searchRpms, { isLoading: isSearchLoading }] =
+    endpoints.searchRpm.useMutation();
+
+  useEffect(() => {
+    if (candidateLangpacks.length === 0) {
+      dispatch(setVerifiedLocaleLangpacks([]));
+      return;
+    }
+    if (!process.env.IS_ON_PREMISE && distroUrls.length === 0) {
+      return;
+    }
+
+    let cancelled = false;
+    const run = async () => {
+      const request = process.env.IS_ON_PREMISE
+        ? {
+            packages: candidateLangpacks,
+            architecture: arch,
+            distribution: asDistribution(distribution),
+          }
+        : { exact_names: candidateLangpacks, urls: distroUrls, limit: 500 };
+
+      try {
+        const data = await searchRpms({
+          apiContentUnitSearchRequest: request,
+        }).unwrap();
+        const verified = extractPackageNames(
+          data as { package_name?: string }[],
+        );
+        if (!cancelled) dispatch(setVerifiedLocaleLangpacks(verified));
+      } catch {
+        if (!cancelled) dispatch(setVerifiedLocaleLangpacks([]));
+      }
+    };
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    arch,
+    distribution,
+    distroUrls,
+    dispatch,
+    candidateLangpacks,
+    searchRpms,
+  ]);
+
+  return { isLoading: isSearchLoading };
+};

--- a/src/store/api/contentSources/index.ts
+++ b/src/store/api/contentSources/index.ts
@@ -1,6 +1,7 @@
 import * as hostedQueries from './hosted';
 import * as onpremQueries from './onprem';
 
+export * from './hooks';
 export type * from './hosted';
 
 // Hooks with different implementations for hosted vs on-prem

--- a/src/store/api/distributions/hooks.tsx
+++ b/src/store/api/distributions/hooks.tsx
@@ -1,19 +1,16 @@
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { simpleTargetNames } from '@/constants';
 import { ImageTypes } from '@/store/api/backend';
-import { useSearchRpmMutation } from '@/store/api/contentSources';
-import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
   selectArchitecture,
   selectDistribution,
   selectImageTypes,
   selectIsImageMode,
-  selectLocaleLangpackCandidates,
-  setVerifiedLocaleLangpacks,
 } from '@/store/slices/wizard';
-import { asDistribution, isImageType } from '@/store/typeGuards';
+import { isImageType } from '@/store/typeGuards';
 import isRhel from '@/Utilities/isRhel';
 
 import { ALL_CUSTOMIZATIONS } from './constants';
@@ -244,63 +241,4 @@ export const useImageTypeCustomizationSupport = (
     isOnPremise,
     isRhel: isRhel(distro),
   });
-};
-
-const extractPackageNames = (data: { package_name?: string }[]): string[] =>
-  Array.from(
-    new Set(data.flatMap((d) => (d.package_name ? [d.package_name] : []))),
-  );
-
-export const useSearchLanguagePacks = (distroUrls: string[]) => {
-  const dispatch = useAppDispatch();
-  const distribution = useAppSelector(selectDistribution);
-  const arch = useAppSelector(selectArchitecture);
-  const candidateLangpacks = useAppSelector(selectLocaleLangpackCandidates);
-  const [searchRpms, { isLoading: isSearchLoading }] = useSearchRpmMutation();
-
-  useEffect(() => {
-    if (candidateLangpacks.length === 0) {
-      dispatch(setVerifiedLocaleLangpacks([]));
-      return;
-    }
-    if (!process.env.IS_ON_PREMISE && distroUrls.length === 0) {
-      return;
-    }
-
-    let cancelled = false;
-    const run = async () => {
-      const request = process.env.IS_ON_PREMISE
-        ? {
-            packages: candidateLangpacks,
-            architecture: arch,
-            distribution: asDistribution(distribution),
-          }
-        : { exact_names: candidateLangpacks, urls: distroUrls, limit: 500 };
-
-      try {
-        const data = await searchRpms({
-          apiContentUnitSearchRequest: request,
-        }).unwrap();
-        const verified = extractPackageNames(
-          data as { package_name?: string }[],
-        );
-        if (!cancelled) dispatch(setVerifiedLocaleLangpacks(verified));
-      } catch {
-        if (!cancelled) dispatch(setVerifiedLocaleLangpacks([]));
-      }
-    };
-    run();
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    arch,
-    distribution,
-    distroUrls,
-    dispatch,
-    candidateLangpacks,
-    searchRpms,
-  ]);
-
-  return { isLoading: isSearchLoading };
 };


### PR DESCRIPTION
## Summary
Relocates `useSearchLanguagePacks` from the distributions API module to contentSources, where its underlying `useSearchRpmMutation` is defined.

## Changes
- Move `useSearchLanguagePacks` hook and helper to `src/store/api/contentSources/hooks.tsx`
- Export the hook from the contentSources index
- Update the Locale step import path
- Clean up unused imports in distributions/hooks.tsx

Resolves #4447