### PR TITLE
tests: Temporarily disable Compliance tests

### DIFF
--- a/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
@@ -28,6 +28,8 @@ import { OpenStackWrapper } from '../helpers/OpenStackWrapper';
 test.use({ storageState: { cookies: [], origins: [] } });
 
 test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
+  // TODO: Re-enable once compliance once compliance is working again
+  test.skip(true, 'Compliance tests are temporarily disabled.');
   test.skip(
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',

--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -31,6 +31,8 @@ test('Create a blueprint with Compliance policy selected', async ({
   page,
   cleanup,
 }) => {
+  // TODO: Re-enable once compliance once compliance is working again
+  test.skip(true, 'Compliance tests are temporarily disabled.');
   test.skip(!isHosted(), 'Compliance is not available in the plugin');
 
   await test.step('Check if Compliance service is available', async () => {
@@ -110,6 +112,8 @@ test('Create a blueprint with Compliance policy selected', async ({
 });
 
 test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
+  // TODO: Re-enable once compliance is working again
+  test.skip(true, 'Compliance tests are temporarily disabled.');
   test.skip(!isHosted(), 'Compliance alerts are not available in the plugin');
   const blueprintName = 'test-compliance-' + uuidv4();
   const policyName = 'test-policy-' + uuidv4();

--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
-import { test } from '../fixtures/cleanup';
+import { test } from '../fixtures/customizations';
 import { exportedDiskBP } from '../fixtures/data/exportBlueprintContents';
 import { isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';

--- a/playwright/Customizations/Filesystem.spec.ts
+++ b/playwright/Customizations/Filesystem.spec.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
-import { test } from '../fixtures/cleanup';
+import { test } from '../fixtures/customizations';
 import { exportedFilesystemBP } from '../fixtures/data/exportBlueprintContents';
 import { isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';

--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
-import { test } from '../fixtures/cleanup';
+import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
 import {


### PR DESCRIPTION
Compliance service is having issues with the new RHEL releases. Disable the tests temporarily until they fix the issues so we don't block CI.