### PR TITLE
Wizard: Disable language remove button when only one remains (HMS-10609)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -122,6 +122,9 @@ const LanguagesDropDown = () => {
 
   const handleRemoveLanguage = (language: string) => {
     dispatch(removeLanguage(language));
+    if (languages.length <= 1) {
+      setShowNewRow(true);
+    }
   };
 
   return (

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -155,6 +155,20 @@ describe('Locale Component', () => {
       ).toBeInTheDocument();
     });
 
+    test('removing the last language shows an empty selection row', async () => {
+      const { store } = renderLocaleStep({
+        locale: { languages: ['en_US.UTF-8'], keyboard: '' },
+      });
+      const user = createUser();
+
+      await removeLanguageAtIndex(user, 0);
+
+      expect(store.getState().wizard.locale.languages).toHaveLength(0);
+      expect(
+        screen.getByRole('button', { name: /select a language/i }),
+      ).toBeInTheDocument();
+    });
+
     test('can select multiple languages', async () => {
       renderLocaleStep({ locale: { languages: [], keyboard: '' } });
       const user = createUser();


### PR DESCRIPTION
Users could remove all languages in the Locale step, leaving the list empty. Disable the remove button when only one language remains to ensure at least one language is always selected. The button re-enables once a second language is added.
JIRA: HMS-10609