### PR TITLE
Fix noisy test warnings in wizard steps (HMS-10715)

### DIFF
--- a/.github/actions/setup-node-cached/action.yml
+++ b/.github/actions/setup-node-cached/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: 24
+        node-version: 24.15.0
 
     - name: Restore npm cache
       id: cache-npm

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { createUser } from '@/test/testUtils';
+import { clickWithWait, createUser } from '@/test/testUtils';
 
 import {
   clearKeyboardSearch,
@@ -79,7 +79,7 @@ describe('Locale Component', () => {
       });
       expect(addButton).toBeEnabled();
 
-      await user.click(addButton);
+      await clickWithWait(user, addButton);
       expect(addButton).toBeDisabled();
 
       await removeLanguageAtIndex(user, 0);

--- a/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/tests/Oscap.test.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
-import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
+import {
+  clickWithWait,
+  createUser,
+  renderWithRedux,
+  typeWithWait,
+} from '@/test/testUtils';
 
 import OscapStep from '../index';
 
@@ -55,7 +60,7 @@ describe('Oscap Component', () => {
       const complianceRadio = await screen.findByRole('radio', {
         name: /Use a custom compliance policy/i,
       });
-      await user.click(complianceRadio);
+      await clickWithWait(user, complianceRadio);
 
       expect(complianceRadio).toBeChecked();
       expect(
@@ -72,7 +77,7 @@ describe('Oscap Component', () => {
       const openscapRadio = await screen.findByRole('radio', {
         name: /Use a default OpenSCAP profile/i,
       });
-      await user.click(openscapRadio);
+      await clickWithWait(user, openscapRadio);
 
       expect(openscapRadio).toBeChecked();
       expect(
@@ -100,7 +105,7 @@ describe('Oscap Component', () => {
       const noneRadio = await screen.findByRole('radio', {
         name: /No additional policy or profile/i,
       });
-      await user.click(noneRadio);
+      await clickWithWait(user, noneRadio);
 
       expect(noneRadio).toBeChecked();
       expect(

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -559,15 +559,15 @@ export const selectUsers = (state: RootState) => {
   return state.wizard.users;
 };
 
-export const selectNonEmptyUsers = (state: RootState) => {
-  return state.wizard.users.filter(
+export const selectNonEmptyUsers = createSelector([selectUsers], (users) =>
+  users.filter(
     (user) =>
       user.name.trim() ||
       user.password.trim() ||
       user.ssh_key.trim() ||
       user.hasPassword,
-  );
-};
+  ),
+);
 
 export const selectUserGroups = (state: RootState) => {
   return state.wizard.userGroups;


### PR DESCRIPTION
## Summary
Fix noisy test warnings and resolve CI Playwright install hang caused by a Node 24.x regression.

## Changes
- Pin Node.js to `24.15.0` in CI runners to work around a regression in newer Node 24.x that causes `npx playwright install` to hang after downloading the browser
- Memoize `selectNonEmptyUsers` with `createSelector` to prevent unnecessary rerenders that caused act warnings in tests
- Replace `user.click()` with `clickWithWait()` in Locale and Oscap tests to resolve act warnings from unmicrotasked state updates