### PR TITLE
Wizard: Deprecate layered repos flag (HMS-10720)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Repositories/components/RepositorySearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/RepositorySearch.tsx
@@ -29,7 +29,6 @@ import {
 } from '@/store/slices';
 import { releaseToVersion } from '@/Utilities/releaseToVersion';
 import useDebounce from '@/Utilities/useDebounce';
-import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import CommunityRepositoryLabel from './CommunityRepositoryLabel';
 import CustomEpelWarning from './CustomEpelWarning';
@@ -64,14 +63,12 @@ const RepositorySearch = ({
   const [inputValue, setInputValue] = useState('');
   const [filterValue, setFilterValue] = useState('');
 
-  const isLayeredReposEnabled = useFlag('image-builder.layered-repos.enabled');
-
   const originParam = useMemo(() => {
     const origins = [ContentOrigin.CUSTOM];
     origins.push(ContentOrigin.COMMUNITY);
-    if (isLayeredReposEnabled) origins.push(ContentOrigin.REDHAT);
+    origins.push(ContentOrigin.REDHAT);
     return origins.join(',');
-  }, [isLayeredReposEnabled]);
+  }, []);
 
   const debouncedFilterValue = useDebounce(filterValue);
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -62,8 +62,8 @@ vi.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => vi.fn(),
   useFlag: vi.fn((flag) => {
     switch (flag) {
-      case 'image-builder.layered-repos.enabled':
-        return true;
+      // case <flag>:
+      //   return true;
       default:
         return false;
     }


### PR DESCRIPTION
This deprecates the 'image-builder.layered-repos.enabled' to fully promote the functionality.