### PR TITLE
playwright: Update popup locator (HMS-10734)

### DIFF
--- a/playwright/helpers/helpers.ts
+++ b/playwright/helpers/helpers.ts
@@ -54,14 +54,8 @@ export const closePopupsIfExist = async (page: Page) => {
       .contentFrame()
       .getByRole('button', { name: 'Profile image for Rob Rob' })
       .last(), // This closes the intercom pop-up notification at the bottom of the screen, the last notification is displayed first if stacked (different from the modal popup handled above)
-    page
-      .locator('iframe[name="trustarc_cm"]')
-      .contentFrame()
-      .getByRole('button', { name: 'Agree and proceed with' }), // closes the EU cookies popup
-    page
-      .locator('iframe[name="trustarc_cm"]')
-      .contentFrame()
-      .getByRole('button', { name: 'Accept default' }), // closes the SSO login cookies popup
+    page.getByRole('button', { name: 'Agree and proceed with' }), // closes the EU cookies popup
+    page.getByRole('button', { name: 'Accept default' }), // closes the SSO login cookies popup
   ];
 
   for (const locator of locatorsToCheck) {

--- a/playwright/helpers/login.ts
+++ b/playwright/helpers/login.ts
@@ -129,9 +129,9 @@ const fillAndSubmitLogin = async (page: Page, user: string) => {
 };
 
 const loginConsole = async (page: Page, user: string, password: string) => {
-  await closePopupsIfExist(page);
   await page.goto('/insights/image-builder/landing');
 
+  await closePopupsIfExist(page);
   await fillAndSubmitLogin(page, user);
 
   let loginInputAttempts = 0;


### PR DESCRIPTION
This removes the locator for cookie consent popup as its context seemingly changed. We should be safe going only by the name of the button, making the tests resistant to locator changes in the future.

The `closePopupsIfExist` function call was also moved after navigating to the page where the popups will start to get rendered.