### PR TITLE
Wizard: Move Users section from Advanced Settings to Image Overview (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
@@ -55,7 +55,11 @@ const AdvancedSettingsOverview = ({
             oscapServices={oscapServices}
           />
           <Firewall shouldHide={restrictions.firewall.shouldHide} />
-          <Users shouldHide={restrictions.users.shouldHide} />
+          <Users
+            shouldHide={
+              restrictions.users.shouldHide || restrictions.users.required
+            }
+          />
           <UserGroups shouldHide={restrictions.users.shouldHide} />
           <Firstboot shouldHide={restrictions.firstBoot.shouldHide} />
         </ReviewList>

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -901,6 +901,34 @@ echo 'Hello there, General Kenobi!'`;
       expect(screen.getByText('guest')).toBeInTheDocument();
       expect(screen.getAllByText('*****')).toHaveLength(3);
     });
+
+    test('renders users section when users are not required', () => {
+      renderWithRedux(
+        <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['guest-image'],
+          users: [adminUser],
+        },
+      );
+
+      expect(screen.getByText('Users')).toBeInTheDocument();
+    });
+
+    test('does not render users section when users are required', () => {
+      renderWithRedux(
+        <AdvancedSettingsOverview
+          restrictions={createDefaultRestrictions({
+            users: { required: true },
+          })}
+        />,
+        {
+          imageTypes: ['guest-image'],
+          users: [adminUser],
+        },
+      );
+
+      expect(screen.queryByText('Users')).not.toBeInTheDocument();
+    });
   });
 
   describe('Firewall', () => {

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
@@ -4,6 +4,7 @@ import { Card, CardBody } from '@patternfly/react-core';
 
 import { ON_PREM_RELEASES, RELEASES } from '@/constants';
 import { useTargetEnvironmentCategories } from '@/Hooks';
+import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { useAppSelector } from '@/store/hooks';
 import {
   selectArchitecture,
@@ -18,6 +19,7 @@ import {
 
 import { MiscFormats, PrivateClouds, PublicClouds } from './components';
 
+import { Users } from '../AdvancedSettings/components';
 import { ReviewCardHeader, ReviewGroup, ReviewList } from '../shared';
 
 const ImageOverview = () => {
@@ -29,8 +31,12 @@ const ImageOverview = () => {
   const distribution = useAppSelector(selectDistribution);
   const arch = useAppSelector(selectArchitecture);
 
+  const environments = useAppSelector(selectImageTypes);
   const { publicClouds, privateClouds, miscFormats } =
-    useTargetEnvironmentCategories(useAppSelector(selectImageTypes));
+    useTargetEnvironmentCategories(environments);
+  const { restrictions } = useCustomizationRestrictions({
+    selectedImageTypes: environments,
+  });
 
   const releases = isOnPremise ? ON_PREM_RELEASES : RELEASES;
 
@@ -70,6 +76,11 @@ const ImageOverview = () => {
           <PrivateClouds environments={privateClouds} />
           <PublicClouds environments={publicClouds} />
           <MiscFormats environments={miscFormats} />
+          <Users
+            shouldHide={
+              restrictions.users.shouldHide || !restrictions.users.required
+            }
+          />
         </ReviewList>
       </CardBody>
     </Card>

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -3,11 +3,28 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { RHEL_10, X86_64 } from '@/constants';
+import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { renderWithRedux } from '@/test/testUtils';
 
+import { adminUser } from '../../AdvancedSettings/tests/mocks';
+import { createDefaultRestrictions } from '../../tests/helpers';
 import ImageOverview from '../index';
 
+vi.mock('@/store/api/distributions', async () => {
+  const actual = await vi.importActual('@/store/api/distributions');
+  return {
+    ...actual,
+    useCustomizationRestrictions: vi.fn(),
+  };
+});
+
 describe('ImageOverview', () => {
+  beforeEach(() => {
+    vi.mocked(useCustomizationRestrictions).mockReturnValue({
+      restrictions: createDefaultRestrictions(),
+    });
+  });
+
   test('renders the card with image overview title', () => {
     renderWithRedux(<ImageOverview />);
 
@@ -228,6 +245,37 @@ describe('ImageOverview', () => {
       expect(
         screen.queryByText('Miscellaneous formats'),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Users', () => {
+    test('renders users section when users are required', () => {
+      vi.mocked(useCustomizationRestrictions).mockReturnValue({
+        restrictions: createDefaultRestrictions({
+          users: { required: true },
+        }),
+      });
+
+      renderWithRedux(<ImageOverview />, {
+        imageTypes: ['guest-image'],
+        users: [adminUser],
+      });
+
+      expect(screen.getByText('Users')).toBeInTheDocument();
+      expect(screen.getByText('admin')).toBeInTheDocument();
+    });
+
+    test('does not render users section when users are not required', () => {
+      vi.mocked(useCustomizationRestrictions).mockReturnValue({
+        restrictions: createDefaultRestrictions(),
+      });
+
+      renderWithRedux(<ImageOverview />, {
+        imageTypes: ['guest-image'],
+        users: [adminUser],
+      });
+
+      expect(screen.queryByText('Users')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Users are configured in Base Settings (for image mode in cockpit-image-builder), but the Review step displayed them under Advanced Settings. 
Move the Users component to the Image Overview card so the review page matches where users are actually set.

JIRA: (HMS-10579)
