### PR TITLE
Packit: Only propose downstream releases for main

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -57,6 +57,7 @@ jobs:
 
   - job: propose_downstream
     trigger: release
+    branch: "^main$"
     dist_git_branches:
       - fedora-all
 


### PR DESCRIPTION
If we need to do a point release for a RHEL Z-stream, we don't want to propose downstream releases for Fedora.