### PR TITLE
vitest: Clean up the test output (HMS-10742)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/components/ManualActivationKey.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ManualActivationKey.tsx
@@ -1,12 +1,13 @@
-import React, { MutableRefObject, useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 
 import {
+  Button,
   Content,
   ContentVariants,
   FormGroup,
-  FormGroupLabelHelp,
   Popover,
 } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
 
 import { ValidatedInput } from '@/Components/CreateImageWizard/ValidatedInput';
 import { CDN_PROD_URL } from '@/constants';
@@ -20,14 +21,9 @@ import {
   selectOrgId,
 } from '@/store/slices/wizard';
 
-const ManualRegistrationPopover = ({
-  ref,
-}: {
-  ref: MutableRefObject<null>;
-}) => {
+const ManualRegistrationPopover = () => {
   return (
     <Popover
-      triggerRef={ref}
       headerContent='About Activation Keys & Organization ID'
       position='right'
       minWidth='30rem'
@@ -46,9 +42,12 @@ const ManualRegistrationPopover = ({
         </Content>
       }
     >
-      <FormGroupLabelHelp
-        ref={ref}
+      <Button
+        icon={<HelpIcon />}
+        variant='plain'
+        size='sm'
         aria-label='About Activation Keys & Organization ID'
+        hasNoPadding
       />
     </Popover>
   );
@@ -58,8 +57,6 @@ export const ManualActivationKey = () => {
   const dispatch = useAppDispatch();
   const orgId = useAppSelector(selectOrgId);
   const activationKey = useAppSelector(selectActivationKey);
-  const orgIdRef = useRef(null);
-  const activationKeyRef = useRef(null);
 
   useEffect(() => {
     dispatch(changeServerUrl('subscription.rhsm.redhat.com'));
@@ -71,7 +68,7 @@ export const ManualActivationKey = () => {
       <FormGroup
         className='pf-v6-u-mb-md'
         label={'Activation key'}
-        labelHelp={<ManualRegistrationPopover ref={activationKeyRef} />}
+        labelHelp={<ManualRegistrationPopover />}
         isRequired
       >
         <ValidatedInput
@@ -88,7 +85,7 @@ export const ManualActivationKey = () => {
       </FormGroup>
       <FormGroup
         label={'Organization ID'}
-        labelHelp={<ManualRegistrationPopover ref={orgIdRef} />}
+        labelHelp={<ManualRegistrationPopover />}
         isRequired
       >
         <ValidatedInput

--- a/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
@@ -3,7 +3,12 @@ import { screen, waitFor } from '@testing-library/react';
 import { mapRequestFromState } from '@/Components/CreateImageWizard/utilities/requestMapper';
 import { CreateBlueprintRequest } from '@/store/api/backend';
 import { server } from '@/test/mocks/server';
-import { createTestStore, createUser, typeWithWait } from '@/test/testUtils';
+import {
+  clickWithWait,
+  createTestStore,
+  createUser,
+  typeWithWait,
+} from '@/test/testUtils';
 
 import {
   removeRepo,
@@ -101,7 +106,7 @@ describe('Repositories Component', () => {
       const toggle = await screen.findByRole('button', {
         name: /menu toggle/i,
       });
-      await user.click(toggle);
+      await clickWithWait(user, toggle);
 
       // Should show repositories without typing
       expect(
@@ -123,7 +128,7 @@ describe('Repositories Component', () => {
       const toggle = await screen.findByRole('button', {
         name: /menu toggle/i,
       });
-      await user.click(toggle);
+      await clickWithWait(user, toggle);
 
       expect(
         await screen.findByRole('option', {
@@ -135,7 +140,7 @@ describe('Repositories Component', () => {
       const searchInput = await screen.findByRole('textbox', {
         name: /filter repositories/i,
       });
-      await user.type(searchInput, 'nonexistent');
+      await typeWithWait(user, searchInput, 'nonexistent');
 
       expect(
         await screen.findByRole('option', {
@@ -166,7 +171,7 @@ describe('Repositories Component', () => {
       const toggle = await screen.findByRole('button', {
         name: /menu toggle/i,
       });
-      await user.click(toggle);
+      await clickWithWait(user, toggle);
 
       await screen.findByRole('option', { name: /no repositories available/i });
 
@@ -174,7 +179,7 @@ describe('Repositories Component', () => {
       const searchInput = await screen.findByRole('textbox', {
         name: /filter repositories/i,
       });
-      await user.type(searchInput, 'test');
+      await typeWithWait(user, searchInput, 'test');
 
       await screen.findByRole('option', {
         name: /no repositories found for "test"/i,
@@ -295,14 +300,16 @@ describe('Repositories Component', () => {
       await selectRepo(user, '01-test-valid-repo');
       await selectRepo(user, '04-test-another-valid-repo');
 
-      expect(
-        await screen.findByRole('cell', { name: /01-test-valid-repo/i }),
-      ).toBeInTheDocument();
-      expect(
-        await screen.findByRole('cell', {
-          name: /04-test-another-valid-repo/i,
-        }),
-      ).toBeInTheDocument();
+      await waitFor(() => {
+        expect(
+          screen.getByRole('cell', { name: /01-test-valid-repo/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('cell', {
+            name: /04-test-another-valid-repo/i,
+          }),
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -32,9 +32,13 @@ describe('Images Table', () => {
     expect(headerCells[2]).toHaveTextContent('Updated');
     expect(headerCells[3]).toHaveTextContent('OS');
     expect(headerCells[4]).toHaveTextContent('Target');
-    expect(headerCells[5]).toHaveTextContent('Version');
-    expect(headerCells[6]).toHaveTextContent('Status');
-    expect(headerCells[7]).toHaveTextContent('Instance');
+    if (!process.env.IS_ON_PREMISE) {
+      expect(headerCells[5]).toHaveTextContent('Version');
+      expect(headerCells[6]).toHaveTextContent('Status');
+      expect(headerCells[7]).toHaveTextContent('Instance');
+    } else {
+      expect(headerCells[5]).toHaveTextContent('Status');
+    }
 
     const imageNameValues = mockComposes.map((compose) =>
       compose.image_name ? compose.image_name : compose.id,

--- a/src/test/fixtures/repositories.ts
+++ b/src/test/fixtures/repositories.ts
@@ -610,7 +610,7 @@ const generateLinks = (
 const generateFillerRepos = (num: number): ApiRepositoryResponse[] => {
   const repos = new Array(num).fill(undefined).map((_, i) => {
     return {
-      uuid: '9cf1d45d-aa06-46fe-87ea-121845cc6bbb',
+      uuid: `filler-repo-${i}`,
       name: `z-filler repo ${i}`,
       url: `http://fillerRepos.org/9/x86_64/packages/${i}`,
       distribution_versions: ['any'],

--- a/src/test/mocks/cockpit/fsinfo.ts
+++ b/src/test/mocks/cockpit/fsinfo.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import { mockBlueprintIds } from '../../fixtures/blueprints';
 import { mockComposes } from '../../fixtures/composes';
 
-const bpDir = '/default/.cache/cockpit-image-builder/';
+const bpDir = '/default/.local/state/cockpit-image-builder';
 
 type fileinfo = {
   entries?: Record<string, fileinfo>;
@@ -65,7 +65,7 @@ export const fsinfo = (
   // abuse one blueprint to return all composes.
   if (
     filepath ===
-    '/default/.cache/cockpit-image-builder/b3ff8307-18bd-418a-9a91-836ce039b035'
+    '/default/.local/state/cockpit-image-builder/b3ff8307-18bd-418a-9a91-836ce039b035'
   ) {
     return listComposes();
   }


### PR DESCRIPTION
This updates tests to clean up the test output and fixes the ImagesTable test in `npm run test:cockpit`.

Rebased on https://github.com/osbuild/image-builder-frontend/pull/4426

JIRA: [HMS-10742](https://issues.redhat.com/browse/HMS-10742)

[HMS-10742]: https://redhat.atlassian.net/browse/HMS-10742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ