### PR TITLE
ImagesTable: Fix image/package mode labels in blueprint view (HMS-10739)

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -621,31 +621,30 @@ const Row = ({
         />
         <Td dataLabel='Image name'>
           {compose.blueprint_id && !selectedBlueprintId ? (
-            <>
-              <Button
-                component='a'
-                variant='link'
-                isInline
-                onClick={() =>
-                  compose.blueprint_id &&
-                  handleClick({ blueprintId: compose.blueprint_id })
-                }
-              >
-                {compose.image_name || compose.id}
-              </Button>{' '}
-              {bootcCompose?.request.bootc ? (
-                <Label isCompact color='yellow'>
-                  Image mode
-                </Label>
-              ) : (
-                <Label isCompact color='teal'>
-                  Package mode
-                </Label>
-              )}
-            </>
+            <Button
+              component='a'
+              variant='link'
+              isInline
+              onClick={() =>
+                compose.blueprint_id &&
+                handleClick({ blueprintId: compose.blueprint_id })
+              }
+            >
+              {compose.image_name || compose.id}
+            </Button>
           ) : (
-            <span> {compose.image_name || compose.id}</span>
-          )}
+            <span>{compose.image_name || compose.id}</span>
+          )}{' '}
+          {compose.blueprint_id &&
+            (bootcCompose?.request.bootc ? (
+              <Label isCompact color='yellow'>
+                Image mode
+              </Label>
+            ) : (
+              <Label isCompact color='teal'>
+                Package mode
+              </Label>
+            ))}
         </Td>
         <Td
           dataLabel='Created'

--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -335,7 +335,7 @@ describe('Blueprints', () => {
 
       expect(
         within(screen.getByTestId('images-table')).getAllByRole('row'),
-      ).toHaveLength(4);
+      ).toHaveLength(5);
 
       await waitFor(() => user.click(composesVersionFilter));
       const option = await screen.findByRole('menuitem', { name: 'Newest' });
@@ -343,7 +343,7 @@ describe('Blueprints', () => {
       await waitFor(() =>
         expect(
           within(screen.getByTestId('images-table')).getAllByRole('row'),
-        ).toHaveLength(2),
+        ).toHaveLength(3),
       );
     });
   });

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -131,6 +131,27 @@ describe('Images Table', () => {
     expect(within(imageModeRow).getByText('Image mode')).toBeInTheDocument();
   });
 
+  test('displays Package mode and Image mode labels in blueprint-filtered view', async () => {
+    await renderCustomRoutesWithReduxRouter();
+
+    const user = userEvent.setup();
+
+    // Select the "Dark Chocolate" blueprint to filter the view
+    const blueprint = await screen.findByTestId(
+      '677b010b-e95e-4694-9813-d11d847f1bfc',
+    );
+    await user.click(blueprint);
+
+    const table = await screen.findByTestId('images-table');
+
+    await waitFor(() => {
+      expect(within(table).getAllByText('Package mode').length).toBeGreaterThan(
+        0,
+      );
+    });
+    expect(within(table).getByText('Image mode')).toBeInTheDocument();
+  });
+
   test('check download compose request action', async () => {
     await renderCustomRoutesWithReduxRouter();
 

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -446,12 +446,13 @@ export const mockCentosBlueprintComposes: GetBlueprintComposesApiResponse = {
 };
 
 export const mockBlueprintComposes: GetBlueprintComposesApiResponse = {
-  meta: { count: 3 },
+  meta: { count: 4 },
   data: [
     {
       id: '63e42aaf-b543-41c6-899f-3de1e61838dc',
       image_name: 'dark-chocolate-aws',
       created_at: '2023-09-08T14:38:00.000Z',
+      blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc',
       blueprint_version: 2,
       request: {
         distribution: RHEL_9,
@@ -494,6 +495,7 @@ export const mockBlueprintComposes: GetBlueprintComposesApiResponse = {
       id: 'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa',
       image_name: 'Dark Chocolate',
       created_at: '2021-04-27T12:31:12Z',
+      blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc',
       blueprint_version: 1,
       request: {
         distribution: RHEL_9,
@@ -516,6 +518,28 @@ export const mockBlueprintComposes: GetBlueprintComposesApiResponse = {
               options: {
                 share_with_accounts: ['123123123123'],
               },
+            },
+          },
+        ],
+      },
+    },
+    {
+      id: 'a8f5e2d1-9c3b-4f6a-b7e8-1d2c3f4a5b6c',
+      image_name: 'dark-chocolate-bootc',
+      created_at: '2024-03-01T10:00:00Z',
+      blueprint_id: '677b010b-e95e-4694-9813-d11d847f1bfc',
+      blueprint_version: 2,
+      request: {
+        bootc: {
+          reference: 'registry.redhat.io/rhel9/rhel-bootc:9.7',
+        },
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'guest-image',
+            upload_request: {
+              type: 'aws.s3',
+              options: {},
             },
           },
         ],

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -1145,6 +1145,33 @@ export const mockStatus = (composeId: string): ComposeStatus => {
         ],
       },
     } as unknown as ComposeStatus,
+    'a8f5e2d1-9c3b-4f6a-b7e8-1d2c3f4a5b6c': {
+      image_status: {
+        status: 'success',
+        upload_status: {
+          options: {
+            url: 'https://s3.amazonaws.com/a8f5e2d1-disk.qcow2',
+          },
+          status: 'success',
+          type: 'aws.s3',
+        },
+      },
+      request: {
+        bootc: {
+          reference: 'registry.redhat.io/rhel9/rhel-bootc:9.7',
+        },
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'guest-image',
+            upload_request: {
+              type: 'aws.s3',
+              options: {},
+            },
+          },
+        ],
+      },
+    } as unknown as ComposeStatus,
   };
   return mockComposes[composeId];
 };


### PR DESCRIPTION
Right now, the image/package mode colorful labels are shown in the unfiltered images table view. As soon as the view is filtered to a single blueprint, the colorful labels disappear. This is due to a lack of separation of concerns in the code, that lumps the logic of rendering a name as a clickable link (to the blueprint) and rendering the labels together.

This commit separates those concerns and always shows the colorful labels, as expected.