### PR TITLE
pr-best-practices: Update authentication scheme for Jira Cloud

### DIFF
--- a/.github/workflows/pr_best_practices.yml
+++ b/.github/workflows/pr_best_practices.yml
@@ -18,5 +18,6 @@ jobs:
         uses: osbuild/pr-best-practices@main
         with:
           token: ${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}
-          jira_token: ${{ secrets.IMAGEBUILDER_BOT_JIRA_TOKEN }}
+          jira_token: ${{ secrets.IMAGE_BUILDER_BOT_JIRA_API_TOKEN }}
+          jira_email: ${{ secrets.IMAGE_BUILDER_BOT_JIRA_EMAIL }}
           new_issues_jira_epic: HMS-10501


### PR DESCRIPTION
Jira Cloud doesn't allow bearer token based authentication anymore, instead a Personal Access Token and Email address need to be used (max expiration: 90 days).

Depends on: https://github.com/osbuild/pr-best-practices/pull/34