### PR TITLE
Wizard: Add "Wizard Opened" analytics event (HMS-10743)

### DIFF
--- a/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
+++ b/src/Components/CreateImageWizard3/CreateImageWizard3.tsx
@@ -113,6 +113,7 @@ const CreateImageWizard3 = () => {
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
   const hasTrackedInitialStepRef = useRef(false);
+  const hasTrackedWizardOpenedRef = useRef(false);
 
   const { data: blueprintDetails, isSuccess } = useGetBlueprintQuery(
     { id: blueprintId || '' },
@@ -275,6 +276,19 @@ const CreateImageWizard3 = () => {
   }, [distribution, targetEnvironments, mode, dispatch]);
 
   useEffect(() => {
+    if (!isOnPremise && showWizardModal && !hasTrackedWizardOpenedRef.current) {
+      const accountId = userData?.identity.internal?.account_id;
+
+      analytics.track(`${AMPLITUDE_MODULE_NAME} - Wizard Opened`, {
+        module: AMPLITUDE_MODULE_NAME,
+        mode: mode,
+        ...(accountId && { account_id: accountId }),
+      });
+      hasTrackedWizardOpenedRef.current = true;
+    }
+  }, [showWizardModal, analytics, isOnPremise, mode, userData]);
+
+  useEffect(() => {
     if (!isOnPremise && showWizardModal && !hasTrackedInitialStepRef.current) {
       const initialStepId =
         mode === 'edit' ? 'review-step' : 'base-settings-step';
@@ -311,6 +325,7 @@ const CreateImageWizard3 = () => {
     dispatch(closeWizardModal());
     dispatch(initializeWizard());
     hasTrackedInitialStepRef.current = false;
+    hasTrackedWizardOpenedRef.current = false;
 
     if (
       searchParams.has('release') ||


### PR DESCRIPTION
This adds a new event that will track any instance of the Image Wizard being opened.

It also contains what mode is the wizard in.

JIRA: [HMS-10743](https://issues.redhat.com/browse/HMS-10743)

[HMS-10743]: https://redhat.atlassian.net/browse/HMS-10743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ