### PR TITLE
Remove dummy 'image-mode' distribution (HMS-10745)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
@@ -22,7 +22,6 @@ import {
   selectDistribution,
   selectIsImageMode,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 import { getHostDistro } from '@/Utilities/getHostInfo';
 
 const BlueprintMode = () => {
@@ -40,11 +39,9 @@ const BlueprintMode = () => {
     const fetchDefaultDistro = async () => {
       try {
         const distro = await getHostDistro();
-        setDefaultDistro(asDistribution(distro as Distributions));
+        setDefaultDistro(distro as Distributions);
       } catch {
         // defaultDistro remains RHEL_10
-        // this is fine since image-mode is
-        // limited to RHEL_10 for now
       }
     };
 
@@ -81,14 +78,12 @@ const BlueprintMode = () => {
           isSelected={isImageMode}
           onChange={() => {
             if (!isOnPremise) {
-              previousDistro.current = distribution as Distributions;
+              previousDistro.current = distribution;
               previousArch.current = architecture;
             }
             dispatch(changeBlueprintMode('image'));
             dispatch(changeImageTypes([]));
-            if (isOnPremise) {
-              dispatch(changeDistribution('image-mode'));
-            } else {
+            if (!isOnPremise) {
               dispatch(changeArchitecture(X86_64));
               dispatch(changeImageSource(RHEL_10_IMAGE_MODE_IMAGE));
             }

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/BlueprintMode.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/BlueprintMode.test.tsx
@@ -103,13 +103,14 @@ describe('BlueprintMode', () => {
       expect(store.getState().wizard.blueprintMode).toBe('image');
     });
 
-    test('updates distribution when switching to image mode', async () => {
+    test('does not change distribution when switching to image mode', async () => {
       const { store } = renderBlueprintMode();
       const user = createUser();
+      const distributionBefore = store.getState().wizard.distribution;
 
       await toggleBlueprintMode(user, 'image');
 
-      expect(store.getState().wizard.distribution).toBe('image-mode');
+      expect(store.getState().wizard.distribution).toBe(distributionBefore);
     });
 
     test('updates store when switching to package mode', async () => {

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
-import { IMAGE_MODE } from '@/constants';
 import {
   selectDistribution,
   selectImageSource as selectImageSourceState,
@@ -39,7 +38,6 @@ vi.mock('@/store/api/backend', async (importOriginal) => {
 
 const renderHostedImageSourceSelect = () => {
   return renderWithRedux(<ImageSourceSelect />, {
-    distribution: IMAGE_MODE,
     blueprintMode: 'image',
   });
 };

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
-import { IMAGE_MODE, RHEL_10 } from '@/constants';
+import { RHEL_10 } from '@/constants';
 import {
   clickWithWait,
   renderWithRedux,
@@ -136,7 +136,6 @@ export const renderImageSourceSelect = (
   return renderWithRedux(
     <ImageSourceSelect />,
     {
-      distribution: IMAGE_MODE,
       blueprintMode: 'image',
       ...wizardStateOverrides,
     },

--- a/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
@@ -14,7 +14,6 @@ import {
   selectDistribution,
   selectKernel,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 
 const KernelArguments = () => {
   const kernelAppend = useAppSelector(selectKernel).append;
@@ -26,7 +25,7 @@ const KernelArguments = () => {
 
   const { data: oscapProfileInfo } = useGetOscapCustomizationsQuery(
     {
-      distribution: asDistribution(release),
+      distribution: release,
       // @ts-ignore if complianceProfileID is undefined the query is going to get skipped, so it's safe here to ignore the linter here
       profile: complianceProfileID,
     },

--- a/src/Components/CreateImageWizard/steps/Locale/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/index.tsx
@@ -12,7 +12,6 @@ import {
   selectLocaleLangpackCandidates,
   selectVerifiedLocaleLangpacks,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 
 import KeyboardDropDown from './components/KeyboardDropDown';
 import LanguagesDropDown from './components/LanguagesDropDown';
@@ -23,7 +22,7 @@ const LocaleStep = () => {
   const candidateLangpacks = useAppSelector(selectLocaleLangpackCandidates);
   const { data: distroRepositories, isLoading: isArchitecturesLoading } =
     useGetArchitecturesQuery({
-      distribution: asDistribution(distribution),
+      distribution: distribution,
     });
 
   const distroUrls = useMemo(() => {

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -26,7 +26,6 @@ import {
   setCompliancePolicy,
   setOscapProfile,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 
 import { useSelectorHandlers } from './useSelectorHandlers';
 
@@ -74,9 +73,7 @@ type PolicySelectorProps = {
 const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
   const policyID = useAppSelector(selectCompliancePolicyID);
   const policyTitle = useAppSelector(selectCompliancePolicyTitle);
-  const release = removeBetaFromRelease(
-    asDistribution(useAppSelector(selectDistribution)),
-  );
+  const release = removeBetaFromRelease(useAppSelector(selectDistribution));
   const majorVersion = release.split('-')[1];
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileDetails.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileDetails.tsx
@@ -21,13 +21,12 @@ import {
   selectComplianceProfileID,
   selectDistribution,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 
 import { removeBetaFromRelease } from '../removeBetaFromRelease';
 
 const ProfileDetails = (): JSX.Element => {
   const releaseRaw = useAppSelector(selectDistribution);
-  const release = removeBetaFromRelease(asDistribution(releaseRaw));
+  const release = removeBetaFromRelease(releaseRaw);
   const profileID = useAppSelector(selectComplianceProfileID);
 
   const { data, isFetching, error } = useGetOscapCustomizationsQuery(

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -35,7 +35,6 @@ import {
   selectDistribution,
   setOscapProfile,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 
 import { useSelectorHandlers } from './useSelectorHandlers';
 
@@ -63,9 +62,7 @@ const ProfileSelector = ({
 }: ProfileSelectorProps) => {
   const isOnPremise = useAppSelector(selectIsOnPremise);
   const profileID = useAppSelector(selectComplianceProfileID);
-  const release = removeBetaFromRelease(
-    asDistribution(useAppSelector(selectDistribution)),
-  );
+  const release = removeBetaFromRelease(useAppSelector(selectDistribution));
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState<string>('');

--- a/src/Components/CreateImageWizard/steps/Oscap/components/SecurityInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/SecurityInformation.tsx
@@ -26,7 +26,6 @@ import {
   selectDistribution,
   selectFips,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 
 export const SecurityInformation = (): JSX.Element => {
   const release = useAppSelector(selectDistribution);
@@ -44,7 +43,7 @@ export const SecurityInformation = (): JSX.Element => {
     error: profileError,
   } = useGetOscapCustomizationsQuery(
     {
-      distribution: asDistribution(release),
+      distribution: release,
       profile: complianceProfileID as unknown as DistributionProfileItem,
     },
     {
@@ -59,7 +58,7 @@ export const SecurityInformation = (): JSX.Element => {
     error: complianceError,
   } = useGetComplianceCustomizationsQuery(
     {
-      distribution: asDistribution(release),
+      distribution: release,
       policy: compliancePolicyID!,
     },
     {

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -58,7 +58,6 @@ import {
   setCompliancePolicy,
   setOscapProfile,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 import { useOnPremOpenSCAPAvailable } from '@/Utilities/useOnPremOpenSCAP';
 
 import OscapOnPremSpinner from './components/OnPremSpinner';
@@ -81,9 +80,7 @@ const OscapContent = () => {
   const services = useAppSelector(selectServices);
   const imageTypes = useAppSelector(selectImageTypes);
   const prefetchOscapProfile = useBackendPrefetch('getOscapProfiles', {});
-  const release = removeBetaFromRelease(
-    asDistribution(useAppSelector(selectDistribution)),
-  );
+  const release = removeBetaFromRelease(useAppSelector(selectDistribution));
   const majorVersion = release.split('-')[1];
 
   const { restrictions } = useCustomizationRestrictions({

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -65,7 +65,6 @@ import {
   selectTemplate,
   selectWizardMode,
 } from '@/store/slices/wizard';
-import { asDistribution } from '@/store/typeGuards';
 import { getEpelUrlForDistribution } from '@/Utilities/epel';
 import { releaseToVersion } from '@/Utilities/releaseToVersion';
 import { convertStringToDate } from '@/Utilities/time';
@@ -177,7 +176,7 @@ const PackageSearch = ({
 
   const { data: distroRepositories, isSuccess: isSuccessDistroRepositories } =
     useGetArchitecturesQuery({
-      distribution: asDistribution(distribution),
+      distribution: distribution,
     });
 
   const distroUrls = useMemo(() => {

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -82,12 +82,6 @@ export const CreateSaveAndBuildBtn = ({
     }
     if (requestBody) {
       const blueprint = (await createBlueprint({
-        // NOTE: We're using 'image-mode' as a dummy distribution for the
-        // on-prem frontend, this is one of the few cases where we
-        // can't work around the type error. This is fine because
-        // on-prem can handle this, while the hosted service should
-        // never receive 'image-mode' as a distribution
-        // @ts-ignore see above note (this errors when running npm run build)
         createBlueprintRequest: requestBody,
       })) as CreateBlueprintResponse;
 
@@ -187,12 +181,6 @@ export const CreateSaveButton = ({
     }
     if (requestBody) {
       const blueprint = (await createBlueprint({
-        // NOTE: We're using 'image-mode' as a dummy distribution for the
-        // on-prem frontend, this is one of the few cases where we
-        // can't work around the type error. This is fine because
-        // on-prem can handle this, while the hosted service should
-        // never receive 'image-mode' as a distribution
-        // @ts-ignore see above note (this errors when running npm run build)
         createBlueprintRequest: requestBody,
       })) as CreateBlueprintResponse;
       dispatch(setBlueprintId(blueprint.id));

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -78,12 +78,6 @@ export const EditSaveAndBuildBtn = ({
     if (requestBody) {
       await updateBlueprint({
         id: blueprintId,
-        // NOTE: We're using 'image-mode' as a dummy distribution for the
-        // on-prem frontend, this is one of the few cases where we
-        // can't work around the type error. This is fine because
-        // on-prem can handle this, while the hosted service should
-        // never receive 'image-mode' as a distribution.
-        // @ts-ignore see above note (this errors when running npm run build)
         createBlueprintRequest: requestBody,
       });
     }
@@ -133,12 +127,6 @@ export const EditSaveButton = ({
     if (requestBody) {
       updateBlueprint({
         id: blueprintId,
-        // NOTE: We're using 'image-mode' as a dummy distribution for the
-        // on-prem frontend, this is one of the few cases where we
-        // can't work around the type error. This is fine because
-        // on-prem can handle this, while the hosted service should
-        // never receive 'image-mode' as a distribution
-        // @ts-ignore see above note (this errors when running npm run build)
         createBlueprintRequest: requestBody,
       });
     }

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -10,7 +10,6 @@ import {
   BlueprintResponse,
   BtrfsVolume,
   ComposerAwsUploadRequestOptions,
-  ComposerBlueprintResponse,
   ComposerCreateBlueprintRequest,
   ComposerImageRequest,
   ComposerUploadTypes,
@@ -125,7 +124,6 @@ import {
   SATELLITE_SERVICE_PATH,
 } from '../../../constants';
 import { RootState } from '../../../store';
-import { isImageMode as isImageModeDistribution } from '../../../store/typeGuards';
 import isRhel from '../../../Utilities/isRhel';
 import { FscModeType } from '../steps/FileSystem';
 import {
@@ -285,10 +283,10 @@ const convertLogicalVolume = (volume: LogicalVolume) => {
  * @param distribution blueprint distribution
  */
 const getLatestRelease = (
-  distribution: Distributions | 'image-mode' | undefined,
-): Distributions | 'image-mode' => {
-  if (distribution === undefined || isImageModeDistribution(distribution)) {
-    return 'image-mode';
+  distribution: Distributions | undefined,
+): Distributions | undefined => {
+  if (distribution === undefined) {
+    return undefined;
   }
 
   return distribution.startsWith('rhel-10')
@@ -400,7 +398,6 @@ function commonRequestToState(
   request:
     | BlueprintResponse
     | CreateBlueprintRequest
-    | ComposerBlueprintResponse
     | ComposerCreateBlueprintRequest,
 ) {
   const gcp = request.image_requests.find(
@@ -546,7 +543,11 @@ function commonRequestToState(
         },
     partitioning_mode: request.customizations.partitioning_mode,
     architecture: arch,
-    distribution: getLatestRelease(request.distribution),
+    // Legacy on-prem bootc blueprints may have undefined distribution.
+    // Fall back to initialState so the wizard state type stays satisfied;
+    // the user can pick the correct distro in the wizard.
+    distribution:
+      getLatestRelease(request.distribution) ?? initialState.distribution,
     imageSource: 'bootc' in request ? request.bootc?.reference : undefined,
     isoPayloadReference: request.bootc?.iso_payload_reference,
     imageTypes: request.image_requests.map((image) => image.image_type),
@@ -618,14 +619,9 @@ function commonRequestToState(
  * @param source  V1ListSourceResponseItem
  * @returns wizardState
  */
-export const mapRequestToState = (
-  request: BlueprintResponse | ComposerBlueprintResponse,
-): wizardState => {
+export const mapRequestToState = (request: BlueprintResponse): wizardState => {
   const wizardMode = 'edit';
-  const blueprintMode =
-    isImageModeDistribution(request.distribution) || request.bootc
-      ? 'image'
-      : 'package';
+  const blueprintMode = request.bootc ? 'image' : 'package';
   return {
     wizardMode,
     blueprintMode,
@@ -740,10 +736,7 @@ export const mapBlueprintExportToState = (
 
   return {
     wizardMode,
-    blueprintMode:
-      isImageModeDistribution(blueprint.distribution) || blueprint.bootc
-        ? 'image'
-        : 'package',
+    blueprintMode: blueprint.bootc ? 'image' : 'package',
     bootcDistributions: [],
     metadata: getMetadata(blueprint.metadata),
     env: initialState.env,
@@ -819,7 +812,6 @@ const getRegistrationType = (
   request:
     | BlueprintResponse
     | CreateBlueprintRequest
-    | ComposerBlueprintResponse
     | ComposerCreateBlueprintRequest,
 ): RegistrationType => {
   const subscription = request.customizations.subscription;

--- a/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
+++ b/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import { RHEL_10, RHEL_9 } from '@/constants';
+import {
+  BlueprintExportResponse,
+  BlueprintResponse,
+  Distributions,
+} from '@/store/api/backend';
+
+import { mapBlueprintExportToState, mapRequestToState } from '../requestMapper';
+
+const createMinimalBlueprintResponse = (
+  overrides: Partial<BlueprintResponse> = {},
+): BlueprintResponse => ({
+  id: 'test-id',
+  name: 'test-blueprint',
+  description: '',
+  lint: { errors: [], warnings: [] },
+  distribution: 'rhel-9' as Distributions,
+  customizations: {},
+  image_requests: [
+    {
+      architecture: 'x86_64',
+      image_type: 'guest-image',
+      upload_request: { type: 'aws.s3', options: {} },
+    },
+  ],
+  ...overrides,
+});
+
+const createMinimalBlueprintExportResponse = (
+  overrides: Partial<BlueprintExportResponse> = {},
+): BlueprintExportResponse => ({
+  name: 'test-blueprint',
+  description: '',
+  distribution: 'rhel-9' as Distributions,
+  customizations: {},
+  metadata: {
+    parent_id: null,
+    exported_at: '',
+    is_on_prem: false,
+  },
+  ...overrides,
+});
+
+describe('mapRequestToState', () => {
+  it('sets blueprintMode to package when bootc is absent', () => {
+    const response = createMinimalBlueprintResponse();
+
+    const state = mapRequestToState(response);
+
+    expect(state.blueprintMode).toBe('package');
+  });
+
+  it('sets blueprintMode to image when bootc is present', () => {
+    const response = createMinimalBlueprintResponse({
+      bootc: { reference: 'quay.io/org/image:latest' },
+    });
+
+    const state = mapRequestToState(response);
+
+    expect(state.blueprintMode).toBe('image');
+  });
+
+  it('maps imageSource from bootc reference', () => {
+    const response = createMinimalBlueprintResponse({
+      bootc: { reference: 'quay.io/org/image:latest' },
+    });
+
+    const state = mapRequestToState(response);
+
+    expect(state.imageSource).toBe('quay.io/org/image:latest');
+  });
+
+  it('sets imageSource to undefined for package-mode blueprints', () => {
+    const response = createMinimalBlueprintResponse();
+
+    const state = mapRequestToState(response);
+
+    expect(state.imageSource).toBeUndefined();
+  });
+
+  it('normalizes distribution via getLatestRelease', () => {
+    const response = createMinimalBlueprintResponse({
+      distribution: 'rhel-9.2' as Distributions,
+    });
+
+    const state = mapRequestToState(response);
+
+    expect(state.distribution).toBe(RHEL_9);
+  });
+
+  it('falls back to initial state distribution for legacy bootc blueprints with undefined distribution', () => {
+    const response = createMinimalBlueprintResponse({
+      distribution: undefined,
+      bootc: { reference: 'quay.io/org/image:latest' },
+    });
+
+    const state = mapRequestToState(response);
+
+    // Falls back to initialState.distribution, not a hardcoded default
+    expect(state.distribution).toBe(RHEL_10);
+  });
+});
+
+describe('mapBlueprintExportToState', () => {
+  it('sets blueprintMode to package when bootc is absent', () => {
+    const blueprint = createMinimalBlueprintExportResponse();
+
+    const state = mapBlueprintExportToState(blueprint, []);
+
+    expect(state.blueprintMode).toBe('package');
+  });
+
+  it('sets blueprintMode to image when bootc is present', () => {
+    const blueprint = createMinimalBlueprintExportResponse({
+      bootc: { reference: 'quay.io/org/image:latest' },
+    });
+
+    const state = mapBlueprintExportToState(blueprint, []);
+
+    expect(state.blueprintMode).toBe('image');
+  });
+
+  it('falls back to initial state distribution for legacy bootc blueprints with undefined distribution', () => {
+    const blueprint = createMinimalBlueprintExportResponse({
+      distribution: undefined,
+      bootc: { reference: 'quay.io/org/image:latest' },
+    });
+
+    const state = mapBlueprintExportToState(blueprint, []);
+
+    // Falls back to initialState.distribution, not a hardcoded default
+    expect(state.distribution).toBe(RHEL_10);
+  });
+});

--- a/src/Components/CreateImageWizard/utilities/useGenerateDefaultName.ts
+++ b/src/Components/CreateImageWizard/utilities/useGenerateDefaultName.ts
@@ -1,7 +1,7 @@
 import { Distributions, ImageRequest } from '@/store/api/backend';
 
 export const generateDefaultName = (
-  distribution: Distributions | 'image-mode',
+  distribution: Distributions,
   arch: ImageRequest['architecture'],
 ) => {
   const date = new Date();

--- a/src/Components/ImagesTable/Release.tsx
+++ b/src/Components/ImagesTable/Release.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { Distributions } from '@/store/api/backend';
 
 type ReleaseProps = {
-  release: Distributions | 'image-mode' | undefined;
+  release: Distributions | undefined;
 };
 
 const Release = ({ release }: ReleaseProps) => {
-  if (release === 'image-mode' || release === undefined) {
+  if (release === undefined) {
     return null;
   }
 

--- a/src/Utilities/distributionToOSShortId.ts
+++ b/src/Utilities/distributionToOSShortId.ts
@@ -8,9 +8,9 @@ import { Distributions } from '../store/api/backend';
  * @returns The libosinfo shortID (e.g., 'rhel9.0', 'rhel8.10', 'fedora41') or undefined if not mappable
  */
 export const distributionToOSShortId = (
-  distribution: Distributions | 'image-mode' | undefined,
+  distribution: Distributions | undefined,
 ): string | undefined => {
-  if (!distribution || distribution === 'image-mode') {
+  if (!distribution) {
     return undefined;
   }
 

--- a/src/Utilities/getHostInfo.ts
+++ b/src/Utilities/getHostInfo.ts
@@ -3,7 +3,6 @@ import { read_os_release } from 'os-release';
 
 import { AARCH64, X86_64 } from '../constants';
 import { Distributions } from '../store/api/backend/hosted';
-import { asDistribution } from '../store/typeGuards';
 
 type Architecture = 'x86_64' | 'aarch64';
 
@@ -22,7 +21,7 @@ export const getHostDistro = async (): Promise<Distributions> => {
         if (distro.indexOf('.') !== -1) {
           distro = distro.split('.')[0];
         }
-        return asDistribution(distro as Distributions);
+        return distro as Distributions;
       } catch (err) {
         cachedHostDistro = null;
         throw err;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -63,7 +63,6 @@ export const FEDORA_42 = 'fedora-42';
 export const FEDORA_43 = 'fedora-43';
 export const FEDORA_44 = 'fedora-44';
 export const FEDORA_45 = 'fedora-45';
-export const IMAGE_MODE = 'image-mode';
 export const X86_64 = 'x86_64';
 export const AARCH64 = 'aarch64';
 

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -6,9 +6,8 @@ import * as serviceQueries from './hosted/imageBuilderApi';
 import * as composerQueries from './onprem/composerApi';
 import { composerApi } from './onprem/enhancedComposerApi';
 
-// NOTE: We cast to the composer query type because it accepts
-// 'image-mode' as a distribution (needed for on-prem). Casting to
-// the service query type breaks selectFromResult inference due to
+// NOTE: We cast to the composer query type because casting to the
+// service query type breaks selectFromResult inference due to
 // different API slice generics. The response shape is identical
 // (composer imports GetArchitecturesApiResponse from hosted).
 export const useGetArchitecturesQuery = (
@@ -120,9 +119,6 @@ export type {
   // Custom on-prem API argument types
   ComposerCreateBlueprintApiArg,
   ComposerCreateBlueprintRequest,
-  ComposerGetArchitecturesApiArg,
-  ComposerGetOscapCustomizationsApiArg,
-  ComposerGetOscapProfilesApiArg,
   ComposerUpdateBlueprintApiArg,
   // Prefixed types to avoid conflicts with hosted
   ComposerBlueprint,
@@ -131,7 +127,6 @@ export type {
   ComposerImageTypes,
   // On-prem specific types
   ComposerAwsUploadRequestOptions,
-  ComposerBlueprintResponse,
   ComposerComposesResponseItem,
   ComposerImageRequest,
   ComposerUploadTypes,

--- a/src/store/api/backend/onprem/composerApi/architecture.ts
+++ b/src/store/api/backend/onprem/composerApi/architecture.ts
@@ -1,4 +1,3 @@
-import { IMAGE_MODE } from '@/constants';
 import { type OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 
 import {
@@ -10,11 +9,12 @@ import {
 } from './helpers';
 
 import {
+  GetArchitecturesApiArg,
   GetArchitecturesApiResponse,
   GetDistributionsApiArg,
   GetDistributionsApiResponse,
 } from '../../hosted';
-import { ComposerGetArchitecturesApiArg, PodmanImageInfo } from '../types';
+import { PodmanImageInfo } from '../types';
 
 export const architectureEndpoints = (builder: OnPremBuilder) => ({
   getDistributions: builder.query<
@@ -38,24 +38,9 @@ export const architectureEndpoints = (builder: OnPremBuilder) => ({
   }),
   getArchitectures: builder.query<
     GetArchitecturesApiResponse,
-    ComposerGetArchitecturesApiArg
+    GetArchitecturesApiArg
   >({
-    queryFn: onPremQueryHandler(async ({ queryArgs: { distribution } }) => {
-      if (distribution === IMAGE_MODE) {
-        return [
-          {
-            arch: 'aarch64',
-            image_types: ['guest-image'],
-            repositories: [],
-          },
-          {
-            arch: 'x86_64',
-            image_types: ['guest-image'],
-            repositories: [],
-          },
-        ];
-      }
-
+    queryFn: onPremQueryHandler(async () => {
       const cloudImageTypes = await getCloudConfigs();
       return [
         {

--- a/src/store/api/backend/onprem/composerApi/blueprints.ts
+++ b/src/store/api/backend/onprem/composerApi/blueprints.ts
@@ -5,7 +5,6 @@ import { fsinfo } from 'cockpit/fsinfo';
 import { v4 as uuidv4 } from 'uuid';
 
 import { mapHostedToOnPrem } from '@/Components/Blueprints/helpers/onPremToHostedBlueprintMapper';
-import { IMAGE_MODE } from '@/constants';
 import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 
 import { getBlueprintsPath } from './helpers';
@@ -29,6 +28,17 @@ import {
   ComposerCreateBlueprintRequest,
   ComposerUpdateBlueprintApiArg,
 } from '../types';
+
+/**
+ * Prepares a blueprint request for on-prem persistence. Bootc blueprints
+ * don't use distribution, so it is stripped to preserve interoperability.
+ */
+export const prepareBlueprintForSave = (
+  blueprintReq: ComposerCreateBlueprintRequest,
+) => ({
+  ...blueprintReq,
+  distribution: blueprintReq.bootc ? undefined : blueprintReq.distribution,
+});
 
 export const blueprintEndpoints = (builder: OnPremBuilder) => ({
   getBlueprint: builder.query<GetBlueprintApiResponse, GetBlueprintApiArg>({
@@ -128,18 +138,9 @@ export const blueprintEndpoints = (builder: OnPremBuilder) => ({
         const id = uuidv4();
         const blueprintsDir = await getBlueprintsPath();
         await cockpit.spawn(['mkdir', '-p', path.join(blueprintsDir, id)], {});
-        await cockpit.file(path.join(blueprintsDir, id, `${id}.json`)).replace(
-          JSON.stringify({
-            ...blueprintReq,
-            // we need to strip the dummy distribution
-            // before saving the blueprint to preserve
-            // blueprint interoperability
-            distribution:
-              blueprintReq.distribution !== IMAGE_MODE
-                ? blueprintReq.distribution
-                : undefined,
-          }),
-        );
+        await cockpit
+          .file(path.join(blueprintsDir, id, `${id}.json`))
+          .replace(JSON.stringify(prepareBlueprintForSave(blueprintReq)));
         return {
           id,
         };
@@ -153,18 +154,9 @@ export const blueprintEndpoints = (builder: OnPremBuilder) => ({
     queryFn: onPremQueryHandler(
       async ({ queryArgs: { id, createBlueprintRequest: blueprintReq } }) => {
         const blueprintsDir = await getBlueprintsPath();
-        await cockpit.file(path.join(blueprintsDir, id, `${id}.json`)).replace(
-          JSON.stringify({
-            ...blueprintReq,
-            // we need to strip the dummy distribution
-            // before saving the blueprint to preserve
-            // blueprint interoperability
-            distribution:
-              blueprintReq.distribution !== IMAGE_MODE
-                ? blueprintReq.distribution
-                : undefined,
-          }),
-        );
+        await cockpit
+          .file(path.join(blueprintsDir, id, `${id}.json`))
+          .replace(JSON.stringify(prepareBlueprintForSave(blueprintReq)));
         return {
           id,
         };

--- a/src/store/api/backend/onprem/composerApi/helpers/toComposerComposeRequest.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/toComposerComposeRequest.ts
@@ -1,5 +1,7 @@
-import { IMAGE_MODE } from '@/constants';
-import type { OpenScapProfile } from '@/store/api/backend/hosted';
+import type {
+  Distributions,
+  OpenScapProfile,
+} from '@/store/api/backend/hosted';
 
 import {
   type ComposerCreateBlueprintRequest,
@@ -11,7 +13,7 @@ import {
 
 export const toComposerComposeRequest = (
   blueprint: ComposerCreateBlueprintRequest,
-  distribution: string,
+  distribution: Distributions | undefined,
   image_requests: ComposerImageRequest[],
 ): ComposeRequest => {
   // subscription, users & openscap are the only options
@@ -55,14 +57,14 @@ export const toComposerComposeRequest = (
     };
   }
 
-  let distro: string | undefined = distribution;
-  if (distro === IMAGE_MODE) {
-    distro = undefined;
-  }
-
   let bootc = undefined;
   if (blueprint.bootc) {
     bootc = blueprint.bootc;
+  }
+
+  let distro: Distributions | undefined = distribution;
+  if (bootc) {
+    distro = undefined;
   }
 
   return {

--- a/src/store/api/backend/onprem/composerApi/oscap.ts
+++ b/src/store/api/backend/onprem/composerApi/oscap.ts
@@ -9,18 +9,16 @@ import { lookupDatastreamDistro } from './helpers';
 import {
   BlueprintItem,
   DistributionProfileItem,
+  GetOscapCustomizationsApiArg,
   GetOscapCustomizationsApiResponse,
+  GetOscapProfilesApiArg,
   GetOscapProfilesApiResponse,
 } from '../../hosted';
-import {
-  ComposerGetOscapCustomizationsApiArg,
-  ComposerGetOscapProfilesApiArg,
-} from '../types';
 
 export const oscapEndpoints = (builder: OnPremBuilder) => ({
   getOscapProfiles: builder.query<
     GetOscapProfilesApiResponse,
-    ComposerGetOscapProfilesApiArg
+    GetOscapProfilesApiArg
   >({
     queryFn: onPremQueryHandler(async ({ queryArgs: { distribution } }) => {
       const dsDistro = lookupDatastreamDistro(distribution);
@@ -45,7 +43,7 @@ export const oscapEndpoints = (builder: OnPremBuilder) => ({
   }),
   getOscapCustomizations: builder.query<
     GetOscapCustomizationsApiResponse,
-    ComposerGetOscapCustomizationsApiArg
+    GetOscapCustomizationsApiArg
   >({
     queryFn: onPremQueryHandler(
       async ({ queryArgs: { distribution, profile } }) => {

--- a/src/store/api/backend/onprem/tests/blueprints.test.ts
+++ b/src/store/api/backend/onprem/tests/blueprints.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { prepareBlueprintForSave } from '@/store/api/backend/onprem/composerApi/blueprints';
+
+import { createMinimalBlueprint } from './mocks/fixtures';
+
+describe('prepareBlueprintForSave', () => {
+  it('preserves distribution for package-mode blueprints', () => {
+    const blueprint = createMinimalBlueprint({ distribution: 'rhel-9' });
+
+    const result = prepareBlueprintForSave(blueprint);
+
+    expect(result.distribution).toBe('rhel-9');
+  });
+
+  it('strips distribution for bootc blueprints', () => {
+    const blueprint = createMinimalBlueprint({
+      distribution: 'rhel-10',
+      bootc: { reference: 'quay.io/org/image:latest' },
+    });
+
+    const result = prepareBlueprintForSave(blueprint);
+
+    expect(result.distribution).toBeUndefined();
+  });
+
+  it('preserves all other fields when stripping distribution', () => {
+    const blueprint = createMinimalBlueprint({
+      name: 'my-bootc-blueprint',
+      description: 'A bootc blueprint',
+      distribution: 'rhel-10',
+      bootc: { reference: 'quay.io/org/image:latest' },
+      customizations: { packages: ['vim'] },
+    });
+
+    const result = prepareBlueprintForSave(blueprint);
+
+    expect(result.name).toBe('my-bootc-blueprint');
+    expect(result.description).toBe('A bootc blueprint');
+    expect(result.bootc).toEqual({ reference: 'quay.io/org/image:latest' });
+    expect(result.customizations).toEqual({ packages: ['vim'] });
+    expect(result.distribution).toBeUndefined();
+  });
+
+  it('preserves all other fields for package-mode blueprints', () => {
+    const blueprint = createMinimalBlueprint({
+      name: 'my-package-blueprint',
+      distribution: 'rhel-9',
+      customizations: { hostname: 'test-host' },
+    });
+
+    const result = prepareBlueprintForSave(blueprint);
+
+    expect(result.name).toBe('my-package-blueprint');
+    expect(result.distribution).toBe('rhel-9');
+    expect(result.customizations).toEqual({ hostname: 'test-host' });
+  });
+});

--- a/src/store/api/backend/onprem/tests/composerApi.test.ts
+++ b/src/store/api/backend/onprem/tests/composerApi.test.ts
@@ -271,6 +271,37 @@ describe('toComposerComposeRequest', () => {
         expect(result.distribution).toBe(dist);
       });
     });
+
+    it('should pass through undefined distribution', () => {
+      const blueprint = createMinimalBlueprint();
+
+      const result = toComposerComposeRequest(blueprint, undefined, []);
+      expect(result.distribution).toBeUndefined();
+    });
+
+    it('should clear distribution when blueprint has bootc', () => {
+      const blueprint = createMinimalBlueprint({
+        bootc: { reference: 'quay.io/org/image:latest' },
+      });
+
+      const result = toComposerComposeRequest(blueprint, 'rhel-9', []);
+      expect(result.distribution).toBeUndefined();
+      expect(result.bootc).toEqual({
+        reference: 'quay.io/org/image:latest',
+      });
+    });
+
+    it('should keep distribution undefined when bootc and no distribution', () => {
+      const blueprint = createMinimalBlueprint({
+        bootc: { reference: 'quay.io/org/image:latest' },
+      });
+
+      const result = toComposerComposeRequest(blueprint, undefined, []);
+      expect(result.distribution).toBeUndefined();
+      expect(result.bootc).toEqual({
+        reference: 'quay.io/org/image:latest',
+      });
+    });
   });
 
   describe('complex scenarios', () => {

--- a/src/store/api/backend/onprem/tests/mocks/fixtures.ts
+++ b/src/store/api/backend/onprem/tests/mocks/fixtures.ts
@@ -1,6 +1,7 @@
 import {
   type ComposerCreateBlueprintRequest,
   type ComposerImageRequest,
+  type Distributions,
   type OpenScapProfile,
 } from '@/store/api/backend';
 
@@ -275,7 +276,7 @@ export const createLocalImageRequest = (): ComposerImageRequest => ({
 });
 
 // Distribution list for testing
-export const testDistributions = [
+export const testDistributions: Distributions[] = [
   'rhel-8',
   'rhel-9',
   'rhel-10',

--- a/src/store/api/backend/onprem/types/custom.ts
+++ b/src/store/api/backend/onprem/types/custom.ts
@@ -1,12 +1,10 @@
 import {
   Awss3UploadRequestOptions,
   AwsUploadRequestOptions,
-  BlueprintResponse,
   ComposeRequest,
   ComposesResponseItem,
   CreateBlueprintApiArg,
   CreateBlueprintRequest,
-  DistributionProfileItem,
   Distributions,
   ImageRequest,
   UpdateBlueprintApiArg,
@@ -44,23 +42,6 @@ export type UpdateWorkerConfigApiArg = {
   updateWorkerConfigRequest: WorkerConfigRequest | undefined;
 };
 
-export type ComposerGetArchitecturesApiArg = {
-  distribution: Distributions | 'image-mode';
-};
-
-export type ComposerGetOscapProfilesApiArg = {
-  // NOTE: this is a workaround to get the types happy,
-  // we will disable openscap for image-mode
-  distribution: Distributions | 'image-mode';
-};
-
-export type ComposerGetOscapCustomizationsApiArg = {
-  // NOTE: this is a workaround to get the types happy,
-  // we will disable openscap for image-mode
-  distribution: Distributions | 'image-mode';
-  profile: DistributionProfileItem;
-};
-
 export type ComposerUploadTypes = UploadTypes | 'local';
 
 export type ComposerAwsUploadRequestOptions = AwsUploadRequestOptions & {
@@ -76,18 +57,10 @@ export type ComposerImageRequest = Omit<ImageRequest, 'upload_request'> & {
   upload_request: ComposerUploadRequest;
 };
 
-export type ComposerBlueprintResponse = Omit<
-  BlueprintResponse,
-  'distribution'
-> & {
-  distribution: Distributions | 'image-mode';
-};
-
 export type ComposerCreateBlueprintRequest = Omit<
   CreateBlueprintRequest,
-  'image_requests' | 'distribution'
+  'image_requests'
 > & {
-  distribution: Distributions | 'image-mode';
   image_requests: ComposerImageRequest[];
   bootc?: Bootc | undefined;
 };
@@ -111,7 +84,7 @@ export type ComposerComposesResponseItem = Omit<
   'request'
 > & {
   request: Omit<ComposeRequest, 'image_requests' | 'distribution'> & {
-    distribution?: Distributions | 'image-mode' | undefined;
+    distribution?: Distributions | undefined;
     image_requests: ComposerImageRequest[];
     bootc?: Bootc | undefined;
   };

--- a/src/store/api/contentSources/hooks.tsx
+++ b/src/store/api/contentSources/hooks.tsx
@@ -8,7 +8,6 @@ import {
   selectLocaleLangpackCandidates,
   setVerifiedLocaleLangpacks,
 } from '@/store/slices';
-import { asDistribution } from '@/store/typeGuards';
 
 import { contentSourcesApi as hostedApi } from './hosted';
 import { contentSourcesApi as onPremApi } from './onprem';
@@ -49,7 +48,7 @@ export const useSearchLanguagePacks = (distroUrls: string[]) => {
         ? {
             packages: candidateLangpacks,
             architecture: arch,
-            distribution: asDistribution(distribution),
+            distribution: distribution,
           }
         : { exact_names: candidateLangpacks, urls: distroUrls, limit: 500 };
 

--- a/src/store/api/distributions/types.ts
+++ b/src/store/api/distributions/types.ts
@@ -39,7 +39,7 @@ export type ImageTypeInfo = {
 };
 
 export type DistributionDetailsCustomizationArgs = {
-  distro: Distributions | 'image-mode';
+  distro: Distributions;
   architecture: string[];
   imageType: ImageTypes[];
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -24,7 +24,6 @@ import {
   wizardModalSlice,
   wizardSlice,
 } from './slices';
-import { asDistribution } from './typeGuards';
 
 export const serviceReducer = combineReducers({
   env: envSlice.reducer,
@@ -74,7 +73,7 @@ startAppListening({
           distribution: distribution,
         })(state as onPremState)
       : imageBuilderApi.endpoints.getArchitectures.select({
-          distribution: asDistribution(distribution),
+          distribution: distribution,
         })(state as serviceState);
 
     const allowedImageTypes = architecturesResponse.data?.find(
@@ -110,7 +109,7 @@ startAppListening({
           distribution: distribution,
         })(state as onPremState)
       : imageBuilderApi.endpoints.getArchitectures.select({
-          distribution: asDistribution(distribution),
+          distribution: distribution,
         })(state as serviceState);
 
     const allowedImageTypes = architecturesResponse.data?.find(

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -122,7 +122,7 @@ export type wizardState = {
   isoPayloadReference?: string | undefined;
   bootcDistributions: BootcDistributionItem[];
   architecture: ImageRequest['architecture'];
-  distribution: Distributions | 'image-mode';
+  distribution: Distributions;
   imageTypes: ImageTypes[];
   aapRegistration: {
     enabled: boolean;
@@ -829,10 +829,7 @@ export const wizardSlice = createSlice({
     ) => {
       state.architecture = action.payload;
     },
-    changeDistribution: (
-      state,
-      action: PayloadAction<Distributions | 'image-mode'>,
-    ) => {
+    changeDistribution: (state, action: PayloadAction<Distributions>) => {
       state.distribution = action.payload;
 
       if (process.env.IS_ON_PREMISE && !isRhel(action.payload)) {

--- a/src/store/typeGuards.ts
+++ b/src/store/typeGuards.ts
@@ -4,7 +4,6 @@ import {
   AzureUploadRequestOptions,
   AzureUploadStatus,
   ComposesResponseItem,
-  Distributions,
   GcpUploadRequestOptions,
   GcpUploadStatus,
   ImageTypes,
@@ -15,7 +14,7 @@ import {
 // import from ./api/backend/onprem to break circular dependency
 import { Bootc } from './api/backend/onprem';
 
-import { IMAGE_MODE, targetOptions } from '../constants';
+import { targetOptions } from '../constants';
 
 export const isGcpUploadRequestOptions = (
   _options: UploadRequest['options'],
@@ -59,12 +58,6 @@ export const isAzureUploadStatus = (
   return 'image_name' in status;
 };
 
-export const isImageMode = (
-  distribution?: Distributions | 'image-mode' | undefined,
-): distribution is 'image-mode' => {
-  return distribution === undefined || distribution === IMAGE_MODE;
-};
-
 export type ComposeWithBootc = ComposesResponseItem & {
   request: ComposesResponseItem['request'] & {
     bootc?: Bootc;
@@ -75,20 +68,6 @@ export const hasBootcRequest = (
   compose: ComposesResponseItem,
 ): compose is ComposeWithBootc => {
   return 'bootc' in compose.request;
-};
-
-// we added a dummy distribution, 'image-mode', for image-mode
-// images on-prem. However this caused a number of type issues
-// in the codebase, mostly in places that won't have image-mode
-// support, but this typeguard is useful for managing this in
-// one place
-export const asDistribution = (
-  distribution: Distributions | 'image-mode',
-): Distributions => {
-  if (isImageMode(distribution)) {
-    throw new Error('Unexpected image-mode distribution');
-  }
-  return distribution;
 };
 
 export const isImageType = (key: string): key is ImageTypes => {


### PR DESCRIPTION
## Summary
Remove the `'image-mode'` dummy distribution that was used as a workaround for on-prem bootc builds. Now that on-prem has a proper `getDistributions` query, blueprint mode detection relies on the `bootc` field instead of a magic distribution string.

## Changes
- Remove `IMAGE_MODE` constant, `isImageMode`/`asDistribution` type guards, and all `Distributions | 'image-mode'` union types
- Unify on-prem API arg types with hosted (`GetArchitecturesApiArg`, `GetOscapProfilesApiArg`, etc.) instead of custom composer variants
- Extract `prepareBlueprintForSave` to strip distribution for bootc blueprints at the persistence boundary, replacing inline `IMAGE_MODE` checks
- Update `toComposerComposeRequest` to clear distribution based on `bootc` presence rather than matching a magic string
- Add unit tests for `mapRequestToState`, `mapBlueprintExportToState`, and `prepareBlueprintForSave`

Depends on #4480 