### PR TITLE
packit: Fix Fedora downstream package builds

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -22,8 +22,8 @@ jobs:
     tmt_plan: /plans/all/main
     targets:
       - centos-stream-10
-      - fedora-42
       - fedora-43
+      - fedora-44
 
   - job: copr_build
     trigger: pull_request

--- a/packit.yaml
+++ b/packit.yaml
@@ -65,3 +65,8 @@ jobs:
     trigger: commit
     dist_git_branches:
       - fedora-all
+
+  - job: bodhi_update
+    trigger: commit
+    dist_git_branches:
+      - fedora-branched # rawhide updates are created automatically


### PR DESCRIPTION
Our Fedora releases didn't really make it into the releases. While dist-git shows v100, Fedora 44 only offers cockpit-image-builder v90. The culprit was the missing `bodhi_update` in our packit configuration.

I have manually triggered them now for Fedora 44 and 43:
- https://bodhi.fedoraproject.org/updates/FEDORA-2026-29ffdcc125
- https://bodhi.fedoraproject.org/updates/FEDORA-2026-08d8c50454

Also, remove Fedora 42 and add Fedora 44 to our pr test builds.