### PR TITLE
vitest: Fail on console errors and warnings (HMS-10806)

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -30,13 +30,18 @@ vi.stubGlobal('ResizeObserver', MockResizeObserver);
 vi.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   default: () => ({
     auth: {
-      getUser: async () => ({
-        identity: {
-          internal: {
-            org_id: 5,
-          },
-        },
-      }),
+      getUser: () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            resolve({
+              identity: {
+                internal: {
+                  org_id: 5,
+                },
+              },
+            });
+          }, 0);
+        }),
     },
     isBeta: () => true,
     isProd: () => true,
@@ -80,6 +85,26 @@ configure({
   },
 });
 
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterAll(() => server.close());
+// Fail tests on console warnings and errors
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+
+  vi.spyOn(console, 'error').mockImplementation((...args) => {
+    throw new Error(`Console error:\n${args.join(' ')}`);
+  });
+
+  vi.spyOn(console, 'warn').mockImplementation((...args) => {
+    const message = args.join(' ');
+    if (message.includes('Maximum update depth exceeded')) {
+      return;
+    }
+    throw new Error(`Console warning:\n${message}`);
+  });
+});
+
+afterAll(() => {
+  server.close();
+  vi.restoreAllMocks();
+});
+
 afterEach(() => server.resetHandlers());


### PR DESCRIPTION
Some changes introduce warning and error console logs in the test output. This will make the test run fail when there's any "mess" and the problems can be fixed in place instead of retroactively when the test output becomes unreadable.

"Maximum update depth exceeded" warning was silences for now and will be revisited later. There's just new act warning and stuff coming in almost every week.

JIRA: [HMS-10806](https://issues.redhat.com/browse/HMS-10806)

[HMS-10806]: https://redhat.atlassian.net/browse/HMS-10806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ