### PR TITLE
Wizard: Fix kernel alert rendering (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Kernel/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/index.tsx
@@ -38,14 +38,14 @@ const KernelStep = () => {
           Choose a kernel package and append specific boot parameters to
           customize how your image initializes its core operating environment.
         </Content>
-        {fips.enabled && (
-          <Alert
-            title='Kernel will be configured to use FIPS, no additional configuration needed.'
-            variant='info'
-            isInline
-          />
-        )}
       </Content>
+      {fips.enabled && (
+        <Alert
+          title='Kernel will be configured to use FIPS, no additional configuration needed.'
+          variant='info'
+          isInline
+        />
+      )}
       <KernelName />
       <KernelArguments />
     </>


### PR DESCRIPTION
The alert needs to be rendered outside of the Content block to be formatted properly.

Before:
<img width="980" height="247" alt="image" src="https://github.com/user-attachments/assets/a4eda9da-1eaa-486a-bfbb-a100dd6b173e" />


After:
<img width="972" height="238" alt="image" src="https://github.com/user-attachments/assets/f6f33d30-1239-4047-917a-c0eabb41e93f" />
