### PR TITLE
[10.2] release: pass tag to release-action for workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
           token: "${{ secrets.SCHUTZBOT_GITHUB_ACCESS_TOKEN }}"
           slack_bot_token: "${{ secrets.SLACK_BOT_TOKEN }}"
           branch: ${{ inputs.branch || 'main' }}
+          tag: ${{ env.TAG }}
 
       # upload release artefact
       # Source0 expands to `https://github.com/osbuild/image-builder-frontend/releases/download/v$VERSION/cockpit-image-builder-v$VERSION.tar.gz`,


### PR DESCRIPTION
The release-action now accepts a tag input, which is needed when triggered via workflow_dispatch since GITHUB_REF is a branch, not a tag.