### PR TITLE
Disable npm lifecycle scripts via .npmrc (HMS-10780)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
## Summary
Add `.npmrc` to disable lifecycle scripts during `npm install`, reducing risk from transitive dependency post-install scripts.

## Changes
- Add `.npmrc` with `ignore-scripts=true` to skip lifecycle scripts on install

JIRA: [HMS-10780](https://issues.redhat.com/browse/HMS-10780)

[HMS-10780]: https://redhat.atlassian.net/browse/HMS-10780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ