### PR TITLE
Wizard: Prevent Users columns from overflowing the card on small screens (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Users.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Users.tsx
@@ -18,7 +18,7 @@ export const Users = ({ shouldHide }: Hideable) => {
   return (
     <>
       <ReviewGroup heading='Users' />
-      <Flex>
+      <Flex flexWrap={{ default: 'nowrap' }} style={{ overflowX: 'auto' }}>
         <FlexColumn
           heading='Username'
           labelKey='user-name-review'


### PR DESCRIPTION
Wizard: Prevent Users columns from overflowing the card on small screens 
<img width="1088" height="862" alt="Screenshot 2026-06-03 at 15 13 06" src="https://github.com/user-attachments/assets/88959398-859f-43fd-b79a-b87333025408" />





JIRA: (HMS-10579)
