### PR TITLE
Wizard: Remove repo link and add template link to the repeatable build (HMS-10579)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Snapshot/components/Snapshot.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/components/Snapshot.tsx
@@ -12,6 +12,7 @@ import {
 } from '@patternfly/react-core';
 
 import { isSnapshotDateValid } from '@/Components/CreateImageWizard/validators';
+import { TEMPLATES_URL } from '@/constants';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeSnapshotDate,
@@ -138,7 +139,22 @@ const Snapshot = () => {
         ouiaId='use-content-template-radio'
         name='snapshot-type'
         label='Use a content template'
-        description='Select a content template and build this image with repository snapshots included in that template.'
+        description={
+          <>
+            Select a content template and build this image with repository
+            snapshots included in that template.{' '}
+            <Button
+              component='a'
+              target='_blank'
+              variant='link'
+              isInline
+              href={TEMPLATES_URL}
+              rel='noopener noreferrer'
+            >
+              Create and manage templates
+            </Button>
+          </>
+        }
         isChecked={selectedOption === 'template'}
         onChange={() => handleOptionChange('template')}
         className='pf-v6-u-pb-sm'

--- a/src/Components/CreateImageWizard/steps/Snapshot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/index.tsx
@@ -6,8 +6,6 @@ import { CustomizationLabels } from '@/Components/sharedComponents/Customization
 
 import Snapshot from './components/Snapshot';
 
-import ManageRepositoriesButton from '../Repositories/components/ManageRepositoriesButton';
-
 const RepeatableBuildStep = () => {
   return (
     <>
@@ -18,7 +16,7 @@ const RepeatableBuildStep = () => {
         </Title>
         <Content component='small'>
           Create images that can be reproduced consistently with the same
-          package versions and configurations. <ManageRepositoriesButton />
+          package versions and configurations.
         </Content>
       </Content>
       <Snapshot />


### PR DESCRIPTION
This removes the "Create and manage repositories" link from the repeatable step as it was out of context of the step. Instead a link leading to template management was added to the template radio button.