### PR TITLE
playwright: fix tmt in dist-git

### DIFF
--- a/schutzbot/playwright_tests.sh
+++ b/schutzbot/playwright_tests.sh
@@ -2,11 +2,17 @@
 set -euo pipefail
 
 PW_WORKERS=4
-if [ -n "${TMT_TREE:-}" ]; then
-    # Move to the directory with sources
+
+if [ -n "${PACKIT_PACKAGE_NAME:-}" ]; then
+    # Runs in CI (Packit)
     cd "${TMT_TREE}"
     npm ci
+elif [ -n "${TMT_SOURCE_DIR:-}" ]; then
+    # Runs in dist-git
+    cd "${TMT_SOURCE_DIR}/cockpit-image-builder"
+    npm ci
 elif [ "${CI:-}" != "true" ]; then
+    # Local fallback
     cd ../
     npm ci
     # halve the workers on schutzbot to increase reliability


### PR DESCRIPTION
Recently testing-farm tests were failing and a fix was merged in 3507013e where TMT_TREE is used instead of TMT_SOURCE.

This got the CI working, but broke the tests when running in dist-git.

We need to use TMT_SOURCE when in CI, and TMT_SOURCE_DIR when in dist-git. This commit adds the dist-git case back while keeping TMT_SOURCE for Packit.