### PR TITLE
Add PlatformContext to replace build-time hook switching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,53 @@ Imports are enforced alphabetically by ESLint. Group order:
 - Playwright tests for E2E coverage of critical flows
 - The `TZ=UTC` prefix is applied automatically by npm scripts
 
+## Platform Context
+
+The app runs on two platforms — **hosted** (console.redhat.com) and **on-premises** (Cockpit plugin). Platform-specific hooks, API slices, and utilities are abstracted behind a React context so components never branch on the environment directly.
+
+### Architecture
+
+| File | Purpose |
+| --- | --- |
+| `src/context/platform/types.ts` | `PlatformHooks` type — the contract for `queries`, `mutations`, `env`, and `api` |
+| `src/context/platform/index.ts` | `PlatformContext`, `PlatformProvider`, and `usePlatform()` hook |
+| `src/context/platform/hosted.ts` | Hosted implementation (`hostedPlatform`) — Unleash flags, hosted RTK Query hooks |
+| `src/context/platform/onprem.ts` | On-prem implementation (`onPremPlatform`) — static flags, Cockpit/composer hooks |
+
+### Barrel files
+
+The store barrel files (`src/store/api/backend/index.ts`, `src/store/api/contentSources/index.ts`) no longer contain any `process.env.IS_ON_PREMISE` ternary logic. All platform-switched hooks are now sourced exclusively through `usePlatform()`. The barrels retain only:
+
+- **Type re-exports** (hosted as canonical, prefixed on-prem types where they conflict)
+- **Platform-independent hooks** — hosted-only hooks gated at the component/route level (e.g. `useComposeImageMutation`, `useListRepositoriesQuery`)
+- **API slice references** (`imageBuilderApi`, `composerApi`, `contentSourcesApi`) for store setup and `invalidateTags`
+
+### Usage
+
+Entry points (`src/AppEntry.tsx`, Cockpit bootstrap) wrap the app with `<PlatformProvider value={hostedPlatform}>` or `<PlatformProvider value={onPremPlatform}>`.
+
+Consumers destructure the specific hooks they need from `usePlatform()`:
+
+```tsx
+import { usePlatform } from '@/context/platform';
+
+const { queries: { useGetBlueprintQuery } } = usePlatform();
+const { data } = useGetBlueprintQuery({ id });
+```
+
+Destructure to the individual hook level — not just `queries`/`mutations`/`api` — so call sites match the original direct-import style and keep diffs minimal.
+
+### PlatformHooks shape
+
+- **`queries`** — RTK Query hooks: `useGetBlueprintQuery`, `useGetBlueprintsQuery`, `useGetComposeStatusQuery`, `useGetArchitecturesQuery`, `useGetDistributionsQuery`, `useGetOscapProfilesQuery`, `useGetOscapCustomizationsQuery`, `useLazyGetBlueprintsQuery`, `useLazyGetOscapCustomizationsQuery`, `useGetComposesQuery`, `useGetBlueprintComposesQuery`
+- **`mutations`** — RTK Query mutation hooks: `useCreateBlueprintMutation`, `useUpdateBlueprintMutation`, `useDeleteBlueprintMutation`, `useComposeBlueprintMutation`, `useSearchRpmMutation`, `useListSnapshotsByDateMutation`
+- **`env`** — `useFlag(flag)` and `useGetEnvironment()`
+- **`api`** — `backendApi` (the RTK API slice for `invalidateTags` etc.), `contentSourcesApi`, `useBackendPrefetch`
+
+### Testing
+
+Tests use a `mockPlatform` fixture from `src/context/platform/tests/mocks/` and render inside a `PlatformProvider`. When mocking `usePlatform` directly via `vi.mock`, spread `mockPlatform` and override only the hooks under test.
+
 ## Feature Flags
 
 Uses Unleash for feature toggles in the hosted service. Import `useFlag` from `src/Utilities/useGetEnvironment.ts` to check flag status:

--- a/src/AppCockpit.tsx
+++ b/src/AppCockpit.tsx
@@ -12,6 +12,8 @@ import { HashRouter } from 'react-router-dom';
 
 import './AppCockpit.scss';
 import { NotReady, RequireAdmin } from './Components/Cockpit';
+import { PlatformProvider } from './context/platform';
+import { onPremPlatform } from './context/platform/onprem';
 import { Router } from './Router';
 import { onPremStore as store } from './store';
 import { useGetComposerSocketStatus } from './Utilities/useComposerStatus';
@@ -41,11 +43,13 @@ const Application = () => {
 };
 const ImageBuilder = () => (
   <Provider store={store}>
-    <Page className='no-masthead-sidebar' isContentFilled>
-      <PageSection>
-        <Application />
-      </PageSection>
-    </Page>
+    <PlatformProvider value={onPremPlatform}>
+      <Page className='no-masthead-sidebar' isContentFilled>
+        <PageSection>
+          <Application />
+        </PageSection>
+      </Page>
+    </PlatformProvider>
   </Provider>
 );
 

--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -3,11 +3,15 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import App from './App';
+import { PlatformProvider } from './context/platform';
+import { hostedPlatform } from './context/platform/hosted';
 import { serviceStore as store } from './store';
 
 const ImageBuilder = () => (
   <Provider store={store}>
-    <App />
+    <PlatformProvider value={hostedPlatform}>
+      <App />
+    </PlatformProvider>
   </Provider>
 );
 

--- a/src/Components/Blueprints/BlueprintDiffModal.tsx
+++ b/src/Components/Blueprints/BlueprintDiffModal.tsx
@@ -10,7 +10,7 @@ import {
   ModalVariant,
 } from '@patternfly/react-core';
 
-import { useGetBlueprintQuery } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 import { selectSelectedBlueprintId } from '@/store/slices/blueprint';
 
 import { BuildImagesButton } from './BuildImagesButton';
@@ -31,6 +31,9 @@ const BlueprintDiffModal = ({
   isOpen,
   onClose,
 }: blueprintDiffProps) => {
+  const {
+    queries: { useGetBlueprintQuery },
+  } = usePlatform();
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
 
   const { data: baseBlueprint } = useGetBlueprintQuery(

--- a/src/Components/Blueprints/BlueprintsPagination.tsx
+++ b/src/Components/Blueprints/BlueprintsPagination.tsx
@@ -3,10 +3,8 @@ import React from 'react';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
 import { OnSetPage } from '@patternfly/react-core/dist/esm/components/Pagination/Pagination';
 
-import {
-  GetBlueprintsApiArg,
-  useGetBlueprintsQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { GetBlueprintsApiArg } from '@/store/api/backend';
 import {
   selectBlueprintSearchInput,
   selectLimit,
@@ -18,6 +16,9 @@ import {
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 
 const BlueprintsPagination = () => {
+  const {
+    queries: { useGetBlueprintsQuery },
+  } = usePlatform();
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
   const blueprintsOffset = useAppSelector(selectOffset) || 0;
   const blueprintsLimit = useAppSelector(selectLimit) || 10;

--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -18,12 +18,8 @@ import { PlusCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import {
-  BlueprintItem,
-  GetBlueprintsApiArg,
-  imageBuilderApi,
-  useGetBlueprintsQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { BlueprintItem, GetBlueprintsApiArg } from '@/store/api/backend';
 import {
   selectBlueprintSearchInput,
   selectLimit,
@@ -57,6 +53,9 @@ type emptyBlueprintStateProps = {
 };
 
 const BlueprintsSidebar = () => {
+  const {
+    queries: { useGetBlueprintsQuery },
+  } = usePlatform();
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
   const isOnPremise = useAppSelector(selectIsOnPremise);
@@ -181,6 +180,9 @@ const BlueprintsSidebar = () => {
 };
 
 const BlueprintSearch = ({ blueprintsTotal }: blueprintSearchProps) => {
+  const {
+    api: { backendApi },
+  } = usePlatform();
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
   const dispatch = useAppDispatch();
   const [localSearchValue, setLocalSearchValue] = useState(
@@ -190,7 +192,7 @@ const BlueprintSearch = ({ blueprintsTotal }: blueprintSearchProps) => {
 
   useEffect(() => {
     dispatch(setBlueprintsOffset(0));
-    dispatch(imageBuilderApi.util.invalidateTags([{ type: 'Blueprints' }]));
+    dispatch(backendApi.util.invalidateTags([{ type: 'Blueprints' }]));
     dispatch(
       setBlueprintSearchInput(
         debouncedSearchValue.length > 0 ? debouncedSearchValue : undefined,

--- a/src/Components/Blueprints/BuildImagesButton.tsx
+++ b/src/Components/Blueprints/BuildImagesButton.tsx
@@ -18,7 +18,8 @@ import { MenuToggleElement } from '@patternfly/react-core/dist/esm/components/Me
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { skipToken } from '@reduxjs/toolkit/query';
 
-import { ImageTypes, useGetBlueprintQuery } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { ImageTypes } from '@/store/api/backend';
 import { selectSelectedBlueprintId } from '@/store/slices/blueprint';
 import { selectIsOnPremise } from '@/store/slices/env';
 
@@ -35,6 +36,9 @@ type BuildImagesButtonPropTypes = {
 };
 
 export const BuildImagesButton = ({ children }: BuildImagesButtonPropTypes) => {
+  const {
+    queries: { useGetBlueprintQuery },
+  } = usePlatform();
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
   const [deselectedTargets, setDeselectedTargets] = useState<ImageTypes[]>([]);
   const { trigger: buildBlueprint, isLoading: imageBuildLoading } =

--- a/src/Components/Blueprints/DeleteBlueprintModal.tsx
+++ b/src/Components/Blueprints/DeleteBlueprintModal.tsx
@@ -10,11 +10,8 @@ import {
 } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import {
-  backendApi,
-  GetBlueprintsApiArg,
-  useGetBlueprintsQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { GetBlueprintsApiArg } from '@/store/api/backend';
 import {
   selectBlueprintSearchInput,
   selectLimit,
@@ -43,6 +40,10 @@ interface DeleteBlueprintModalProps {
 export const DeleteBlueprintModal: React.FunctionComponent<
   DeleteBlueprintModalProps
 > = ({ setShowDeleteModal, isOpen }: DeleteBlueprintModalProps) => {
+  const {
+    queries: { useGetBlueprintsQuery },
+    api: { backendApi },
+  } = usePlatform();
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
   const blueprintsOffset = useAppSelector(selectOffset) || PAGINATION_OFFSET;

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -18,8 +18,8 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
+import { usePlatform } from '@/context/platform';
 import { useGetUser } from '@/Hooks';
-import { useGetBlueprintQuery } from '@/store/api/backend';
 import { useCustomizationRestrictions } from '@/store/api/distributions/hooks';
 import {
   selectSelectedBlueprintId,
@@ -124,6 +124,10 @@ const CreateImageWizard = () => {
   const hasTrackedInitialStepRef = useRef(false);
   const hasTrackedWizardOpenedRef = useRef(false);
   const isHostDistroDetected = useRef(!isOnPremise);
+
+  const {
+    queries: { useGetBlueprintQuery },
+  } = usePlatform();
 
   const {
     data: blueprintDetails,

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -19,10 +19,8 @@ import {
 import { SyncAltIcon } from '@patternfly/react-icons';
 
 import { RHEL_10_IMAGE_MODE_IMAGE } from '@/constants';
-import {
-  BootcDistributionItem,
-  useGetDistributionsQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { BootcDistributionItem } from '@/store/api/backend';
 import { Distributions } from '@/store/api/backend/hosted';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
@@ -63,6 +61,9 @@ const InfoMessageContent = ({ source }: { source: string }) => {
 };
 
 const ImageSourceSelect = () => {
+  const {
+    queries: { useGetDistributionsQuery },
+  } = usePlatform();
   const dispatch = useAppDispatch();
   const isOnPremise = useAppSelector(selectIsOnPremise);
   const arch = useAppSelector(selectArchitecture);

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -11,14 +11,10 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 
+import { usePlatform } from '@/context/platform';
 import { useTargetEnvironmentCategories } from '@/Hooks';
 import { rhsmApi } from '@/store/api';
-import {
-  BootcDistributionItem,
-  ImageTypes,
-  useGetArchitecturesQuery,
-  useGetDistributionsQuery,
-} from '@/store/api/backend';
+import { BootcDistributionItem, ImageTypes } from '@/store/api/backend';
 import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -67,6 +63,9 @@ const createLabelWithTooltip = (
 };
 
 const TargetEnvironment = () => {
+  const {
+    queries: { useGetArchitecturesQuery, useGetDistributionsQuery },
+  } = usePlatform();
   const arch = useAppSelector(selectArchitecture);
   const environments = useAppSelector(selectImageTypes);
   const distribution = useAppSelector(selectDistribution);

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -27,12 +27,19 @@ import ImageSourceSelect from '../components/ImageSourceSelect';
 const mockRefetch = vi.fn();
 const mockUseGetDistributionsQuery = vi.fn();
 
-vi.mock('@/store/api/backend', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/store/api/backend')>();
+vi.mock('@/context/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/context/platform')>();
+  const { mockPlatform } = await import('@/context/platform/tests/mocks');
   return {
     ...actual,
-    useGetDistributionsQuery: (...args: unknown[]) =>
-      mockUseGetDistributionsQuery(...args),
+    usePlatform: () => ({
+      ...mockPlatform,
+      queries: {
+        ...mockPlatform.queries,
+        useGetDistributionsQuery: (...args: unknown[]) =>
+          mockUseGetDistributionsQuery(...args),
+      },
+    }),
   };
 });
 

--- a/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
@@ -5,7 +5,7 @@ import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 import LabelInput from '@/Components/CreateImageWizard/LabelInput';
 import { useKernelValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import { isKernelArgumentValid } from '@/Components/CreateImageWizard/validators';
-import { useGetOscapCustomizationsQuery } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 import { useAppSelector } from '@/store/hooks';
 import {
   addKernelArg,
@@ -16,6 +16,9 @@ import {
 } from '@/store/slices/wizard';
 
 const KernelArguments = () => {
+  const {
+    queries: { useGetOscapCustomizationsQuery },
+  } = usePlatform();
   const kernelAppend = useAppSelector(selectKernel).append;
 
   const stepValidation = useKernelValidation();

--- a/src/Components/CreateImageWizard/steps/Locale/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/index.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import { Content, Spinner, Title } from '@patternfly/react-core';
 
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
-import { useGetArchitecturesQuery } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 import { useSearchLanguagePacks } from '@/store/api/contentSources';
 import { useAppSelector } from '@/store/hooks';
 import {
@@ -17,6 +17,9 @@ import KeyboardDropDown from './components/KeyboardDropDown';
 import LanguagesDropDown from './components/LanguagesDropDown';
 
 const LocaleStep = () => {
+  const {
+    queries: { useGetArchitecturesQuery },
+  } = usePlatform();
   const distribution = useAppSelector(selectDistribution);
   const arch = useAppSelector(selectArchitecture);
   const candidateLangpacks = useAppSelector(selectLocaleLangpackCandidates);

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileDetails.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileDetails.tsx
@@ -10,11 +10,11 @@ import {
   Spinner,
 } from '@patternfly/react-core';
 
+import { usePlatform } from '@/context/platform';
 import {
   DistributionProfileItem,
   OpenScap,
   OpenScapProfile,
-  useGetOscapCustomizationsQuery,
 } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
 import {
@@ -25,6 +25,9 @@ import {
 import { removeBetaFromRelease } from '../removeBetaFromRelease';
 
 const ProfileDetails = (): JSX.Element => {
+  const {
+    queries: { useGetOscapCustomizationsQuery },
+  } = usePlatform();
   const releaseRaw = useAppSelector(selectDistribution);
   const release = removeBetaFromRelease(releaseRaw);
   const profileID = useAppSelector(selectComplianceProfileID);

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -15,14 +15,12 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 
+import { usePlatform } from '@/context/platform';
 import {
   DistributionProfileItem,
   DistributionProfileResponse,
   OpenScap,
   OpenScapProfile,
-  useBackendPrefetch,
-  useGetOscapCustomizationsQuery,
-  useLazyGetOscapCustomizationsQuery,
 } from '@/store/api/backend';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
@@ -60,6 +58,13 @@ const ProfileSelector = ({
   isSuccess,
   refetch,
 }: ProfileSelectorProps) => {
+  const {
+    queries: {
+      useGetOscapCustomizationsQuery,
+      useLazyGetOscapCustomizationsQuery,
+    },
+    api: { useBackendPrefetch },
+  } = usePlatform();
   const isOnPremise = useAppSelector(selectIsOnPremise);
   const profileID = useAppSelector(selectComplianceProfileID);
   const release = removeBetaFromRelease(useAppSelector(selectDistribution));

--- a/src/Components/CreateImageWizard/steps/Oscap/components/SecurityInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/SecurityInformation.tsx
@@ -10,11 +10,11 @@ import {
 } from '@patternfly/react-core';
 import { CheckCircleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 
+import { usePlatform } from '@/context/platform';
 import {
   DistributionProfileItem,
   OpenScapProfile,
   useGetComplianceCustomizationsQuery,
-  useGetOscapCustomizationsQuery,
 } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
@@ -28,6 +28,9 @@ import {
 } from '@/store/slices/wizard';
 
 export const SecurityInformation = (): JSX.Element => {
+  const {
+    queries: { useGetOscapCustomizationsQuery },
+  } = usePlatform();
   const release = useAppSelector(selectDistribution);
   const complianceType = useAppSelector(selectComplianceType);
   const complianceProfileID = useAppSelector(selectComplianceProfileID);

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -26,12 +26,8 @@ import {
   FIRST_BOOT_SERVICE,
   OSCAP_URL,
 } from '@/constants';
+import { usePlatform } from '@/context/platform';
 import { useGetUser } from '@/Hooks';
-import {
-  useBackendPrefetch,
-  useGetOscapCustomizationsQuery,
-  useGetOscapProfilesQuery,
-} from '@/store/api/backend';
 import { useSecuritySummary } from '@/store/api/backend/hooks';
 import { usePoliciesQuery } from '@/store/api/compliance';
 import { useCustomizationRestrictions } from '@/store/api/distributions';
@@ -71,6 +67,10 @@ import { removeBetaFromRelease } from './removeBetaFromRelease';
 import ExternalLinkButton from '../../utilities/ExternalLinkButton';
 
 const OscapContent = () => {
+  const {
+    queries: { useGetOscapProfilesQuery, useGetOscapCustomizationsQuery },
+    api: { useBackendPrefetch },
+  } = usePlatform();
   const dispatch = useAppDispatch();
   const registrationType = useAppSelector(selectRegistrationType);
   const complianceType = useAppSelector(selectComplianceType);

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -33,7 +33,6 @@ import {
 import { usePlatform } from '@/context/platform';
 import {
   Module,
-  useGetArchitecturesQuery,
   useRecommendPackageMutation,
   useSecuritySummary,
 } from '@/store/api/backend';
@@ -101,6 +100,7 @@ const PackageSearch = ({
   setActiveStream,
 }: PackageSearchProps) => {
   const {
+    queries: { useGetArchitecturesQuery },
     mutations: { useSearchRpmMutation },
   } = usePlatform();
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -30,6 +30,7 @@ import {
   ContentOrigin,
   EPEL_10_REPO_DEFINITION,
 } from '@/constants';
+import { usePlatform } from '@/context/platform';
 import {
   Module,
   useGetArchitecturesQuery,
@@ -42,7 +43,6 @@ import {
   useListRepositoriesQuery,
   useSearchPackageGroupMutation,
   useSearchRepositoryModuleStreamsMutation,
-  useSearchRpmMutation,
 } from '@/store/api/contentSources';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
@@ -100,6 +100,9 @@ const PackageSearch = ({
   activeStream,
   setActiveStream,
 }: PackageSearchProps) => {
+  const {
+    mutations: { useSearchRpmMutation },
+  } = usePlatform();
   const dispatch = useAppDispatch();
   const { analytics, isBeta } = useChrome();
 
@@ -254,13 +257,16 @@ const PackageSearch = ({
     }
     if (debouncedSearchTerm.length > 1 && isSuccessDistroRepositories) {
       if (isOnPremise) {
+        // On-prem uses a different request shape with packages/architecture/distribution
+        // fields that don't exist in the hosted ApiContentUnitSearchRequest type.
+        // The on-prem implementation accepts these fields at runtime via PlatformContext.
         searchDistroRpms({
           apiContentUnitSearchRequest: {
             packages: [debouncedSearchTerm],
             architecture: arch,
             distribution,
           },
-        });
+        } as Parameters<typeof searchDistroRpms>[0]);
       } else {
         searchDistroRpms({
           apiContentUnitSearchRequest: {

--- a/src/Components/CreateImageWizard/steps/Repositories/components/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/Repositories.tsx
@@ -16,12 +16,12 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import { CONTENT_URL, ContentOrigin } from '@/constants';
+import { usePlatform } from '@/context/platform';
 import {
   ApiRepositoryResponseRead,
   useGetTemplateQuery,
   useListRepositoriesQuery,
   useListRepositoryParametersQuery,
-  useListSnapshotsByDateMutation,
 } from '@/store/api/contentSources';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -70,6 +70,9 @@ import {
 } from '../repositoriesUtilities';
 
 const Repositories = () => {
+  const {
+    mutations: { useListSnapshotsByDateMutation },
+  } = usePlatform();
   const dispatch = useAppDispatch();
 
   const arch = useAppSelector(selectArchitecture);

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -82,7 +82,7 @@ export const CreateSaveAndBuildBtn = ({
     }
     if (requestBody) {
       const blueprint = (await createBlueprint({
-        createBlueprintRequest: requestBody,
+        createBlueprintRequest: requestBody as CreateBlueprintRequest,
       })) as CreateBlueprintResponse;
 
       buildBlueprint({ id: blueprint.id, body: {} });
@@ -181,7 +181,7 @@ export const CreateSaveButton = ({
     }
     if (requestBody) {
       const blueprint = (await createBlueprint({
-        createBlueprintRequest: requestBody,
+        createBlueprintRequest: requestBody as CreateBlueprintRequest,
       })) as CreateBlueprintResponse;
       dispatch(setBlueprintId(blueprint.id));
     }

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -78,7 +78,7 @@ export const EditSaveAndBuildBtn = ({
     if (requestBody) {
       await updateBlueprint({
         id: blueprintId,
-        createBlueprintRequest: requestBody,
+        createBlueprintRequest: requestBody as CreateBlueprintRequest,
       });
     }
     buildBlueprint({ id: blueprintId, body: {} });
@@ -127,7 +127,7 @@ export const EditSaveButton = ({
     if (requestBody) {
       updateBlueprint({
         id: blueprintId,
-        createBlueprintRequest: requestBody,
+        createBlueprintRequest: requestBody as CreateBlueprintRequest,
       });
     }
   };

--- a/src/Components/CreateImageWizard/steps/Services/components/ServicesInputs.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/components/ServicesInputs.tsx
@@ -5,7 +5,7 @@ import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 import LabelInput from '@/Components/CreateImageWizard/LabelInput';
 import { useServicesValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import { isServiceValid } from '@/Components/CreateImageWizard/validators';
-import { useGetOscapCustomizationsQuery } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 import { useAppSelector } from '@/store/hooks';
 import {
   addDisabledService,
@@ -20,6 +20,9 @@ import {
 } from '@/store/slices/wizard';
 
 const ServicesInput = () => {
+  const {
+    queries: { useGetOscapCustomizationsQuery },
+  } = usePlatform();
   const disabledServices = useAppSelector(selectServices).disabled;
   const maskedServices = useAppSelector(selectServices).masked;
   const enabledServices = useAppSelector(selectServices).enabled;

--- a/src/Components/CreateImageWizard/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/tests/helpers.tsx
@@ -5,6 +5,8 @@ import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
+import { PlatformProvider } from '@/context/platform';
+import { hostedPlatform } from '@/context/platform/hosted';
 import { RootState, serviceMiddleware, serviceReducer } from '@/store';
 
 import CreateImageWizard from '../CreateImageWizard';
@@ -36,12 +38,14 @@ export const renderWithQueryParams = async (
 
   render(
     <Provider store={store}>
-      <RouterProvider
-        router={router}
-        future={{
-          v7_startTransition: true,
-        }}
-      />
+      <PlatformProvider value={hostedPlatform}>
+        <RouterProvider
+          router={router}
+          future={{
+            v7_startTransition: true,
+          }}
+        />
+      </PlatformProvider>
     </Provider>,
   );
 

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -3,10 +3,8 @@ import React, { useEffect, useState } from 'react';
 import { CheckCircleIcon } from '@patternfly/react-icons';
 import { jwtDecode } from 'jwt-decode';
 
-import {
-  BlueprintsResponse,
-  useLazyGetBlueprintsQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { BlueprintsResponse } from '@/store/api/backend';
 import { useShowActivationKeyQuery } from '@/store/api/rhsm';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
@@ -1098,6 +1096,9 @@ const countCharacterTypes = (value: string) => {
 };
 
 export function useDetailsValidation(): StepValidation {
+  const {
+    queries: { useLazyGetBlueprintsQuery },
+  } = usePlatform();
   const name = useAppSelector(selectBlueprintName);
   const description = useAppSelector(selectBlueprintDescription);
   const blueprintId = useAppSelector(selectBlueprintId);

--- a/src/Components/ImagesTable/ImageDetails.tsx
+++ b/src/Components/ImagesTable/ImageDetails.tsx
@@ -12,10 +12,10 @@ import {
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
+import { usePlatform } from '@/context/platform';
 import {
   ComposesResponseItem,
   GcpUploadRequestOptions,
-  useGetComposeStatusQuery,
 } from '@/store/api/backend';
 import { selectIsOnPremise } from '@/store/slices/env';
 
@@ -45,6 +45,9 @@ type AwsDetailsPropTypes = {
 };
 
 export const AwsDetails = ({ compose }: AwsDetailsPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const options = compose.request.image_requests[0].upload_request.options;
 
   const { analytics, auth } = useChrome();
@@ -176,6 +179,9 @@ type AzureDetailsPropTypes = {
 };
 
 export const AzureDetails = ({ compose }: AzureDetailsPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { data: composeStatus } = useGetComposeStatusQuery({
     composeId: compose.id,
   });
@@ -256,6 +262,9 @@ type GcpDetailsPropTypes = {
 };
 
 export const GcpDetails = ({ compose }: GcpDetailsPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { data: composeStatus } = useGetComposeStatusQuery({
     composeId: compose.id,
   });
@@ -344,6 +353,9 @@ type OciDetailsPropTypes = {
 };
 
 export const OciDetails = ({ compose }: OciDetailsPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { data: composeStatus } = useGetComposeStatusQuery({
     composeId: compose.id,
   });

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -31,16 +31,13 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import cockpit from 'cockpit';
 import { useDispatch } from 'react-redux';
 
+import { usePlatform } from '@/context/platform';
 import {
   BlueprintItem,
   ComposesResponseItem,
   GetBlueprintComposesApiArg,
   GetBlueprintsApiArg,
   LocalUploadStatus,
-  useGetBlueprintComposesQuery,
-  useGetBlueprintsQuery,
-  useGetComposesQuery,
-  useGetComposeStatusQuery,
 } from '@/store/api/backend';
 import {
   selectBlueprintSearchInput,
@@ -96,6 +93,13 @@ import { GcpLaunchModal } from '../Launch/GcpLaunchModal';
 import { OciLaunchModal } from '../Launch/OciLaunchModal';
 
 const ImagesTable = () => {
+  const {
+    queries: {
+      useGetBlueprintsQuery,
+      useGetBlueprintComposesQuery,
+      useGetComposesQuery,
+    },
+  } = usePlatform();
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
 
@@ -322,6 +326,9 @@ type ImagesTableRowPropTypes = {
 };
 
 const ImagesTableRow = ({ compose, rowIndex }: ImagesTableRowPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const [pollingInterval, setPollingInterval] = useState(
     STATUS_POLLING_INTERVAL,
   );
@@ -580,6 +587,9 @@ const Row = ({
   details,
   instance,
 }: RowPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
   const isOnPremise = useAppSelector(selectIsOnPremise);

--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -13,13 +13,11 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 
+import { usePlatform } from '@/context/platform';
 import {
   BlueprintItem,
   Distributions,
   GetBlueprintComposesApiArg,
-  useGetBlueprintComposesQuery,
-  useGetBlueprintQuery,
-  useGetBlueprintsQuery,
 } from '@/store/api/backend';
 import {
   selectBlueprintSearchInput,
@@ -58,6 +56,13 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
   setPage,
   onPerPageSelect,
 }: imagesTableToolbarProps) => {
+  const {
+    queries: {
+      useGetBlueprintQuery,
+      useGetBlueprintComposesQuery,
+      useGetBlueprintsQuery,
+    },
+  } = usePlatform();
   const isOnPremise = useAppSelector(selectIsOnPremise);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDiffModal, setShowDiffModal] = useState(false);

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -6,11 +6,11 @@ import { Button, Skeleton } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import cockpit from 'cockpit';
 
+import { usePlatform } from '@/context/platform';
 import {
   ComposesResponseItem,
   ImageTypes,
   LocalUploadStatus,
-  useGetComposeStatusQuery,
 } from '@/store/api/backend';
 import { selectIsOnPremise } from '@/store/slices/env';
 
@@ -32,6 +32,9 @@ export const AwsS3Instance = ({
   compose,
   isExpired,
 }: AwsS3InstancePropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { analytics } = useChrome();
   const isOnPremise = useAppSelector(selectIsOnPremise);
 
@@ -121,6 +124,9 @@ const VM_INSTALLABLE_IMAGE_TYPES: ImageTypes[] = [
 ];
 
 export const LocalInstance = ({ compose }: LocalInstancePropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const isMachinesAvailable = useCockpitMachinesAvailable();
   const { data: composeStatus, isSuccess } = useGetComposeStatusQuery({
     composeId: compose.id,

--- a/src/Components/ImagesTable/Status.tsx
+++ b/src/Components/ImagesTable/Status.tsx
@@ -24,12 +24,12 @@ import {
   PendingIcon,
 } from '@patternfly/react-icons';
 
+import { usePlatform } from '@/context/platform';
 import {
   ComposerComposesResponseItem,
   ComposesResponseItem,
   ComposeStatus,
   ComposeStatusError,
-  useGetComposeStatusQuery,
 } from '@/store/api/backend';
 
 import {
@@ -42,6 +42,9 @@ type ComposeStatusPropTypes = {
 };
 
 export const AwsDetailsStatus = ({ compose }: ComposeStatusPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { data, isSuccess } = useGetComposeStatusQuery({
     composeId: compose.id,
   });
@@ -77,6 +80,9 @@ type CloudStatusPropTypes = {
 };
 
 export const CloudStatus = ({ compose }: CloudStatusPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { data, isSuccess } = useGetComposeStatusQuery({
     composeId: compose.id,
   });
@@ -145,6 +151,9 @@ export const ExpiringStatus = ({
   isExpired,
   timeToExpiration,
 }: ExpiringStatusPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { data: composeStatus, isSuccess } = useGetComposeStatusQuery({
     composeId: compose.id,
   });
@@ -237,6 +246,9 @@ type LocalStatusPropTypes = {
 };
 
 export const LocalStatus = ({ compose }: LocalStatusPropTypes) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const { data: composeStatus, isSuccess } = useGetComposeStatusQuery({
     composeId: compose.id,
   });

--- a/src/Components/LandingPage/tests/helpers.tsx
+++ b/src/Components/LandingPage/tests/helpers.tsx
@@ -4,6 +4,9 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
+import { PlatformProvider } from '@/context/platform';
+import { hostedPlatform } from '@/context/platform/hosted';
+import { onPremPlatform } from '@/context/platform/onprem';
 import { createTestStore, type RenderWithReduxOptions } from '@/test/testUtils';
 
 import LandingPage from '../LandingPage';
@@ -22,14 +25,18 @@ export const renderLandingPage = (options: RenderWithReduxOptions = {}) => {
     initialEntries: ['/'],
   });
 
+  const isOnPremise = options.preloadedState?.env?.isOnPremise;
+  const platform = isOnPremise ? onPremPlatform : hostedPlatform;
   const view = render(
     <Provider store={store}>
-      <RouterProvider
-        router={router}
-        future={{
-          v7_startTransition: true,
-        }}
-      />
+      <PlatformProvider value={platform}>
+        <RouterProvider
+          router={router}
+          future={{
+            v7_startTransition: true,
+          }}
+        />
+      </PlatformProvider>
     </Provider>,
   );
 

--- a/src/Components/Launch/AWSLaunchModal.tsx
+++ b/src/Components/Launch/AWSLaunchModal.tsx
@@ -15,10 +15,8 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import {
-  ComposesResponseItem,
-  useGetComposeStatusQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { ComposesResponseItem } from '@/store/api/backend';
 
 import { isAwsUploadRequestOptions } from '../../store/typeGuards';
 
@@ -27,6 +25,9 @@ type LaunchProps = {
 };
 
 export const AWSLaunchModal = ({ compose }: LaunchProps) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data, isSuccess, isFetching } = useGetComposeStatusQuery({
     composeId: compose.id,

--- a/src/Components/Launch/AzureLaunchModal.tsx
+++ b/src/Components/Launch/AzureLaunchModal.tsx
@@ -15,10 +15,8 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import {
-  ComposesResponseItem,
-  useGetComposeStatusQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { ComposesResponseItem } from '@/store/api/backend';
 
 import { isAzureUploadStatus } from '../../store/typeGuards';
 
@@ -27,6 +25,9 @@ type LaunchProps = {
 };
 
 export const AzureLaunchModal = ({ compose }: LaunchProps) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data, isSuccess, isFetching } = useGetComposeStatusQuery({
     composeId: compose.id,

--- a/src/Components/Launch/GcpLaunchModal.tsx
+++ b/src/Components/Launch/GcpLaunchModal.tsx
@@ -18,10 +18,8 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import {
-  ComposesResponseItem,
-  useGetComposeStatusQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { ComposesResponseItem } from '@/store/api/backend';
 
 import { generateDefaultName } from './useGenerateDefaultName';
 
@@ -34,6 +32,9 @@ import { parseGcpSharedWith } from '../ImagesTable/ImageDetails';
 type LaunchProps = { compose: ComposesResponseItem };
 
 export const GcpLaunchModal = ({ compose }: LaunchProps) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [customerProjectId, setCustomerProjectId] = useState('');
   const { data, isSuccess, isFetching } = useGetComposeStatusQuery({

--- a/src/Components/Launch/OciLaunchModal.tsx
+++ b/src/Components/Launch/OciLaunchModal.tsx
@@ -18,10 +18,8 @@ import {
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useNavigate } from 'react-router-dom';
 
-import {
-  ComposesResponseItem,
-  useGetComposeStatusQuery,
-} from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
+import { ComposesResponseItem } from '@/store/api/backend';
 import { selectPathResolver } from '@/store/slices/env';
 
 import { useAppSelector } from '../../store/hooks';
@@ -33,6 +31,9 @@ type LaunchProps = {
 };
 
 export const OciLaunchModal = ({ isExpired, compose }: LaunchProps) => {
+  const {
+    queries: { useGetComposeStatusQuery },
+  } = usePlatform();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data, isSuccess, isFetching } = useGetComposeStatusQuery({
     composeId: compose.id,

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -8,7 +8,7 @@ import {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
 
-import { useBackendPrefetch } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 import { selectIsOnPremise } from '@/store/slices/env';
 import { selectDistribution } from '@/store/slices/wizard';
 import { openWizardModal } from '@/store/slices/wizardModal';
@@ -72,6 +72,9 @@ export const ImageBuilderHeader = ({
   const dispatch = useAppDispatch();
   const isOnPremise = useAppSelector(selectIsOnPremise);
 
+  const {
+    api: { useBackendPrefetch },
+  } = usePlatform();
   const distribution = useAppSelector(selectDistribution);
   const prefetchTargets = useBackendPrefetch('getArchitectures');
 

--- a/src/Hooks/MutationNotifications/useComposeBPWithNotification.tsx
+++ b/src/Hooks/MutationNotifications/useComposeBPWithNotification.tsx
@@ -1,8 +1,11 @@
-import { useComposeBlueprintMutation } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 
 import { useMutationWithNotification } from './useMutationWithNotification';
 
 export const useComposeBPWithNotification = () => {
+  const {
+    mutations: { useComposeBlueprintMutation },
+  } = usePlatform();
   const { trigger: composeBlueprint, ...rest } = useMutationWithNotification(
     useComposeBlueprintMutation,
     {

--- a/src/Hooks/MutationNotifications/useCreateBPWithNotification.tsx
+++ b/src/Hooks/MutationNotifications/useCreateBPWithNotification.tsx
@@ -1,4 +1,4 @@
-import { useCreateBlueprintMutation } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 
 import {
   HookOptions,
@@ -6,8 +6,10 @@ import {
 } from './useMutationWithNotification';
 
 export const useCreateBPWithNotification = (options?: HookOptions) => {
+  const {
+    mutations: { useCreateBlueprintMutation },
+  } = usePlatform();
   const { trigger: createBlueprint, ...rest } = useMutationWithNotification(
-    // @ts-expect-error TODO: this will need to be revisited
     useCreateBlueprintMutation,
     {
       options,

--- a/src/Hooks/MutationNotifications/useDeleteBPWithNotification.tsx
+++ b/src/Hooks/MutationNotifications/useDeleteBPWithNotification.tsx
@@ -1,4 +1,4 @@
-import { useDeleteBlueprintMutation } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 
 import {
   HookOptions,
@@ -6,6 +6,9 @@ import {
 } from './useMutationWithNotification';
 
 export const useDeleteBPWithNotification = (options?: HookOptions) => {
+  const {
+    mutations: { useDeleteBlueprintMutation },
+  } = usePlatform();
   const { trigger: deleteBlueprint, ...rest } = useMutationWithNotification(
     useDeleteBlueprintMutation,
     {

--- a/src/Hooks/MutationNotifications/useUpdateBPWithNotification.tsx
+++ b/src/Hooks/MutationNotifications/useUpdateBPWithNotification.tsx
@@ -1,4 +1,4 @@
-import { useUpdateBlueprintMutation } from '@/store/api/backend';
+import { usePlatform } from '@/context/platform';
 
 import {
   HookOptions,
@@ -6,8 +6,10 @@ import {
 } from './useMutationWithNotification';
 
 export const useUpdateBPWithNotification = (options?: HookOptions) => {
+  const {
+    mutations: { useUpdateBlueprintMutation },
+  } = usePlatform();
   const { trigger: updateBlueprint, ...rest } = useMutationWithNotification(
-    // @ts-expect-error TODO: this will need to be revisited
     useUpdateBlueprintMutation,
     {
       options,

--- a/src/context/platform/hosted.ts
+++ b/src/context/platform/hosted.ts
@@ -1,0 +1,87 @@
+import { useMemo } from 'react';
+
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useFlag as useUnleashFlag } from '@unleash/proxy-client-react';
+
+import { imageBuilderApi } from '@/store/api/backend/hosted/enhancedImageBuilderApi';
+import {
+  useComposeBlueprintMutation,
+  useCreateBlueprintMutation,
+  useDeleteBlueprintMutation,
+  useGetArchitecturesQuery,
+  useGetBlueprintComposesQuery,
+  useGetBlueprintQuery,
+  useGetBlueprintsQuery,
+  useGetComposesQuery,
+  useGetComposeStatusQuery,
+  useGetDistributionsQuery,
+  useGetOscapCustomizationsQuery,
+  useGetOscapProfilesQuery,
+  useLazyGetBlueprintsQuery,
+  useLazyGetOscapCustomizationsQuery,
+  useUpdateBlueprintMutation,
+} from '@/store/api/backend/hosted/imageBuilderApi';
+import {
+  contentSourcesApi,
+  useListSnapshotsByDateMutation,
+  useSearchRpmMutation,
+} from '@/store/api/contentSources/hosted';
+
+import type { PlatformHooks } from './types';
+
+// Hoisted stable function references to avoid per-call allocations
+const isBetaTrue = () => true;
+const isBetaFalse = () => false;
+
+const useHostedGetEnvironment = () => {
+  const { isBeta, isProd, getEnvironment } = useChrome();
+  const isBetaStable =
+    isBeta() || getEnvironment() === 'qa' ? isBetaTrue : isBetaFalse;
+  return useMemo(
+    () => ({ isBeta: isBetaStable, isProd }),
+    [isBetaStable, isProd],
+  );
+};
+
+const hostedQueries = {
+  // PlatformHooks uses the on-prem type which accepts wider input.
+  // The hosted version is narrower, but runtime behavior is identical.
+  useGetArchitecturesQuery:
+    useGetArchitecturesQuery as unknown as PlatformHooks['queries']['useGetArchitecturesQuery'],
+  useGetDistributionsQuery:
+    useGetDistributionsQuery as unknown as PlatformHooks['queries']['useGetDistributionsQuery'],
+  useGetBlueprintQuery,
+  useGetBlueprintsQuery,
+  useLazyGetBlueprintsQuery,
+  useGetOscapProfilesQuery,
+  useGetOscapCustomizationsQuery,
+  useLazyGetOscapCustomizationsQuery,
+  useGetComposesQuery,
+  useGetBlueprintComposesQuery,
+  useGetComposeStatusQuery,
+} satisfies Record<keyof PlatformHooks['queries'], unknown>;
+
+const hostedMutations = {
+  useCreateBlueprintMutation,
+  useUpdateBlueprintMutation,
+  useDeleteBlueprintMutation,
+  useComposeBlueprintMutation,
+  useSearchRpmMutation,
+  useListSnapshotsByDateMutation,
+} satisfies Record<keyof PlatformHooks['mutations'], unknown>;
+
+const hostedApi = {
+  backendApi: imageBuilderApi,
+  contentSourcesApi,
+  useBackendPrefetch: imageBuilderApi.usePrefetch,
+} satisfies Record<keyof PlatformHooks['api'], unknown>;
+
+export const hostedPlatform: PlatformHooks = {
+  queries: hostedQueries as unknown as PlatformHooks['queries'],
+  mutations: hostedMutations as unknown as PlatformHooks['mutations'],
+  env: {
+    useFlag: useUnleashFlag,
+    useGetEnvironment: useHostedGetEnvironment,
+  },
+  api: hostedApi as unknown as PlatformHooks['api'],
+};

--- a/src/context/platform/index.ts
+++ b/src/context/platform/index.ts
@@ -1,0 +1,16 @@
+import { createContext, useContext } from 'react';
+
+import type { PlatformHooks } from './types';
+
+const PlatformContext = createContext<PlatformHooks | null>(null);
+PlatformContext.displayName = 'PlatformContext';
+
+export const usePlatform = (): PlatformHooks => {
+  const ctx = useContext(PlatformContext);
+  if (ctx === null) {
+    throw new Error('usePlatform must be used within a PlatformProvider');
+  }
+  return ctx;
+};
+
+export const PlatformProvider = PlatformContext.Provider;

--- a/src/context/platform/onprem.ts
+++ b/src/context/platform/onprem.ts
@@ -1,0 +1,84 @@
+import {
+  useComposeBlueprintMutation,
+  useCreateBlueprintMutation,
+  useDeleteBlueprintMutation,
+  useGetArchitecturesQuery,
+  useGetBlueprintComposesQuery,
+  useGetBlueprintQuery,
+  useGetBlueprintsQuery,
+  useGetComposesQuery,
+  useGetComposeStatusQuery,
+  useGetDistributionsQuery,
+  useGetOscapCustomizationsQuery,
+  useGetOscapProfilesQuery,
+  useLazyGetBlueprintsQuery,
+  useLazyGetOscapCustomizationsQuery,
+  useUpdateBlueprintMutation,
+} from '@/store/api/backend/onprem/composerApi';
+import { composerApi } from '@/store/api/backend/onprem/enhancedComposerApi';
+import {
+  contentSourcesApi,
+  useListSnapshotsByDateMutation,
+  useSearchRpmMutation,
+} from '@/store/api/contentSources/onprem';
+
+import type { PlatformHooks } from './types';
+
+// Feature flag defaults for on-premises — Unleash is not available.
+// All flags default to false (default-deny). Add cases to the switch
+// when a flag-gated feature needs to be enabled for on-prem users.
+// NOTE: useGetEnvironment.ts has a parallel copy; both will be unified
+// when we migrate useFlag to usePlatform().env.
+export const onPremFlag = (flag: string): boolean => {
+  switch (flag) {
+    // case '<flag-name>':
+    //   return true;
+    default:
+      return false;
+  }
+};
+
+// On-prem environment is static — hoist to avoid allocations per call
+const onPremEnv = { isBeta: () => false, isProd: () => true };
+
+// satisfies checks that every key in PlatformHooks['queries'] is present.
+// The cast handles the RTK UseQuery<D> invariance mismatch — the runtime
+// behavior is identical across platforms.
+const onPremQueries = {
+  useGetArchitecturesQuery,
+  useGetDistributionsQuery,
+  useGetBlueprintQuery,
+  useGetBlueprintsQuery,
+  useLazyGetBlueprintsQuery,
+  useGetOscapProfilesQuery,
+  useGetOscapCustomizationsQuery,
+  useLazyGetOscapCustomizationsQuery,
+  useGetComposesQuery,
+  useGetBlueprintComposesQuery,
+  useGetComposeStatusQuery,
+} satisfies Record<keyof PlatformHooks['queries'], unknown>;
+
+const onPremMutations = {
+  useCreateBlueprintMutation,
+  useUpdateBlueprintMutation,
+  useDeleteBlueprintMutation,
+  useComposeBlueprintMutation,
+  useSearchRpmMutation,
+  useListSnapshotsByDateMutation,
+} satisfies Record<keyof PlatformHooks['mutations'], unknown>;
+
+const onPremApi = {
+  backendApi: composerApi,
+  contentSourcesApi,
+  useBackendPrefetch: composerApi.usePrefetch,
+} satisfies Record<keyof PlatformHooks['api'], unknown>;
+
+export const onPremPlatform: PlatformHooks = {
+  queries: onPremQueries as unknown as PlatformHooks['queries'],
+  mutations: onPremMutations as unknown as PlatformHooks['mutations'],
+  env: {
+    useFlag: onPremFlag,
+    useGetEnvironment: () => onPremEnv,
+  },
+  api: onPremApi as unknown as PlatformHooks['api'],
+};

--- a/src/context/platform/tests/PlatformContext.test.tsx
+++ b/src/context/platform/tests/PlatformContext.test.tsx
@@ -1,34 +1,26 @@
 import React from 'react';
 
 import { renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { PlatformProvider, usePlatform } from '@/context/platform';
-import type { PlatformHooks } from '@/context/platform/types';
+
+import { mockPlatform } from './mocks';
 
 describe('PlatformContext', () => {
   it('throws when usePlatform is called outside PlatformProvider', () => {
-    const onError = (e: ErrorEvent) => e.preventDefault();
-    window.addEventListener('error', onError);
+    // React logs to console.error before the error propagates;
+    // suppress it so the global setup spy doesn't treat it as a failure.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     expect(() => {
       renderHook(() => usePlatform());
     }).toThrow('usePlatform must be used within a PlatformProvider');
 
-    window.removeEventListener('error', onError);
+    spy.mockRestore();
   });
 
   it('provides the platform object when wrapped in PlatformProvider', () => {
-    const mockPlatform = {
-      queries: {},
-      mutations: {},
-      env: {
-        useFlag: () => false,
-        useGetEnvironment: () => ({ isBeta: () => false, isProd: () => true }),
-      },
-      api: {},
-    } as unknown as PlatformHooks;
-
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <PlatformProvider value={mockPlatform}>{children}</PlatformProvider>
     );

--- a/src/context/platform/tests/PlatformContext.test.tsx
+++ b/src/context/platform/tests/PlatformContext.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { PlatformProvider, usePlatform } from '@/context/platform';
+import type { PlatformHooks } from '@/context/platform/types';
+
+describe('PlatformContext', () => {
+  it('throws when usePlatform is called outside PlatformProvider', () => {
+    const onError = (e: ErrorEvent) => e.preventDefault();
+    window.addEventListener('error', onError);
+
+    expect(() => {
+      renderHook(() => usePlatform());
+    }).toThrow('usePlatform must be used within a PlatformProvider');
+
+    window.removeEventListener('error', onError);
+  });
+
+  it('provides the platform object when wrapped in PlatformProvider', () => {
+    const mockPlatform = {
+      queries: {},
+      mutations: {},
+      env: {
+        useFlag: () => false,
+        useGetEnvironment: () => ({ isBeta: () => false, isProd: () => true }),
+      },
+      api: {},
+    } as unknown as PlatformHooks;
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <PlatformProvider value={mockPlatform}>{children}</PlatformProvider>
+    );
+
+    const { result } = renderHook(() => usePlatform(), { wrapper });
+    expect(result.current).toBe(mockPlatform);
+    expect(result.current.env.useFlag('test')).toBe(false);
+  });
+});

--- a/src/context/platform/tests/mocks/fixtures.ts
+++ b/src/context/platform/tests/mocks/fixtures.ts
@@ -1,0 +1,30 @@
+import type { PlatformHooks } from '@/context/platform/types';
+
+/**
+ * Creates a Proxy that throws a descriptive error when an unmocked hook is
+ * accessed. Tests must spread `mockPlatform` and override the specific hooks
+ * they need — any hook that isn't overridden will throw immediately with a
+ * clear message instead of the opaque "undefined is not a function".
+ */
+const throwOnAccess = <T extends string>(section: T): Record<string, never> =>
+  new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        throw new Error(
+          `mockPlatform.${section}.${String(prop)} is not mocked. ` +
+            `Override it in your test via { ...mockPlatform, ${section}: { ${String(prop)}: vi.fn() } }.`,
+        );
+      },
+    },
+  ) as Record<string, never>;
+
+export const mockPlatform = {
+  queries: throwOnAccess('queries'),
+  mutations: throwOnAccess('mutations'),
+  env: {
+    useFlag: () => false,
+    useGetEnvironment: () => ({ isBeta: () => false, isProd: () => true }),
+  },
+  api: throwOnAccess('api'),
+} as unknown as PlatformHooks;

--- a/src/context/platform/tests/mocks/index.ts
+++ b/src/context/platform/tests/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './fixtures';

--- a/src/context/platform/types.ts
+++ b/src/context/platform/types.ts
@@ -1,3 +1,69 @@
-// Placeholder — replaced by the full PlatformHooks type in Task 2.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type PlatformHooks = Record<string, any>;
+import type { imageBuilderApi } from '@/store/api/backend/hosted/enhancedImageBuilderApi';
+import type {
+  useComposeBlueprintMutation as useHostedComposeBlueprintMutation,
+  useCreateBlueprintMutation as useHostedCreateBlueprintMutation,
+  useDeleteBlueprintMutation as useHostedDeleteBlueprintMutation,
+  useGetBlueprintComposesQuery as useHostedGetBlueprintComposesQuery,
+  useGetBlueprintQuery as useHostedGetBlueprintQuery,
+  useGetBlueprintsQuery as useHostedGetBlueprintsQuery,
+  useGetComposesQuery as useHostedGetComposesQuery,
+  useGetComposeStatusQuery as useHostedGetComposeStatusQuery,
+  useGetOscapCustomizationsQuery as useHostedGetOscapCustomizationsQuery,
+  useGetOscapProfilesQuery as useHostedGetOscapProfilesQuery,
+  useLazyGetBlueprintsQuery as useHostedLazyGetBlueprintsQuery,
+  useLazyGetOscapCustomizationsQuery as useHostedLazyGetOscapCustomizationsQuery,
+  useUpdateBlueprintMutation as useHostedUpdateBlueprintMutation,
+} from '@/store/api/backend/hosted/imageBuilderApi';
+import type {
+  useGetArchitecturesQuery as useComposerGetArchitecturesQuery,
+  useGetDistributionsQuery as useComposerGetDistributionsQuery,
+} from '@/store/api/backend/onprem/composerApi';
+import type { composerApi } from '@/store/api/backend/onprem/enhancedComposerApi';
+import type {
+  contentSourcesApi,
+  useListSnapshotsByDateMutation as useHostedListSnapshotsByDateMutation,
+  useSearchRpmMutation as useHostedSearchRpmMutation,
+} from '@/store/api/contentSources/hosted/contentSourcesApi';
+
+// The useGetArchitecturesQuery and useGetDistributionsQuery types are
+// widened to the composer (on-prem) versions because they accept wider
+// input types. The response shapes are identical across platforms.
+type UseGetArchitecturesQuery = typeof useComposerGetArchitecturesQuery;
+type UseGetDistributionsQuery = typeof useComposerGetDistributionsQuery;
+
+type PlatformHooks = {
+  queries: {
+    useGetArchitecturesQuery: UseGetArchitecturesQuery;
+    useGetDistributionsQuery: UseGetDistributionsQuery;
+    useGetBlueprintQuery: typeof useHostedGetBlueprintQuery;
+    useGetBlueprintsQuery: typeof useHostedGetBlueprintsQuery;
+    useLazyGetBlueprintsQuery: typeof useHostedLazyGetBlueprintsQuery;
+    useGetOscapProfilesQuery: typeof useHostedGetOscapProfilesQuery;
+    useGetOscapCustomizationsQuery: typeof useHostedGetOscapCustomizationsQuery;
+    useLazyGetOscapCustomizationsQuery: typeof useHostedLazyGetOscapCustomizationsQuery;
+    useGetComposesQuery: typeof useHostedGetComposesQuery;
+    useGetBlueprintComposesQuery: typeof useHostedGetBlueprintComposesQuery;
+    useGetComposeStatusQuery: typeof useHostedGetComposeStatusQuery;
+  };
+  mutations: {
+    useCreateBlueprintMutation: typeof useHostedCreateBlueprintMutation;
+    useUpdateBlueprintMutation: typeof useHostedUpdateBlueprintMutation;
+    useDeleteBlueprintMutation: typeof useHostedDeleteBlueprintMutation;
+    useComposeBlueprintMutation: typeof useHostedComposeBlueprintMutation;
+    useSearchRpmMutation: typeof useHostedSearchRpmMutation;
+    useListSnapshotsByDateMutation: typeof useHostedListSnapshotsByDateMutation;
+  };
+  env: {
+    useFlag: (flag: string) => boolean;
+    useGetEnvironment: () => { isBeta: () => boolean; isProd: () => boolean };
+  };
+  api: {
+    backendApi: typeof imageBuilderApi | typeof composerApi;
+    contentSourcesApi: typeof contentSourcesApi;
+    useBackendPrefetch:
+      | typeof imageBuilderApi.usePrefetch
+      | typeof composerApi.usePrefetch;
+  };
+};
+
+export type { PlatformHooks };

--- a/src/context/platform/types.ts
+++ b/src/context/platform/types.ts
@@ -1,0 +1,3 @@
+// Placeholder — replaced by the full PlatformHooks type in Task 2.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PlatformHooks = Record<string, any>;

--- a/src/context/platform/types.ts
+++ b/src/context/platform/types.ts
@@ -18,7 +18,6 @@ import type {
   useGetArchitecturesQuery as useComposerGetArchitecturesQuery,
   useGetDistributionsQuery as useComposerGetDistributionsQuery,
 } from '@/store/api/backend/onprem/composerApi';
-import type { composerApi } from '@/store/api/backend/onprem/enhancedComposerApi';
 import type {
   contentSourcesApi,
   useListSnapshotsByDateMutation as useHostedListSnapshotsByDateMutation,
@@ -58,11 +57,9 @@ type PlatformHooks = {
     useGetEnvironment: () => { isBeta: () => boolean; isProd: () => boolean };
   };
   api: {
-    backendApi: typeof imageBuilderApi | typeof composerApi;
+    backendApi: typeof imageBuilderApi;
     contentSourcesApi: typeof contentSourcesApi;
-    useBackendPrefetch:
-      | typeof imageBuilderApi.usePrefetch
-      | typeof composerApi.usePrefetch;
+    useBackendPrefetch: typeof imageBuilderApi.usePrefetch;
   };
 };
 

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -3,95 +3,15 @@ import {
   imageBuilderApi,
 } from './hosted/enhancedImageBuilderApi';
 import * as serviceQueries from './hosted/imageBuilderApi';
-import * as composerQueries from './onprem/composerApi';
 import { composerApi } from './onprem/enhancedComposerApi';
 
-// NOTE: We cast to the composer query type because casting to the
-// service query type breaks selectFromResult inference due to
-// different API slice generics. The response shape is identical
-// (composer imports GetArchitecturesApiResponse from hosted).
-export const useGetArchitecturesQuery = (
-  process.env.IS_ON_PREMISE
-    ? composerQueries.useGetArchitecturesQuery
-    : serviceQueries.useGetArchitecturesQuery
-) as typeof composerQueries.useGetArchitecturesQuery;
-
-// NOTE: same logic as above
-export const useGetDistributionsQuery = (
-  process.env.IS_ON_PREMISE
-    ? composerQueries.useGetDistributionsQuery
-    : serviceQueries.useGetDistributionsQuery
-) as typeof composerQueries.useGetDistributionsQuery;
-
-export const useGetBlueprintQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useGetBlueprintQuery
-  : serviceQueries.useGetBlueprintQuery;
-
-export const useGetBlueprintsQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useGetBlueprintsQuery
-  : serviceQueries.useGetBlueprintsQuery;
-
-export const useLazyGetBlueprintsQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useLazyGetBlueprintsQuery
-  : serviceQueries.useLazyGetBlueprintsQuery;
-
-export const useCreateBlueprintMutation = process.env.IS_ON_PREMISE
-  ? composerQueries.useCreateBlueprintMutation
-  : serviceQueries.useCreateBlueprintMutation;
-
-export const useUpdateBlueprintMutation = process.env.IS_ON_PREMISE
-  ? composerQueries.useUpdateBlueprintMutation
-  : serviceQueries.useUpdateBlueprintMutation;
-
-export const useDeleteBlueprintMutation = process.env.IS_ON_PREMISE
-  ? composerQueries.useDeleteBlueprintMutation
-  : serviceQueries.useDeleteBlueprintMutation;
-
-export const useGetOscapProfilesQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useGetOscapProfilesQuery
-  : serviceQueries.useGetOscapProfilesQuery;
-
-export const useGetOscapCustomizationsQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useGetOscapCustomizationsQuery
-  : serviceQueries.useGetOscapCustomizationsQuery;
-
-export const useLazyGetOscapCustomizationsQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useLazyGetOscapCustomizationsQuery
-  : serviceQueries.useLazyGetOscapCustomizationsQuery;
-
+// Hosted-only aliases for compliance endpoints (not platform-switched)
 export const useGetComplianceCustomizationsQuery =
   serviceQueries.useGetOscapCustomizationsForPolicyQuery;
-
 export const useLazyGetComplianceCustomizationsQuery =
   serviceQueries.useLazyGetOscapCustomizationsForPolicyQuery;
 
-export const useComposeBlueprintMutation = process.env.IS_ON_PREMISE
-  ? composerQueries.useComposeBlueprintMutation
-  : serviceQueries.useComposeBlueprintMutation;
-
-export const useGetComposesQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useGetComposesQuery
-  : serviceQueries.useGetComposesQuery;
-
-export const useGetBlueprintComposesQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useGetBlueprintComposesQuery
-  : serviceQueries.useGetBlueprintComposesQuery;
-
-export const useGetComposeStatusQuery = process.env.IS_ON_PREMISE
-  ? composerQueries.useGetComposeStatusQuery
-  : serviceQueries.useGetComposeStatusQuery;
-
-export const useBackendPrefetch = process.env.IS_ON_PREMISE
-  ? composerApi.usePrefetch
-  : imageBuilderApi.usePrefetch;
-
-export const backendApi = process.env.IS_ON_PREMISE
-  ? composerApi
-  : imageBuilderApi;
-
-// These aren't used by on-prem so they aren't covered by the conditional
-// exports above. Let's re-export them so we can consolidate our imports
-// in other parts of the project.
+// Platform-independent hooks — hosted-only, not part of the platform switching
 export {
   useComposeImageMutation,
   useExportBlueprintQuery,

--- a/src/store/api/contentSources/index.ts
+++ b/src/store/api/contentSources/index.ts
@@ -1,17 +1,7 @@
 import * as hostedQueries from './hosted';
-import * as onpremQueries from './onprem';
 
 export * from './hooks';
 export type * from './hosted';
-
-// Hooks with different implementations for hosted vs on-prem
-export const useSearchRpmMutation = process.env.IS_ON_PREMISE
-  ? onpremQueries.useSearchRpmMutation
-  : hostedQueries.useSearchRpmMutation;
-
-export const useListSnapshotsByDateMutation = process.env.IS_ON_PREMISE
-  ? onpremQueries.useListSnapshotsByDateMutation
-  : hostedQueries.useListSnapshotsByDateMutation;
 
 // NOTE: We have to explicitly export **only** the hosted contentSourcesApi
 // here because of RTK. The on-prem version of the contentSourcesApi shares

--- a/src/test/renderUtils.jsx
+++ b/src/test/renderUtils.jsx
@@ -1,3 +1,7 @@
+// TODO: This legacy render utility derives platform from process.env.IS_ON_PREMISE.
+// New tests should use src/test/testUtils/renderUtils.tsx which reads platform
+// from Redux state (options.preloadedState.env.isOnPremise), enabling per-test
+// platform switching without env-var manipulation.
 import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
@@ -6,6 +10,9 @@ import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
 import LandingPage from '../Components/LandingPage/LandingPage';
+import { PlatformProvider } from '../context/platform';
+import { hostedPlatform } from '../context/platform/hosted';
+import { onPremPlatform } from '../context/platform/onprem';
 import {
   serviceMiddleware as middleware,
   onPremMiddleware as onPremMiddleware,
@@ -52,14 +59,18 @@ export const renderCustomRoutesWithReduxRouter = async (
     initialEntries: [resolveRelPath(route)],
   });
 
+  const platform = process.env.IS_ON_PREMISE ? onPremPlatform : hostedPlatform;
+
   render(
     <Provider store={store}>
-      <RouterProvider
-        router={router}
-        future={{
-          v7_startTransition: true,
-        }}
-      />
+      <PlatformProvider value={platform}>
+        <RouterProvider
+          router={router}
+          future={{
+            v7_startTransition: true,
+          }}
+        />
+      </PlatformProvider>
     </Provider>,
   );
 

--- a/src/test/testUtils/renderUtils.tsx
+++ b/src/test/testUtils/renderUtils.tsx
@@ -4,6 +4,9 @@ import { configureStore, EnhancedStore } from '@reduxjs/toolkit';
 import { render, RenderResult } from '@testing-library/react';
 import { Provider } from 'react-redux';
 
+import { PlatformProvider } from '@/context/platform';
+import { hostedPlatform } from '@/context/platform/hosted';
+import { onPremPlatform } from '@/context/platform/onprem';
 import {
   onPremMiddleware,
   onPremReducer,
@@ -29,7 +32,13 @@ export const renderWithRedux = (
   options: RenderWithReduxOptions = {},
 ): RenderWithReduxResult => {
   const store = createTestStore(wizardStateOverrides, options);
-  const view = render(<Provider store={store}>{component}</Provider>);
+  const isOnPremise = options.preloadedState?.env?.isOnPremise;
+  const platform = isOnPremise ? onPremPlatform : hostedPlatform;
+  const view = render(
+    <Provider store={store}>
+      <PlatformProvider value={platform}>{component}</PlatformProvider>
+    </Provider>,
+  );
   return { ...view, store };
 };
 


### PR DESCRIPTION
## Summary
Introduce a `PlatformContext` to replace build-time `process.env.IS_ON_PREMISE` ternaries with a runtime React context, enabling both hosted and
 on-prem platform implementations to coexist in the same bundle and be testable without separate builds.

## Changes
   - Add `PlatformContext`, `usePlatform()` hook, and `PlatformProvider` with a `PlatformHooks` type contract enforcing compile-time exhaustiveness
 via `satisfies`
   - Implement `hostedPlatform` and `onPremPlatform` as module-level singletons providing platform-specific RTK Query hooks, feature flags, and
 environment helpers
   - Migrate all 40+ consumer components from direct barrel-file imports to `usePlatform()` destructuring
   - Remove `process.env.IS_ON_PREMISE` ternary switching from backend and content sources barrel files, replacing with clean re-exports
   - Add `Proxy`-based `mockPlatform` fixture for tests and update all test utilities (`renderWithRedux`, `renderLandingPage`) to derive platform
 from Redux state
 
 ## Motivation for these changes

So this might be a hard sell, but I was looking at ways to reduce the `process.env.IS_ON_PREMISE` calls.
But it's fundamentally about decoupling the two frontends. There are a couple of reasons for this but the most important one is:
- if we forget to add a ternary here, the on premise frontend could end up with a hosted hook and things would fail and we might only realise much later

This approach establishes a type contract here that could help us catch weird bugs at compilation rather than at run time. We can more effectively isolate things so hosted only gets hosted queries & mutations, environment flags and 
so on. And on-prem would only get what it knows about.

In the future, it would also make it easier to switch to a mono repo and isolate cockpit and the service even further (this is an entirely separate discussion altogether though).

## Notes

I haven't done a `useFlag` migration yet, that can be done in a follow up along with a general tidy up.

