### PR TITLE
[rhel-10.2] store/cockpit: create bp dir before copying from .cache

### DIFF
--- a/schutzbot/playwright_tests.sh
+++ b/schutzbot/playwright_tests.sh
@@ -2,11 +2,17 @@
 set -euo pipefail
 
 PW_WORKERS=4
-if [ -n "${TMT_TREE:-}" ]; then
-    # Move to the directory with sources
+
+if [ -n "${PACKIT_PACKAGE_NAME:-}" ]; then
+    # Runs in CI (Packit)
     cd "${TMT_TREE}"
     npm ci
+elif [ -n "${TMT_SOURCE_DIR:-}" ]; then
+    # Runs in dist-git
+    cd "${TMT_SOURCE_DIR}/cockpit-image-builder"
+    npm ci
 elif [ "${CI:-}" != "true" ]; then
+    # Local fallback
     cd ../
     npm ci
     # halve the workers on schutzbot to increase reliability

--- a/src/store/cockpit/cockpitApi.ts
+++ b/src/store/cockpit/cockpitApi.ts
@@ -110,6 +110,7 @@ const getBlueprintsPath = async () => {
   // Backwards compatibility, drop after rhel 10.2.
   await cockpit.script(`
 if [ ! -e "${blueprintsDir}" ] && [ -d "${user.home}/.cache/cockpit-image-builder" ] ; then
+  mkdir -p "${stateDir}"
   cp -a "${user.home}/.cache/cockpit-image-builder" ${blueprintsDir}
 fi
 `);


### PR DESCRIPTION
The backwards compatibility script fails in case the target .state directory doesn't exist. Ensure the state directory exists.