### PR TITLE
[rhel-10.2] store/cockpit: prevent race condition when copying from .cache

### DIFF
--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -1,5 +1,5 @@
 Name:           cockpit-image-builder
-Version:        94.3.2
+Version:        94.3
 Release:        1%{?dist}
 Summary:        Image builder plugin for Cockpit
 

--- a/src/store/cockpit/cockpitApi.ts
+++ b/src/store/cockpit/cockpitApi.ts
@@ -111,7 +111,7 @@ const getBlueprintsPath = async () => {
   await cockpit.script(`
 if [ ! -e "${blueprintsDir}" ] && [ -d "${user.home}/.cache/cockpit-image-builder" ] ; then
   mkdir -p "${stateDir}"
-  cp -a "${user.home}/.cache/cockpit-image-builder" ${blueprintsDir}
+  cp -a "${user.home}/.cache/cockpit-image-builder" "${stateDir}/"
 fi
 `);
 


### PR DESCRIPTION
`getBlueprintsPath` can be executed in parallel, and could result in the
    `.cache/cockpit-image-builder` directory being copied into
    `state/cockpit-image-builder`, resulting in
    `state/cockpit-image-builder/cockpit-image-builder`. This of course
    breaks the frontend.
  
By copying the directory to the state directory, at most it overwrites
    the existing content, preventing the creation of nested folders.
