### PR TITLE
ImagesTable: Setup scaffolding for the revamp (HMS-10809)

### DIFF
--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -12,10 +12,7 @@ import { ibFrame, navigateToLandingPage } from './navHelpers';
 import isRhel from '../../src/Utilities/isRhel';
 
 export const openWizard = async (scope: Page | FrameLocator) => {
-  await scope
-    .getByRole('button', { name: 'Create image blueprint' })
-    .first()
-    .click();
+  await scope.getByRole('button', { name: 'Build new image' }).first().click();
 };
 
 /**

--- a/src/Components/sharedComponents/ImageBuilderHeader.scss
+++ b/src/Components/sharedComponents/ImageBuilderHeader.scss
@@ -1,0 +1,3 @@
+.image-builder-header {
+  box-shadow: none;
+}

--- a/src/Components/sharedComponents/ImageBuilderHeader.scss
+++ b/src/Components/sharedComponents/ImageBuilderHeader.scss
@@ -1,3 +1,7 @@
 .image-builder-header {
   box-shadow: none;
 }
+
+.image-builder-header__description {
+  max-width: 70%;
+}

--- a/src/Components/sharedComponents/ImageBuilderHeader.scss
+++ b/src/Components/sharedComponents/ImageBuilderHeader.scss
@@ -1,5 +1,12 @@
 .image-builder-header {
   box-shadow: none;
+
+  // make the "About Image Builder" and Open Source badge aligned with the
+  // title vertically
+  .pf-v6-c-badge,
+  .pf-v6-c-button {
+    vertical-align: middle;
+  }
 }
 
 .image-builder-header__description {

--- a/src/Components/sharedComponents/ImageBuilderHeader.scss
+++ b/src/Components/sharedComponents/ImageBuilderHeader.scss
@@ -1,5 +1,6 @@
 .image-builder-header {
   box-shadow: none;
+  gap: 0.5rem; // makes gap between title and description smaller
 
   // make the "About Image Builder" and Open Source badge aligned with the
   // title vertically

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -8,6 +8,8 @@ import {
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
 
+import './ImageBuilderHeader.scss';
+
 import { useBackendPrefetch } from '@/store/api/backend';
 import { selectIsOnPremise } from '@/store/slices/env';
 import { selectDistribution } from '@/store/slices/wizard';
@@ -78,12 +80,6 @@ export const ImageBuilderHeader = ({
   const [showImportModal, setShowImportModal] = useState(false);
   const [showCloudConfigModal, setShowCloudConfigModal] = useState(false);
 
-  const pageHeaderProps: React.ComponentProps<typeof PageHeader> &
-    React.ComponentPropsWithoutRef<'section'> = {
-    className: 'pf-m-sticky-top',
-    style: { boxShadow: 'none' },
-  };
-
   return (
     <>
       <ImportBlueprintModal
@@ -96,7 +92,7 @@ export const ImageBuilderHeader = ({
           isOpen={showCloudConfigModal}
         />
       )}
-      <PageHeader {...pageHeaderProps}>
+      <PageHeader className='pf-m-sticky-top image-builder-header'>
         <PageHeaderTitle
           title={
             <>

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -123,7 +123,9 @@ export const ImageBuilderHeader = ({
                       })
                     }
                   >
-                    Create image blueprint
+                    {isImagesTableRevampEnabled
+                      ? 'Build new image'
+                      : 'Create image blueprint'}
                   </Button>
                   <Button
                     variant='secondary'

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -14,6 +14,7 @@ import { useBackendPrefetch } from '@/store/api/backend';
 import { selectIsOnPremise } from '@/store/slices/env';
 import { selectDistribution } from '@/store/slices/wizard';
 import { openWizardModal } from '@/store/slices/wizardModal';
+import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import { OSBUILD_SERVICE_ARCHITECTURE_URL } from '../../constants';
 import { useGetDocumentationUrl } from '../../Hooks';
@@ -77,6 +78,10 @@ export const ImageBuilderHeader = ({
   const distribution = useAppSelector(selectDistribution);
   const prefetchTargets = useBackendPrefetch('getArchitectures');
 
+  const isImagesTableRevampEnabled = useFlag(
+    'image-builder.images-table-revamp.enabled',
+  );
+
   const [showImportModal, setShowImportModal] = useState(false);
   const [showCloudConfigModal, setShowCloudConfigModal] = useState(false);
 
@@ -139,6 +144,15 @@ export const ImageBuilderHeader = ({
             </>
           }
         />
+        {isImagesTableRevampEnabled && (
+          <Content className='image-builder-header__description'>
+            Build, customize, and deploy RHEL images for public cloud, private
+            cloud, and on-premise environments. You can manage your images by
+            duplicating, rebuilding, or editing existing configurations.
+            Download your finished builds or launch them directly as
+            deployment-ready systems.
+          </Content>
+        )}
       </PageHeader>
     </>
   );

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -39,8 +39,8 @@ export const useFlagWithEphemDefault = (
 
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
-    // case <flag>:
-    //   return true;
+    case 'image-builder.images-table-revamp.enabled':
+      return true;
     default:
       return false;
   }

--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -67,10 +67,9 @@ describe('Blueprints', () => {
 
     renderCustomRoutesWithReduxRouter();
     await screen.findByText('No blueprints');
-    const emptyStateActions = screen.getAllByRole('button', {
+    const emptyStateAction = await screen.findByRole('button', {
       name: /Create image blueprint/i,
     });
-    const emptyStateAction = emptyStateActions[1]; // Second button is the empty state
     expect(emptyStateAction).toBeInTheDocument();
 
     await waitFor(() => user.click(emptyStateAction));

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -67,8 +67,8 @@ vi.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => vi.fn(),
   useFlag: vi.fn((flag) => {
     switch (flag) {
-      // case <flag>:
-      //   return true;
+      case 'image-builder.images-table-revamp.enabled':
+        return true;
       default:
         return false;
     }


### PR DESCRIPTION
This adds an unleash flag for gating the Images Table revamp and updates the table header as per the revamp mocks.

JIRA: [HMS-10809](https://issues.redhat.com/browse/HMS-10809)

[HMS-10809]: https://redhat.atlassian.net/browse/HMS-10809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ