### PR TITLE
vitest: Filter maximum update depth also for errors (HMS-10810)

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -90,7 +90,11 @@ beforeAll(() => {
   server.listen({ onUnhandledRequest: 'error' });
 
   vi.spyOn(console, 'error').mockImplementation((...args) => {
-    throw new Error(`Console error:\n${args.join(' ')}`);
+    const message = args.join(' ');
+    if (message.includes('Maximum update depth exceeded')) {
+      return;
+    }
+    throw new Error(`Console error:\n${message}`);
   });
 
   vi.spyOn(console, 'warn').mockImplementation((...args) => {


### PR DESCRIPTION
I've originally filtered this for warnings only, but looks like it can also appear as an error.

JIRA: [HMS-10810](https://issues.redhat.com/browse/HMS-10810)

[HMS-10810]: https://redhat.atlassian.net/browse/HMS-10810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ