### PR TITLE
Add `./claude` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ rpmbuild
 .env
 .auth
 /image-downloads/
+
+# claude config
+.claude/


### PR DESCRIPTION
Claude config doesn't need to be included in the PRs.