### PR TITLE
playwright: Fix boot tests (HMS-10818)

### DIFF
--- a/playwright/BootTests/helpers/imageBuilding.ts
+++ b/playwright/BootTests/helpers/imageBuilding.ts
@@ -14,7 +14,7 @@ export const buildImage = async (page: Page) => {
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   while (true) {
     if (
-      (await page.getByText('Ready').isVisible()) ||
+      (await page.getByText('Ready', { exact: true }).isVisible()) ||
       (await page.getByText('Expires in').isVisible())
     ) {
       console.log(`Image is ready (Time spent: ${timeSpentBuilding / 60000}m)`);
@@ -43,7 +43,8 @@ export const downloadImage = async (page: Page, filePath: string) => {
   // Start waiting for download before clicking. Note no await.
   console.log('Downloading image');
   const downloadPromise = page.waitForEvent('download');
-  await page.getByText('Download').first().click();
+  // Use a more specific selector to avoid matching "Download" in header description
+  await page.getByRole('link', { name: /Download \(\./ }).click();
   const download = await downloadPromise;
   await download.saveAs(filePath);
   console.log(`Downloaded file: ${filePath}`);


### PR DESCRIPTION
The tests were skipping the wait for the image to be ready because of the duplicate matching on "deployment-ready" vs "Ready".

And the download part of the test was failing due to duplicate word "download" ;_;

JIRA: [HMS-10818](https://issues.redhat.com/browse/HMS-10818)

[HMS-10818]: https://redhat.atlassian.net/browse/HMS-10818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ