### PR TITLE
Wizard: prevent duplicate languages in Locale step (HMS-10599)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -129,15 +129,20 @@ const LanguagesDropDown = () => {
 
   return (
     <FormGroup isRequired={false} label='Languages' role='group'>
-      {languages.map((lang) => (
-        <LanguageRow
-          key={lang}
-          selectedLanguage={lang}
-          onSelect={(newLang) => handleChangeLanguage(lang, newLang)}
-          onRemove={() => handleRemoveLanguage(lang)}
-          existingLanguages={languages}
-        />
-      ))}
+      {languages.map((lang, index) => {
+        const occurrenceIndex = languages
+          .slice(0, index)
+          .filter((l) => l === lang).length;
+        return (
+          <LanguageRow
+            key={`${lang}-${occurrenceIndex}`}
+            selectedLanguage={lang}
+            onSelect={(newLang) => handleChangeLanguage(lang, newLang)}
+            onRemove={() => handleRemoveLanguage(lang)}
+            existingLanguages={languages}
+          />
+        );
+      })}
       {showNewRow && (
         <LanguageRow
           onSelect={handleSelectNewLanguage}

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -1,6 +1,6 @@
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
-import { initialState } from '@/store/slices/wizard';
+import { initialState, replaceLanguage } from '@/store/slices/wizard';
 import { clickWithWait, createUser } from '@/test/testUtils';
 
 import {
@@ -381,6 +381,70 @@ describe('Locale Component', () => {
       await selectKeyboardOption(user, 'us');
 
       expect(store.getState().wizard.system.locale.keyboard).toBe('us');
+    });
+  });
+
+  describe('Validation', () => {
+    test('displays error for duplicate languages from state', async () => {
+      renderLocaleStep({
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: ['en_US.UTF-8', 'en_US.UTF-8'],
+            keyboard: '',
+          },
+        },
+      });
+
+      expect(
+        await screen.findByText(/duplicated languages/i),
+      ).toBeInTheDocument();
+    });
+
+    test('replaceLanguage prevents creating duplicates', async () => {
+      const { store } = renderLocaleStep({
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: ['en_US.UTF-8', 'de_DE.UTF-8'],
+            keyboard: '',
+          },
+        },
+      });
+
+      store.dispatch(
+        replaceLanguage({
+          oldLanguage: 'de_DE.UTF-8',
+          newLanguage: 'en_US.UTF-8',
+        }),
+      );
+
+      const languages = store.getState().wizard.system.locale.languages;
+      expect(languages).toEqual(['en_US.UTF-8', 'de_DE.UTF-8']);
+    });
+
+    test('replaceLanguage succeeds for valid non-duplicate replacement', async () => {
+      const { store } = renderLocaleStep({
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: ['en_US.UTF-8', 'de_DE.UTF-8'],
+            keyboard: '',
+          },
+        },
+      });
+
+      act(() => {
+        store.dispatch(
+          replaceLanguage({
+            oldLanguage: 'de_DE.UTF-8',
+            newLanguage: 'nl_NL.UTF-8',
+          }),
+        );
+      });
+
+      const languages = store.getState().wizard.system.locale.languages;
+      expect(languages).toEqual(['en_US.UTF-8', 'nl_NL.UTF-8']);
     });
   });
 

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -195,9 +195,14 @@ export const wizardSlice = createSlice({
         const index = state.system.locale.languages.findIndex(
           (lang) => lang === action.payload.oldLanguage,
         );
-        if (index !== -1) {
-          state.system.locale.languages[index] = action.payload.newLanguage;
-        }
+        if (index === -1) return;
+
+        const isDuplicate = state.system.locale.languages.some(
+          (lang, i) => i !== index && lang === action.payload.newLanguage,
+        );
+        if (isDuplicate) return;
+
+        state.system.locale.languages[index] = action.payload.newLanguage;
       }
     },
     clearLanguages: (state) => {


### PR DESCRIPTION
`replaceLanguage` did not guard against duplicates, and `LanguageRow`
used `key={lang}` which caused React warnings when duplicates arrived
from an imported blueprint.

- Add duplicate guard to `replaceLanguage`
- Fix list key to handle duplicate entries
- Add tests for duplicate language validation

### Why is this needed?

The duplicate language validation and error message were already
implemented in a previous commit, but had no test coverage.
Additionally, `replaceLanguage` did not prevent creating duplicates
at the reducer level, and React would log warnings about duplicate
keys when a blueprint with duplicate languages was loaded from the API.

These changes harden the existing validation by preventing duplicates
at the source and ensuring the rendering handles them gracefully.

### To reproduce

Create a blueprint via API with duplicate languages:
```js
fetch('/api/image-builder/v1/blueprints', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({
    name: "test-duplicate-languages",
    distribution: "rhel-9",
    image_requests: [{ architecture: "x86_64", image_type: "guest-image",
      upload_request: { type: "aws.s3", options: {} } }],
    customizations: { locale: { languages: ["en_US.UTF-8", "en_US.UTF-8", "C.UTF-8"] } }
  })
}).then(r => r.json()).then(console.log)
```
Then open the blueprint in the wizard — the Locale step shows
"Duplicated languages: en_US.UTF-8" and blocks the Next button.

JIRA: HMS-10599