### PR TITLE
Image mode fedora

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -73,7 +73,7 @@ const ImageOutputStep = () => {
           Learn more about <DocumentationButton />.
         </Content>
       </Content>
-      {!(distribution as string).startsWith('fedora') && <BlueprintMode />}
+      <BlueprintMode />
       {isImageMode && <ImageSourceSelect />}
       {!isImageMode && (
         <>

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { CENTOS_9, RHEL_10, RHEL_8, RHEL_9 } from '@/constants';
+import { CENTOS_9, FEDORA_44, RHEL_10, RHEL_8, RHEL_9 } from '@/constants';
 import { selectBlueprintName } from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
 import { clickWithWait, createUser, fetchMock } from '@/test/testUtils';
@@ -130,6 +130,17 @@ describe('ImageOutput Step', () => {
           /centos stream builds are intended for the development/i,
         ),
       ).not.toBeInTheDocument();
+    });
+
+    test('displays blueprint mode toggle for Fedora distribution', async () => {
+      renderImageOutputStep({ distribution: FEDORA_44 });
+
+      expect(
+        await screen.findByRole('button', { name: /image mode/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /package mode/i }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -17,6 +17,7 @@ import {
 } from './helpers';
 import {
   mockBootcDistributions,
+  mockBootcDistributionsMixed,
   mockBootcDistributionsMultipleTypes,
   mockBootcDistributionsNoRhel10,
   mockBootcDistributionsWithMinorVersions,
@@ -400,6 +401,126 @@ describe('ImageSourceSelect', () => {
       expect(
         screen.queryByRole('button', { name: /refresh image sources/i }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Non-RHEL distributions', () => {
+    beforeEach(() => {
+      mockUseGetDistributionsQuery.mockReturnValue({
+        data: mockBootcDistributionsMixed,
+        isLoading: false,
+        isError: false,
+        refetch: mockRefetch,
+      });
+    });
+
+    test('displays all distro names including non-RHEL in dropdown', async () => {
+      renderImageSourceSelect();
+      const user = createUser();
+
+      const toggle = await screen.findByRole('button', {
+        name: /red hat enterprise linux \(rhel\) 10/i,
+      });
+      await clickWithWait(user, toggle);
+
+      expect(
+        screen.getByRole('option', {
+          name: /red hat enterprise linux \(rhel\) 10/i,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('option', { name: /fedora 42/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('option', { name: /centos stream 10/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('option', {
+          name: /localhost\/my-custom-image:latest/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    test('selecting Fedora dispatches correct distribution and image source', async () => {
+      const { store } = renderImageSourceSelect();
+      const user = createUser();
+
+      // Wait for auto-select
+      await waitFor(() => {
+        expect(selectImageSourceState(store.getState())).toBe(
+          'registry.redhat.io/rhel10/rhel-bootc:rhel-10',
+        );
+      });
+
+      const toggle = await screen.findByRole('button', {
+        name: /red hat enterprise linux \(rhel\) 10/i,
+      });
+      await clickWithWait(user, toggle);
+      const fedoraOption = await screen.findByRole('option', {
+        name: /fedora 42/i,
+      });
+      await clickWithWait(user, fedoraOption);
+
+      await waitFor(() => {
+        expect(selectImageSourceState(store.getState())).toBe(
+          'quay.io/fedora/fedora-bootc:42',
+        );
+        expect(selectDistribution(store.getState())).toBe('fedora-42');
+      });
+    });
+
+    test('selecting CentOS dispatches correct distribution and image source', async () => {
+      const { store } = renderImageSourceSelect();
+      const user = createUser();
+
+      await waitFor(() => {
+        expect(selectImageSourceState(store.getState())).toBe(
+          'registry.redhat.io/rhel10/rhel-bootc:rhel-10',
+        );
+      });
+
+      const toggle = await screen.findByRole('button', {
+        name: /red hat enterprise linux \(rhel\) 10/i,
+      });
+      await clickWithWait(user, toggle);
+      const centosOption = await screen.findByRole('option', {
+        name: /centos stream 10/i,
+      });
+      await clickWithWait(user, centosOption);
+
+      await waitFor(() => {
+        expect(selectImageSourceState(store.getState())).toBe(
+          'quay.io/centos-bootc/centos-bootc:stream10',
+        );
+        expect(selectDistribution(store.getState())).toBe('centos-10');
+      });
+    });
+
+    test('selecting unknown image dispatches correct distribution and image source', async () => {
+      const { store } = renderImageSourceSelect();
+      const user = createUser();
+
+      await waitFor(() => {
+        expect(selectImageSourceState(store.getState())).toBe(
+          'registry.redhat.io/rhel10/rhel-bootc:rhel-10',
+        );
+      });
+
+      const toggle = await screen.findByRole('button', {
+        name: /red hat enterprise linux \(rhel\) 10/i,
+      });
+      await clickWithWait(user, toggle);
+      const customOption = await screen.findByRole('option', {
+        name: /localhost\/my-custom-image:latest/i,
+      });
+      await clickWithWait(user, customOption);
+
+      await waitFor(() => {
+        expect(selectImageSourceState(store.getState())).toBe(
+          'localhost/my-custom-image:latest',
+        );
+        expect(selectDistribution(store.getState())).toBe('unknown-custom');
+      });
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/mocks/fixtures.ts
@@ -141,3 +141,34 @@ export const mockBootcDistributionsMultipleTypes: BootcDistributionItem[] = [
     reference: 'registry.redhat.io/rhel10/rhel-bootc:rhel-10',
   },
 ];
+
+export const mockBootcDistributionsMixed: BootcDistributionItem[] = [
+  {
+    distro: 'rhel-10',
+    name: 'Red Hat Enterprise Linux (RHEL) 10',
+    type: 'guest-image',
+    arch: 'x86_64',
+    reference: 'registry.redhat.io/rhel10/rhel-bootc:rhel-10',
+  },
+  {
+    distro: 'fedora-42',
+    name: 'Fedora 42',
+    type: 'guest-image',
+    arch: 'x86_64',
+    reference: 'quay.io/fedora/fedora-bootc:42',
+  },
+  {
+    distro: 'centos-10',
+    name: 'CentOS Stream 10',
+    type: 'guest-image',
+    arch: 'x86_64',
+    reference: 'quay.io/centos-bootc/centos-bootc:stream10',
+  },
+  {
+    distro: 'unknown-custom',
+    name: 'localhost/my-custom-image:latest',
+    type: 'guest-image',
+    arch: 'x86_64',
+    reference: 'localhost/my-custom-image:latest',
+  },
+];

--- a/src/store/api/backend/onprem/composerApi/architecture.ts
+++ b/src/store/api/backend/onprem/composerApi/architecture.ts
@@ -33,7 +33,9 @@ export const architectureEndpoints = (builder: OnPremBuilder) => ({
         throw new Error('Unexpected podman images output');
       }
 
-      return parsed.filter(filterBootcImages(arch)).map(toBootcDistro);
+      return parsed
+        .filter(filterBootcImages(arch))
+        .map(toBootcDistro(arch ?? ''));
     }),
   }),
   getArchitectures: builder.query<

--- a/src/store/api/backend/onprem/composerApi/architecture.ts
+++ b/src/store/api/backend/onprem/composerApi/architecture.ts
@@ -33,9 +33,7 @@ export const architectureEndpoints = (builder: OnPremBuilder) => ({
         throw new Error('Unexpected podman images output');
       }
 
-      return parsed
-        .filter(filterBootcImages(arch))
-        .map(toBootcDistro(arch ?? ''));
+      return parsed.filter(filterBootcImages(arch)).map(toBootcDistro());
     }),
   }),
   getArchitectures: builder.query<

--- a/src/store/api/backend/onprem/composerApi/architecture.ts
+++ b/src/store/api/backend/onprem/composerApi/architecture.ts
@@ -1,4 +1,5 @@
 import { type OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
+import { getHostArch } from '@/Utilities/getHostInfo';
 
 import {
   filterBootcImages,
@@ -26,14 +27,19 @@ export const architectureEndpoints = (builder: OnPremBuilder) => ({
     // when consumers pass different optional params (e.g. distro).
     serializeQueryArgs: ({ queryArgs }) => ({ arch: queryArgs.arch }),
     queryFn: onPremQueryHandler(async ({ queryArgs: { arch } }) => {
-      const result = await listPodmanImages();
+      const [result, hostArch] = await Promise.all([
+        listPodmanImages(),
+        getHostArch().catch(() => undefined),
+      ]);
       const parsed = parseJsonUnsafe<PodmanImageInfo[]>(result);
 
       if (!Array.isArray(parsed)) {
         throw new Error('Unexpected podman images output');
       }
 
-      return parsed.filter(filterBootcImages(arch)).map(toBootcDistro());
+      return parsed
+        .filter(filterBootcImages(arch, hostArch))
+        .map(toBootcDistro(hostArch));
     }),
   }),
   getArchitectures: builder.query<

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -6,6 +6,7 @@ export { getCloudConfigs } from './getCloudConfigs';
 export {
   filterBootcImages,
   listPodmanImages,
+  normalizeArch,
   toBootcDistro,
 } from './podmanImages';
 export { readComposes } from './readComposes';

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -1,3 +1,4 @@
+export { inferDistro } from './inferDistro';
 export { parseJsonUnsafe } from './parseJson';
 export { lookupDatastreamDistro } from './dataStreamLookup';
 export { getBlueprintsPath } from './getBlueprintsPath';

--- a/src/store/api/backend/onprem/composerApi/helpers/inferDistro.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/inferDistro.ts
@@ -5,6 +5,22 @@ type InferredDistro = {
   name: string;
 };
 
+const parseVersionFromTag = (reference: string): string | undefined => {
+  const tag = reference.split(':').pop();
+  if (!tag) return undefined;
+  const match = tag.match(/^(\d+[\d.]*)$/);
+  return match?.[1];
+};
+
+const parseCentosVersionFromTag = (reference: string): string | undefined => {
+  const tag = reference.split(':').pop();
+  if (!tag) return undefined;
+  const streamMatch = tag.match(/^stream(\d+)$/);
+  if (streamMatch) return streamMatch[1];
+  const match = tag.match(/^(\d+[\d.]*)$/);
+  return match?.[1];
+};
+
 export const inferDistro = (image: ValidatedPodmanImage): InferredDistro => {
   const labels = image.Labels;
   const reference = image.Names[0].toLowerCase();
@@ -12,7 +28,7 @@ export const inferDistro = (image: ValidatedPodmanImage): InferredDistro => {
 
   // RHEL — has redhat.id label
   if (labels['redhat.id']) {
-    const v = version ?? 'unknown';
+    const v = version ?? parseVersionFromTag(reference) ?? 'unknown';
     return {
       distro: `rhel-${v}`,
       name: `Red Hat Enterprise Linux (RHEL) ${v}`,
@@ -32,15 +48,16 @@ export const inferDistro = (image: ValidatedPodmanImage): InferredDistro => {
     labels.name?.toLowerCase().includes('fedora') ||
     reference.includes('fedora')
   ) {
-    if (version) {
+    const v = version ?? parseVersionFromTag(reference);
+    if (v) {
       return {
-        distro: `fedora-${version}`,
-        name: `Fedora ${version}`,
+        distro: `fedora-${v}`,
+        name: `Fedora ${v}`,
       };
     }
     return {
       distro: 'fedora',
-      name: 'Fedora',
+      name: `Fedora (${image.Names[0]})`,
     };
   }
 
@@ -49,15 +66,16 @@ export const inferDistro = (image: ValidatedPodmanImage): InferredDistro => {
     labels.name?.toLowerCase().includes('centos') ||
     reference.includes('centos')
   ) {
-    if (version) {
+    const v = version ?? parseCentosVersionFromTag(reference);
+    if (v) {
       return {
-        distro: `centos-${version}`,
-        name: `CentOS Stream ${version}`,
+        distro: `centos-${v}`,
+        name: `CentOS Stream ${v}`,
       };
     }
     return {
       distro: 'centos',
-      name: 'CentOS Stream',
+      name: `CentOS Stream (${image.Names[0]})`,
     };
   }
 

--- a/src/store/api/backend/onprem/composerApi/helpers/inferDistro.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/inferDistro.ts
@@ -1,0 +1,69 @@
+import { ValidatedPodmanImage } from '../../types';
+
+type InferredDistro = {
+  distro: string;
+  name: string;
+};
+
+export const inferDistro = (image: ValidatedPodmanImage): InferredDistro => {
+  const labels = image.Labels;
+  const reference = image.Names[0].toLowerCase();
+  const version = labels.version;
+
+  // RHEL — has redhat.id label
+  if (labels['redhat.id']) {
+    const v = version ?? 'unknown';
+    return {
+      distro: `rhel-${v}`,
+      name: `Red Hat Enterprise Linux (RHEL) ${v}`,
+    };
+  }
+
+  // Fedora Hummingbird — check before generic Fedora
+  if (reference.includes('hummingbird')) {
+    return {
+      distro: 'hummingbird',
+      name: 'Fedora Hummingbird',
+    };
+  }
+
+  // Fedora — name label or reference contains 'fedora'
+  if (
+    labels.name?.toLowerCase().includes('fedora') ||
+    reference.includes('fedora')
+  ) {
+    if (version) {
+      return {
+        distro: `fedora-${version}`,
+        name: `Fedora ${version}`,
+      };
+    }
+    return {
+      distro: 'fedora',
+      name: 'Fedora',
+    };
+  }
+
+  // CentOS Stream — name label or reference contains 'centos'
+  if (
+    labels.name?.toLowerCase().includes('centos') ||
+    reference.includes('centos')
+  ) {
+    if (version) {
+      return {
+        distro: `centos-${version}`,
+        name: `CentOS Stream ${version}`,
+      };
+    }
+    return {
+      distro: 'centos',
+      name: 'CentOS Stream',
+    };
+  }
+
+  // Fallback — use the image reference as the name
+  return {
+    distro: image.Names[0],
+    name: image.Names[0],
+  };
+};

--- a/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
@@ -5,6 +5,16 @@ import { inferDistro } from './inferDistro';
 import { BootcDistributionItem } from '../../../hosted';
 import { PodmanImageInfo, ValidatedPodmanImage } from '../../types';
 
+const archMap: Record<string, string> = {
+  amd64: 'x86_64',
+  arm64: 'aarch64',
+  x86_64: 'x86_64',
+  aarch64: 'aarch64',
+};
+
+export const normalizeArch = (arch: string | undefined): string | undefined =>
+  arch ? archMap[arch] : undefined;
+
 export const listPodmanImages = async () => {
   try {
     const result = (await cockpit.spawn(
@@ -40,7 +50,9 @@ export const filterBootcImages = (arch: string | undefined) => {
       return false;
     }
 
-    if (image.Labels.architecture !== arch) {
+    const filterArch = normalizeArch(arch);
+    const imageArch = normalizeArch(image.Architecture);
+    if (!arch || !imageArch || imageArch !== filterArch) {
       return false;
     }
 
@@ -52,12 +64,12 @@ export const filterBootcImages = (arch: string | undefined) => {
   };
 };
 
-export const toBootcDistro = (arch: string) => {
+export const toBootcDistro = () => {
   return (image: ValidatedPodmanImage): BootcDistributionItem => {
     const { distro, name } = inferDistro(image);
 
     return {
-      arch: image.Labels.architecture ?? arch,
+      arch: normalizeArch(image.Architecture) ?? '',
       distro,
       reference: image.Names[0],
       name,

--- a/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
@@ -37,11 +37,11 @@ export const listPodmanImages = async () => {
   }
 };
 
-export const filterBootcImages = (arch: string | undefined) => {
+export const filterBootcImages = (
+  arch: string | undefined,
+  hostArch?: string,
+) => {
   return (image: PodmanImageInfo): image is ValidatedPodmanImage => {
-    // we use the names to get the full image reference,
-    // if this is empty, there isn't really a fallback,
-    // so we should just filter this item out
     if (!image.Names?.length) {
       return false;
     }
@@ -51,8 +51,9 @@ export const filterBootcImages = (arch: string | undefined) => {
     }
 
     const filterArch = normalizeArch(arch);
-    const imageArch = normalizeArch(image.Architecture);
-    if (!arch || !imageArch || imageArch !== filterArch) {
+    const imageArch =
+      normalizeArch(image.Architecture) ?? normalizeArch(hostArch);
+    if (!filterArch || !imageArch || imageArch !== filterArch) {
       return false;
     }
 
@@ -64,12 +65,12 @@ export const filterBootcImages = (arch: string | undefined) => {
   };
 };
 
-export const toBootcDistro = () => {
+export const toBootcDistro = (hostArch?: string) => {
   return (image: ValidatedPodmanImage): BootcDistributionItem => {
     const { distro, name } = inferDistro(image);
 
     return {
-      arch: normalizeArch(image.Architecture) ?? '',
+      arch: normalizeArch(image.Architecture) ?? normalizeArch(hostArch) ?? '',
       distro,
       reference: image.Names[0],
       name,

--- a/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
@@ -1,5 +1,7 @@
 import cockpit from 'cockpit';
 
+import { inferDistro } from './inferDistro';
+
 import { BootcDistributionItem } from '../../../hosted';
 import { PodmanImageInfo, ValidatedPodmanImage } from '../../types';
 
@@ -50,23 +52,16 @@ export const filterBootcImages = (arch: string | undefined) => {
   };
 };
 
-export const toBootcDistro = (
-  image: ValidatedPodmanImage,
-): BootcDistributionItem => {
-  // at the moment we're filtering out all non-rhel image mode
-  // images so we're fine to assume the distro as being a rhel
-  // variant. We'll have to re-think this a little bit later on
-  const d = `rhel-${image.Labels.version}`;
+export const toBootcDistro = (arch: string) => {
+  return (image: ValidatedPodmanImage): BootcDistributionItem => {
+    const { distro, name } = inferDistro(image);
 
-  return {
-    arch: image.Labels.architecture ?? '',
-    distro: d,
-    reference: image.Names[0],
-    // Align with the hosted API naming pattern
-    name: `Red Hat Enterprise Linux (RHEL) ${image.Labels.version ?? ''}`,
-    // we're hardcoding the image type in here
-    // because this is the only target we support
-    // on-prem at the moment
-    type: 'guest-image',
+    return {
+      arch: image.Labels.architecture ?? arch,
+      distro,
+      reference: image.Names[0],
+      name,
+      type: 'guest-image',
+    };
   };
 };

--- a/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
@@ -70,11 +70,11 @@ export const toBootcDistro = (
   const d = `rhel-${image.Labels.version}`;
 
   return {
-    arch: image.Labels.architecture,
+    arch: image.Labels.architecture ?? '',
     distro: d,
     reference: image.Names[0],
     // Align with the hosted API naming pattern
-    name: `Red Hat Enterprise Linux (RHEL) ${image.Labels.version}`,
+    name: `Red Hat Enterprise Linux (RHEL) ${image.Labels.version ?? ''}`,
     // we're hardcoding the image type in here
     // because this is the only target we support
     // on-prem at the moment

--- a/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podmanImages.ts
@@ -6,14 +6,7 @@ import { PodmanImageInfo, ValidatedPodmanImage } from '../../types';
 export const listPodmanImages = async () => {
   try {
     const result = (await cockpit.spawn(
-      [
-        'podman',
-        'images',
-        '--filter',
-        'reference=registry.redhat.io/rhel*/rhel-bootc',
-        '--format',
-        'json',
-      ],
+      ['podman', 'images', '--format', 'json'],
       {
         // Root is required to access system-level podman images
         superuser: 'require',
@@ -49,15 +42,11 @@ export const filterBootcImages = (arch: string | undefined) => {
       return false;
     }
 
-    // just include rhel bootable containers for now
-    if (!('redhat.id' in image.Labels)) {
-      return false;
-    }
+    const isBootc =
+      image.Labels['containers.bootc'] === '1' ||
+      image.Labels['ostree.bootable'] === 'true';
 
-    return (
-      'containers.bootc' in image.Labels &&
-      image.Labels['containers.bootc'] === '1'
-    );
+    return isBootc;
   };
 };
 

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/filterBootcImages.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/filterBootcImages.test.ts
@@ -9,7 +9,6 @@ const makeImage = (
   Labels: {
     architecture: 'x86_64',
     version: '10',
-    'redhat.id': 'rhel',
     'containers.bootc': '1',
     ...overrides,
   },
@@ -27,15 +26,38 @@ describe('filterBootcImages', () => {
     expect(predicate(makeImage({ architecture: 'x86_64' }))).toBe(false);
   });
 
-  it('returns false when redhat.id label is missing', () => {
+  it('returns true when ostree.bootable is true (no containers.bootc)', () => {
     const predicate = filterBootcImages('x86_64');
-    const image = makeImage();
-    delete image.Labels!['redhat.id'];
+    const image = makeImage({
+      'ostree.bootable': 'true',
+    });
+    delete image.Labels!['containers.bootc'];
+
+    expect(predicate(image)).toBe(true);
+  });
+
+  it('returns false when ostree.bootable is true but architecture differs', () => {
+    const predicate = filterBootcImages('x86_64');
+    const image = makeImage({
+      architecture: 'aarch64',
+      'ostree.bootable': 'true',
+    });
+    delete image.Labels!['containers.bootc'];
 
     expect(predicate(image)).toBe(false);
   });
 
-  it('returns false when containers.bootc label is missing', () => {
+  it('returns true when both containers.bootc and ostree.bootable are present', () => {
+    const predicate = filterBootcImages('x86_64');
+    const image = makeImage({
+      'containers.bootc': '1',
+      'ostree.bootable': 'true',
+    });
+
+    expect(predicate(image)).toBe(true);
+  });
+
+  it('returns false when neither bootc label is present', () => {
     const predicate = filterBootcImages('x86_64');
     const image = makeImage();
     delete image.Labels!['containers.bootc'];
@@ -43,7 +65,7 @@ describe('filterBootcImages', () => {
     expect(predicate(image)).toBe(false);
   });
 
-  it('returns false when containers.bootc is 0', () => {
+  it('returns false when containers.bootc is 0 and ostree.bootable is absent', () => {
     const predicate = filterBootcImages('x86_64');
     expect(predicate(makeImage({ 'containers.bootc': '0' }))).toBe(false);
   });

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/filterBootcImages.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/filterBootcImages.test.ts
@@ -134,4 +134,19 @@ describe('filterBootcImages', () => {
 
     expect(predicate(image)).toBe(false);
   });
+
+  it('falls back to hostArch when image Architecture is empty', () => {
+    const predicate = filterBootcImages('x86_64', 'x86_64');
+    expect(predicate(makeImage({ Architecture: '' }))).toBe(true);
+  });
+
+  it('rejects when image Architecture is empty and hostArch does not match filter', () => {
+    const predicate = filterBootcImages('aarch64', 'x86_64');
+    expect(predicate(makeImage({ Architecture: '' }))).toBe(false);
+  });
+
+  it('rejects when image Architecture is empty and no hostArch provided', () => {
+    const predicate = filterBootcImages('x86_64');
+    expect(predicate(makeImage({ Architecture: '' }))).toBe(false);
+  });
 });

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/filterBootcImages.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/filterBootcImages.test.ts
@@ -1,18 +1,45 @@
 import { describe, expect, it } from 'vitest';
 
 import { PodmanImageInfo } from '../../../types';
-import { filterBootcImages } from '../podmanImages';
+import { filterBootcImages, normalizeArch } from '../podmanImages';
+
+const defaultLabels = {
+  version: '10',
+  'containers.bootc': '1' as const,
+};
 
 const makeImage = (
-  overrides: Partial<PodmanImageInfo['Labels']> = {},
-): PodmanImageInfo => ({
-  Labels: {
-    architecture: 'x86_64',
-    version: '10',
-    'containers.bootc': '1',
-    ...overrides,
-  },
-  Names: ['registry.redhat.io/rhel10/rhel-bootc:10.0'],
+  overrides: Partial<Omit<PodmanImageInfo, 'Labels'>> & {
+    Labels?: Partial<PodmanImageInfo['Labels']> | null;
+  } = {},
+): PodmanImageInfo => {
+  const { Labels, ...rest } = overrides;
+  return {
+    Architecture: 'amd64',
+    Labels: Labels === null ? undefined : { ...defaultLabels, ...Labels },
+    Names: ['registry.redhat.io/rhel10/rhel-bootc:10.0'],
+    ...rest,
+  };
+};
+
+describe('normalizeArch', () => {
+  it('maps kernel arch to RPM arch', () => {
+    expect(normalizeArch('amd64')).toBe('x86_64');
+    expect(normalizeArch('arm64')).toBe('aarch64');
+  });
+
+  it('passes through RPM arch unchanged', () => {
+    expect(normalizeArch('x86_64')).toBe('x86_64');
+    expect(normalizeArch('aarch64')).toBe('aarch64');
+  });
+
+  it('returns undefined for unknown arch', () => {
+    expect(normalizeArch('sparc')).toBeUndefined();
+  });
+
+  it('returns undefined when arch is undefined', () => {
+    expect(normalizeArch(undefined)).toBeUndefined();
+  });
 });
 
 describe('filterBootcImages', () => {
@@ -21,17 +48,23 @@ describe('filterBootcImages', () => {
     expect(predicate(makeImage())).toBe(true);
   });
 
+  it('matches when filter arch is in kernel format', () => {
+    const predicate = filterBootcImages('amd64');
+    expect(predicate(makeImage())).toBe(true);
+  });
+
   it('returns false when architecture does not match', () => {
     const predicate = filterBootcImages('aarch64');
-    expect(predicate(makeImage({ architecture: 'x86_64' }))).toBe(false);
+    expect(predicate(makeImage())).toBe(false);
   });
 
   it('returns true when ostree.bootable is true (no containers.bootc)', () => {
     const predicate = filterBootcImages('x86_64');
     const image = makeImage({
-      'ostree.bootable': 'true',
+      Labels: {
+        'ostree.bootable': 'true',
+      },
     });
-    delete image.Labels!['containers.bootc'];
 
     expect(predicate(image)).toBe(true);
   });
@@ -39,10 +72,11 @@ describe('filterBootcImages', () => {
   it('returns false when ostree.bootable is true but architecture differs', () => {
     const predicate = filterBootcImages('x86_64');
     const image = makeImage({
-      architecture: 'aarch64',
-      'ostree.bootable': 'true',
+      Architecture: 'arm64',
+      Labels: {
+        'ostree.bootable': 'true',
+      },
     });
-    delete image.Labels!['containers.bootc'];
 
     expect(predicate(image)).toBe(false);
   });
@@ -50,8 +84,10 @@ describe('filterBootcImages', () => {
   it('returns true when both containers.bootc and ostree.bootable are present', () => {
     const predicate = filterBootcImages('x86_64');
     const image = makeImage({
-      'containers.bootc': '1',
-      'ostree.bootable': 'true',
+      Labels: {
+        'containers.bootc': '1',
+        'ostree.bootable': 'true',
+      },
     });
 
     expect(predicate(image)).toBe(true);
@@ -59,34 +95,42 @@ describe('filterBootcImages', () => {
 
   it('returns false when neither bootc label is present', () => {
     const predicate = filterBootcImages('x86_64');
-    const image = makeImage();
-    delete image.Labels!['containers.bootc'];
+    const image: PodmanImageInfo = {
+      Architecture: 'amd64',
+      Labels: { version: '10' },
+      Names: ['registry.example.com/test:latest'],
+    };
 
     expect(predicate(image)).toBe(false);
   });
 
   it('returns false when containers.bootc is 0 and ostree.bootable is absent', () => {
     const predicate = filterBootcImages('x86_64');
-    expect(predicate(makeImage({ 'containers.bootc': '0' }))).toBe(false);
+    expect(predicate(makeImage({ Labels: { 'containers.bootc': '0' } }))).toBe(
+      false,
+    );
   });
 
-  it('returns false when arch argument is undefined', () => {
+  it('returns false when filter arch is undefined', () => {
     const predicate = filterBootcImages(undefined);
     expect(predicate(makeImage())).toBe(false);
   });
 
+  it('returns false when image arch is unknown', () => {
+    const predicate = filterBootcImages('x86_64');
+    expect(predicate(makeImage({ Architecture: 'sparc' }))).toBe(false);
+  });
+
   it('returns false when Names array is empty', () => {
     const predicate = filterBootcImages('x86_64');
-    const image = makeImage();
-    image.Names = [];
+    const image = makeImage({ Names: [] });
 
     expect(predicate(image)).toBe(false);
   });
 
   it('returns false when Labels is missing', () => {
     const predicate = filterBootcImages('x86_64');
-    const image = makeImage();
-    image.Labels = undefined;
+    const image = makeImage({ Labels: null });
 
     expect(predicate(image)).toBe(false);
   });

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/inferDistro.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/inferDistro.test.ts
@@ -27,7 +27,7 @@ describe('inferDistro', () => {
       });
     });
 
-    it('returns rhel-unknown when redhat.id is present but version is missing', () => {
+    it('returns rhel-unknown when redhat.id is present but version is missing and tag is not numeric', () => {
       const image = makeImage({ 'redhat.id': 'rhel' }, [
         'registry.redhat.io/rhel10/rhel-bootc:latest',
       ]);
@@ -35,6 +35,17 @@ describe('inferDistro', () => {
       expect(inferDistro(image)).toEqual({
         distro: 'rhel-unknown',
         name: 'Red Hat Enterprise Linux (RHEL) unknown',
+      });
+    });
+
+    it('extracts version from tag when redhat.id is present but version label is missing', () => {
+      const image = makeImage({ 'redhat.id': 'rhel' }, [
+        'registry.redhat.io/rhel10/rhel-bootc:10.0',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'rhel-10.0',
+        name: 'Red Hat Enterprise Linux (RHEL) 10.0',
       });
     });
 
@@ -97,14 +108,23 @@ describe('inferDistro', () => {
       });
     });
 
-    it('returns fedora without version when version is missing', () => {
+    it('extracts version from tag when version label is missing', () => {
+      const image = makeImage({}, ['quay.io/fedora/fedora-bootc:44']);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'fedora-44',
+        name: 'Fedora 44',
+      });
+    });
+
+    it('shows reference in brackets when tag is not version-like', () => {
       const image = makeImage({ name: 'Fedora Linux' }, [
         'quay.io/fedora/fedora-bootc:latest',
       ]);
 
       expect(inferDistro(image)).toEqual({
         distro: 'fedora',
-        name: 'Fedora',
+        name: 'Fedora (quay.io/fedora/fedora-bootc:latest)',
       });
     });
   });
@@ -132,14 +152,25 @@ describe('inferDistro', () => {
       });
     });
 
-    it('returns centos without version when version is missing', () => {
+    it('extracts version from stream tag when version label is missing', () => {
+      const image = makeImage({ name: 'CentOS Stream' }, [
+        'quay.io/centos-bootc/centos-bootc:stream10',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'centos-10',
+        name: 'CentOS Stream 10',
+      });
+    });
+
+    it('shows reference in brackets when tag is not version-like', () => {
       const image = makeImage({ name: 'CentOS Stream' }, [
         'quay.io/centos-bootc/centos-bootc:latest',
       ]);
 
       expect(inferDistro(image)).toEqual({
         distro: 'centos',
-        name: 'CentOS Stream',
+        name: 'CentOS Stream (quay.io/centos-bootc/centos-bootc:latest)',
       });
     });
   });

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/inferDistro.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/inferDistro.test.ts
@@ -7,6 +7,7 @@ const makeImage = (
   labels: Partial<ValidatedPodmanImage['Labels']> = {},
   names: string[] = ['registry.example.com/some-image:latest'],
 ): ValidatedPodmanImage => ({
+  Architecture: 'amd64',
   Labels: {
     ...labels,
   },

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/inferDistro.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/inferDistro.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import { ValidatedPodmanImage } from '../../../types';
+import { inferDistro } from '../inferDistro';
+
+const makeImage = (
+  labels: Partial<ValidatedPodmanImage['Labels']> = {},
+  names: string[] = ['registry.example.com/some-image:latest'],
+): ValidatedPodmanImage => ({
+  Labels: {
+    ...labels,
+  },
+  Names: names,
+});
+
+describe('inferDistro', () => {
+  describe('RHEL images', () => {
+    it('returns rhel-${version} when redhat.id is present', () => {
+      const image = makeImage({ 'redhat.id': 'rhel', version: '10' }, [
+        'registry.redhat.io/rhel10/rhel-bootc:10.0',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'rhel-10',
+        name: 'Red Hat Enterprise Linux (RHEL) 10',
+      });
+    });
+
+    it('returns rhel-unknown when redhat.id is present but version is missing', () => {
+      const image = makeImage({ 'redhat.id': 'rhel' }, [
+        'registry.redhat.io/rhel10/rhel-bootc:latest',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'rhel-unknown',
+        name: 'Red Hat Enterprise Linux (RHEL) unknown',
+      });
+    });
+
+    it('RHEL wins over reference containing fedora', () => {
+      const image = makeImage({ 'redhat.id': 'rhel', version: '10' }, [
+        'registry.example.com/fedora-rhel-bootc:10',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'rhel-10',
+        name: 'Red Hat Enterprise Linux (RHEL) 10',
+      });
+    });
+  });
+
+  describe('Fedora Hummingbird images', () => {
+    it('returns hummingbird when reference contains hummingbird', () => {
+      const image = makeImage({ name: 'Fedora Hummingbird', version: '42' }, [
+        'quay.io/fedora/fedora-hummingbird:42',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'hummingbird',
+        name: 'Fedora Hummingbird',
+      });
+    });
+
+    it('hummingbird wins over generic Fedora', () => {
+      const image = makeImage({ name: 'Fedora Linux', version: '42' }, [
+        'quay.io/fedora/fedora-hummingbird:42',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'hummingbird',
+        name: 'Fedora Hummingbird',
+      });
+    });
+  });
+
+  describe('Fedora images', () => {
+    it('returns fedora-${version} when reference contains fedora', () => {
+      const image = makeImage({ version: '42' }, [
+        'quay.io/fedora/fedora-bootc:42',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'fedora-42',
+        name: 'Fedora 42',
+      });
+    });
+
+    it('returns fedora-${version} when label name contains fedora', () => {
+      const image = makeImage({ name: 'Fedora Linux', version: '41' }, [
+        'registry.example.com/custom-bootc:41',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'fedora-41',
+        name: 'Fedora 41',
+      });
+    });
+
+    it('returns fedora without version when version is missing', () => {
+      const image = makeImage({ name: 'Fedora Linux' }, [
+        'quay.io/fedora/fedora-bootc:latest',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'fedora',
+        name: 'Fedora',
+      });
+    });
+  });
+
+  describe('CentOS Stream images', () => {
+    it('returns centos-${version} when reference contains centos', () => {
+      const image = makeImage({ version: '10' }, [
+        'quay.io/centos-bootc/centos-bootc:stream10',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'centos-10',
+        name: 'CentOS Stream 10',
+      });
+    });
+
+    it('returns centos-${version} when label name contains centos', () => {
+      const image = makeImage({ name: 'CentOS Stream', version: '9' }, [
+        'registry.example.com/custom-bootc:9',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'centos-9',
+        name: 'CentOS Stream 9',
+      });
+    });
+
+    it('returns centos without version when version is missing', () => {
+      const image = makeImage({ name: 'CentOS Stream' }, [
+        'quay.io/centos-bootc/centos-bootc:latest',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'centos',
+        name: 'CentOS Stream',
+      });
+    });
+  });
+
+  describe('unknown images', () => {
+    it('falls back to image reference for unknown images', () => {
+      const image = makeImage({ version: '1.0' }, [
+        'registry.example.com/my-custom-bootc:1.0',
+      ]);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'registry.example.com/my-custom-bootc:1.0',
+        name: 'registry.example.com/my-custom-bootc:1.0',
+      });
+    });
+
+    it('falls back to reference when no labels match any known distro', () => {
+      const image = makeImage({}, ['localhost/my-image:latest']);
+
+      expect(inferDistro(image)).toEqual({
+        distro: 'localhost/my-image:latest',
+        name: 'localhost/my-image:latest',
+      });
+    });
+  });
+});

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/listPodmanImages.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/listPodmanImages.test.ts
@@ -22,14 +22,7 @@ describe('listPodmanImages', () => {
 
     expect(result).toBe(mockOutput);
     expect(cockpit.spawn).toHaveBeenCalledWith(
-      [
-        'podman',
-        'images',
-        '--filter',
-        'reference=registry.redhat.io/rhel*/rhel-bootc',
-        '--format',
-        'json',
-      ],
+      ['podman', 'images', '--format', 'json'],
       { superuser: 'require' },
     );
   });

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/toBootcDistro.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/toBootcDistro.test.ts
@@ -146,4 +146,10 @@ describe('toBootcDistro', () => {
       type: 'guest-image',
     });
   });
+
+  it('falls back to hostArch when image Architecture is empty', () => {
+    const result = toBootcDistro('x86_64')(makeImage({}, undefined, ''));
+
+    expect(result.arch).toBe('x86_64');
+  });
 });

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/toBootcDistro.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/toBootcDistro.test.ts
@@ -6,9 +6,10 @@ import { toBootcDistro } from '../podmanImages';
 const makeImage = (
   overrides: Partial<ValidatedPodmanImage['Labels']> = {},
   names: string[] = ['registry.redhat.io/rhel10/rhel-bootc:10.0'],
+  architecture = 'amd64',
 ): ValidatedPodmanImage => ({
+  Architecture: architecture,
   Labels: {
-    architecture: 'x86_64',
     version: '10',
     'redhat.id': 'rhel',
     ...overrides,
@@ -18,7 +19,7 @@ const makeImage = (
 
 describe('toBootcDistro', () => {
   it('maps a RHEL podman image to a bootc distro object', () => {
-    const result = toBootcDistro('x86_64')(makeImage());
+    const result = toBootcDistro()(makeImage());
 
     expect(result).toEqual({
       arch: 'x86_64',
@@ -30,7 +31,7 @@ describe('toBootcDistro', () => {
   });
 
   it('uses the first entry from Names as the reference', () => {
-    const result = toBootcDistro('x86_64')(
+    const result = toBootcDistro()(
       makeImage({}, [
         'registry.redhat.io/rhel9/rhel-bootc:9.6',
         'some-other-name',
@@ -41,31 +42,34 @@ describe('toBootcDistro', () => {
   });
 
   it('constructs the distro string from the version label for RHEL', () => {
-    const result = toBootcDistro('x86_64')(makeImage({ version: '9' }));
+    const result = toBootcDistro()(makeImage({ version: '9' }));
 
     expect(result.distro).toBe('rhel-9');
     expect(result.name).toBe('Red Hat Enterprise Linux (RHEL) 9');
   });
 
-  it('uses the architecture from the image labels', () => {
-    const result = toBootcDistro('x86_64')(
-      makeImage({ architecture: 'aarch64' }),
-    );
+  it('normalizes kernel arch to RPM arch', () => {
+    const result = toBootcDistro()(makeImage({}, undefined, 'arm64'));
 
     expect(result.arch).toBe('aarch64');
   });
 
+  it('passes through RPM arch unchanged', () => {
+    const result = toBootcDistro()(makeImage({}, undefined, 'x86_64'));
+
+    expect(result.arch).toBe('x86_64');
+  });
+
   it('always sets type to guest-image', () => {
-    const result = toBootcDistro('x86_64')(makeImage());
+    const result = toBootcDistro()(makeImage());
 
     expect(result.type).toBe('guest-image');
   });
 
   it('produces fedora distro for a Fedora image', () => {
-    const result = toBootcDistro('x86_64')(
+    const result = toBootcDistro()(
       makeImage(
         {
-          architecture: 'x86_64',
           version: '42',
           'redhat.id': undefined,
         },
@@ -83,10 +87,9 @@ describe('toBootcDistro', () => {
   });
 
   it('produces centos distro for a CentOS image', () => {
-    const result = toBootcDistro('x86_64')(
+    const result = toBootcDistro()(
       makeImage(
         {
-          architecture: 'x86_64',
           version: '10',
           'redhat.id': undefined,
         },
@@ -104,10 +107,9 @@ describe('toBootcDistro', () => {
   });
 
   it('produces hummingbird distro for a Hummingbird image', () => {
-    const result = toBootcDistro('x86_64')(
+    const result = toBootcDistro()(
       makeImage(
         {
-          architecture: 'x86_64',
           version: '42',
           name: 'Fedora Hummingbird',
           'redhat.id': undefined,
@@ -126,10 +128,9 @@ describe('toBootcDistro', () => {
   });
 
   it('uses reference as name for an unknown image', () => {
-    const result = toBootcDistro('x86_64')(
+    const result = toBootcDistro()(
       makeImage(
         {
-          architecture: 'x86_64',
           version: '1.0',
           'redhat.id': undefined,
         },
@@ -144,15 +145,5 @@ describe('toBootcDistro', () => {
       name: 'registry.example.com/my-custom-bootc:1.0',
       type: 'guest-image',
     });
-  });
-
-  it('falls back to arch argument when architecture label is missing', () => {
-    const result = toBootcDistro('aarch64')(
-      makeImage({
-        architecture: undefined,
-      }),
-    );
-
-    expect(result.arch).toBe('aarch64');
   });
 });

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/toBootcDistro.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/toBootcDistro.test.ts
@@ -10,14 +10,15 @@ const makeImage = (
   Labels: {
     architecture: 'x86_64',
     version: '10',
+    'redhat.id': 'rhel',
     ...overrides,
   },
   Names: names,
 });
 
 describe('toBootcDistro', () => {
-  it('maps a podman image to a bootc distro object', () => {
-    const result = toBootcDistro(makeImage());
+  it('maps a RHEL podman image to a bootc distro object', () => {
+    const result = toBootcDistro('x86_64')(makeImage());
 
     expect(result).toEqual({
       arch: 'x86_64',
@@ -29,7 +30,7 @@ describe('toBootcDistro', () => {
   });
 
   it('uses the first entry from Names as the reference', () => {
-    const result = toBootcDistro(
+    const result = toBootcDistro('x86_64')(
       makeImage({}, [
         'registry.redhat.io/rhel9/rhel-bootc:9.6',
         'some-other-name',
@@ -39,22 +40,119 @@ describe('toBootcDistro', () => {
     expect(result.reference).toBe('registry.redhat.io/rhel9/rhel-bootc:9.6');
   });
 
-  it('constructs the distro string from the version label', () => {
-    const result = toBootcDistro(makeImage({ version: '9' }));
+  it('constructs the distro string from the version label for RHEL', () => {
+    const result = toBootcDistro('x86_64')(makeImage({ version: '9' }));
 
     expect(result.distro).toBe('rhel-9');
     expect(result.name).toBe('Red Hat Enterprise Linux (RHEL) 9');
   });
 
-  it('converts the architecture to a string', () => {
-    const result = toBootcDistro(makeImage({ architecture: 'aarch64' }));
+  it('uses the architecture from the image labels', () => {
+    const result = toBootcDistro('x86_64')(
+      makeImage({ architecture: 'aarch64' }),
+    );
 
     expect(result.arch).toBe('aarch64');
   });
 
   it('always sets type to guest-image', () => {
-    const result = toBootcDistro(makeImage());
+    const result = toBootcDistro('x86_64')(makeImage());
 
     expect(result.type).toBe('guest-image');
+  });
+
+  it('produces fedora distro for a Fedora image', () => {
+    const result = toBootcDistro('x86_64')(
+      makeImage(
+        {
+          architecture: 'x86_64',
+          version: '42',
+          'redhat.id': undefined,
+        },
+        ['quay.io/fedora/fedora-bootc:42'],
+      ),
+    );
+
+    expect(result).toEqual({
+      arch: 'x86_64',
+      distro: 'fedora-42',
+      reference: 'quay.io/fedora/fedora-bootc:42',
+      name: 'Fedora 42',
+      type: 'guest-image',
+    });
+  });
+
+  it('produces centos distro for a CentOS image', () => {
+    const result = toBootcDistro('x86_64')(
+      makeImage(
+        {
+          architecture: 'x86_64',
+          version: '10',
+          'redhat.id': undefined,
+        },
+        ['quay.io/centos-bootc/centos-bootc:stream10'],
+      ),
+    );
+
+    expect(result).toEqual({
+      arch: 'x86_64',
+      distro: 'centos-10',
+      reference: 'quay.io/centos-bootc/centos-bootc:stream10',
+      name: 'CentOS Stream 10',
+      type: 'guest-image',
+    });
+  });
+
+  it('produces hummingbird distro for a Hummingbird image', () => {
+    const result = toBootcDistro('x86_64')(
+      makeImage(
+        {
+          architecture: 'x86_64',
+          version: '42',
+          name: 'Fedora Hummingbird',
+          'redhat.id': undefined,
+        },
+        ['quay.io/fedora/fedora-hummingbird:42'],
+      ),
+    );
+
+    expect(result).toEqual({
+      arch: 'x86_64',
+      distro: 'hummingbird',
+      reference: 'quay.io/fedora/fedora-hummingbird:42',
+      name: 'Fedora Hummingbird',
+      type: 'guest-image',
+    });
+  });
+
+  it('uses reference as name for an unknown image', () => {
+    const result = toBootcDistro('x86_64')(
+      makeImage(
+        {
+          architecture: 'x86_64',
+          version: '1.0',
+          'redhat.id': undefined,
+        },
+        ['registry.example.com/my-custom-bootc:1.0'],
+      ),
+    );
+
+    expect(result).toEqual({
+      arch: 'x86_64',
+      distro: 'registry.example.com/my-custom-bootc:1.0',
+      reference: 'registry.example.com/my-custom-bootc:1.0',
+      name: 'registry.example.com/my-custom-bootc:1.0',
+      type: 'guest-image',
+    });
+  });
+
+  it('falls back to arch argument when architecture label is missing', () => {
+    const result = toBootcDistro('aarch64')(
+      makeImage({
+        architecture: undefined,
+      }),
+    );
+
+    expect(result.arch).toBe('aarch64');
   });
 });

--- a/src/store/api/backend/onprem/types/custom.ts
+++ b/src/store/api/backend/onprem/types/custom.ts
@@ -91,7 +91,6 @@ export type ComposerComposesResponseItem = Omit<
 };
 
 type PodmanLabels = Record<string, string | undefined> & {
-  architecture?: string | undefined;
   version?: string | undefined;
   name?: string | undefined;
   ['redhat.id']?: string | undefined;
@@ -100,11 +99,13 @@ type PodmanLabels = Record<string, string | undefined> & {
 };
 
 export type PodmanImageInfo = {
+  Architecture: string;
   Labels?: PodmanLabels | undefined;
   Names?: string[] | undefined;
 };
 
 export type ValidatedPodmanImage = {
+  Architecture: string;
   Labels: PodmanLabels;
   Names: string[];
 };

--- a/src/store/api/backend/onprem/types/custom.ts
+++ b/src/store/api/backend/onprem/types/custom.ts
@@ -90,13 +90,13 @@ export type ComposerComposesResponseItem = Omit<
   };
 };
 
-type PodmanLabels = {
-  // let's just hardcode this for now, we don't have any
-  // rpm builds for other arches for the on-prem frontend
-  architecture: 'x86_64' | 'aarch64';
-  version: string;
+type PodmanLabels = Record<string, string | undefined> & {
+  architecture?: string | undefined;
+  version?: string | undefined;
+  name?: string | undefined;
   ['redhat.id']?: string | undefined;
   ['containers.bootc']?: '0' | '1' | undefined;
+  ['ostree.bootable']?: string | undefined;
 };
 
 export type PodmanImageInfo = {


### PR DESCRIPTION
Based on #4526 

This pull request extends #4526 by essentially three changes:
1. Enable "Image Mode" on Fedora (this was previously blocked by a filter)
2. Derive the architecture by means of `podman inspect`
3. Extract the distribution version to show "Fedora 44" instead of "Fedora"