### PR TITLE
Cockpit: Add container registry status and login (HMS-10831)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -34,6 +34,8 @@ import {
   selectImageSource,
 } from '@/store/slices/wizard';
 
+import RegistryAuthSection from './RegistryAuthSection';
+
 const CopyInlineCompact = ({ text }: { text: string }) => (
   <ClipboardCopy
     copyAriaLabel='Copy podman pull command'
@@ -178,6 +180,7 @@ const ImageSourceSelect = () => {
 
   return (
     <FormGroup label='Image source' isRequired>
+      {isOnPremise && <RegistryAuthSection />}
       {isError && (
         <Alert
           title='Error loading bootc images'

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/RegistryAuthSection.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/RegistryAuthSection.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+
+import {
+  useGetRegistryAuthStatusQuery,
+  useRegistryLoginMutation,
+} from '@/store/api/backend';
+import { OnPremError } from '@/store/api/shared/types';
+
+import RegistryAuthStatus from './RegistryAuthStatus';
+import RegistryLoginModal from './RegistryLoginModal';
+
+const RegistryAuthSection = () => {
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
+
+  const {
+    data: registryAuth,
+    isFetching: isCheckingAuth,
+    isError: isAuthError,
+    error: authQueryError,
+  } = useGetRegistryAuthStatusQuery(undefined, {
+    refetchOnMountOrArgChange: true,
+  });
+
+  const [registryLogin, { isLoading: isLoggingIn, error: loginMutationError }] =
+    useRegistryLoginMutation();
+
+  const authState = isCheckingAuth
+    ? ({ status: 'checking' } as const)
+    : isAuthError
+      ? ({
+          status: 'network-error',
+          error:
+            (authQueryError as OnPremError).message ||
+            'Unable to reach registry',
+        } as const)
+      : (registryAuth ?? ({ status: 'checking' } as const));
+
+  const handleLogin = async (username: string, password: string) => {
+    await registryLogin({ username, password }).unwrap();
+  };
+
+  return (
+    <>
+      <RegistryAuthStatus
+        authState={authState}
+        onLoginClick={() => setIsLoginModalOpen(true)}
+      />
+      <RegistryLoginModal
+        isOpen={isLoginModalOpen}
+        onClose={() => setIsLoginModalOpen(false)}
+        onLogin={handleLogin}
+        isLoggingIn={isLoggingIn}
+        error={
+          loginMutationError
+            ? (loginMutationError as OnPremError).message || 'Login failed'
+            : null
+        }
+      />
+    </>
+  );
+};
+
+export default RegistryAuthSection;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/RegistryAuthStatus.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/RegistryAuthStatus.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+
+import {
+  Button,
+  Content,
+  Flex,
+  FlexItem,
+  Label,
+  Spinner,
+} from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+} from '@patternfly/react-icons';
+
+import type { RegistryAuthStatus as ApiRegistryAuthStatus } from '@/store/api/backend/onprem';
+
+type RegistryAuthState =
+  | ApiRegistryAuthStatus
+  | { status: 'checking' }
+  | { status: 'network-error'; error: string };
+
+type RegistryAuthStatusProps = {
+  authState: RegistryAuthState;
+  onLoginClick: () => void;
+};
+
+const RegistryAuthStatus = ({
+  authState,
+  onLoginClick,
+}: RegistryAuthStatusProps) => {
+  return (
+    <div className='pf-v6-u-mb-sm'>
+      {authState.status === 'checking' && (
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          gap={{ default: 'gapSm' }}
+        >
+          <FlexItem>
+            <Spinner size='sm' aria-label='Checking registry authentication' />
+          </FlexItem>
+          <FlexItem>
+            <Content>Checking registry authentication...</Content>
+          </FlexItem>
+        </Flex>
+      )}
+      {authState.status === 'authenticated' && (
+        <Label
+          color='green'
+          variant='outline'
+          icon={
+            <CheckCircleIcon color='var(--pf-t--global--icon--color--status--success--default)' />
+          }
+        >
+          Logged in to registry.redhat.io as {authState.username}
+        </Label>
+      )}
+      {authState.status === 'not-logged-in' && (
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          gap={{ default: 'gapSm' }}
+        >
+          <FlexItem>
+            <Label
+              color='orange'
+              variant='outline'
+              icon={
+                <ExclamationTriangleIcon color='var(--pf-t--global--icon--color--status--warning--default)' />
+              }
+            >
+              Not logged in to registry.redhat.io
+            </Label>
+          </FlexItem>
+          <FlexItem>
+            <Button variant='link' onClick={onLoginClick} isInline>
+              Log in
+            </Button>
+          </FlexItem>
+        </Flex>
+      )}
+      {authState.status === 'auth-failed' && (
+        <Flex
+          alignItems={{ default: 'alignItemsCenter' }}
+          gap={{ default: 'gapSm' }}
+        >
+          <FlexItem>
+            <Label
+              color='orange'
+              variant='outline'
+              icon={
+                <ExclamationTriangleIcon color='var(--pf-t--global--icon--color--status--warning--default)' />
+              }
+            >
+              Authentication failed for {authState.username} - credentials may
+              be expired
+            </Label>
+          </FlexItem>
+          <FlexItem>
+            <Button variant='link' onClick={onLoginClick} isInline>
+              Log in
+            </Button>
+          </FlexItem>
+        </Flex>
+      )}
+      {authState.status === 'network-error' && (
+        <Content>Unable to reach registry.redhat.io: {authState.error}</Content>
+      )}
+    </div>
+  );
+};
+
+export default RegistryAuthStatus;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/RegistryLoginModal.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/RegistryLoginModal.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+
+import {
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  TextInput,
+} from '@patternfly/react-core';
+
+type RegistryLoginModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onLogin: (username: string, password: string) => Promise<void>;
+  isLoggingIn: boolean;
+  error: string | null;
+};
+
+const RegistryLoginModal = ({
+  isOpen,
+  onClose,
+  onLogin,
+  isLoggingIn,
+  error,
+}: RegistryLoginModalProps) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleClose = () => {
+    setUsername('');
+    setPassword('');
+    onClose();
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (username && password) {
+      try {
+        await onLogin(username, password);
+        handleClose();
+      } catch {
+        // Modal stays open on error; error is displayed via the error prop
+      }
+    }
+  };
+
+  const isSubmitDisabled = !username || !password || isLoggingIn;
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} variant='small'>
+      <ModalHeader title='Log in to registry.redhat.io' />
+      <ModalBody>
+        <Form id='registry-login-form' onSubmit={handleSubmit}>
+          {error && (
+            <Alert
+              variant='danger'
+              title='Login failed'
+              className='pf-v6-u-mb-md'
+            >
+              {error}
+            </Alert>
+          )}
+          <FormGroup label='Username' isRequired fieldId='registry-username'>
+            <TextInput
+              isRequired
+              type='text'
+              id='registry-username'
+              name='registry-username'
+              value={username}
+              onChange={(_event, value) => setUsername(value)}
+              autoComplete='username'
+            />
+          </FormGroup>
+          <FormGroup label='Password' isRequired fieldId='registry-password'>
+            <TextInput
+              isRequired
+              type='password'
+              id='registry-password'
+              name='registry-password'
+              value={password}
+              onChange={(_event, value) => setPassword(value)}
+              autoComplete='current-password'
+            />
+          </FormGroup>
+        </Form>
+      </ModalBody>
+      <ModalFooter>
+        <Button
+          variant='primary'
+          type='submit'
+          form='registry-login-form'
+          isDisabled={isSubmitDisabled}
+          isLoading={isLoggingIn}
+        >
+          Log in
+        </Button>
+        <Button variant='link' onClick={handleClose}>
+          Cancel
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default RegistryLoginModal;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -28,6 +28,7 @@ import ImageSourceSelect from '../components/ImageSourceSelect';
 
 const mockRefetch = vi.fn();
 const mockUseGetDistributionsQuery = vi.fn();
+const mockRegistryLogin = vi.fn().mockReturnValue({ unwrap: vi.fn() });
 
 vi.mock('@/store/api/backend', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/store/api/backend')>();
@@ -35,6 +36,16 @@ vi.mock('@/store/api/backend', async (importOriginal) => {
     ...actual,
     useGetDistributionsQuery: (...args: unknown[]) =>
       mockUseGetDistributionsQuery(...args),
+    useGetRegistryAuthStatusQuery: () => ({
+      data: { status: 'authenticated', username: 'testuser' },
+      isLoading: false,
+      isError: false,
+      error: undefined,
+    }),
+    useRegistryLoginMutation: () => [
+      mockRegistryLogin,
+      { isLoading: false, error: undefined },
+    ],
   };
 });
 

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -104,8 +104,10 @@ export {
 export {
   toComposerComposeRequest,
   useExportBlueprintCockpitQuery,
+  useGetRegistryAuthStatusQuery,
   useGetWorkerConfigQuery,
   useLazyExportBlueprintCockpitQuery,
+  useRegistryLoginMutation,
   useUpdateWorkerConfigMutation,
 } from './onprem';
 
@@ -137,6 +139,8 @@ export type {
   WorkerConfigFile,
   WorkerConfigRequest,
   WorkerConfigResponse,
+  // Registry auth types (on-prem only)
+  RegistryAuthStatus,
   // Non-conflicting generated types
   Bootc,
   LocalUploadStatus,

--- a/src/store/api/backend/onprem/composerApi/index.ts
+++ b/src/store/api/backend/onprem/composerApi/index.ts
@@ -2,6 +2,7 @@ import { architectureEndpoints } from './architecture';
 import { blueprintEndpoints } from './blueprints';
 import { composeEndpoints } from './composes';
 import { oscapEndpoints } from './oscap';
+import { registryEndpoints } from './registry';
 import { workerEndpoints } from './worker';
 
 import { emptyComposerApi } from '../emptyComposerApi';
@@ -13,6 +14,7 @@ export const composerApi = emptyComposerApi.injectEndpoints({
       ...blueprintEndpoints(builder),
       ...composeEndpoints(builder),
       ...oscapEndpoints(builder),
+      ...registryEndpoints(builder),
       ...workerEndpoints(builder),
     };
   },
@@ -40,7 +42,9 @@ export const {
   useGetComposesQuery,
   useGetBlueprintComposesQuery,
   useGetComposeStatusQuery,
+  useGetRegistryAuthStatusQuery,
   useGetWorkerConfigQuery,
+  useRegistryLoginMutation,
   useUpdateWorkerConfigMutation,
 } = composerApi;
 

--- a/src/store/api/backend/onprem/composerApi/registry.ts
+++ b/src/store/api/backend/onprem/composerApi/registry.ts
@@ -1,0 +1,54 @@
+import cockpit from 'cockpit';
+
+import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
+
+import type { RegistryAuthStatus, RegistryLoginApiArg } from '../types';
+
+export const registryEndpoints = (builder: OnPremBuilder) => ({
+  getRegistryAuthStatus: builder.query<RegistryAuthStatus, void>({
+    queryFn: onPremQueryHandler(async () => {
+      let username: string;
+      try {
+        const result = await cockpit.spawn(
+          ['podman', 'login', '--get-login', 'registry.redhat.io'],
+          { superuser: 'require' },
+        );
+        username = (result as string).trim();
+      } catch {
+        return { status: 'not-logged-in' };
+      }
+
+      try {
+        await cockpit.spawn(
+          ['podman', 'search', 'registry.redhat.io/rhel10', '--limit', '1'],
+          { superuser: 'require' },
+        );
+      } catch {
+        return { status: 'auth-failed', username };
+      }
+
+      return { status: 'authenticated', username };
+    }),
+  }),
+
+  registryLogin: builder.mutation<RegistryAuthStatus, RegistryLoginApiArg>({
+    queryFn: onPremQueryHandler(
+      async ({ queryArgs: { username, password } }) => {
+        await cockpit
+          .spawn(
+            [
+              'podman',
+              'login',
+              '--username',
+              username,
+              '--password-stdin',
+              'registry.redhat.io',
+            ],
+            { superuser: 'require', err: 'message' },
+          )
+          .input(password);
+        return { status: 'authenticated', username };
+      },
+    ),
+  }),
+});

--- a/src/store/api/backend/onprem/enhancedComposerApi.ts
+++ b/src/store/api/backend/onprem/enhancedComposerApi.ts
@@ -6,6 +6,7 @@ const enhancedApi = composerApi.enhanceEndpoints({
     'Blueprints',
     'Compose',
     'BlueprintComposes',
+    'RegistryAuth',
     'WorkerConfig',
   ],
   endpoints: {
@@ -41,8 +42,14 @@ const enhancedApi = composerApi.enhanceEndpoints({
     getBlueprintComposes: {
       providesTags: [{ type: 'BlueprintComposes' }],
     },
+    getRegistryAuthStatus: {
+      providesTags: [{ type: 'RegistryAuth' }],
+    },
     getWorkerConfig: {
       providesTags: [{ type: 'WorkerConfig' }],
+    },
+    registryLogin: {
+      invalidatesTags: [{ type: 'RegistryAuth' }],
     },
     updateWorkerConfig: {
       invalidatesTags: [{ type: 'WorkerConfig' }],

--- a/src/store/api/backend/onprem/index.ts
+++ b/src/store/api/backend/onprem/index.ts
@@ -14,10 +14,12 @@ export {
   useGetComposeStatusQuery,
   useGetOscapCustomizationsQuery,
   useGetOscapProfilesQuery,
+  useGetRegistryAuthStatusQuery,
   useGetWorkerConfigQuery,
   useLazyExportBlueprintCockpitQuery,
   useLazyGetBlueprintsQuery,
   useLazyGetOscapCustomizationsQuery,
+  useRegistryLoginMutation,
   useUpdateBlueprintMutation,
   useUpdateWorkerConfigMutation,
 } from './composerApi';

--- a/src/store/api/backend/onprem/tests/registry.test.ts
+++ b/src/store/api/backend/onprem/tests/registry.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import cockpit from 'cockpit';
+
+import { registryEndpoints } from '../composerApi/registry';
+
+vi.mock('cockpit', () => ({
+  default: {
+    spawn: vi.fn(),
+  },
+}));
+
+const mockSpawn = vi.mocked(cockpit.spawn);
+
+// Minimal mock matching BaseQueryApi shape
+const createMockApi = () =>
+  ({
+    signal: new AbortController().signal,
+    abort: vi.fn(),
+    dispatch: vi.fn(),
+    getState: vi.fn(),
+    extra: undefined,
+    endpoint: 'test',
+    type: 'query' as const,
+  }) as const;
+
+const mockBaseQuery = vi.fn();
+const mockExtraOptions = {};
+
+type EndpointFn<Args> = (
+  queryArgs: Args,
+  api: ReturnType<typeof createMockApi>,
+  extraOptions: typeof mockExtraOptions,
+  baseQuery: typeof mockBaseQuery,
+) => Promise<{ data: unknown } | { error: unknown }>;
+
+// Extract the queryFn from each endpoint definition for direct testing
+const mockBuilder = {
+  query: <T>({ queryFn }: { queryFn: T }) => queryFn,
+  mutation: <T>({ queryFn }: { queryFn: T }) => queryFn,
+} as never;
+
+const endpoints = registryEndpoints(mockBuilder);
+const getRegistryAuthStatusFn =
+  endpoints.getRegistryAuthStatus as unknown as EndpointFn<void>;
+const registryLoginFn = endpoints.registryLogin as unknown as EndpointFn<{
+  username: string;
+  password: string;
+}>;
+
+describe('registryEndpoints', () => {
+  describe('getRegistryAuthStatus', () => {
+    it('should return authenticated when get-login and search both succeed', async () => {
+      mockSpawn
+        .mockResolvedValueOnce('testuser\n' as never) // podman login --get-login
+        .mockResolvedValueOnce('INDEX  NAME' as never); // podman search
+
+      const result = await getRegistryAuthStatusFn(
+        undefined as never,
+        createMockApi(),
+        mockExtraOptions,
+        mockBaseQuery,
+      );
+
+      expect(result).toEqual({
+        data: { status: 'authenticated', username: 'testuser' },
+      });
+    });
+
+    it('should return not-logged-in when get-login fails', async () => {
+      const getLoginError = Object.assign(
+        new Error('Error: not logged into registry.redhat.io'),
+        { exit_status: 1 },
+      );
+      mockSpawn.mockRejectedValueOnce(getLoginError as never); // podman login --get-login fails
+
+      const result = await getRegistryAuthStatusFn(
+        undefined as never,
+        createMockApi(),
+        mockExtraOptions,
+        mockBaseQuery,
+      );
+
+      expect(result).toEqual({
+        data: { status: 'not-logged-in' },
+      });
+    });
+
+    it('should return auth-failed when get-login succeeds but search fails', async () => {
+      const searchError = Object.assign(new Error('unauthorized'), {
+        exit_status: 125,
+      });
+      mockSpawn
+        .mockResolvedValueOnce('expireduser\n' as never) // podman login --get-login
+        .mockRejectedValueOnce(searchError as never); // podman search fails
+
+      const result = await getRegistryAuthStatusFn(
+        undefined as never,
+        createMockApi(),
+        mockExtraOptions,
+        mockBaseQuery,
+      );
+
+      expect(result).toEqual({
+        data: { status: 'auth-failed', username: 'expireduser' },
+      });
+    });
+  });
+
+  describe('registryLogin', () => {
+    it('should return authenticated on successful login', async () => {
+      const mockInput = vi.fn();
+      mockSpawn.mockReturnValueOnce({
+        input: mockInput,
+      } as never);
+      mockInput.mockResolvedValueOnce(undefined);
+
+      const result = await registryLoginFn(
+        { username: 'myuser', password: 'mypassword' },
+        createMockApi(),
+        mockExtraOptions,
+        mockBaseQuery,
+      );
+
+      expect(result).toEqual({
+        data: { status: 'authenticated', username: 'myuser' },
+      });
+      expect(mockSpawn).toHaveBeenCalledWith(
+        [
+          'podman',
+          'login',
+          '--username',
+          'myuser',
+          '--password-stdin',
+          'registry.redhat.io',
+        ],
+        { superuser: 'require', err: 'message' },
+      );
+    });
+
+    it('should return an error when login fails', async () => {
+      const networkError = Object.assign(new Error('network timeout'), {
+        exit_status: 1,
+      });
+      const mockInput = vi.fn();
+      mockSpawn.mockReturnValueOnce({
+        input: mockInput,
+      } as never);
+      mockInput.mockRejectedValueOnce(networkError);
+
+      const result = await registryLoginFn(
+        { username: 'user', password: 'pass' },
+        createMockApi(),
+        mockExtraOptions,
+        mockBaseQuery,
+      );
+
+      expect(result).toEqual({
+        error: { message: 'network timeout' },
+      });
+    });
+  });
+});

--- a/src/store/api/backend/onprem/types/custom.ts
+++ b/src/store/api/backend/onprem/types/custom.ts
@@ -98,6 +98,16 @@ type PodmanLabels = Record<string, string | undefined> & {
   ['ostree.bootable']?: string | undefined;
 };
 
+export type RegistryAuthStatus =
+  | { status: 'authenticated'; username: string }
+  | { status: 'not-logged-in' }
+  | { status: 'auth-failed'; username: string };
+
+export type RegistryLoginApiArg = {
+  username: string;
+  password: string;
+};
+
 export type PodmanImageInfo = {
   Id: string;
   Architecture?: string | undefined;

--- a/src/types/cockpit.d.ts
+++ b/src/types/cockpit.d.ts
@@ -25,6 +25,10 @@ declare module 'cockpit' {
     err?: 'message' | 'out' | 'ignore';
   };
 
+  type SpawnProcess = Promise<string | Uint8Array> & {
+    input(data: string): SpawnProcess;
+  };
+
   type HttpOptions = {
     superuser?: 'try' | 'require';
   };
@@ -56,7 +60,7 @@ declare module 'cockpit' {
     jump(url: string, host: string): void;
     user(): Promise<UserInfo>;
     file(path: string, options?: FileOptions): FileHandle;
-    spawn(args: string[], options?: SpawnOptions): Promise<string | Uint8Array>;
+    spawn(args: string[], options?: SpawnOptions): SpawnProcess;
     script(script: string): Promise<string | Uint8Array>;
     http(address: string, options?: HttpOptions): HttpClient;
     permission(options: PermissionOptions): PermissionObject;


### PR DESCRIPTION
This commit introduces a simple way of verifying that a user is logged in to `registry.redhat.io` through a simple and fairly light-weight run-time test shelling out to `podman search`. This will not only verify that the user is logged in, but also that the registry is reachable.
A subsequent call to `podman login` will help narrow down the failure causes that we can then communicate to the user.

The final implementation of this feature should likely be gated to RHEL.

## Screencast
Here's a screen recording of the feature in action.

https://github.com/user-attachments/assets/92fc7596-590f-4e44-9fef-9719cc20e440

## Local testing
If you would like to test this branch on Fedora, you need to ungate Image Mode:

```
diff --git a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
index 5f554dc3..9341182d 100644
--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -73,7 +73,7 @@ const ImageOutputStep = () => {
           Learn more about <DocumentationButton />.
         </Content>
       </Content>
-      {!(distribution as string).startsWith('fedora') && <BlueprintMode />}
+      <BlueprintMode />
       {isImageMode && <ImageSourceSelect />}
       {!isImageMode && (
         <>
```