### PR TITLE
Show Image Mode toggle on Fedora distributions (HMS-10832)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -73,7 +73,7 @@ const ImageOutputStep = () => {
           Learn more about <DocumentationButton />.
         </Content>
       </Content>
-      {!(distribution as string).startsWith('fedora') && <BlueprintMode />}
+      <BlueprintMode />
       {isImageMode && <ImageSourceSelect />}
       {!isImageMode && (
         <>

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { CENTOS_9, RHEL_10, RHEL_8, RHEL_9 } from '@/constants';
+import { CENTOS_9, FEDORA_44, RHEL_10, RHEL_8, RHEL_9 } from '@/constants';
 import { selectBlueprintName } from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
 import { clickWithWait, createUser, fetchMock } from '@/test/testUtils';
@@ -130,6 +130,17 @@ describe('ImageOutput Step', () => {
           /centos stream builds are intended for the development/i,
         ),
       ).not.toBeInTheDocument();
+    });
+
+    test('displays blueprint mode toggle for Fedora distribution', async () => {
+      renderImageOutputStep({ distribution: FEDORA_44 });
+
+      expect(
+        await screen.findByRole('button', { name: /image mode/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /package mode/i }),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -429,7 +429,7 @@ describe('ImageSourceSelect', () => {
         }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('option', { name: /fedora 42/i }),
+        screen.getByRole('option', { name: /fedora 44/i }),
       ).toBeInTheDocument();
       expect(
         screen.getByRole('option', { name: /centos stream 10/i }),
@@ -457,15 +457,15 @@ describe('ImageSourceSelect', () => {
       });
       await clickWithWait(user, toggle);
       const fedoraOption = await screen.findByRole('option', {
-        name: /fedora 42/i,
+        name: /fedora 44/i,
       });
       await clickWithWait(user, fedoraOption);
 
       await waitFor(() => {
         expect(selectImageSourceState(store.getState())).toBe(
-          'quay.io/fedora/fedora-bootc:42',
+          'quay.io/fedora/fedora-bootc:44',
         );
-        expect(selectDistribution(store.getState())).toBe('fedora-42');
+        expect(selectDistribution(store.getState())).toBe('fedora-44');
       });
     });
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/mocks/fixtures.ts
@@ -151,11 +151,11 @@ export const mockBootcDistributionsMixed: BootcDistributionItem[] = [
     reference: 'registry.redhat.io/rhel10/rhel-bootc:rhel-10',
   },
   {
-    distro: 'fedora-42',
-    name: 'Fedora 42',
+    distro: 'fedora-44',
+    name: 'Fedora 44',
     type: 'guest-image',
     arch: 'x86_64',
-    reference: 'quay.io/fedora/fedora-bootc:42',
+    reference: 'quay.io/fedora/fedora-bootc:44',
   },
   {
     distro: 'centos-10',


### PR DESCRIPTION
## Summary

The Image Mode / Package Mode toggle was hidden for Fedora distributions, preventing users from switching build modes. This PR removes that restriction and updates stale test fixtures.

## Changes

- Show the Blueprint Mode (Image Mode / Package Mode) toggle for Fedora distributions instead of hiding it
- Update test fixtures to use Fedora 44 instead of the outdated Fedora 42
- Add test coverage verifying the blueprint mode toggle is displayed for Fedora


JIRA: [HMS-10832](https://issues.redhat.com/browse/HMS-10832)

[HMS-10832]: https://redhat.atlassian.net/browse/HMS-10832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ