### PR TITLE
Wizard: Render user groups in review conditionally (HMS-10841)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
@@ -60,7 +60,11 @@ const AdvancedSettingsOverview = ({
               restrictions.users.shouldHide || restrictions.users.required
             }
           />
-          <UserGroups shouldHide={restrictions.users.shouldHide} />
+          <UserGroups
+            shouldHide={
+              restrictions.users.shouldHide || restrictions.users.required
+            }
+          />
           <Firstboot shouldHide={restrictions.firstBoot.shouldHide} />
         </ReviewList>
       </CardBody>

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/store/slices/wizard/tests/mocks';
 import { renderWithRedux } from '@/test/testUtils';
 
-import { adminUser, developerUser, guestUser } from './mocks';
+import { adminUser, developerUser, guestUser, userGroups } from './mocks';
 
 import { createDefaultRestrictions } from '../../tests/helpers';
 import AdvancedSettingsOverview from '../index';
@@ -976,10 +976,12 @@ echo 'Hello there, General Kenobi!'`;
         {
           imageTypes: ['guest-image'],
           users: [adminUser],
+          userGroups: userGroups,
         },
       );
 
       expect(screen.getByText('Users')).toBeInTheDocument();
+      expect(screen.getByText('User groups')).toBeInTheDocument();
     });
 
     test('does not render users section when users are required', () => {
@@ -992,10 +994,12 @@ echo 'Hello there, General Kenobi!'`;
         {
           imageTypes: ['guest-image'],
           users: [adminUser],
+          userGroups: userGroups,
         },
       );
 
       expect(screen.queryByText('Users')).not.toBeInTheDocument();
+      expect(screen.queryByText('User groups')).not.toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/mocks/index.ts
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/mocks/index.ts
@@ -1,1 +1,1 @@
-export { adminUser, developerUser, guestUser } from './users';
+export { adminUser, developerUser, guestUser, userGroups } from './users';

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/mocks/users.ts
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/mocks/users.ts
@@ -29,3 +29,10 @@ export const guestUser = {
   groups: [] as string[],
   isAdministrator: false,
 };
+
+export const userGroups = [
+  {
+    name: 'developers',
+    gid: 1000,
+  },
+];

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
@@ -4,7 +4,6 @@ import { Card, CardBody } from '@patternfly/react-core';
 
 import { ON_PREM_RELEASES, RELEASES } from '@/constants';
 import { useTargetEnvironmentCategories } from '@/Hooks';
-import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { useAppSelector } from '@/store/hooks';
 import {
   selectArchitecture,
@@ -20,9 +19,11 @@ import {
 import { MiscFormats, PrivateClouds, PublicClouds } from './components';
 
 import { Users } from '../AdvancedSettings/components';
+import { UserGroups } from '../AdvancedSettings/components/UserGroups';
 import { ReviewCardHeader, ReviewGroup, ReviewList } from '../shared';
+import { ReviewCardProps } from '../types';
 
-const ImageOverview = () => {
+const ImageOverview = ({ restrictions }: ReviewCardProps) => {
   const imageName = useAppSelector(selectBlueprintName);
   const description = useAppSelector(selectBlueprintDescription);
   const isOnPremise = useAppSelector(selectIsOnPremise);
@@ -34,9 +35,6 @@ const ImageOverview = () => {
   const environments = useAppSelector(selectImageTypes);
   const { publicClouds, privateClouds, miscFormats } =
     useTargetEnvironmentCategories(environments);
-  const { restrictions } = useCustomizationRestrictions({
-    selectedImageTypes: environments,
-  });
 
   const releases = isOnPremise ? ON_PREM_RELEASES : RELEASES;
 
@@ -77,6 +75,11 @@ const ImageOverview = () => {
           <PublicClouds environments={publicClouds} />
           <MiscFormats environments={miscFormats} />
           <Users
+            shouldHide={
+              restrictions.users.shouldHide || !restrictions.users.required
+            }
+          />
+          <UserGroups
             shouldHide={
               restrictions.users.shouldHide || !restrictions.users.required
             }

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -3,65 +3,61 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { RHEL_10, X86_64 } from '@/constants';
-import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { renderWithRedux } from '@/test/testUtils';
 
-import { adminUser } from '../../AdvancedSettings/tests/mocks';
+import { adminUser, userGroups } from '../../AdvancedSettings/tests/mocks';
 import { createDefaultRestrictions } from '../../tests/helpers';
 import ImageOverview from '../index';
 
-vi.mock('@/store/api/distributions', async () => {
-  const actual = await vi.importActual('@/store/api/distributions');
-  return {
-    ...actual,
-    useCustomizationRestrictions: vi.fn(),
-  };
-});
-
 describe('ImageOverview', () => {
-  beforeEach(() => {
-    vi.mocked(useCustomizationRestrictions).mockReturnValue({
-      restrictions: createDefaultRestrictions(),
-    });
-  });
-
   test('renders the card with image overview title', () => {
-    renderWithRedux(<ImageOverview />);
+    renderWithRedux(
+      <ImageOverview restrictions={createDefaultRestrictions()} />,
+    );
 
     expect(screen.getByText('Image overview')).toBeInTheDocument();
   });
 
   test('displays the blueprint name', () => {
-    renderWithRedux(<ImageOverview />, {
-      details: {
-        blueprintName: 'my-test-blueprint',
-        blueprintDescription: '',
-        isCustomName: true,
+    renderWithRedux(
+      <ImageOverview restrictions={createDefaultRestrictions()} />,
+      {
+        details: {
+          blueprintName: 'my-test-blueprint',
+          blueprintDescription: '',
+          isCustomName: true,
+        },
       },
-    });
+    );
 
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('my-test-blueprint')).toBeInTheDocument();
   });
 
   test('displays the blueprint description', () => {
-    renderWithRedux(<ImageOverview />, {
-      details: {
-        blueprintName: 'test-blueprint',
-        blueprintDescription: 'This is a test description',
-        isCustomName: true,
+    renderWithRedux(
+      <ImageOverview restrictions={createDefaultRestrictions()} />,
+      {
+        details: {
+          blueprintName: 'test-blueprint',
+          blueprintDescription: 'This is a test description',
+          isCustomName: true,
+        },
       },
-    });
+    );
 
     expect(screen.getByText('Details')).toBeInTheDocument();
     expect(screen.getByText('This is a test description')).toBeInTheDocument();
   });
 
   test('displays the base release for package mode', () => {
-    renderWithRedux(<ImageOverview />, {
-      distribution: RHEL_10,
-      blueprintMode: 'package',
-    });
+    renderWithRedux(
+      <ImageOverview restrictions={createDefaultRestrictions()} />,
+      {
+        distribution: RHEL_10,
+        blueprintMode: 'package',
+      },
+    );
 
     expect(screen.getByText('Base release')).toBeInTheDocument();
     expect(
@@ -70,52 +66,69 @@ describe('ImageOverview', () => {
   });
 
   test('displays the architecture', () => {
-    renderWithRedux(<ImageOverview />, {
-      architecture: X86_64,
-    });
+    renderWithRedux(
+      <ImageOverview restrictions={createDefaultRestrictions()} />,
+      {
+        architecture: X86_64,
+      },
+    );
 
     expect(screen.getByText('Architecture')).toBeInTheDocument();
     expect(screen.getByText(X86_64)).toBeInTheDocument();
   });
 
   test('displays target environments heading', () => {
-    renderWithRedux(<ImageOverview />);
+    renderWithRedux(
+      <ImageOverview restrictions={createDefaultRestrictions()} />,
+    );
 
     expect(screen.getByText('Target environments')).toBeInTheDocument();
   });
 
   describe('Private clouds', () => {
     test('displays vsphere when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['vsphere'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['vsphere'],
+        },
+      );
 
       expect(screen.getByText('Private cloud')).toBeInTheDocument();
       expect(screen.getByText('VMware vSphere (.vmdk)')).toBeInTheDocument();
     });
 
     test('displays vsphere-ova when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['vsphere-ova'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['vsphere-ova'],
+        },
+      );
 
       expect(screen.getByText('Private cloud')).toBeInTheDocument();
       expect(screen.getByText('VMware vSphere (.ova)')).toBeInTheDocument();
     });
 
     test('displays multiple private clouds when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['vsphere', 'vsphere-ova'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['vsphere', 'vsphere-ova'],
+        },
+      );
 
       expect(screen.getByText('VMware vSphere (.vmdk)')).toBeInTheDocument();
       expect(screen.getByText('VMware vSphere (.ova)')).toBeInTheDocument();
     });
 
     test('does not display private cloud section when none selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['aws'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['aws'],
+        },
+      );
 
       expect(screen.queryByText('Private cloud')).not.toBeInTheDocument();
     });
@@ -123,15 +136,18 @@ describe('ImageOverview', () => {
 
   describe('Public clouds', () => {
     test('displays AWS details when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['aws'],
-        aws: {
-          accountId: '123456789012',
-          shareMethod: 'manual',
-          source: undefined,
-          region: 'us-west-2',
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['aws'],
+          aws: {
+            accountId: '123456789012',
+            shareMethod: 'manual',
+            source: undefined,
+            region: 'us-west-2',
+          },
         },
-      });
+      );
 
       expect(screen.getByText('Public cloud')).toBeInTheDocument();
       expect(screen.getByText('Amazon Web Services')).toBeInTheDocument();
@@ -142,13 +158,16 @@ describe('ImageOverview', () => {
     });
 
     test('displays GCP details when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['gcp'],
-        gcp: {
-          accountType: 'user',
-          email: 'test@example.com',
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['gcp'],
+          gcp: {
+            accountType: 'user',
+            email: 'test@example.com',
+          },
         },
-      });
+      );
 
       expect(screen.getByText('Google Cloud')).toBeInTheDocument();
       expect(
@@ -160,15 +179,18 @@ describe('ImageOverview', () => {
     });
 
     test('displays Azure details when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['azure'],
-        azure: {
-          tenantId: 'tenant-123',
-          subscriptionId: 'sub-456',
-          resourceGroup: 'my-resource-group',
-          hyperVGeneration: 'V2',
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['azure'],
+          azure: {
+            tenantId: 'tenant-123',
+            subscriptionId: 'sub-456',
+            resourceGroup: 'my-resource-group',
+            hyperVGeneration: 'V2',
+          },
         },
-      });
+      );
 
       expect(screen.getByText('Microsoft Azure')).toBeInTheDocument();
       expect(screen.getByText(/Tenant ID: tenant-123/)).toBeInTheDocument();
@@ -179,9 +201,12 @@ describe('ImageOverview', () => {
     });
 
     test('displays OCI when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['oci'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['oci'],
+        },
+      );
 
       expect(
         screen.getByText('Oracle Cloud Infrastructure'),
@@ -189,9 +214,12 @@ describe('ImageOverview', () => {
     });
 
     test('does not display public cloud section when none selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['vsphere'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['vsphere'],
+        },
+      );
 
       expect(screen.queryByText('Public cloud')).not.toBeInTheDocument();
     });
@@ -199,26 +227,35 @@ describe('ImageOverview', () => {
 
   describe('Miscellaneous formats', () => {
     test('displays guest-image when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['guest-image'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['guest-image'],
+        },
+      );
 
       expect(screen.getByText('Miscellaneous formats')).toBeInTheDocument();
       expect(screen.getByText('Virtualization (.qcow2)')).toBeInTheDocument();
     });
 
     test('displays image-installer when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['image-installer'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['image-installer'],
+        },
+      );
 
       expect(screen.getByText('Baremetal (.iso)')).toBeInTheDocument();
     });
 
     test('displays wsl when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['wsl'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['wsl'],
+        },
+      );
 
       expect(
         screen.getByText('Windows Subsystem for Linux (.tar.gz)'),
@@ -226,9 +263,12 @@ describe('ImageOverview', () => {
     });
 
     test('displays multiple misc formats when selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['guest-image', 'image-installer', 'wsl'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['guest-image', 'image-installer', 'wsl'],
+        },
+      );
 
       expect(screen.getByText('Virtualization (.qcow2)')).toBeInTheDocument();
       expect(screen.getByText('Baremetal (.iso)')).toBeInTheDocument();
@@ -238,9 +278,12 @@ describe('ImageOverview', () => {
     });
 
     test('does not display misc formats section when none selected', () => {
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['aws'],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['aws'],
+        },
+      );
 
       expect(
         screen.queryByText('Miscellaneous formats'),
@@ -249,33 +292,38 @@ describe('ImageOverview', () => {
   });
 
   describe('Users', () => {
-    test('renders users section when users are required', () => {
-      vi.mocked(useCustomizationRestrictions).mockReturnValue({
-        restrictions: createDefaultRestrictions({
-          users: { required: true },
-        }),
-      });
-
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['guest-image'],
-        users: [adminUser],
-      });
+    test('renders users + groups section when users are required', () => {
+      renderWithRedux(
+        <ImageOverview
+          restrictions={createDefaultRestrictions({
+            users: { required: true },
+          })}
+        />,
+        {
+          imageTypes: ['guest-image'],
+          users: [adminUser],
+          userGroups: userGroups,
+        },
+      );
 
       expect(screen.getByText('Users')).toBeInTheDocument();
       expect(screen.getByText('admin')).toBeInTheDocument();
+      expect(screen.getByText('User groups')).toBeInTheDocument();
+      expect(screen.getByText('developers')).toBeInTheDocument();
     });
 
     test('does not render users section when users are not required', () => {
-      vi.mocked(useCustomizationRestrictions).mockReturnValue({
-        restrictions: createDefaultRestrictions(),
-      });
-
-      renderWithRedux(<ImageOverview />, {
-        imageTypes: ['guest-image'],
-        users: [adminUser],
-      });
+      renderWithRedux(
+        <ImageOverview restrictions={createDefaultRestrictions()} />,
+        {
+          imageTypes: ['guest-image'],
+          users: [adminUser],
+          userGroups: userGroups,
+        },
+      );
 
       expect(screen.queryByText('Users')).not.toBeInTheDocument();
+      expect(screen.queryByText('User groups')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Review/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/index.tsx
@@ -33,7 +33,7 @@ const ReviewStep = () => {
   return (
     <>
       <FormHeader />
-      <ImageOverview />
+      <ImageOverview restrictions={restrictions} />
       <Registration restrictions={restrictions} />
       <RepeatableBuild restrictions={restrictions} />
       <Security restrictions={restrictions} security={security} />


### PR DESCRIPTION
This renders the block with user groups conditionally on the Review step, based on whether the user customization is or is not required.

Restrictions were also added to the props of the image overview component to pass them consistently with the other review components.

JIRA: [HMS-10841](https://issues.redhat.com/browse/HMS-10841)

[HMS-10841]: https://redhat.atlassian.net/browse/HMS-10841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ