### PR TITLE
Wizard slice: phase 2 — nest remaining state domains (HMS-10847)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Details/tests/Details.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/tests/Details.test.tsx
@@ -74,7 +74,10 @@ describe('Details Component', () => {
       renderDetailsStep({
         details: {
           ...initialState.details,
-          blueprintName: 'Initial Name',
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'Initial Name',
+          },
         },
       });
       const user = createUser();
@@ -185,10 +188,13 @@ describe('Details Component', () => {
 
       // When editing, the blueprintId matches the returned blueprint's id
       renderDetailsStep({
-        blueprintId: 'existing-blueprint-id',
         details: {
           ...initialState.details,
-          blueprintName: 'Existing Blueprint',
+          blueprintId: 'existing-blueprint-id',
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'Existing Blueprint',
+          },
         },
       });
 
@@ -206,7 +212,10 @@ describe('Details Component', () => {
       renderDetailsStep({
         details: {
           ...initialState.details,
-          blueprintName: 'Valid Name',
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'Valid Name',
+          },
         },
       });
       const user = createUser();
@@ -223,7 +232,10 @@ describe('Details Component', () => {
       renderDetailsStep({
         details: {
           ...initialState.details,
-          blueprintName: 'Valid Name',
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'Valid Name',
+          },
         },
       });
       const user = createUser();
@@ -240,7 +252,10 @@ describe('Details Component', () => {
       renderDetailsStep({
         details: {
           ...initialState.details,
-          blueprintName: 'Valid Name',
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'Valid Name',
+          },
         },
       });
 
@@ -255,7 +270,10 @@ describe('Details Component', () => {
       renderDetailsStep({
         details: {
           ...initialState.details,
-          blueprintName: 'My Custom Blueprint',
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'My Custom Blueprint',
+          },
         },
       });
 
@@ -269,7 +287,10 @@ describe('Details Component', () => {
       renderDetailsStep({
         details: {
           ...initialState.details,
-          blueprintDescription: 'A detailed description',
+          blueprint: {
+            ...initialState.details.blueprint,
+            description: 'A detailed description',
+          },
         },
       });
 
@@ -288,7 +309,7 @@ describe('Details Component', () => {
       await enterBlueprintName(user, 'New Blueprint Name');
 
       const state = store.getState();
-      expect(state.wizard.details.blueprintName).toBe('New Blueprint Name');
+      expect(state.wizard.details.blueprint.name).toBe('New Blueprint Name');
     });
 
     test('updates store when description is changed', async () => {
@@ -298,18 +319,22 @@ describe('Details Component', () => {
       await enterBlueprintDescription(user, 'New description');
 
       const state = store.getState();
-      expect(state.wizard.details.blueprintDescription).toBe('New description');
+      expect(state.wizard.details.blueprint.description).toBe(
+        'New description',
+      );
     });
 
     test('sets isCustomName when name is changed', async () => {
       const { store } = renderDetailsStep();
       const user = createUser();
 
-      expect(store.getState().wizard.details.isCustomName).toBe(false);
+      expect(store.getState().wizard.details.blueprint.isCustomName).toBe(
+        false,
+      );
 
       await enterBlueprintName(user, 'Custom Name');
 
-      expect(store.getState().wizard.details.isCustomName).toBe(true);
+      expect(store.getState().wizard.details.blueprint.isCustomName).toBe(true);
     });
   });
 
@@ -328,7 +353,7 @@ describe('Details Component', () => {
         screen.getByRole('heading', { name: /Details/i }),
       ).toBeInTheDocument();
       expect(nameInput).toBeInTheDocument();
-      expect(store.getState().wizard.details.blueprintName).toBe(
+      expect(store.getState().wizard.details.blueprint.name).toBe(
         'custom-blueprint-name',
       );
     });
@@ -346,7 +371,7 @@ describe('Details Component', () => {
         screen.getByRole('heading', { name: /Details/i }),
       ).toBeInTheDocument();
       expect(descriptionInput).toBeInTheDocument();
-      expect(store.getState().wizard.details.blueprintDescription).toBe(
+      expect(store.getState().wizard.details.blueprint.description).toBe(
         'Test description',
       );
     });

--- a/src/Components/CreateImageWizard/steps/Firewall/tests/Firewall.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/tests/Firewall.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { createUser } from '@/test/testUtils';
 
 import {
@@ -220,11 +221,14 @@ describe('Firewall Component', () => {
   describe('Initial State', () => {
     test('renders with pre-populated ports from state', async () => {
       renderFirewallStep({
-        firewall: {
-          ports: ['80:tcp', '443:udp'],
-          services: {
-            enabled: [],
-            disabled: [],
+        system: {
+          ...initialState.system,
+          firewall: {
+            ports: ['80:tcp', '443:udp'],
+            services: {
+              enabled: [],
+              disabled: [],
+            },
           },
         },
       });
@@ -235,11 +239,14 @@ describe('Firewall Component', () => {
 
     test('renders with pre-populated enabled services from state', async () => {
       renderFirewallStep({
-        firewall: {
-          ports: [],
-          services: {
-            enabled: ['ssh', 'http'],
-            disabled: [],
+        system: {
+          ...initialState.system,
+          firewall: {
+            ports: [],
+            services: {
+              enabled: ['ssh', 'http'],
+              disabled: [],
+            },
           },
         },
       });
@@ -250,11 +257,14 @@ describe('Firewall Component', () => {
 
     test('renders with pre-populated disabled services from state', async () => {
       renderFirewallStep({
-        firewall: {
-          ports: [],
-          services: {
-            enabled: [],
-            disabled: ['telnet', 'ftp'],
+        system: {
+          ...initialState.system,
+          firewall: {
+            ports: [],
+            services: {
+              enabled: [],
+              disabled: ['telnet', 'ftp'],
+            },
           },
         },
       });
@@ -269,11 +279,11 @@ describe('Firewall Component', () => {
       const { store } = renderFirewallStep();
       const user = createUser();
 
-      expect(store.getState().wizard.firewall.ports).toHaveLength(0);
+      expect(store.getState().wizard.system.firewall.ports).toHaveLength(0);
 
       await addPort(user, '80:tcp');
 
-      expect(store.getState().wizard.firewall.ports).toContain('80:tcp');
+      expect(store.getState().wizard.system.firewall.ports).toContain('80:tcp');
     });
 
     test('updates store when multiple ports are added', async () => {
@@ -283,79 +293,89 @@ describe('Firewall Component', () => {
       await addPort(user, '80:tcp');
       await addPort(user, '443:udp');
 
-      const ports = store.getState().wizard.firewall.ports;
+      const ports = store.getState().wizard.system.firewall.ports;
       expect(ports).toContain('80:tcp');
       expect(ports).toContain('443:udp');
     });
 
     test('updates store when port is removed', async () => {
       const { store } = renderFirewallStep({
-        firewall: {
-          ports: ['80:tcp'],
-          services: {
-            enabled: [],
-            disabled: [],
+        system: {
+          ...initialState.system,
+          firewall: {
+            ports: ['80:tcp'],
+            services: {
+              enabled: [],
+              disabled: [],
+            },
           },
         },
       });
       const user = createUser();
 
-      expect(store.getState().wizard.firewall.ports).toContain('80:tcp');
+      expect(store.getState().wizard.system.firewall.ports).toContain('80:tcp');
 
       await removeItem(user, '80:tcp');
 
-      expect(store.getState().wizard.firewall.ports).not.toContain('80:tcp');
+      expect(store.getState().wizard.system.firewall.ports).not.toContain(
+        '80:tcp',
+      );
     });
 
     test('updates store when enabled service is added', async () => {
       const { store } = renderFirewallStep();
       const user = createUser();
 
-      expect(store.getState().wizard.firewall.services.enabled).toHaveLength(0);
+      expect(
+        store.getState().wizard.system.firewall.services.enabled,
+      ).toHaveLength(0);
 
       await addEnabledService(user, 'ssh');
 
-      expect(store.getState().wizard.firewall.services.enabled).toContain(
-        'ssh',
-      );
+      expect(
+        store.getState().wizard.system.firewall.services.enabled,
+      ).toContain('ssh');
     });
 
     test('updates store when disabled service is added', async () => {
       const { store } = renderFirewallStep();
       const user = createUser();
 
-      expect(store.getState().wizard.firewall.services.disabled).toHaveLength(
-        0,
-      );
+      expect(
+        store.getState().wizard.system.firewall.services.disabled,
+      ).toHaveLength(0);
 
       await addDisabledService(user, 'telnet');
 
-      expect(store.getState().wizard.firewall.services.disabled).toContain(
-        'telnet',
-      );
+      expect(
+        store.getState().wizard.system.firewall.services.disabled,
+      ).toContain('telnet');
     });
 
     test('updates store when service is removed', async () => {
       const { store } = renderFirewallStep({
-        firewall: {
-          ports: [],
-          services: {
-            enabled: ['ssh'],
-            disabled: [],
+        system: {
+          ...initialState.system,
+          firewall: {
+            ports: [],
+            services: {
+              enabled: ['ssh'],
+              disabled: [],
+            },
           },
         },
       });
       const user = createUser();
 
-      expect(store.getState().wizard.firewall.services.enabled).toContain(
-        'ssh',
-      );
+      expect(
+        store.getState().wizard.system.firewall.services.enabled,
+      ).toContain('ssh');
 
       await removeItem(user, 'ssh');
 
-      expect(store.getState().wizard.firewall.services.enabled).not.toContain(
-        'ssh',
-      );
+      expect(
+        store.getState().wizard.system.firewall.services.enabled,
+      ).not.toContain('ssh');
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/FirstBoot/tests/FirstBoot.test.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/tests/FirstBoot.test.tsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { FIRST_BOOT_SERVICE } from '@/constants';
+import { initialState } from '@/store/slices/wizard';
 import { createUser, waitForAction } from '@/test/testUtils';
 
 import { renderFirstBootStep, uploadScript } from './helpers';
@@ -78,8 +79,11 @@ describe('FirstBoot Component', () => {
 
     test('does not show empty state when script is pre-populated', async () => {
       renderFirstBootStep({
-        firstBoot: {
-          script: VALID_SCRIPT,
+        system: {
+          ...initialState.system,
+          firstBoot: {
+            script: VALID_SCRIPT,
+          },
         },
       });
 
@@ -115,7 +119,7 @@ describe('FirstBoot Component', () => {
   describe('Custom Controls', () => {
     test('displays revert button', async () => {
       renderFirstBootStep({
-        firstBoot: { script: VALID_SCRIPT },
+        system: { ...initialState.system, firstBoot: { script: VALID_SCRIPT } },
       });
 
       expect(
@@ -130,7 +134,9 @@ describe('FirstBoot Component', () => {
       await uploadScript(user, VALID_SCRIPT);
 
       await waitForAction(() => {
-        expect(store.getState().wizard.firstBoot.script).toBe(VALID_SCRIPT);
+        expect(store.getState().wizard.system.firstBoot.script).toBe(
+          VALID_SCRIPT,
+        );
       });
 
       const revertButton = screen.getByRole('button', {
@@ -139,7 +145,9 @@ describe('FirstBoot Component', () => {
       await waitForAction(() => user.click(revertButton));
 
       await waitForAction(() => {
-        expect(store.getState().wizard.firstBoot.script).toBe(VALID_SCRIPT);
+        expect(store.getState().wizard.system.firstBoot.script).toBe(
+          VALID_SCRIPT,
+        );
       });
     });
   });
@@ -149,12 +157,14 @@ describe('FirstBoot Component', () => {
       const { store } = renderFirstBootStep();
       const user = createUser();
 
-      expect(store.getState().wizard.firstBoot.script).toBe('');
+      expect(store.getState().wizard.system.firstBoot.script).toBe('');
 
       await uploadScript(user, VALID_SCRIPT);
 
       await waitForAction(() => {
-        expect(store.getState().wizard.firstBoot.script).toBe(VALID_SCRIPT);
+        expect(store.getState().wizard.system.firstBoot.script).toBe(
+          VALID_SCRIPT,
+        );
       });
     });
 
@@ -165,7 +175,7 @@ describe('FirstBoot Component', () => {
       await uploadScript(user, VALID_SCRIPT);
 
       await waitForAction(() => {
-        expect(store.getState().wizard.services.enabled).toContain(
+        expect(store.getState().wizard.system.services.enabled).toContain(
           FIRST_BOOT_SERVICE,
         );
       });
@@ -178,7 +188,7 @@ describe('FirstBoot Component', () => {
       await uploadScript(user, CRLF_SCRIPT);
 
       await waitForAction(() => {
-        const storedScript = store.getState().wizard.firstBoot.script;
+        const storedScript = store.getState().wizard.system.firstBoot.script;
         expect(storedScript).toBe(LF_SCRIPT);
         expect(storedScript).not.toContain('\r\n');
       });

--- a/src/Components/CreateImageWizard/steps/Hostname/tests/Hostname.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Hostname/tests/Hostname.test.tsx
@@ -69,18 +69,18 @@ describe('Hostname Component', () => {
       await enterHostname(user, 'my-new-hostname');
 
       const state = store.getState();
-      expect(state.wizard.hostname).toBe('my-new-hostname');
+      expect(state.wizard.system.hostname).toBe('my-new-hostname');
     });
 
     test('clears store when hostname is cleared via X button', async () => {
       const { store } = renderHostnameStep({ hostname: 'existing-hostname' });
       const user = createUser();
 
-      expect(store.getState().wizard.hostname).toBe('existing-hostname');
+      expect(store.getState().wizard.system.hostname).toBe('existing-hostname');
 
       await clearHostname(user);
 
-      expect(store.getState().wizard.hostname).toBe('');
+      expect(store.getState().wizard.system.hostname).toBe('');
     });
   });
 
@@ -184,7 +184,7 @@ describe('Hostname Component', () => {
         screen.getByRole('heading', { name: /Hostname/i }),
       ).toBeInTheDocument();
       expect(hostnameInput).toBeInTheDocument();
-      expect(store.getState().wizard.hostname).toBe('test-hostname');
+      expect(store.getState().wizard.system.hostname).toBe('test-hostname');
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Hostname/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Hostname/tests/helpers.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import {
   clickWithWait,
   renderWithRedux,
@@ -14,8 +15,12 @@ import {
 import HostnameStep from '../index';
 
 export const renderHostnameStep = (
-  wizardStateOverrides: WizardStateOverrides = {},
+  systemOverrides: Partial<typeof initialState.system> = {},
 ) => {
+  const wizardStateOverrides: WizardStateOverrides =
+    Object.keys(systemOverrides).length > 0
+      ? { system: { ...initialState.system, ...systemOverrides } }
+      : {};
   return renderWithRedux(<HostnameStep />, wizardStateOverrides);
 };
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Aws/tests/AwsTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Aws/tests/AwsTarget.test.tsx
@@ -27,7 +27,10 @@ const createStoreWithAwsState = (
     preloadedState: {
       wizard: {
         ...initialState,
-        imageTypes: ['aws'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['aws'],
+        },
         registration: {
           ...initialState.registration,
           type: 'register-later',

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
@@ -34,7 +34,10 @@ const createStoreWithAzureState = (
     preloadedState: {
       wizard: {
         ...initialState,
-        imageTypes: ['azure'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['azure'],
+        },
         registration: {
           ...initialState.registration,
           type: 'register-later',

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/tests/GcpTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/tests/GcpTarget.test.tsx
@@ -29,7 +29,10 @@ const createStoreWithGcpState = (
     preloadedState: {
       wizard: {
         ...initialState,
-        imageTypes: ['gcp'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['gcp'],
+        },
         registration: {
           ...initialState.registration,
           type: 'register-later',

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ArchSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ArchSelect.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
 
 import { AARCH64, X86_64 } from '@/constants';
-import { selectArchitecture } from '@/store/slices/wizard';
+import { initialState, selectArchitecture } from '@/store/slices/wizard';
 import { clickWithWait, createUser } from '@/test/testUtils';
 
 import { openArchSelect, renderArchSelect, selectArch } from './helpers';
@@ -22,7 +22,9 @@ describe('ArchSelect', () => {
   });
 
   test('renders with aarch64 architecture when set in state', () => {
-    renderArchSelect({ architecture: AARCH64 });
+    renderArchSelect({
+      output: { ...initialState.output, architecture: AARCH64 },
+    });
 
     const toggle = screen.getByTestId('arch_select');
     expect(toggle).toHaveTextContent(AARCH64);
@@ -52,7 +54,9 @@ describe('ArchSelect', () => {
 
   test('selects x86_64 after switching from aarch64', async () => {
     const user = createUser();
-    const { store } = renderArchSelect({ architecture: AARCH64 });
+    const { store } = renderArchSelect({
+      output: { ...initialState.output, architecture: AARCH64 },
+    });
 
     await selectArch(user, X86_64);
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/BlueprintMode.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/BlueprintMode.test.tsx
@@ -106,11 +106,13 @@ describe('BlueprintMode', () => {
     test('does not change distribution when switching to image mode', async () => {
       const { store } = renderBlueprintMode();
       const user = createUser();
-      const distributionBefore = store.getState().wizard.distribution;
+      const distributionBefore = store.getState().wizard.output.distribution;
 
       await toggleBlueprintMode(user, 'image');
 
-      expect(store.getState().wizard.distribution).toBe(distributionBefore);
+      expect(store.getState().wizard.output.distribution).toBe(
+        distributionBefore,
+      );
     });
 
     test('updates store when switching to package mode', async () => {

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/BlueprintMode.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/BlueprintMode.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { createUser } from '@/test/testUtils';
 
 import { renderBlueprintMode, toggleBlueprintMode } from './helpers';
@@ -69,7 +70,12 @@ describe('BlueprintMode', () => {
     });
 
     test('displays image mode description when image mode selected', async () => {
-      renderBlueprintMode({ blueprintMode: 'image' });
+      renderBlueprintMode({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'image' },
+        },
+      });
 
       expect(
         await screen.findByText(
@@ -79,7 +85,12 @@ describe('BlueprintMode', () => {
     });
 
     test('can switch back to package mode', async () => {
-      renderBlueprintMode({ blueprintMode: 'image' });
+      renderBlueprintMode({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'image' },
+        },
+      });
       const user = createUser();
 
       await toggleBlueprintMode(user, 'package');
@@ -96,11 +107,11 @@ describe('BlueprintMode', () => {
       const { store } = renderBlueprintMode();
       const user = createUser();
 
-      expect(store.getState().wizard.blueprintMode).toBe('package');
+      expect(store.getState().wizard.details.blueprint.mode).toBe('package');
 
       await toggleBlueprintMode(user, 'image');
 
-      expect(store.getState().wizard.blueprintMode).toBe('image');
+      expect(store.getState().wizard.details.blueprint.mode).toBe('image');
     });
 
     test('does not change distribution when switching to image mode', async () => {
@@ -116,16 +127,26 @@ describe('BlueprintMode', () => {
     });
 
     test('updates store when switching to package mode', async () => {
-      const { store } = renderBlueprintMode({ blueprintMode: 'image' });
+      const { store } = renderBlueprintMode({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'image' },
+        },
+      });
       const user = createUser();
 
       await toggleBlueprintMode(user, 'package');
 
-      expect(store.getState().wizard.blueprintMode).toBe('package');
+      expect(store.getState().wizard.details.blueprint.mode).toBe('package');
     });
 
     test('renders with pre-populated image mode from state', async () => {
-      renderBlueprintMode({ blueprintMode: 'image' });
+      renderBlueprintMode({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'image' },
+        },
+      });
 
       const imageModeButton = await screen.findByRole('button', {
         name: /image mode/i,

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
@@ -226,9 +226,13 @@ describe('ImageOutput Step', () => {
           architecture: 'x86_64',
         },
         details: {
-          blueprintName: 'my-custom-blueprint',
-          blueprintDescription: '',
-          isCustomName: true,
+          ...initialState.details,
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'my-custom-blueprint',
+            description: '',
+            isCustomName: true,
+          },
         },
       });
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
@@ -1,7 +1,7 @@
 import { screen } from '@testing-library/react';
 
 import { CENTOS_9, FEDORA_44, RHEL_10, RHEL_8, RHEL_9 } from '@/constants';
-import { selectBlueprintName } from '@/store/slices/wizard';
+import { initialState, selectBlueprintName } from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
 import { clickWithWait, createUser, fetchMock } from '@/test/testUtils';
 
@@ -79,7 +79,9 @@ describe('ImageOutput Step', () => {
 
   describe('Conditional rendering', () => {
     test('displays release lifecycle for RHEL 9', async () => {
-      renderImageOutputStep({ distribution: RHEL_9 });
+      renderImageOutputStep({
+        output: { ...initialState.output, distribution: RHEL_9 },
+      });
 
       expect(
         await screen.findByRole('button', {
@@ -89,7 +91,9 @@ describe('ImageOutput Step', () => {
     });
 
     test('displays release lifecycle for RHEL 8', async () => {
-      renderImageOutputStep({ distribution: RHEL_8 });
+      renderImageOutputStep({
+        output: { ...initialState.output, distribution: RHEL_8 },
+      });
 
       expect(
         await screen.findByRole('button', {
@@ -99,7 +103,9 @@ describe('ImageOutput Step', () => {
     });
 
     test('does not display release lifecycle for RHEL 10', async () => {
-      renderImageOutputStep({ distribution: RHEL_10 });
+      renderImageOutputStep({
+        output: { ...initialState.output, distribution: RHEL_10 },
+      });
 
       await screen.findByRole('heading', { name: /image output/i });
 
@@ -111,7 +117,9 @@ describe('ImageOutput Step', () => {
     });
 
     test('displays CentOS acknowledgement for CentOS distribution', async () => {
-      renderImageOutputStep({ distribution: CENTOS_9 });
+      renderImageOutputStep({
+        output: { ...initialState.output, distribution: CENTOS_9 },
+      });
 
       expect(
         await screen.findByText(
@@ -121,7 +129,9 @@ describe('ImageOutput Step', () => {
     });
 
     test('does not display CentOS acknowledgement for RHEL distribution', async () => {
-      renderImageOutputStep({ distribution: RHEL_10 });
+      renderImageOutputStep({
+        output: { ...initialState.output, distribution: RHEL_10 },
+      });
 
       await screen.findByRole('heading', { name: /image output/i });
 
@@ -133,7 +143,9 @@ describe('ImageOutput Step', () => {
     });
 
     test('displays blueprint mode toggle for Fedora distribution', async () => {
-      renderImageOutputStep({ distribution: FEDORA_44 });
+      renderImageOutputStep({
+        output: { ...initialState.output, distribution: FEDORA_44 },
+      });
 
       expect(
         await screen.findByRole('button', { name: /image mode/i }),
@@ -147,8 +159,11 @@ describe('ImageOutput Step', () => {
   describe('Auto-generated blueprint name', () => {
     test('generates default name from distribution and architecture', async () => {
       const { store } = renderImageOutputStep({
-        distribution: RHEL_10,
-        architecture: 'x86_64',
+        output: {
+          ...initialState.output,
+          distribution: RHEL_10,
+          architecture: 'x86_64',
+        },
       });
 
       await screen.findByRole('heading', { name: /image output/i });
@@ -160,8 +175,11 @@ describe('ImageOutput Step', () => {
     test('updates name when architecture changes', async () => {
       const user = createUser();
       const { store } = renderImageOutputStep({
-        distribution: RHEL_10,
-        architecture: 'x86_64',
+        output: {
+          ...initialState.output,
+          distribution: RHEL_10,
+          architecture: 'x86_64',
+        },
       });
 
       await screen.findByRole('heading', { name: /image output/i });
@@ -180,8 +198,11 @@ describe('ImageOutput Step', () => {
     test('updates name when distribution changes', async () => {
       const user = createUser();
       const { store } = renderImageOutputStep({
-        distribution: RHEL_10,
-        architecture: 'x86_64',
+        output: {
+          ...initialState.output,
+          distribution: RHEL_10,
+          architecture: 'x86_64',
+        },
       });
 
       await screen.findByRole('heading', { name: /image output/i });
@@ -199,8 +220,11 @@ describe('ImageOutput Step', () => {
 
     test('preserves custom name on initial render', async () => {
       const { store } = renderImageOutputStep({
-        distribution: RHEL_10,
-        architecture: 'x86_64',
+        output: {
+          ...initialState.output,
+          distribution: RHEL_10,
+          architecture: 'x86_64',
+        },
         details: {
           blueprintName: 'my-custom-blueprint',
           blueprintDescription: '',

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -4,6 +4,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import {
+  initialState,
   selectDistribution,
   selectImageSource as selectImageSourceState,
 } from '@/store/slices/wizard';
@@ -39,7 +40,10 @@ vi.mock('@/store/api/backend', async (importOriginal) => {
 
 const renderHostedImageSourceSelect = () => {
   return renderWithRedux(<ImageSourceSelect />, {
-    blueprintMode: 'image',
+    details: {
+      ...initialState.details,
+      blueprint: { ...initialState.details.blueprint, mode: 'image' },
+    },
   });
 };
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ReleaseSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ReleaseSelect.test.tsx
@@ -25,14 +25,18 @@ describe('ReleaseSelect', () => {
     });
 
     test('renders with RHEL 9 when set in state', () => {
-      renderReleaseSelect({ distribution: RHEL_9 });
+      renderReleaseSelect({
+        output: { ...initialState.output, distribution: RHEL_9 },
+      });
 
       const toggle = screen.getByTestId('release_select');
       expect(toggle).toHaveTextContent(/Red Hat Enterprise Linux \(RHEL\) 9/i);
     });
 
     test('renders with RHEL 8 when set in state', () => {
-      renderReleaseSelect({ distribution: RHEL_8 });
+      renderReleaseSelect({
+        output: { ...initialState.output, distribution: RHEL_8 },
+      });
 
       const toggle = screen.getByTestId('release_select');
       expect(toggle).toHaveTextContent(/Red Hat Enterprise Linux \(RHEL\) 8/i);
@@ -162,7 +166,7 @@ describe('ReleaseSelect', () => {
     test('selecting RHEL sets registration type to register-now-rhc', async () => {
       const user = createUser();
       const { store } = renderReleaseSelect({
-        distribution: CENTOS_9,
+        output: { ...initialState.output, distribution: CENTOS_9 },
         registration: {
           ...initialState.registration,
           type: 'register-later',

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/TargetEnvironment.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/TargetEnvironment.test.tsx
@@ -2,7 +2,7 @@ import { screen } from '@testing-library/react';
 
 import { RHEL_10 } from '@/constants';
 import { Distributions } from '@/store/api/backend';
-import { selectImageTypes } from '@/store/slices/wizard';
+import { initialState, selectImageTypes } from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
 import {
   clickWithWait,
@@ -183,7 +183,12 @@ describe('TargetEnvironment', () => {
     });
 
     test('disables other targets when network installer is selected', async () => {
-      renderTargetEnvironment({ imageTypes: ['network-installer'] });
+      renderTargetEnvironment({
+        output: {
+          ...initialState.output,
+          imageTypes: ['network-installer'],
+        },
+      });
 
       await screen.findByRole('checkbox', { name: /Network installer/i });
 
@@ -196,7 +201,12 @@ describe('TargetEnvironment', () => {
     });
 
     test('shows info alert when network installer is selected', async () => {
-      renderTargetEnvironment({ imageTypes: ['network-installer'] });
+      renderTargetEnvironment({
+        output: {
+          ...initialState.output,
+          imageTypes: ['network-installer'],
+        },
+      });
 
       expect(
         await screen.findByText(
@@ -206,7 +216,12 @@ describe('TargetEnvironment', () => {
     });
 
     test('disables network installer when other targets are selected', async () => {
-      renderTargetEnvironment({ imageTypes: ['guest-image'] });
+      renderTargetEnvironment({
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
+      });
 
       const networkInstallerCheckbox = await screen.findByRole('checkbox', {
         name: /Network installer/i,
@@ -251,7 +266,10 @@ describe('TargetEnvironment', () => {
   describe('Image mode', () => {
     const imageModeOverrides: WizardStateOverrides = {
       blueprintMode: 'image',
-      distribution: RHEL_10 as Distributions,
+      output: {
+        ...initialState.output,
+        distribution: RHEL_10 as Distributions,
+      },
     };
 
     const createImageModeHandler = (

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/TargetEnvironment.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/TargetEnvironment.test.tsx
@@ -265,7 +265,10 @@ describe('TargetEnvironment', () => {
 
   describe('Image mode', () => {
     const imageModeOverrides: WizardStateOverrides = {
-      blueprintMode: 'image',
+      details: {
+        ...initialState.details,
+        blueprint: { ...initialState.details.blueprint, mode: 'image' },
+      },
       output: {
         ...initialState.output,
         distribution: RHEL_10 as Distributions,

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
@@ -140,7 +140,10 @@ export const renderImageSourceSelect = (
   return renderWithRedux(
     <ImageSourceSelect />,
     {
-      blueprintMode: 'image',
+      details: {
+        ...initialState.details,
+        blueprint: { ...initialState.details.blueprint, mode: 'image' },
+      },
       ...wizardStateOverrides,
     },
     {

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { RHEL_10 } from '@/constants';
+import { initialState } from '@/store/slices/wizard';
 import {
   clickWithWait,
   renderWithRedux,
@@ -19,8 +20,11 @@ import ImageOutputStep from '../index';
 
 // Default state overrides for most tests
 const defaultStateOverrides: WizardStateOverrides = {
-  distribution: RHEL_10,
-  architecture: 'x86_64',
+  output: {
+    ...initialState.output,
+    distribution: RHEL_10,
+    architecture: 'x86_64',
+  },
 };
 
 export const renderImageOutputStep = (

--- a/src/Components/CreateImageWizard/steps/Kernel/tests/Kernel.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/tests/Kernel.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { createUser } from '@/test/testUtils';
 
 import {
@@ -167,9 +168,12 @@ describe('Kernel Component', () => {
   describe('Initial State', () => {
     test('renders with pre-populated kernel name from state', async () => {
       renderKernelStep({
-        kernel: {
-          name: 'kernel-debug',
-          append: [],
+        system: {
+          ...initialState.system,
+          kernel: {
+            name: 'kernel-debug',
+            append: [],
+          },
         },
       });
 
@@ -180,9 +184,12 @@ describe('Kernel Component', () => {
 
     test('renders with pre-populated kernel arguments from state', async () => {
       renderKernelStep({
-        kernel: {
-          name: '',
-          append: ['nosmt=force', 'audit=1'],
+        system: {
+          ...initialState.system,
+          kernel: {
+            name: '',
+            append: ['nosmt=force', 'audit=1'],
+          },
         },
       });
 
@@ -196,23 +203,25 @@ describe('Kernel Component', () => {
       const { store } = renderKernelStep();
       const user = createUser();
 
-      expect(store.getState().wizard.kernel.name).toBe('');
+      expect(store.getState().wizard.system.kernel.name).toBe('');
 
       await openKernelNameDropdown(user);
       await selectKernelOption(user, 'kernel-debug');
 
-      expect(store.getState().wizard.kernel.name).toBe('kernel-debug');
+      expect(store.getState().wizard.system.kernel.name).toBe('kernel-debug');
     });
 
     test('updates store when kernel argument is added', async () => {
       const { store } = renderKernelStep();
       const user = createUser();
 
-      expect(store.getState().wizard.kernel.append).toHaveLength(0);
+      expect(store.getState().wizard.system.kernel.append).toHaveLength(0);
 
       await addKernelArgument(user, 'nosmt=force');
 
-      expect(store.getState().wizard.kernel.append).toContain('nosmt=force');
+      expect(store.getState().wizard.system.kernel.append).toContain(
+        'nosmt=force',
+      );
     });
 
     test('updates store when multiple kernel arguments are added', async () => {
@@ -222,25 +231,30 @@ describe('Kernel Component', () => {
       await addKernelArgument(user, 'nosmt=force');
       await addKernelArgument(user, 'page_poison=1');
 
-      const append = store.getState().wizard.kernel.append;
+      const append = store.getState().wizard.system.kernel.append;
       expect(append).toContain('nosmt=force');
       expect(append).toContain('page_poison=1');
     });
 
     test('updates store when kernel argument is removed', async () => {
       const { store } = renderKernelStep({
-        kernel: {
-          name: '',
-          append: ['nosmt=force'],
+        system: {
+          ...initialState.system,
+          kernel: {
+            name: '',
+            append: ['nosmt=force'],
+          },
         },
       });
       const user = createUser();
 
-      expect(store.getState().wizard.kernel.append).toContain('nosmt=force');
+      expect(store.getState().wizard.system.kernel.append).toContain(
+        'nosmt=force',
+      );
 
       await removeKernelArgument(user, 'nosmt=force');
 
-      expect(store.getState().wizard.kernel.append).not.toContain(
+      expect(store.getState().wizard.system.kernel.append).not.toContain(
         'nosmt=force',
       );
     });

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { clickWithWait, createUser } from '@/test/testUtils';
 
 import {
@@ -71,7 +72,12 @@ describe('Locale Component', () => {
     });
 
     test('disables Add language button while new language row is visible', async () => {
-      renderLocaleStep({ locale: { languages: [], keyboard: '' } });
+      renderLocaleStep({
+        system: {
+          ...initialState.system,
+          locale: { languages: [], keyboard: '' },
+        },
+      });
       const user = createUser();
 
       const addButton = await screen.findByRole('button', {
@@ -141,7 +147,12 @@ describe('Locale Component', () => {
 
   describe('Language Selection', () => {
     test('can select a language', async () => {
-      renderLocaleStep({ locale: { languages: [], keyboard: '' } });
+      renderLocaleStep({
+        system: {
+          ...initialState.system,
+          locale: { languages: [], keyboard: '' },
+        },
+      });
       const user = createUser();
 
       await clickAddLanguage(user);
@@ -157,20 +168,28 @@ describe('Locale Component', () => {
 
     test('removing the last language shows an empty selection row', async () => {
       const { store } = renderLocaleStep({
-        locale: { languages: ['en_US.UTF-8'], keyboard: '' },
+        system: {
+          ...initialState.system,
+          locale: { languages: ['en_US.UTF-8'], keyboard: '' },
+        },
       });
       const user = createUser();
 
       await removeLanguageAtIndex(user, 0);
 
-      expect(store.getState().wizard.locale.languages).toHaveLength(0);
+      expect(store.getState().wizard.system.locale.languages).toHaveLength(0);
       expect(
         screen.getByRole('button', { name: /select a language/i }),
       ).toBeInTheDocument();
     });
 
     test('can select multiple languages', async () => {
-      renderLocaleStep({ locale: { languages: [], keyboard: '' } });
+      renderLocaleStep({
+        system: {
+          ...initialState.system,
+          locale: { languages: [], keyboard: '' },
+        },
+      });
       const user = createUser();
 
       await clickAddLanguage(user);
@@ -254,9 +273,12 @@ describe('Locale Component', () => {
   describe('Initial State', () => {
     test('renders with pre-populated languages from state', async () => {
       renderLocaleStep({
-        locale: {
-          languages: ['en_US.UTF-8', 'de_DE.UTF-8'],
-          keyboard: '',
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: ['en_US.UTF-8', 'de_DE.UTF-8'],
+            keyboard: '',
+          },
         },
       });
 
@@ -274,9 +296,12 @@ describe('Locale Component', () => {
 
     test('renders with pre-populated keyboard from state', async () => {
       renderLocaleStep({
-        locale: {
-          languages: [],
-          keyboard: 'de',
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: [],
+            keyboard: 'de',
+          },
         },
       });
 
@@ -289,27 +314,35 @@ describe('Locale Component', () => {
   describe('State Updates', () => {
     test('updates store when language is selected', async () => {
       const { store } = renderLocaleStep({
-        locale: {
-          languages: [],
-          keyboard: '',
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: [],
+            keyboard: '',
+          },
         },
       });
       const user = createUser();
 
-      expect(store.getState().wizard.locale.languages).toHaveLength(0);
+      expect(store.getState().wizard.system.locale.languages).toHaveLength(0);
 
       await clickAddLanguage(user);
       await searchForLanguage(user, 'nl');
       await selectLanguageOption(user, 'Dutch - Netherlands (nl_NL.UTF-8)');
 
-      expect(store.getState().wizard.locale.languages).toContain('nl_NL.UTF-8');
+      expect(store.getState().wizard.system.locale.languages).toContain(
+        'nl_NL.UTF-8',
+      );
     });
 
     test('updates store when multiple languages are selected', async () => {
       const { store } = renderLocaleStep({
-        locale: {
-          languages: [],
-          keyboard: '',
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: [],
+            keyboard: '',
+          },
         },
       });
       const user = createUser();
@@ -325,26 +358,29 @@ describe('Locale Component', () => {
         'English - United Kingdom (en_GB.UTF-8)',
       );
 
-      const languages = store.getState().wizard.locale.languages;
+      const languages = store.getState().wizard.system.locale.languages;
       expect(languages).toContain('nl_NL.UTF-8');
       expect(languages).toContain('en_GB.UTF-8');
     });
 
     test('updates store when keyboard is selected', async () => {
       const { store } = renderLocaleStep({
-        locale: {
-          languages: [],
-          keyboard: '',
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: [],
+            keyboard: '',
+          },
         },
       });
       const user = createUser();
 
-      expect(store.getState().wizard.locale.keyboard).toBe('');
+      expect(store.getState().wizard.system.locale.keyboard).toBe('');
 
       await searchForKeyboard(user, 'us');
       await selectKeyboardOption(user, 'us');
 
-      expect(store.getState().wizard.locale.keyboard).toBe('us');
+      expect(store.getState().wizard.system.locale.keyboard).toBe('us');
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/Packages/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/helpers.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { RHEL_10 } from '@/constants';
+import { initialState } from '@/store/slices/wizard';
 import {
   clearWithWait,
   clickWithWait,
@@ -22,8 +23,11 @@ export const renderPackagesStep = (
   return renderWithRedux(
     <PackagesStep />,
     {
-      distribution: RHEL_10,
-      architecture: 'x86_64',
+      output: {
+        ...initialState.output,
+        distribution: RHEL_10,
+        architecture: 'x86_64',
+      },
       ...wizardStateOverrides,
     },
     options,

--- a/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
@@ -478,7 +478,10 @@ const createStoreWithRepositoriesState = (
   } = {},
 ) => {
   return createTestStore({
-    imageTypes: ['guest-image'],
+    output: {
+      ...initialState.output,
+      imageTypes: ['guest-image'],
+    },
     registration: {
       ...initialState.registration,
       type: 'register-later',

--- a/src/Components/CreateImageWizard/steps/Repositories/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/tests/helpers.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { RHEL_10 } from '@/constants';
+import { initialState } from '@/store/slices/wizard';
 import {
   clickWithWait,
   renderWithRedux,
@@ -17,8 +18,11 @@ export const renderRepositoriesStep = (
   wizardStateOverrides: WizardStateOverrides = {},
 ) => {
   return renderWithRedux(<RepositoriesStep />, {
-    distribution: RHEL_10,
-    architecture: 'x86_64',
+    output: {
+      ...initialState.output,
+      distribution: RHEL_10,
+      architecture: 'x86_64',
+    },
     ...wizardStateOverrides,
   });
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -19,7 +19,10 @@ describe('AdvancedSettingsOverview', () => {
     renderWithRedux(
       <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
       {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
       },
     );
 
@@ -34,7 +37,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'automatic',
               disk: {
@@ -58,7 +64,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'automatic',
               disk: {
@@ -86,7 +95,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'basic',
               disk: {
@@ -112,7 +124,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'basic',
               disk: {
@@ -138,7 +153,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'basic',
               disk: {
@@ -167,7 +185,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'advanced',
               disk: {
@@ -191,7 +212,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'advanced',
               disk: {
@@ -216,7 +240,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'advanced',
               disk: {
@@ -244,7 +271,10 @@ describe('AdvancedSettingsOverview', () => {
             restrictions={createDefaultRestrictions()}
           />,
           {
-            imageTypes: ['guest-image'],
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
             filesystem: {
               mode: 'basic',
               disk: {
@@ -271,7 +301,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             timezone: {
@@ -290,7 +323,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             timezone: {
@@ -308,7 +344,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             timezone: {
@@ -328,7 +367,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             timezone: {
@@ -348,7 +390,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             locale: {
@@ -369,7 +414,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             locale: {
@@ -389,7 +437,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             locale: {
@@ -409,7 +460,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             locale: {
@@ -429,7 +483,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             locale: {
@@ -450,7 +507,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, hostname: 'my-server.example.com' },
         },
       );
@@ -463,7 +523,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, hostname: '' },
         },
       );
@@ -477,7 +540,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             kernel: {
@@ -496,7 +562,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             kernel: {
@@ -520,7 +589,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             kernel: {
@@ -542,7 +614,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             kernel: {
@@ -561,7 +636,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             kernel: {
@@ -586,7 +664,10 @@ describe('AdvancedSettingsOverview', () => {
           oscapKernelArgs={['audit=1', 'audit_backlog_limit=8192']}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             kernel: {
@@ -610,7 +691,10 @@ describe('AdvancedSettingsOverview', () => {
           oscapKernelArgs={['audit=1']}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             kernel: {
@@ -635,7 +719,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             services: {
@@ -657,7 +744,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             services: {
@@ -680,7 +770,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             services: {
@@ -700,7 +793,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             services: {
@@ -719,7 +815,10 @@ describe('AdvancedSettingsOverview', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             services: {
@@ -753,7 +852,10 @@ describe('AdvancedSettingsOverview', () => {
           }}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             services: {
@@ -786,7 +888,10 @@ describe('AdvancedSettingsOverview', () => {
           }}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             services: {
@@ -816,7 +921,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, firstBoot: { script: '' } },
         },
       );
@@ -830,7 +938,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firstBoot: { script: firstBootScript },
@@ -845,7 +956,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firstBoot: { script: firstBootScript },
@@ -862,7 +976,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, users: [] },
         },
       );
@@ -874,7 +991,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [
@@ -898,7 +1018,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [
@@ -925,7 +1048,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, users: [adminUser, developerUser] },
         },
       );
@@ -937,7 +1063,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, users: [] },
         },
       );
@@ -953,7 +1082,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, users: [adminUser] },
         },
       );
@@ -969,7 +1101,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, users: [adminUser, developerUser] },
         },
       );
@@ -982,7 +1117,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, users: [adminUser, developerUser] },
         },
       );
@@ -996,7 +1134,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: { ...initialState.system, users: [adminUser, developerUser] },
         },
       );
@@ -1011,7 +1152,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [{ ...adminUser, ssh_key: 'ssh-rsa AAAA' }],
@@ -1027,7 +1171,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [{ ...adminUser, groups: ['wheel', 'docker'] }],
@@ -1043,7 +1190,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [
@@ -1069,7 +1219,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [adminUser],
@@ -1090,7 +1243,10 @@ echo 'Hello there, General Kenobi!'`;
           })}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [adminUser],
@@ -1109,7 +1265,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {
@@ -1130,7 +1289,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {
@@ -1152,7 +1314,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {
@@ -1173,7 +1338,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {
@@ -1197,7 +1365,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {
@@ -1220,7 +1391,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {
@@ -1243,7 +1417,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {
@@ -1267,7 +1444,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {
@@ -1295,7 +1475,10 @@ echo 'Hello there, General Kenobi!'`;
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             firewall: {

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import {
   advancedPartitions,
   basicPartitions,
@@ -271,9 +272,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          timezone: {
-            timezone: 'America/New_York',
-            ntpservers: [],
+          system: {
+            ...initialState.system,
+            timezone: {
+              timezone: 'America/New_York',
+              ntpservers: [],
+            },
           },
         },
       );
@@ -287,9 +291,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          timezone: {
-            timezone: '',
-            ntpservers: [],
+          system: {
+            ...initialState.system,
+            timezone: {
+              timezone: '',
+              ntpservers: [],
+            },
           },
         },
       );
@@ -302,9 +309,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          timezone: {
-            timezone: 'UTC',
-            ntpservers: ['0.pool.ntp.org', '1.pool.ntp.org'],
+          system: {
+            ...initialState.system,
+            timezone: {
+              timezone: 'UTC',
+              ntpservers: ['0.pool.ntp.org', '1.pool.ntp.org'],
+            },
           },
         },
       );
@@ -319,9 +329,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          timezone: {
-            timezone: 'Europe/London',
-            ntpservers: [],
+          system: {
+            ...initialState.system,
+            timezone: {
+              timezone: 'Europe/London',
+              ntpservers: [],
+            },
           },
         },
       );
@@ -336,9 +349,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          locale: {
-            languages: ['en_US.UTF-8'],
-            keyboard: 'us',
+          system: {
+            ...initialState.system,
+            locale: {
+              languages: ['en_US.UTF-8'],
+              keyboard: 'us',
+            },
           },
         },
       );
@@ -354,9 +370,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          locale: {
-            languages: ['en_US.UTF-8', 'es_ES.UTF-8', 'fr_FR.UTF-8'],
-            keyboard: 'us',
+          system: {
+            ...initialState.system,
+            locale: {
+              languages: ['en_US.UTF-8', 'es_ES.UTF-8', 'fr_FR.UTF-8'],
+              keyboard: 'us',
+            },
           },
         },
       );
@@ -371,9 +390,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          locale: {
-            languages: [],
-            keyboard: 'us',
+          system: {
+            ...initialState.system,
+            locale: {
+              languages: [],
+              keyboard: 'us',
+            },
           },
         },
       );
@@ -388,9 +410,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          locale: {
-            languages: ['en_US.UTF-8'],
-            keyboard: '',
+          system: {
+            ...initialState.system,
+            locale: {
+              languages: ['en_US.UTF-8'],
+              keyboard: '',
+            },
           },
         },
       );
@@ -405,9 +430,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          locale: {
-            languages: [],
-            keyboard: '',
+          system: {
+            ...initialState.system,
+            locale: {
+              languages: [],
+              keyboard: '',
+            },
           },
         },
       );
@@ -423,7 +451,7 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          hostname: 'my-server.example.com',
+          system: { ...initialState.system, hostname: 'my-server.example.com' },
         },
       );
 
@@ -436,7 +464,7 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          hostname: '',
+          system: { ...initialState.system, hostname: '' },
         },
       );
 
@@ -450,9 +478,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          kernel: {
-            name: 'kernel-rt',
-            append: [],
+          system: {
+            ...initialState.system,
+            kernel: {
+              name: 'kernel-rt',
+              append: [],
+            },
           },
         },
       );
@@ -466,9 +497,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          kernel: {
-            name: '',
-            append: ['quiet', 'splash', 'rhgb'],
+          system: {
+            ...initialState.system,
+            kernel: {
+              name: '',
+              append: ['quiet', 'splash', 'rhgb'],
+            },
           },
         },
       );
@@ -487,9 +521,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          kernel: {
-            name: 'kernel-debug',
-            append: ['debug', 'console=ttyS0'],
+          system: {
+            ...initialState.system,
+            kernel: {
+              name: 'kernel-debug',
+              append: ['debug', 'console=ttyS0'],
+            },
           },
         },
       );
@@ -506,9 +543,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          kernel: {
-            name: '',
-            append: [],
+          system: {
+            ...initialState.system,
+            kernel: {
+              name: '',
+              append: [],
+            },
           },
         },
       );
@@ -522,9 +562,12 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          kernel: {
-            name: '',
-            append: ['quiet', 'splash'],
+          system: {
+            ...initialState.system,
+            kernel: {
+              name: '',
+              append: ['quiet', 'splash'],
+            },
           },
         },
       );
@@ -544,9 +587,12 @@ describe('AdvancedSettingsOverview', () => {
         />,
         {
           imageTypes: ['guest-image'],
-          kernel: {
-            name: '',
-            append: ['audit=1'],
+          system: {
+            ...initialState.system,
+            kernel: {
+              name: '',
+              append: ['audit=1'],
+            },
           },
         },
       );
@@ -565,9 +611,12 @@ describe('AdvancedSettingsOverview', () => {
         />,
         {
           imageTypes: ['guest-image'],
-          kernel: {
-            name: '',
-            append: ['audit=1', 'quiet'],
+          system: {
+            ...initialState.system,
+            kernel: {
+              name: '',
+              append: ['audit=1', 'quiet'],
+            },
           },
         },
       );
@@ -587,10 +636,13 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          services: {
-            enabled: [],
-            disabled: [],
-            masked: [],
+          system: {
+            ...initialState.system,
+            services: {
+              enabled: [],
+              disabled: [],
+              masked: [],
+            },
           },
         },
       );
@@ -606,10 +658,13 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          services: {
-            enabled: ['httpd', 'sshd'],
-            disabled: [],
-            masked: [],
+          system: {
+            ...initialState.system,
+            services: {
+              enabled: ['httpd', 'sshd'],
+              disabled: [],
+              masked: [],
+            },
           },
         },
       );
@@ -626,10 +681,13 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          services: {
-            enabled: [],
-            disabled: ['bluetooth', 'cups'],
-            masked: [],
+          system: {
+            ...initialState.system,
+            services: {
+              enabled: [],
+              disabled: ['bluetooth', 'cups'],
+              masked: [],
+            },
           },
         },
       );
@@ -643,10 +701,13 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          services: {
-            enabled: [],
-            disabled: [],
-            masked: ['firewalld'],
+          system: {
+            ...initialState.system,
+            services: {
+              enabled: [],
+              disabled: [],
+              masked: ['firewalld'],
+            },
           },
         },
       );
@@ -659,10 +720,13 @@ describe('AdvancedSettingsOverview', () => {
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          services: {
-            enabled: ['httpd'],
-            disabled: ['cups'],
-            masked: ['firewalld'],
+          system: {
+            ...initialState.system,
+            services: {
+              enabled: ['httpd'],
+              disabled: ['cups'],
+              masked: ['firewalld'],
+            },
           },
         },
       );
@@ -690,10 +754,13 @@ describe('AdvancedSettingsOverview', () => {
         />,
         {
           imageTypes: ['guest-image'],
-          services: {
-            enabled: ['auditd'],
-            disabled: ['autofs'],
-            masked: ['nfs-server'],
+          system: {
+            ...initialState.system,
+            services: {
+              enabled: ['auditd'],
+              disabled: ['autofs'],
+              masked: ['nfs-server'],
+            },
           },
         },
       );
@@ -720,10 +787,13 @@ describe('AdvancedSettingsOverview', () => {
         />,
         {
           imageTypes: ['guest-image'],
-          services: {
-            enabled: ['auditd', 'httpd'],
-            disabled: [],
-            masked: [],
+          system: {
+            ...initialState.system,
+            services: {
+              enabled: ['auditd', 'httpd'],
+              disabled: [],
+              masked: [],
+            },
           },
         },
       );
@@ -747,7 +817,7 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firstBoot: { script: '' },
+          system: { ...initialState.system, firstBoot: { script: '' } },
         },
       );
 
@@ -761,7 +831,10 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firstBoot: { script: firstBootScript },
+          system: {
+            ...initialState.system,
+            firstBoot: { script: firstBootScript },
+          },
         },
       );
 
@@ -773,7 +846,10 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firstBoot: { script: firstBootScript },
+          system: {
+            ...initialState.system,
+            firstBoot: { script: firstBootScript },
+          },
         },
       );
 
@@ -787,7 +863,7 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [],
+          system: { ...initialState.system, users: [] },
         },
       );
 
@@ -799,16 +875,19 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [
-            {
-              name: '',
-              password: '',
-              hasPassword: false,
-              ssh_key: '',
-              groups: [],
-              isAdministrator: false,
-            },
-          ],
+          system: {
+            ...initialState.system,
+            users: [
+              {
+                name: '',
+                password: '',
+                hasPassword: false,
+                ssh_key: '',
+                groups: [],
+                isAdministrator: false,
+              },
+            ],
+          },
         },
       );
 
@@ -820,17 +899,20 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [
-            {
-              name: '',
-              password: '',
-              hasPassword: false,
-              ssh_key: '',
-              groups: [],
-              isAdministrator: false,
-            },
-            adminUser,
-          ],
+          system: {
+            ...initialState.system,
+            users: [
+              {
+                name: '',
+                password: '',
+                hasPassword: false,
+                ssh_key: '',
+                groups: [],
+                isAdministrator: false,
+              },
+              adminUser,
+            ],
+          },
         },
       );
 
@@ -844,7 +926,7 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser, developerUser],
+          system: { ...initialState.system, users: [adminUser, developerUser] },
         },
       );
 
@@ -856,7 +938,7 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [],
+          system: { ...initialState.system, users: [] },
         },
       );
 
@@ -872,7 +954,7 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser],
+          system: { ...initialState.system, users: [adminUser] },
         },
       );
 
@@ -888,7 +970,7 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser, developerUser],
+          system: { ...initialState.system, users: [adminUser, developerUser] },
         },
       );
 
@@ -901,7 +983,7 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser, developerUser],
+          system: { ...initialState.system, users: [adminUser, developerUser] },
         },
       );
 
@@ -915,7 +997,7 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser, developerUser],
+          system: { ...initialState.system, users: [adminUser, developerUser] },
         },
       );
 
@@ -930,7 +1012,10 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [{ ...adminUser, ssh_key: 'ssh-rsa AAAA' }],
+          system: {
+            ...initialState.system,
+            users: [{ ...adminUser, ssh_key: 'ssh-rsa AAAA' }],
+          },
         },
       );
 
@@ -943,7 +1028,10 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [{ ...adminUser, groups: ['wheel', 'docker'] }],
+          system: {
+            ...initialState.system,
+            users: [{ ...adminUser, groups: ['wheel', 'docker'] }],
+          },
         },
       );
 
@@ -956,11 +1044,18 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [
-            { ...adminUser, ssh_key: 'ssh-rsa adminkey', groups: ['wheel'] },
-            { ...developerUser, ssh_key: 'ssh-rsa devkey', groups: ['docker'] },
-            guestUser,
-          ],
+          system: {
+            ...initialState.system,
+            users: [
+              { ...adminUser, ssh_key: 'ssh-rsa adminkey', groups: ['wheel'] },
+              {
+                ...developerUser,
+                ssh_key: 'ssh-rsa devkey',
+                groups: ['docker'],
+              },
+              guestUser,
+            ],
+          },
         },
       );
 
@@ -975,8 +1070,11 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser],
-          userGroups: userGroups,
+          system: {
+            ...initialState.system,
+            users: [adminUser],
+            groups: userGroups,
+          },
         },
       );
 
@@ -993,8 +1091,11 @@ echo 'Hello there, General Kenobi!'`;
         />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser],
-          userGroups: userGroups,
+          system: {
+            ...initialState.system,
+            users: [adminUser],
+            groups: userGroups,
+          },
         },
       );
 
@@ -1009,11 +1110,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: [],
-            services: {
-              enabled: [],
-              disabled: [],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: [],
+              services: {
+                enabled: [],
+                disabled: [],
+              },
             },
           },
         },
@@ -1027,11 +1131,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: ['22/tcp', '443/tcp'],
-            services: {
-              enabled: [],
-              disabled: [],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: ['22/tcp', '443/tcp'],
+              services: {
+                enabled: [],
+                disabled: [],
+              },
             },
           },
         },
@@ -1046,11 +1153,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: [],
-            services: {
-              enabled: ['httpd'],
-              disabled: [],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: [],
+              services: {
+                enabled: ['httpd'],
+                disabled: [],
+              },
             },
           },
         },
@@ -1064,11 +1174,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: ['22/tcp', '443/tcp', '8080/tcp'],
-            services: {
-              enabled: [],
-              disabled: [],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: ['22/tcp', '443/tcp', '8080/tcp'],
+              services: {
+                enabled: [],
+                disabled: [],
+              },
             },
           },
         },
@@ -1085,11 +1198,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: [],
-            services: {
-              enabled: ['httpd', 'sshd'],
-              disabled: [],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: [],
+              services: {
+                enabled: ['httpd', 'sshd'],
+                disabled: [],
+              },
             },
           },
         },
@@ -1105,11 +1221,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: [],
-            services: {
-              enabled: [],
-              disabled: ['cups', 'bluetooth'],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: [],
+              services: {
+                enabled: [],
+                disabled: ['cups', 'bluetooth'],
+              },
             },
           },
         },
@@ -1125,11 +1244,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: ['22/tcp', '443/tcp', '8080/tcp'],
-            services: {
-              enabled: ['httpd'],
-              disabled: [],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: ['22/tcp', '443/tcp', '8080/tcp'],
+              services: {
+                enabled: ['httpd'],
+                disabled: [],
+              },
             },
           },
         },
@@ -1146,11 +1268,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: ['22/tcp'],
-            services: {
-              enabled: ['httpd', 'sshd'],
-              disabled: ['cups'],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: ['22/tcp'],
+              services: {
+                enabled: ['httpd', 'sshd'],
+                disabled: ['cups'],
+              },
             },
           },
         },
@@ -1171,11 +1296,14 @@ echo 'Hello there, General Kenobi!'`;
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          firewall: {
-            ports: [],
-            services: {
-              enabled: [],
-              disabled: [],
+          system: {
+            ...initialState.system,
+            firewall: {
+              ports: [],
+              services: {
+                enabled: [],
+                disabled: [],
+              },
             },
           },
         },

--- a/src/Components/CreateImageWizard/steps/Review/components/Content/tests/Content.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Content/tests/Content.test.tsx
@@ -13,7 +13,10 @@ describe('ContentOverview', () => {
     renderWithRedux(
       <ContentOverview restrictions={createDefaultRestrictions()} />,
       {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
       },
     );
 
@@ -25,7 +28,10 @@ describe('ContentOverview', () => {
       renderWithRedux(
         <ContentOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           content: {
             ...initialState.content,
             repositories: {
@@ -48,7 +54,10 @@ describe('ContentOverview', () => {
       renderWithRedux(
         <ContentOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           content: {
             ...initialState.content,
             packages: [],
@@ -64,7 +73,10 @@ describe('ContentOverview', () => {
       renderWithRedux(
         <ContentOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           content: {
             ...initialState.content,
             packages: [
@@ -87,7 +99,10 @@ describe('ContentOverview', () => {
       renderWithRedux(
         <ContentOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           content: {
             ...initialState.content,
             packages: [
@@ -108,7 +123,10 @@ describe('ContentOverview', () => {
           oscapPackages={['aide', 'audit']}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           content: {
             ...initialState.content,
             packages: [
@@ -135,7 +153,10 @@ describe('ContentOverview', () => {
           oscapPackages={['aide']}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           content: {
             ...initialState.content,
             packages: [
@@ -164,7 +185,10 @@ describe('ContentOverview', () => {
       renderWithRedux(
         <ContentOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           content: {
             ...initialState.content,
             groups: [],
@@ -180,7 +204,10 @@ describe('ContentOverview', () => {
       renderWithRedux(
         <ContentOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           content: {
             ...initialState.content,
             groups: [

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -55,7 +55,7 @@ describe('ImageOverview', () => {
     renderWithRedux(
       <ImageOverview restrictions={createDefaultRestrictions()} />,
       {
-        distribution: RHEL_10,
+        output: { ...initialState.output, distribution: RHEL_10 },
         blueprintMode: 'package',
       },
     );
@@ -70,7 +70,7 @@ describe('ImageOverview', () => {
     renderWithRedux(
       <ImageOverview restrictions={createDefaultRestrictions()} />,
       {
-        architecture: X86_64,
+        output: { ...initialState.output, architecture: X86_64 },
       },
     );
 
@@ -91,7 +91,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['vsphere'],
+          output: { ...initialState.output, imageTypes: ['vsphere'] },
         },
       );
 
@@ -103,7 +103,10 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['vsphere-ova'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['vsphere-ova'],
+          },
         },
       );
 
@@ -115,7 +118,10 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['vsphere', 'vsphere-ova'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['vsphere', 'vsphere-ova'],
+          },
         },
       );
 
@@ -127,7 +133,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['aws'],
+          output: { ...initialState.output, imageTypes: ['aws'] },
         },
       );
 
@@ -140,7 +146,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['aws'],
+          output: { ...initialState.output, imageTypes: ['aws'] },
           cloudProviders: {
             ...initialState.cloudProviders,
             aws: {
@@ -165,7 +171,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['gcp'],
+          output: { ...initialState.output, imageTypes: ['gcp'] },
           cloudProviders: {
             ...initialState.cloudProviders,
             gcp: {
@@ -189,7 +195,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['azure'],
+          output: { ...initialState.output, imageTypes: ['azure'] },
           cloudProviders: {
             ...initialState.cloudProviders,
             azure: {
@@ -214,7 +220,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['oci'],
+          output: { ...initialState.output, imageTypes: ['oci'] },
         },
       );
 
@@ -227,7 +233,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['vsphere'],
+          output: { ...initialState.output, imageTypes: ['vsphere'] },
         },
       );
 
@@ -240,7 +246,10 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
         },
       );
 
@@ -252,7 +261,10 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['image-installer'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['image-installer'],
+          },
         },
       );
 
@@ -263,7 +275,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['wsl'],
+          output: { ...initialState.output, imageTypes: ['wsl'] },
         },
       );
 
@@ -276,7 +288,10 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image', 'image-installer', 'wsl'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image', 'image-installer', 'wsl'],
+          },
         },
       );
 
@@ -291,7 +306,7 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['aws'],
+          output: { ...initialState.output, imageTypes: ['aws'] },
         },
       );
 
@@ -310,7 +325,10 @@ describe('ImageOverview', () => {
           })}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [adminUser],
@@ -329,7 +347,10 @@ describe('ImageOverview', () => {
       renderWithRedux(
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           system: {
             ...initialState.system,
             users: [adminUser],

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -311,8 +311,11 @@ describe('ImageOverview', () => {
         />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser],
-          userGroups: userGroups,
+          system: {
+            ...initialState.system,
+            users: [adminUser],
+            groups: userGroups,
+          },
         },
       );
 
@@ -327,8 +330,11 @@ describe('ImageOverview', () => {
         <ImageOverview restrictions={createDefaultRestrictions()} />,
         {
           imageTypes: ['guest-image'],
-          users: [adminUser],
-          userGroups: userGroups,
+          system: {
+            ...initialState.system,
+            users: [adminUser],
+            groups: userGroups,
+          },
         },
       );
 

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -24,9 +24,13 @@ describe('ImageOverview', () => {
       <ImageOverview restrictions={createDefaultRestrictions()} />,
       {
         details: {
-          blueprintName: 'my-test-blueprint',
-          blueprintDescription: '',
-          isCustomName: true,
+          ...initialState.details,
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'my-test-blueprint',
+            description: '',
+            isCustomName: true,
+          },
         },
       },
     );
@@ -40,9 +44,13 @@ describe('ImageOverview', () => {
       <ImageOverview restrictions={createDefaultRestrictions()} />,
       {
         details: {
-          blueprintName: 'test-blueprint',
-          blueprintDescription: 'This is a test description',
-          isCustomName: true,
+          ...initialState.details,
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'test-blueprint',
+            description: 'This is a test description',
+            isCustomName: true,
+          },
         },
       },
     );
@@ -56,7 +64,10 @@ describe('ImageOverview', () => {
       <ImageOverview restrictions={createDefaultRestrictions()} />,
       {
         output: { ...initialState.output, distribution: RHEL_10 },
-        blueprintMode: 'package',
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'package' },
+        },
       },
     );
 

--- a/src/Components/CreateImageWizard/steps/Review/components/Registration/tests/Registration.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Registration/tests/Registration.test.tsx
@@ -13,7 +13,10 @@ describe('Registration', () => {
     renderWithRedux(
       <Registration restrictions={createDefaultRestrictions()} />,
       {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
       },
     );
 
@@ -30,7 +33,10 @@ describe('Registration', () => {
           })}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
         },
       );
 
@@ -46,7 +52,10 @@ describe('Registration', () => {
           })}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             aap: {
@@ -75,7 +84,10 @@ describe('Registration', () => {
           })}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
         },
       );
 
@@ -88,7 +100,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             type: 'register-later',
@@ -112,7 +127,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             type: 'register-now',
@@ -139,7 +157,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             type: 'register-now-insights',
@@ -164,7 +185,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             type: 'register-now-rhc',
@@ -196,7 +220,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             type: 'register-satellite',
@@ -219,7 +246,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             aap: {
@@ -242,7 +272,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             aap: {
@@ -267,7 +300,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             aap: {
@@ -294,7 +330,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             aap: {
@@ -316,7 +355,10 @@ describe('Registration', () => {
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             aap: {
@@ -344,7 +386,10 @@ aWRnaXRzIFB0eSBMdGQwHhcNMjMwMTAxMDAwMDAwWhcNMjQwMTAxMDAwMDAwWjBF
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             aap: {
@@ -366,7 +411,10 @@ aWRnaXRzIFB0eSBMdGQwHhcNMjMwMTAxMDAwMDAwWhcNMjQwMTAxMDAwMDAwWjBF
       renderWithRedux(
         <Registration restrictions={createDefaultRestrictions()} />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           registration: {
             ...initialState.registration,
             aap: {

--- a/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/tests/RepeatableBuild.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/RepeatableBuild/tests/RepeatableBuild.test.tsx
@@ -13,7 +13,10 @@ describe('RepeatableBuild', () => {
     renderWithRedux(
       <RepeatableBuild restrictions={createDefaultRestrictions()} />,
       {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         content: {
           ...initialState.content,
           snapshotting: {
@@ -35,7 +38,10 @@ describe('RepeatableBuild', () => {
     renderWithRedux(
       <RepeatableBuild restrictions={createDefaultRestrictions()} />,
       {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         content: {
           ...initialState.content,
           snapshotting: {
@@ -56,7 +62,10 @@ describe('RepeatableBuild', () => {
     renderWithRedux(
       <RepeatableBuild restrictions={createDefaultRestrictions()} />,
       {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         content: {
           ...initialState.content,
           snapshotting: {
@@ -76,7 +85,10 @@ describe('RepeatableBuild', () => {
     renderWithRedux(
       <RepeatableBuild restrictions={createDefaultRestrictions()} />,
       {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         content: {
           ...initialState.content,
           snapshotting: {

--- a/src/Components/CreateImageWizard/steps/Review/components/Security/tests/Security.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Security/tests/Security.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { renderWithRedux } from '@/test/testUtils';
 
 import { createDefaultRestrictions } from '../../tests/helpers';
@@ -23,7 +24,10 @@ describe('Security', () => {
         security={mockSecuritySummary}
       />,
       {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
       },
     );
 
@@ -35,7 +39,10 @@ describe('Security', () => {
   describe('FIPS', () => {
     test('displays FIPS enabled status', () => {
       renderWithRedux(<Security restrictions={createDefaultRestrictions()} />, {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         compliance: {
           type: 'none',
           policyID: undefined,
@@ -51,7 +58,10 @@ describe('Security', () => {
 
     test('does not render FIPS when disabled', () => {
       renderWithRedux(<Security restrictions={createDefaultRestrictions()} />, {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         compliance: {
           type: 'none',
           policyID: undefined,
@@ -84,7 +94,10 @@ describe('Security', () => {
           security={mockSummaryWithCIS}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           compliance: {
             type: 'openscap',
             profileID: 'xccdf_org.ssgproject.content_profile_cis',
@@ -116,7 +129,10 @@ describe('Security', () => {
           security={mockComplianceSummary}
         />,
         {
-          imageTypes: ['guest-image'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
           compliance: {
             type: 'compliance',
             profileID: undefined,
@@ -133,7 +149,10 @@ describe('Security', () => {
 
     test('does not display added items when no packages or services', () => {
       renderWithRedux(<Security restrictions={createDefaultRestrictions()} />, {
-        imageTypes: ['guest-image'],
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
+        },
         compliance: {
           type: 'openscap',
           profileID: 'test-profile',

--- a/src/Components/CreateImageWizard/steps/Services/tests/Services.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/tests/Services.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { createUser } from '@/test/testUtils';
 
 import {
@@ -223,10 +224,13 @@ describe('Services Component', () => {
   describe('Initial State', () => {
     test('renders with pre-populated enabled services from state', async () => {
       renderServicesStep({
-        services: {
-          enabled: ['httpd', 'sshd'],
-          disabled: [],
-          masked: [],
+        system: {
+          ...initialState.system,
+          services: {
+            enabled: ['httpd', 'sshd'],
+            disabled: [],
+            masked: [],
+          },
         },
       });
 
@@ -236,10 +240,13 @@ describe('Services Component', () => {
 
     test('renders with pre-populated disabled services from state', async () => {
       renderServicesStep({
-        services: {
-          enabled: [],
-          disabled: ['telnet', 'rsh'],
-          masked: [],
+        system: {
+          ...initialState.system,
+          services: {
+            enabled: [],
+            disabled: ['telnet', 'rsh'],
+            masked: [],
+          },
         },
       });
 
@@ -249,10 +256,13 @@ describe('Services Component', () => {
 
     test('renders with pre-populated masked services from state', async () => {
       renderServicesStep({
-        services: {
-          enabled: [],
-          disabled: [],
-          masked: ['nfs-server', 'rpcbind'],
+        system: {
+          ...initialState.system,
+          services: {
+            enabled: [],
+            disabled: [],
+            masked: ['nfs-server', 'rpcbind'],
+          },
         },
       });
 
@@ -266,50 +276,63 @@ describe('Services Component', () => {
       const { store } = renderServicesStep();
       const user = createUser();
 
-      expect(store.getState().wizard.services.enabled).toHaveLength(0);
+      expect(store.getState().wizard.system.services.enabled).toHaveLength(0);
 
       await addEnabledService(user, 'httpd');
 
-      expect(store.getState().wizard.services.enabled).toContain('httpd');
+      expect(store.getState().wizard.system.services.enabled).toContain(
+        'httpd',
+      );
     });
 
     test('updates store when disabled service is added', async () => {
       const { store } = renderServicesStep();
       const user = createUser();
 
-      expect(store.getState().wizard.services.disabled).toHaveLength(0);
+      expect(store.getState().wizard.system.services.disabled).toHaveLength(0);
 
       await addDisabledService(user, 'telnet');
 
-      expect(store.getState().wizard.services.disabled).toContain('telnet');
+      expect(store.getState().wizard.system.services.disabled).toContain(
+        'telnet',
+      );
     });
 
     test('updates store when masked service is added', async () => {
       const { store } = renderServicesStep();
       const user = createUser();
 
-      expect(store.getState().wizard.services.masked).toHaveLength(0);
+      expect(store.getState().wizard.system.services.masked).toHaveLength(0);
 
       await addMaskedService(user, 'nfs-server');
 
-      expect(store.getState().wizard.services.masked).toContain('nfs-server');
+      expect(store.getState().wizard.system.services.masked).toContain(
+        'nfs-server',
+      );
     });
 
     test('updates store when service is removed', async () => {
       const { store } = renderServicesStep({
-        services: {
-          enabled: ['httpd'],
-          disabled: [],
-          masked: [],
+        system: {
+          ...initialState.system,
+          services: {
+            enabled: ['httpd'],
+            disabled: [],
+            masked: [],
+          },
         },
       });
       const user = createUser();
 
-      expect(store.getState().wizard.services.enabled).toContain('httpd');
+      expect(store.getState().wizard.system.services.enabled).toContain(
+        'httpd',
+      );
 
       await removeService(user, 'httpd');
 
-      expect(store.getState().wizard.services.enabled).not.toContain('httpd');
+      expect(store.getState().wizard.system.services.enabled).not.toContain(
+        'httpd',
+      );
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Timezone/tests/Timezone.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/tests/Timezone.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { createUser, typeWithWait } from '@/test/testUtils';
 
 import {
@@ -193,9 +194,12 @@ describe('Timezone Component', () => {
   describe('Initial State', () => {
     test('renders with pre-populated timezone from state', async () => {
       renderTimezoneStep({
-        timezone: {
-          timezone: 'Europe/Amsterdam',
-          ntpservers: [],
+        system: {
+          ...initialState.system,
+          timezone: {
+            timezone: 'Europe/Amsterdam',
+            ntpservers: [],
+          },
         },
       });
 
@@ -206,9 +210,12 @@ describe('Timezone Component', () => {
 
     test('renders with pre-populated NTP servers from state', async () => {
       renderTimezoneStep({
-        timezone: {
-          timezone: 'Etc/UTC',
-          ntpservers: ['0.nl.pool.ntp.org', '1.nl.pool.ntp.org'],
+        system: {
+          ...initialState.system,
+          timezone: {
+            timezone: 'Etc/UTC',
+            ntpservers: ['0.nl.pool.ntp.org', '1.nl.pool.ntp.org'],
+          },
         },
       });
 
@@ -222,12 +229,12 @@ describe('Timezone Component', () => {
       const { store } = renderTimezoneStep();
       const user = createUser();
 
-      expect(store.getState().wizard.timezone.timezone).toBe('');
+      expect(store.getState().wizard.system.timezone.timezone).toBe('');
 
       await openTimezoneDropdown(user);
       await selectTimezoneOption(user, /Europe\/Amsterdam/i);
 
-      expect(store.getState().wizard.timezone.timezone).toBe(
+      expect(store.getState().wizard.system.timezone.timezone).toBe(
         'Europe/Amsterdam',
       );
     });
@@ -236,11 +243,13 @@ describe('Timezone Component', () => {
       const { store } = renderTimezoneStep();
       const user = createUser();
 
-      expect(store.getState().wizard.timezone.ntpservers).toHaveLength(0);
+      expect(store.getState().wizard.system.timezone.ntpservers).toHaveLength(
+        0,
+      );
 
       await addNtpServer(user, '0.nl.pool.ntp.org');
 
-      expect(store.getState().wizard.timezone.ntpservers).toContain(
+      expect(store.getState().wizard.system.timezone.ntpservers).toContain(
         '0.nl.pool.ntp.org',
       );
     });
@@ -252,27 +261,30 @@ describe('Timezone Component', () => {
       await addNtpServer(user, '0.nl.pool.ntp.org');
       await addNtpServer(user, '1.nl.pool.ntp.org');
 
-      const ntpservers = store.getState().wizard.timezone.ntpservers;
+      const ntpservers = store.getState().wizard.system.timezone.ntpservers;
       expect(ntpservers).toContain('0.nl.pool.ntp.org');
       expect(ntpservers).toContain('1.nl.pool.ntp.org');
     });
 
     test('updates store when NTP server is removed', async () => {
       const { store } = renderTimezoneStep({
-        timezone: {
-          timezone: 'Etc/UTC',
-          ntpservers: ['0.nl.pool.ntp.org'],
+        system: {
+          ...initialState.system,
+          timezone: {
+            timezone: 'Etc/UTC',
+            ntpservers: ['0.nl.pool.ntp.org'],
+          },
         },
       });
       const user = createUser();
 
-      expect(store.getState().wizard.timezone.ntpservers).toContain(
+      expect(store.getState().wizard.system.timezone.ntpservers).toContain(
         '0.nl.pool.ntp.org',
       );
 
       await removeNtpServer(user, '0.nl.pool.ntp.org');
 
-      expect(store.getState().wizard.timezone.ntpservers).not.toContain(
+      expect(store.getState().wizard.system.timezone.ntpservers).not.toContain(
         '0.nl.pool.ntp.org',
       );
     });
@@ -290,7 +302,7 @@ describe('Timezone Component', () => {
 
       expect(searchInput).toBeInTheDocument();
       expect(searchInput).toHaveValue('Europe');
-      expect(store.getState().wizard.timezone.timezone).toBe('');
+      expect(store.getState().wizard.system.timezone.timezone).toBe('');
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/UserGroups/tests/UserGroups.test.tsx
+++ b/src/Components/CreateImageWizard/steps/UserGroups/tests/UserGroups.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
 
 import UserGroupsStep from '../index';
@@ -10,11 +11,14 @@ describe('UserGroups Component', () => {
   describe('Form submission', () => {
     test('pressing Enter in group name input does not trigger page reload', async () => {
       const { store } = renderWithRedux(<UserGroupsStep />, {
-        userGroups: [
-          {
-            name: '',
-          },
-        ],
+        system: {
+          ...initialState.system,
+          groups: [
+            {
+              name: '',
+            },
+          ],
+        },
       });
       const user = createUser();
 
@@ -24,16 +28,19 @@ describe('UserGroups Component', () => {
       await typeWithWait(user, groupInput, 'developers{Enter}');
 
       expect(groupInput).toBeInTheDocument();
-      expect(store.getState().wizard.userGroups[0].name).toBe('developers');
+      expect(store.getState().wizard.system.groups[0].name).toBe('developers');
     });
 
     test('pressing Enter in group ID input does not trigger page reload', async () => {
       const { store } = renderWithRedux(<UserGroupsStep />, {
-        userGroups: [
-          {
-            name: 'developers',
-          },
-        ],
+        system: {
+          ...initialState.system,
+          groups: [
+            {
+              name: 'developers',
+            },
+          ],
+        },
       });
       const user = createUser();
 
@@ -43,7 +50,7 @@ describe('UserGroups Component', () => {
       await typeWithWait(user, gidInput, '1001{Enter}');
 
       expect(gidInput).toBeInTheDocument();
-      expect(store.getState().wizard.userGroups[0].gid).toBe(1001);
+      expect(store.getState().wizard.system.groups[0].gid).toBe(1001);
     });
   });
 });

--- a/src/Components/CreateImageWizard/steps/Users/tests/Users.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/tests/Users.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
+import { initialState } from '@/store/slices/wizard';
 import { createUser, renderWithRedux, typeWithWait } from '@/test/testUtils';
 
 import UsersStep from '../index';
@@ -10,16 +11,19 @@ describe('Users Component', () => {
   describe('Form submission', () => {
     test('pressing Enter in username input does not trigger page reload', async () => {
       const { store } = renderWithRedux(<UsersStep />, {
-        users: [
-          {
-            name: '',
-            password: '',
-            ssh_key: '',
-            isAdministrator: false,
-            groups: [],
-            hasPassword: false,
-          },
-        ],
+        system: {
+          ...initialState.system,
+          users: [
+            {
+              name: '',
+              password: '',
+              ssh_key: '',
+              isAdministrator: false,
+              groups: [],
+              hasPassword: false,
+            },
+          ],
+        },
       });
       const user = createUser();
 
@@ -29,21 +33,24 @@ describe('Users Component', () => {
       await typeWithWait(user, usernameInput, 'testuser{Enter}');
 
       expect(usernameInput).toBeInTheDocument();
-      expect(store.getState().wizard.users[0].name).toBe('testuser');
+      expect(store.getState().wizard.system.users[0].name).toBe('testuser');
     });
 
     test('pressing Enter in password input does not trigger page reload', async () => {
       const { store } = renderWithRedux(<UsersStep />, {
-        users: [
-          {
-            name: 'testuser',
-            password: '',
-            ssh_key: '',
-            isAdministrator: false,
-            groups: [],
-            hasPassword: false,
-          },
-        ],
+        system: {
+          ...initialState.system,
+          users: [
+            {
+              name: 'testuser',
+              password: '',
+              ssh_key: '',
+              isAdministrator: false,
+              groups: [],
+              hasPassword: false,
+            },
+          ],
+        },
       });
       const user = createUser();
 
@@ -51,21 +58,26 @@ describe('Users Component', () => {
       await typeWithWait(user, passwordInput, 'SecurePass123{Enter}');
 
       expect(passwordInput).toBeInTheDocument();
-      expect(store.getState().wizard.users[0].password).toBe('SecurePass123');
+      expect(store.getState().wizard.system.users[0].password).toBe(
+        'SecurePass123',
+      );
     });
 
     test('pressing Enter in SSH key input does not trigger page reload', async () => {
       const { store } = renderWithRedux(<UsersStep />, {
-        users: [
-          {
-            name: 'testuser',
-            password: '',
-            ssh_key: '',
-            isAdministrator: false,
-            groups: [],
-            hasPassword: false,
-          },
-        ],
+        system: {
+          ...initialState.system,
+          users: [
+            {
+              name: 'testuser',
+              password: '',
+              ssh_key: '',
+              isAdministrator: false,
+              groups: [],
+              hasPassword: false,
+            },
+          ],
+        },
       });
       const user = createUser();
 
@@ -79,7 +91,7 @@ describe('Users Component', () => {
       );
 
       expect(sshKeyInput).toBeInTheDocument();
-      expect(store.getState().wizard.users[0].ssh_key).toBe(
+      expect(store.getState().wizard.system.users[0].ssh_key).toBe(
         'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ',
       );
     });

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -469,9 +469,13 @@ function commonRequestToState(
 
   return {
     details: {
-      blueprintName: request.name || '',
-      isCustomName: true,
-      blueprintDescription: request.description || '',
+      mode: 'create' as const,
+      blueprint: {
+        name: request.name || '',
+        isCustomName: true,
+        description: request.description || '',
+        mode: 'package' as const,
+      },
     },
     compliance:
       compliancePolicyID !== undefined
@@ -641,12 +645,18 @@ function commonRequestToState(
  * @returns wizardState
  */
 export const mapRequestToState = (request: BlueprintResponse): wizardState => {
-  const wizardMode = 'edit';
-  const blueprintMode = request.bootc ? 'image' : 'package';
+  const commonState = commonRequestToState(request);
   return {
-    wizardMode,
-    blueprintMode,
-    blueprintId: request.id,
+    ...commonState,
+    details: {
+      ...commonState.details,
+      blueprintId: request.id,
+      mode: 'edit',
+      blueprint: {
+        ...commonState.details.blueprint,
+        mode: request.bootc ? 'image' : 'package',
+      },
+    },
     registration: {
       serverUrl: request.customizations.subscription?.['server-url'] || '',
       baseUrl: request.customizations.subscription?.['base-url'] || '',
@@ -673,7 +683,6 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
           request.customizations.aap_registration?.skip_tls_verification,
       },
     },
-    ...commonRequestToState(request),
   };
 };
 
@@ -722,7 +731,6 @@ export const mapBlueprintExportToState = (
   blueprint: BlueprintExportResponse,
   image_requests: ImageRequest[],
 ): wizardState => {
-  const wizardMode = 'create';
   const blueprintResponse: CreateBlueprintRequest = {
     name: blueprint.name,
     description: blueprint.description,
@@ -756,9 +764,16 @@ export const mapBlueprintExportToState = (
   }
 
   return {
-    wizardMode,
-    blueprintMode: blueprint.bootc ? 'image' : 'package',
-    metadata: getMetadata(blueprint.metadata),
+    ...commonState,
+    details: {
+      ...commonState.details,
+      mode: 'create',
+      blueprint: {
+        ...commonState.details.blueprint,
+        mode: blueprint.bootc ? 'image' : 'package',
+      },
+      metadata: getMetadata(blueprint.metadata),
+    },
     registration: {
       ...initialState.registration,
       aap: {
@@ -773,7 +788,6 @@ export const mapBlueprintExportToState = (
           blueprint.customizations.aap_registration?.skip_tls_verification,
       },
     },
-    ...commonState,
     content: {
       ...commonState.content,
       snapshotting,

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -438,7 +438,7 @@ function commonRequestToState(
     .options as AzureUploadRequestOptions;
 
   const arch =
-    request.image_requests[0]?.architecture ?? initialState.architecture;
+    request.image_requests[0]?.architecture ?? initialState.output.architecture;
   if (!['x86_64', 'aarch64'].includes(arch)) {
     throw new Error(`image type: ${arch} has no implementation yet`);
   }
@@ -536,15 +536,19 @@ function commonRequestToState(
           },
       partitioningMode: request.customizations.partitioning_mode,
     },
-    architecture: arch,
-    // Legacy on-prem bootc blueprints may have undefined distribution.
-    // Fall back to initialState so the wizard state type stays satisfied;
-    // the user can pick the correct distro in the wizard.
-    distribution:
-      getLatestRelease(request.distribution) ?? initialState.distribution,
-    imageSource: 'bootc' in request ? request.bootc?.reference : undefined,
-    isoPayloadReference: request.bootc?.iso_payload_reference,
-    imageTypes: request.image_requests.map((image) => image.image_type),
+    output: {
+      architecture: arch,
+      // Legacy on-prem bootc blueprints may have undefined distribution.
+      // Fall back to initialState so the wizard state type stays satisfied;
+      // the user can pick the correct distro in the wizard.
+      distribution:
+        getLatestRelease(request.distribution) ??
+        initialState.output.distribution,
+      imageSource: 'bootc' in request ? request.bootc?.reference : undefined,
+      isoPayloadReference: request.bootc?.iso_payload_reference,
+      imageTypes: request.image_requests.map((image) => image.image_type),
+      bootcDistributions: [],
+    },
     cloudProviders: {
       azure: azureTargetOptions(azureUploadOptions),
       gcp: gcpTargetOptions(gcpUploadOptions),
@@ -642,7 +646,6 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
   return {
     wizardMode,
     blueprintMode,
-    bootcDistributions: [],
     blueprintId: request.id,
     registration: {
       serverUrl: request.customizations.subscription?.['server-url'] || '',
@@ -755,7 +758,6 @@ export const mapBlueprintExportToState = (
   return {
     wizardMode,
     blueprintMode: blueprint.bootc ? 'image' : 'package',
-    bootcDistributions: [],
     metadata: getMetadata(blueprint.metadata),
     registration: {
       ...initialState.registration,

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -473,20 +473,6 @@ function commonRequestToState(
       isCustomName: true,
       blueprintDescription: request.description || '',
     },
-    users:
-      request.customizations.users?.map((user) => ({
-        name: user.name,
-        password: '', // The image-builder API does not return the password.
-        ssh_key: user.ssh_key || '',
-        groups: user.groups || [],
-        isAdministrator: user.groups?.includes('wheel') || false,
-        hasPassword: user.hasPassword || false,
-      })) || [],
-    userGroups:
-      request.customizations.groups?.map((group) => ({
-        name: group.name,
-        ...(group.gid !== undefined && { gid: group.gid }),
-      })) || [],
     compliance:
       compliancePolicyID !== undefined
         ? {
@@ -514,11 +500,6 @@ function commonRequestToState(
                 enabled: request.customizations.fips?.enabled || false,
               },
             },
-    firstBoot: request.customizations.files
-      ? {
-          script: getFirstBootScript(request.customizations.files),
-        }
-      : initialState.firstBoot,
     filesystem: {
       mode: request.customizations.filesystem
         ? ('basic' as FscModeType)
@@ -600,30 +581,51 @@ function commonRequestToState(
       },
       verifiedLocaleLangpacks: localeLangpacks,
     },
-    locale: {
-      languages: request.customizations.locale?.languages || [],
-      keyboard: request.customizations.locale?.keyboard || '',
-    },
-    services: {
-      enabled: request.customizations.services?.enabled || [],
-      masked: request.customizations.services?.masked || [],
-      disabled: request.customizations.services?.disabled || [],
-    },
-    kernel: {
-      name: request.customizations.kernel?.name || '',
-      append: request.customizations.kernel?.append?.split(' ') || [],
-    },
-    timezone: {
-      timezone: request.customizations.timezone?.timezone || '',
-      ntpservers: request.customizations.timezone?.ntpservers || [],
-    },
-    hostname: request.customizations.hostname || '',
-    firewall: {
-      ports: request.customizations.firewall?.ports || [],
+    system: {
       services: {
-        enabled: request.customizations.firewall?.services?.enabled || [],
-        disabled: request.customizations.firewall?.services?.disabled || [],
+        enabled: request.customizations.services?.enabled || [],
+        masked: request.customizations.services?.masked || [],
+        disabled: request.customizations.services?.disabled || [],
       },
+      kernel: {
+        name: request.customizations.kernel?.name || '',
+        append: request.customizations.kernel?.append?.split(' ') || [],
+      },
+      locale: {
+        languages: request.customizations.locale?.languages || [],
+        keyboard: request.customizations.locale?.keyboard || '',
+      },
+      timezone: {
+        timezone: request.customizations.timezone?.timezone || '',
+        ntpservers: request.customizations.timezone?.ntpservers || [],
+      },
+      hostname: request.customizations.hostname || '',
+      firewall: {
+        ports: request.customizations.firewall?.ports || [],
+        services: {
+          enabled: request.customizations.firewall?.services?.enabled || [],
+          disabled: request.customizations.firewall?.services?.disabled || [],
+        },
+      },
+      firstBoot: request.customizations.files
+        ? {
+            script: getFirstBootScript(request.customizations.files),
+          }
+        : initialState.system.firstBoot,
+      users:
+        request.customizations.users?.map((user) => ({
+          name: user.name,
+          password: '', // The image-builder API does not return the password.
+          ssh_key: user.ssh_key || '',
+          groups: user.groups || [],
+          isAdministrator: user.groups?.includes('wheel') || false,
+          hasPassword: user.hasPassword || false,
+        })) || [],
+      groups:
+        request.customizations.groups?.map((group) => ({
+          name: group.name,
+          ...(group.gid !== undefined && { gid: group.gid }),
+        })) || [],
     },
   };
 }

--- a/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
+++ b/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
@@ -56,7 +56,7 @@ describe('mapRequestToState', () => {
 
     const state = mapRequestToState(response);
 
-    expect(state.blueprintMode).toBe('package');
+    expect(state.details.blueprint.mode).toBe('package');
   });
 
   it('sets blueprintMode to image when bootc is present', () => {
@@ -66,7 +66,7 @@ describe('mapRequestToState', () => {
 
     const state = mapRequestToState(response);
 
-    expect(state.blueprintMode).toBe('image');
+    expect(state.details.blueprint.mode).toBe('image');
   });
 
   it('maps imageSource from bootc reference', () => {
@@ -116,7 +116,7 @@ describe('mapBlueprintExportToState', () => {
 
     const state = mapBlueprintExportToState(blueprint, []);
 
-    expect(state.blueprintMode).toBe('package');
+    expect(state.details.blueprint.mode).toBe('package');
   });
 
   it('sets blueprintMode to image when bootc is present', () => {
@@ -126,7 +126,7 @@ describe('mapBlueprintExportToState', () => {
 
     const state = mapBlueprintExportToState(blueprint, []);
 
-    expect(state.blueprintMode).toBe('image');
+    expect(state.details.blueprint.mode).toBe('image');
   });
 
   it('falls back to initial state distribution for legacy bootc blueprints with undefined distribution', () => {

--- a/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
+++ b/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
@@ -76,7 +76,7 @@ describe('mapRequestToState', () => {
 
     const state = mapRequestToState(response);
 
-    expect(state.imageSource).toBe('quay.io/org/image:latest');
+    expect(state.output.imageSource).toBe('quay.io/org/image:latest');
   });
 
   it('sets imageSource to undefined for package-mode blueprints', () => {
@@ -84,7 +84,7 @@ describe('mapRequestToState', () => {
 
     const state = mapRequestToState(response);
 
-    expect(state.imageSource).toBeUndefined();
+    expect(state.output.imageSource).toBeUndefined();
   });
 
   it('normalizes distribution via getLatestRelease', () => {
@@ -94,7 +94,7 @@ describe('mapRequestToState', () => {
 
     const state = mapRequestToState(response);
 
-    expect(state.distribution).toBe(RHEL_9);
+    expect(state.output.distribution).toBe(RHEL_9);
   });
 
   it('falls back to initial state distribution for legacy bootc blueprints with undefined distribution', () => {
@@ -106,7 +106,7 @@ describe('mapRequestToState', () => {
     const state = mapRequestToState(response);
 
     // Falls back to initialState.distribution, not a hardcoded default
-    expect(state.distribution).toBe(RHEL_10);
+    expect(state.output.distribution).toBe(RHEL_10);
   });
 });
 
@@ -138,7 +138,7 @@ describe('mapBlueprintExportToState', () => {
     const state = mapBlueprintExportToState(blueprint, []);
 
     // Falls back to initialState.distribution, not a hardcoded default
-    expect(state.distribution).toBe(RHEL_10);
+    expect(state.output.distribution).toBe(RHEL_10);
   });
 });
 

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -113,7 +113,6 @@ export type wizardState = {
   wizardMode: WizardModeOptions;
   blueprintMode: BlueprintModeOptions;
   imageSource?: ImageSource | undefined;
-  /** Embedded OS image ref for bootable-container-iso (installer ref is the bootc `reference` for that target). */
   isoPayloadReference?: string | undefined;
   bootcDistributions: BootcDistributionItem[];
   architecture: ImageRequest['architecture'];
@@ -192,34 +191,36 @@ export type wizardState = {
     };
     verifiedLocaleLangpacks: string[];
   };
-  users: UserWithAdditionalInfo[];
-  userGroups: UserGroup[];
-  firstBoot: {
-    script: string;
+  system: {
+    services: {
+      enabled: string[];
+      masked: string[];
+      disabled: string[];
+    };
+    kernel: {
+      name: string;
+      append: string[];
+    };
+    locale: Locale;
+    timezone: Timezone;
+    hostname: string;
+    firewall: {
+      ports: string[];
+      services: {
+        enabled: string[];
+        disabled: string[];
+      };
+    };
+    firstBoot: {
+      script: string;
+    };
+    users: UserWithAdditionalInfo[];
+    groups: UserGroup[];
   };
-  services: {
-    enabled: string[];
-    masked: string[];
-    disabled: string[];
-  };
-  kernel: {
-    name: string;
-    append: string[];
-  };
-  locale: Locale;
   details: {
     blueprintName: string;
     isCustomName: boolean;
     blueprintDescription: string;
-  };
-  timezone: Timezone;
-  hostname: string;
-  firewall: {
-    ports: string[];
-    services: {
-      enabled: string[];
-      disabled: string[];
-    };
   };
   metadata?: {
     parent_id: string | null;
@@ -312,39 +313,41 @@ export const initialState: wizardState = {
     },
     verifiedLocaleLangpacks: [],
   },
-  services: {
-    enabled: [],
-    masked: [],
-    disabled: [],
-  },
-  kernel: {
-    name: '',
-    append: [],
-  },
-  locale: {
-    languages: ['C.UTF-8'],
-    keyboard: '',
+  system: {
+    services: {
+      enabled: [],
+      masked: [],
+      disabled: [],
+    },
+    kernel: {
+      name: '',
+      append: [],
+    },
+    locale: {
+      languages: ['C.UTF-8'],
+      keyboard: '',
+    },
+    timezone: {
+      timezone: '',
+      ntpservers: [],
+    },
+    hostname: '',
+    firewall: {
+      ports: [],
+      services: {
+        enabled: [],
+        disabled: [],
+      },
+    },
+    firstBoot: { script: '' },
+    users: [],
+    groups: [{ name: '' }],
   },
   details: {
     blueprintName: generateDefaultName(RHEL_10, X86_64),
     isCustomName: false,
     blueprintDescription: '',
   },
-  timezone: {
-    timezone: '',
-    ntpservers: [],
-  },
-  hostname: '',
-  firewall: {
-    ports: [],
-    services: {
-      enabled: [],
-      disabled: [],
-    },
-  },
-  firstBoot: { script: '' },
-  users: [],
-  userGroups: [{ name: '' }],
 };
 
 export const selectServerUrl = (state: RootState) => {
@@ -560,11 +563,11 @@ export const selectPackageGroups = (state: RootState) => {
 };
 
 export const selectServices = (state: RootState) => {
-  return state.wizard.services;
+  return state.wizard.system.services;
 };
 
 export const selectUsers = (state: RootState) => {
-  return state.wizard.users;
+  return state.wizard.system.users;
 };
 
 export const selectNonEmptyUsers = createSelector([selectUsers], (users) =>
@@ -578,19 +581,19 @@ export const selectNonEmptyUsers = createSelector([selectUsers], (users) =>
 );
 
 export const selectUserGroups = (state: RootState) => {
-  return state.wizard.userGroups;
+  return state.wizard.system.groups;
 };
 
 export const selectKernel = (state: RootState) => {
-  return state.wizard.kernel;
+  return state.wizard.system.kernel;
 };
 
 export const selectLanguages = (state: RootState) => {
-  return state.wizard.locale.languages;
+  return state.wizard.system.locale.languages;
 };
 
 export const selectKeyboard = (state: RootState) => {
-  return state.wizard.locale.keyboard;
+  return state.wizard.system.locale.keyboard;
 };
 
 export const selectBlueprintName = (state: RootState) => {
@@ -610,23 +613,23 @@ export const selectBlueprintDescription = (state: RootState) => {
 };
 
 export const selectFirstBootScript = (state: RootState) => {
-  return state.wizard.firstBoot.script;
+  return state.wizard.system.firstBoot.script;
 };
 
 export const selectTimezone = (state: RootState) => {
-  return state.wizard.timezone.timezone;
+  return state.wizard.system.timezone.timezone;
 };
 
 export const selectNtpServers = (state: RootState) => {
-  return state.wizard.timezone.ntpservers;
+  return state.wizard.system.timezone.ntpservers;
 };
 
 export const selectHostname = (state: RootState) => {
-  return state.wizard.hostname;
+  return state.wizard.system.hostname;
 };
 
 export const selectFirewall = (state: RootState) => {
-  return state.wizard.firewall;
+  return state.wizard.system.firewall;
 };
 
 export const selectFips = (state: RootState) => {
@@ -1445,19 +1448,19 @@ export const wizardSlice = createSlice({
     },
     addLanguage: (state, action: PayloadAction<string>) => {
       if (
-        state.locale.languages &&
-        !state.locale.languages.some((lang) => lang === action.payload)
+        state.system.locale.languages &&
+        !state.system.locale.languages.some((lang) => lang === action.payload)
       ) {
-        state.locale.languages.push(action.payload);
+        state.system.locale.languages.push(action.payload);
       }
     },
     removeLanguage: (state, action: PayloadAction<string>) => {
-      if (state.locale.languages) {
-        const index = state.locale.languages.findIndex(
+      if (state.system.locale.languages) {
+        const index = state.system.locale.languages.findIndex(
           (lang) => lang === action.payload,
         );
         if (index !== -1) {
-          state.locale.languages.splice(index, 1);
+          state.system.locale.languages.splice(index, 1);
         }
       }
     },
@@ -1465,24 +1468,24 @@ export const wizardSlice = createSlice({
       state,
       action: PayloadAction<{ oldLanguage: string; newLanguage: string }>,
     ) => {
-      if (state.locale.languages) {
-        const index = state.locale.languages.findIndex(
+      if (state.system.locale.languages) {
+        const index = state.system.locale.languages.findIndex(
           (lang) => lang === action.payload.oldLanguage,
         );
         if (index !== -1) {
-          state.locale.languages[index] = action.payload.newLanguage;
+          state.system.locale.languages[index] = action.payload.newLanguage;
         }
       }
     },
     clearLanguages: (state) => {
-      state.locale.languages = [];
+      state.system.locale.languages = [];
     },
     clearLocale: (state) => {
-      state.locale.languages = [];
-      state.locale.keyboard = '';
+      state.system.locale.languages = [];
+      state.system.locale.keyboard = '';
     },
     changeKeyboard: (state, action: PayloadAction<string>) => {
-      state.locale.keyboard = action.payload;
+      state.system.locale.keyboard = action.payload;
     },
     changeBlueprintName: (state, action: PayloadAction<string>) => {
       state.details.blueprintName = action.payload;
@@ -1494,149 +1497,157 @@ export const wizardSlice = createSlice({
       state.details.blueprintDescription = action.payload;
     },
     setFirstBootScript: (state, action: PayloadAction<string>) => {
-      state.firstBoot.script = action.payload;
+      state.system.firstBoot.script = action.payload;
     },
     changeEnabledServices: (state, action: PayloadAction<string[]>) => {
-      state.services.enabled = action.payload;
+      state.system.services.enabled = action.payload;
     },
     addEnabledService: (state, action: PayloadAction<string>) => {
       if (
-        !state.services.enabled.some((service) => service === action.payload)
+        !state.system.services.enabled.some(
+          (service) => service === action.payload,
+        )
       ) {
-        state.services.enabled.push(action.payload);
+        state.system.services.enabled.push(action.payload);
       }
     },
     removeEnabledService: (state, action: PayloadAction<string>) => {
-      const index = state.services.enabled.findIndex(
+      const index = state.system.services.enabled.findIndex(
         (service) => service === action.payload,
       );
       if (index !== -1) {
-        state.services.enabled.splice(index, 1);
+        state.system.services.enabled.splice(index, 1);
       }
     },
     changeMaskedServices: (state, action: PayloadAction<string[]>) => {
-      state.services.masked = action.payload;
+      state.system.services.masked = action.payload;
     },
     addMaskedService: (state, action: PayloadAction<string>) => {
       if (
-        !state.services.masked.some((service) => service === action.payload)
+        !state.system.services.masked.some(
+          (service) => service === action.payload,
+        )
       ) {
-        state.services.masked.push(action.payload);
+        state.system.services.masked.push(action.payload);
       }
     },
     removeMaskedService: (state, action: PayloadAction<string>) => {
-      const index = state.services.masked.findIndex(
+      const index = state.system.services.masked.findIndex(
         (service) => service === action.payload,
       );
       if (index !== -1) {
-        state.services.masked.splice(index, 1);
+        state.system.services.masked.splice(index, 1);
       }
     },
     changeDisabledServices: (state, action: PayloadAction<string[]>) => {
-      state.services.disabled = action.payload;
+      state.system.services.disabled = action.payload;
     },
     addDisabledService: (state, action: PayloadAction<string>) => {
       if (
-        !state.services.disabled.some((service) => service === action.payload)
+        !state.system.services.disabled.some(
+          (service) => service === action.payload,
+        )
       ) {
-        state.services.disabled.push(action.payload);
+        state.system.services.disabled.push(action.payload);
       }
     },
     removeDisabledService: (state, action: PayloadAction<string>) => {
-      const index = state.services.disabled.findIndex(
+      const index = state.system.services.disabled.findIndex(
         (service) => service === action.payload,
       );
       if (index !== -1) {
-        state.services.disabled.splice(index, 1);
+        state.system.services.disabled.splice(index, 1);
       }
     },
     changeKernelName: (state, action: PayloadAction<string>) => {
-      state.kernel.name = action.payload;
+      state.system.kernel.name = action.payload;
     },
     addKernelArg: (state, action: PayloadAction<string>) => {
-      const existingArgIndex = state.kernel.append.findIndex(
+      const existingArgIndex = state.system.kernel.append.findIndex(
         (arg) => arg === action.payload,
       );
 
       if (existingArgIndex !== -1) {
-        state.kernel.append[existingArgIndex] = action.payload;
+        state.system.kernel.append[existingArgIndex] = action.payload;
       } else {
-        state.kernel.append.push(action.payload);
+        state.system.kernel.append.push(action.payload);
       }
     },
     removeKernelArg: (state, action: PayloadAction<string>) => {
-      if (state.kernel.append.length > 0) {
-        const index = state.kernel.append.findIndex(
+      if (state.system.kernel.append.length > 0) {
+        const index = state.system.kernel.append.findIndex(
           (arg) => arg === action.payload,
         );
         if (index !== -1) {
-          state.kernel.append.splice(index, 1);
+          state.system.kernel.append.splice(index, 1);
         }
       }
     },
     clearKernelAppend: (state) => {
-      state.kernel.append = [];
+      state.system.kernel.append = [];
     },
     addEnabledFirewallService: (state, action: PayloadAction<string>) => {
       if (
-        !state.firewall.services.enabled.some(
+        !state.system.firewall.services.enabled.some(
           (service) => service === action.payload,
         )
       ) {
-        state.firewall.services.enabled.push(action.payload);
+        state.system.firewall.services.enabled.push(action.payload);
       }
     },
     removeEnabledFirewallService: (state, action: PayloadAction<string>) => {
-      const index = state.firewall.services.enabled.findIndex(
+      const index = state.system.firewall.services.enabled.findIndex(
         (service) => service === action.payload,
       );
       if (index !== -1) {
-        state.firewall.services.enabled.splice(index, 1);
+        state.system.firewall.services.enabled.splice(index, 1);
       }
     },
     addDisabledFirewallService: (state, action: PayloadAction<string>) => {
       if (
-        !state.firewall.services.disabled.some(
+        !state.system.firewall.services.disabled.some(
           (service) => service === action.payload,
         )
       ) {
-        state.firewall.services.disabled.push(action.payload);
+        state.system.firewall.services.disabled.push(action.payload);
       }
     },
     removeDisabledFirewallService: (state, action: PayloadAction<string>) => {
-      const index = state.firewall.services.disabled.findIndex(
+      const index = state.system.firewall.services.disabled.findIndex(
         (service) => service === action.payload,
       );
       if (index !== -1) {
-        state.firewall.services.disabled.splice(index, 1);
+        state.system.firewall.services.disabled.splice(index, 1);
       }
     },
     changeTimezone: (state, action: PayloadAction<string>) => {
-      state.timezone.timezone = action.payload;
+      state.system.timezone.timezone = action.payload;
     },
     addNtpServer: (state, action: PayloadAction<string>) => {
       if (
-        !state.timezone.ntpservers?.some((server) => server === action.payload)
+        !state.system.timezone.ntpservers?.some(
+          (server) => server === action.payload,
+        )
       ) {
-        state.timezone.ntpservers?.push(action.payload);
+        state.system.timezone.ntpservers?.push(action.payload);
       }
     },
     removeNtpServer: (state, action: PayloadAction<string>) => {
-      if (state.timezone.ntpservers) {
-        const index = state.timezone.ntpservers.findIndex(
+      if (state.system.timezone.ntpservers) {
+        const index = state.system.timezone.ntpservers.findIndex(
           (server) => server === action.payload,
         );
         if (index !== -1) {
-          state.timezone.ntpservers.splice(index, 1);
+          state.system.timezone.ntpservers.splice(index, 1);
         }
       }
     },
     clearTimezone: (state) => {
-      state.timezone.timezone = '';
-      state.timezone.ntpservers = [];
+      state.system.timezone.timezone = '';
+      state.system.timezone.ntpservers = [];
     },
     changeHostname: (state, action: PayloadAction<string>) => {
-      state.hostname = action.payload;
+      state.system.hostname = action.payload;
     },
     addUser: (state) => {
       const newUser = {
@@ -1648,34 +1659,39 @@ export const wizardSlice = createSlice({
         hasPassword: false,
       };
 
-      state.users.push(newUser);
+      state.system.users.push(newUser);
     },
     removeUser: (state, action: PayloadAction<number>) => {
-      state.users = state.users.filter((_, index) => index !== action.payload);
+      state.system.users = state.system.users.filter(
+        (_, index) => index !== action.payload,
+      );
     },
     setUserNameByIndex: (state, action: PayloadAction<UserPayload>) => {
-      state.users[action.payload.index].name = action.payload.name;
+      state.system.users[action.payload.index].name = action.payload.name;
     },
     setUserPasswordByIndex: (
       state,
       action: PayloadAction<UserPasswordPayload>,
     ) => {
-      state.users[action.payload.index].password = action.payload.password;
+      state.system.users[action.payload.index].password =
+        action.payload.password;
     },
     setUserSshKeyByIndex: (state, action: PayloadAction<UserSshKeyPayload>) => {
-      state.users[action.payload.index].ssh_key = action.payload.sshKey;
+      state.system.users[action.payload.index].ssh_key = action.payload.sshKey;
     },
     addPort: (state, action: PayloadAction<string>) => {
-      if (!state.firewall.ports.some((port) => port === action.payload)) {
-        state.firewall.ports.push(action.payload);
+      if (
+        !state.system.firewall.ports.some((port) => port === action.payload)
+      ) {
+        state.system.firewall.ports.push(action.payload);
       }
     },
     removePort: (state, action: PayloadAction<string>) => {
-      const index = state.firewall.ports.findIndex(
+      const index = state.system.firewall.ports.findIndex(
         (port) => port === action.payload,
       );
       if (index !== -1) {
-        state.firewall.ports.splice(index, 1);
+        state.system.firewall.ports.splice(index, 1);
       }
     },
     setUserAdministratorByIndex: (
@@ -1683,7 +1699,7 @@ export const wizardSlice = createSlice({
       action: PayloadAction<UserAdministratorPayload>,
     ) => {
       const { index, isAdministrator } = action.payload;
-      const user = state.users[index];
+      const user = state.system.users[index];
 
       user.isAdministrator = isAdministrator;
       if (isAdministrator) {
@@ -1698,14 +1714,14 @@ export const wizardSlice = createSlice({
     ) => {
       const { index, group } = action.payload;
       if (
-        !state.users[index].groups.some(
+        !state.system.users[index].groups.some(
           (existingGroup) => existingGroup === group,
         )
       ) {
-        state.users[index].groups.push(group);
+        state.system.users[index].groups.push(group);
 
         if (group === 'wheel') {
-          state.users[index].isAdministrator = true;
+          state.system.users[index].isAdministrator = true;
         }
       }
     },
@@ -1713,19 +1729,19 @@ export const wizardSlice = createSlice({
       state,
       action: PayloadAction<UserGroupPayload>,
     ) => {
-      const groupIndex = state.users[action.payload.index].groups.findIndex(
-        (group) => group === action.payload.group,
-      );
+      const groupIndex = state.system.users[
+        action.payload.index
+      ].groups.findIndex((group) => group === action.payload.group);
       if (groupIndex !== -1) {
         if (action.payload.group === 'wheel') {
-          state.users[action.payload.index].isAdministrator = false;
+          state.system.users[action.payload.index].isAdministrator = false;
         }
-        state.users[action.payload.index].groups.splice(groupIndex, 1);
+        state.system.users[action.payload.index].groups.splice(groupIndex, 1);
       }
     },
     addUserGroup: (state) => {
       const existingGids = new Set(
-        state.userGroups
+        state.system.groups
           .map((g) => g.gid)
           .filter((gid): gid is number => gid !== undefined),
       );
@@ -1734,9 +1750,9 @@ export const wizardSlice = createSlice({
         nextGid++;
       }
       if (nextGid <= MAX_REGULAR_GID) {
-        state.userGroups.push({ name: '', gid: nextGid });
+        state.system.groups.push({ name: '', gid: nextGid });
       } else {
-        state.userGroups.push({ name: '' });
+        state.system.groups.push({ name: '' });
       }
     },
     setUserGroupNameByIndex: (
@@ -1744,12 +1760,12 @@ export const wizardSlice = createSlice({
       action: PayloadAction<UserGroupNamePayload>,
     ) => {
       const { index, name } = action.payload;
-      state.userGroups[index].name = name.trim();
+      state.system.groups[index].name = name.trim();
       if (name.trim() === '') {
-        delete state.userGroups[index].gid;
-      } else if (state.userGroups[index].gid === undefined) {
+        delete state.system.groups[index].gid;
+      } else if (state.system.groups[index].gid === undefined) {
         const existingGids = new Set(
-          state.userGroups
+          state.system.groups
             .map((g) => g.gid)
             .filter((gid): gid is number => gid !== undefined),
         );
@@ -1758,7 +1774,7 @@ export const wizardSlice = createSlice({
           nextGid++;
         }
         if (nextGid <= MAX_REGULAR_GID) {
-          state.userGroups[index].gid = nextGid;
+          state.system.groups[index].gid = nextGid;
         }
       }
     },
@@ -1768,13 +1784,13 @@ export const wizardSlice = createSlice({
     ) => {
       const { index, gid } = action.payload;
       if (gid === undefined) {
-        delete state.userGroups[index].gid;
+        delete state.system.groups[index].gid;
       } else {
-        state.userGroups[index].gid = gid;
+        state.system.groups[index].gid = gid;
       }
     },
     removeUserGroup: (state, action: PayloadAction<number>) => {
-      state.userGroups = state.userGroups.filter(
+      state.system.groups = state.system.groups.filter(
         (_, index) => index !== action.payload,
       );
     },

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -109,9 +109,21 @@ export type UserGroup = {
 };
 
 export type wizardState = {
-  blueprintId?: string;
-  wizardMode: WizardModeOptions;
-  blueprintMode: BlueprintModeOptions;
+  details: {
+    blueprintId?: string;
+    mode: WizardModeOptions;
+    blueprint: {
+      name: string;
+      isCustomName: boolean;
+      description: string;
+      mode: BlueprintModeOptions;
+    };
+    metadata?: {
+      parent_id: string | null;
+      exported_at: string;
+      is_on_prem: boolean;
+    };
+  };
   output: {
     imageSource?: ImageSource | undefined;
     isoPayloadReference?: string | undefined;
@@ -219,21 +231,18 @@ export type wizardState = {
     users: UserWithAdditionalInfo[];
     groups: UserGroup[];
   };
-  details: {
-    blueprintName: string;
-    isCustomName: boolean;
-    blueprintDescription: string;
-  };
-  metadata?: {
-    parent_id: string | null;
-    exported_at: string;
-    is_on_prem: boolean;
-  };
 };
 
 export const initialState: wizardState = {
-  wizardMode: 'create',
-  blueprintMode: 'package',
+  details: {
+    mode: 'create',
+    blueprint: {
+      name: generateDefaultName(RHEL_10, X86_64),
+      isCustomName: false,
+      description: '',
+      mode: 'package',
+    },
+  },
   output: {
     bootcDistributions: [],
     architecture: X86_64,
@@ -347,11 +356,6 @@ export const initialState: wizardState = {
     users: [],
     groups: [{ name: '' }],
   },
-  details: {
-    blueprintName: generateDefaultName(RHEL_10, X86_64),
-    isCustomName: false,
-    blueprintDescription: '',
-  },
 };
 
 export const selectServerUrl = (state: RootState) => {
@@ -359,11 +363,11 @@ export const selectServerUrl = (state: RootState) => {
 };
 
 export const selectWizardMode = (state: RootState) => {
-  return state.wizard.wizardMode;
+  return state.wizard.details.mode;
 };
 
 export const selectBlueprintMode = (state: RootState) => {
-  return state.wizard.blueprintMode;
+  return state.wizard.details.blueprint.mode;
 };
 
 export const selectImageSource = (state: RootState) => {
@@ -379,7 +383,7 @@ export const selectBootcDistributions = (state: RootState) => {
 };
 
 export const selectBlueprintId = (state: RootState) => {
-  return state.wizard.blueprintId;
+  return state.wizard.details.blueprintId;
 };
 
 export const selectBaseUrl = (state: RootState) => {
@@ -601,19 +605,19 @@ export const selectKeyboard = (state: RootState) => {
 };
 
 export const selectBlueprintName = (state: RootState) => {
-  return state.wizard.details.blueprintName;
+  return state.wizard.details.blueprint.name;
 };
 
 export const selectIsCustomName = (state: RootState) => {
-  return state.wizard.details.isCustomName;
+  return state.wizard.details.blueprint.isCustomName;
 };
 
 export const selectMetadata = (state: RootState) => {
-  return state.wizard.metadata;
+  return state.wizard.details.metadata;
 };
 
 export const selectBlueprintDescription = (state: RootState) => {
-  return state.wizard.details.blueprintDescription;
+  return state.wizard.details.blueprint.description;
 };
 
 export const selectFirstBootScript = (state: RootState) => {
@@ -818,7 +822,7 @@ export const wizardSlice = createSlice({
       state,
       action: PayloadAction<BlueprintModeOptions>,
     ) => {
-      state.blueprintMode = action.payload;
+      state.details.blueprint.mode = action.payload;
     },
     changeImageSource: (
       state,
@@ -1492,13 +1496,13 @@ export const wizardSlice = createSlice({
       state.system.locale.keyboard = action.payload;
     },
     changeBlueprintName: (state, action: PayloadAction<string>) => {
-      state.details.blueprintName = action.payload;
+      state.details.blueprint.name = action.payload;
     },
     setIsCustomName: (state) => {
-      state.details.isCustomName = true;
+      state.details.blueprint.isCustomName = true;
     },
     changeBlueprintDescription: (state, action: PayloadAction<string>) => {
-      state.details.blueprintDescription = action.payload;
+      state.details.blueprint.description = action.payload;
     },
     setFirstBootScript: (state, action: PayloadAction<string>) => {
       state.system.firstBoot.script = action.payload;

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -112,12 +112,14 @@ export type wizardState = {
   blueprintId?: string;
   wizardMode: WizardModeOptions;
   blueprintMode: BlueprintModeOptions;
-  imageSource?: ImageSource | undefined;
-  isoPayloadReference?: string | undefined;
-  bootcDistributions: BootcDistributionItem[];
-  architecture: ImageRequest['architecture'];
-  distribution: Distributions;
-  imageTypes: ImageTypes[];
+  output: {
+    imageSource?: ImageSource | undefined;
+    isoPayloadReference?: string | undefined;
+    bootcDistributions: BootcDistributionItem[];
+    architecture: ImageRequest['architecture'];
+    distribution: Distributions;
+    imageTypes: ImageTypes[];
+  };
   cloudProviders: {
     aws: {
       accountId: string;
@@ -232,10 +234,12 @@ export type wizardState = {
 export const initialState: wizardState = {
   wizardMode: 'create',
   blueprintMode: 'package',
-  bootcDistributions: [],
-  architecture: X86_64,
-  distribution: RHEL_10,
-  imageTypes: [],
+  output: {
+    bootcDistributions: [],
+    architecture: X86_64,
+    distribution: RHEL_10,
+    imageTypes: [],
+  },
   cloudProviders: {
     aws: {
       accountId: '',
@@ -363,15 +367,15 @@ export const selectBlueprintMode = (state: RootState) => {
 };
 
 export const selectImageSource = (state: RootState) => {
-  return state.wizard.imageSource;
+  return state.wizard.output.imageSource;
 };
 
 export const selectIsoPayloadReference = (state: RootState) => {
-  return state.wizard.isoPayloadReference;
+  return state.wizard.output.isoPayloadReference;
 };
 
 export const selectBootcDistributions = (state: RootState) => {
-  return state.wizard.bootcDistributions;
+  return state.wizard.output.bootcDistributions;
 };
 
 export const selectBlueprintId = (state: RootState) => {
@@ -387,15 +391,15 @@ export const selectProxy = (state: RootState) => {
 };
 
 export const selectArchitecture = (state: RootState) => {
-  return state.wizard.architecture;
+  return state.wizard.output.architecture;
 };
 
 export const selectDistribution = (state: RootState) => {
-  return state.wizard.distribution;
+  return state.wizard.output.distribution;
 };
 
 export const selectImageTypes = (state: RootState) => {
-  return state.wizard.imageTypes;
+  return state.wizard.output.imageTypes;
 };
 
 export const selectAwsAccountId = (state: RootState): string => {
@@ -820,28 +824,28 @@ export const wizardSlice = createSlice({
       state,
       action: PayloadAction<ImageSource | undefined>,
     ) => {
-      state.imageSource = action.payload;
+      state.output.imageSource = action.payload;
     },
     changeIsoPayloadReference: (
       state,
       action: PayloadAction<string | undefined>,
     ) => {
-      state.isoPayloadReference = action.payload;
+      state.output.isoPayloadReference = action.payload;
     },
     changeBootcDistributions: (
       state,
       action: PayloadAction<BootcDistributionItem[]>,
     ) => {
-      state.bootcDistributions = action.payload;
+      state.output.bootcDistributions = action.payload;
     },
     changeArchitecture: (
       state,
       action: PayloadAction<ImageRequest['architecture']>,
     ) => {
-      state.architecture = action.payload;
+      state.output.architecture = action.payload;
     },
     changeDistribution: (state, action: PayloadAction<Distributions>) => {
-      state.distribution = action.payload;
+      state.output.distribution = action.payload;
 
       if (process.env.IS_ON_PREMISE && !isRhel(action.payload)) {
         state.registration.type = 'register-later';
@@ -849,22 +853,22 @@ export const wizardSlice = createSlice({
     },
     addImageType: (state, action: PayloadAction<ImageTypes>) => {
       // Remove (if present) before adding to avoid duplicates
-      state.imageTypes = state.imageTypes.filter(
+      state.output.imageTypes = state.output.imageTypes.filter(
         (imageType) => imageType !== action.payload,
       );
-      state.imageTypes.push(action.payload);
+      state.output.imageTypes.push(action.payload);
     },
     removeImageType: (state, action: PayloadAction<ImageTypes>) => {
-      state.imageTypes = state.imageTypes.filter(
+      state.output.imageTypes = state.output.imageTypes.filter(
         (imageType) => imageType !== action.payload,
       );
     },
     changeImageTypes: (state, action: PayloadAction<ImageTypes[]>) => {
-      state.imageTypes = action.payload;
+      state.output.imageTypes = action.payload;
       // isoPayloadReference is only relevant for bootable-container-iso,
       // clear it when that image type is no longer selected
       if (!action.payload.includes('bootable-container-iso')) {
-        state.isoPayloadReference = undefined;
+        state.output.isoPayloadReference = undefined;
       }
     },
     changeAwsAccountId: (state, action: PayloadAction<string>) => {

--- a/src/store/slices/wizard/tests/details.test.ts
+++ b/src/store/slices/wizard/tests/details.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  changeBlueprintDescription,
+  changeBlueprintMode,
+  changeBlueprintName,
+  initialState,
+  loadWizardState,
+  selectBlueprintDescription,
+  selectBlueprintId,
+  selectBlueprintMode,
+  selectBlueprintName,
+  selectIsCustomName,
+  selectMetadata,
+  selectWizardMode,
+  setIsCustomName,
+  wizardReducer,
+  type wizardState,
+} from '@/store/slices/wizard';
+
+import { createMockState } from './mockWizardState';
+
+describe('details submodule', () => {
+  describe('reducers', () => {
+    it('changeBlueprintName should update details.blueprint.name', () => {
+      const result = wizardReducer(
+        initialState,
+        changeBlueprintName('my-blueprint'),
+      );
+
+      expect(result.details.blueprint.name).toBe('my-blueprint');
+    });
+
+    it('setIsCustomName should set details.blueprint.isCustomName to true', () => {
+      const result = wizardReducer(initialState, setIsCustomName());
+
+      expect(result.details.blueprint.isCustomName).toBe(true);
+    });
+
+    it('changeBlueprintDescription should update details.blueprint.description', () => {
+      const result = wizardReducer(
+        initialState,
+        changeBlueprintDescription('A test description'),
+      );
+
+      expect(result.details.blueprint.description).toBe('A test description');
+    });
+
+    it('changeBlueprintMode should update details.blueprint.mode', () => {
+      const result = wizardReducer(initialState, changeBlueprintMode('image'));
+
+      expect(result.details.blueprint.mode).toBe('image');
+    });
+
+    it('loadWizardState should load full state including details', () => {
+      const stateToLoad: wizardState = {
+        ...initialState,
+        details: {
+          ...initialState.details,
+          blueprintId: 'test-id-123',
+          mode: 'edit',
+          blueprint: {
+            name: 'loaded-blueprint',
+            isCustomName: true,
+            description: 'loaded description',
+            mode: 'image',
+          },
+          metadata: {
+            parent_id: 'parent-123',
+            exported_at: '2024-01-01',
+            is_on_prem: true,
+          },
+        },
+      };
+
+      const result = wizardReducer(initialState, loadWizardState(stateToLoad));
+
+      expect(result.details.blueprintId).toBe('test-id-123');
+      expect(result.details.mode).toBe('edit');
+      expect(result.details.blueprint.name).toBe('loaded-blueprint');
+      expect(result.details.blueprint.isCustomName).toBe(true);
+      expect(result.details.blueprint.description).toBe('loaded description');
+      expect(result.details.blueprint.mode).toBe('image');
+      expect(result.details.metadata).toEqual({
+        parent_id: 'parent-123',
+        exported_at: '2024-01-01',
+        is_on_prem: true,
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    it('selectBlueprintId should read from details.blueprintId', () => {
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          blueprintId: 'bp-456',
+        },
+      });
+
+      expect(selectBlueprintId(state)).toBe('bp-456');
+    });
+
+    it('selectWizardMode should read from details.mode', () => {
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          mode: 'edit',
+        },
+      });
+
+      expect(selectWizardMode(state)).toBe('edit');
+    });
+
+    it('selectBlueprintMode should read from details.blueprint.mode', () => {
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          blueprint: {
+            ...initialState.details.blueprint,
+            mode: 'image',
+          },
+        },
+      });
+
+      expect(selectBlueprintMode(state)).toBe('image');
+    });
+
+    it('selectBlueprintName should read from details.blueprint.name', () => {
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'my-bp',
+          },
+        },
+      });
+
+      expect(selectBlueprintName(state)).toBe('my-bp');
+    });
+
+    it('selectIsCustomName should read from details.blueprint.isCustomName', () => {
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          blueprint: {
+            ...initialState.details.blueprint,
+            isCustomName: true,
+          },
+        },
+      });
+
+      expect(selectIsCustomName(state)).toBe(true);
+    });
+
+    it('selectBlueprintDescription should read from details.blueprint.description', () => {
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          blueprint: {
+            ...initialState.details.blueprint,
+            description: 'Test description',
+          },
+        },
+      });
+
+      expect(selectBlueprintDescription(state)).toBe('Test description');
+    });
+
+    it('selectMetadata should read from details.metadata', () => {
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          metadata: {
+            parent_id: 'parent-1',
+            exported_at: '2024-06-01',
+            is_on_prem: false,
+          },
+        },
+      });
+
+      expect(selectMetadata(state)).toEqual({
+        parent_id: 'parent-1',
+        exported_at: '2024-06-01',
+        is_on_prem: false,
+      });
+    });
+
+    it('selectMetadata should return undefined when no metadata', () => {
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+        },
+      });
+
+      expect(selectMetadata(state)).toBeUndefined();
+    });
+  });
+
+  describe('initial state shape', () => {
+    it('should have details at top level with correct structure', () => {
+      expect(initialState.details).toBeDefined();
+      expect(initialState.details.mode).toBe('create');
+      expect(initialState.details.blueprint).toBeDefined();
+      expect(initialState.details.blueprint.mode).toBe('package');
+      expect(initialState.details.blueprint.isCustomName).toBe(false);
+      expect(initialState.details.blueprint.description).toBe('');
+      expect(initialState.details.blueprintId).toBeUndefined();
+      expect(initialState.details.metadata).toBeUndefined();
+    });
+
+    it('should NOT have wizardMode, blueprintMode, blueprintId, or metadata at top level', () => {
+      const state = initialState as Record<string, unknown>;
+      expect(state).not.toHaveProperty('wizardMode');
+      expect(state).not.toHaveProperty('blueprintMode');
+      expect(state).not.toHaveProperty('blueprintId');
+      expect(state).not.toHaveProperty('metadata');
+    });
+
+    it('should NOT have blueprintName, blueprintDescription, isCustomName directly in details', () => {
+      const details = initialState.details as Record<string, unknown>;
+      expect(details).not.toHaveProperty('blueprintName');
+      expect(details).not.toHaveProperty('blueprintDescription');
+      expect(details).not.toHaveProperty('isCustomName');
+    });
+  });
+});

--- a/src/store/slices/wizard/tests/mockWizardState.ts
+++ b/src/store/slices/wizard/tests/mockWizardState.ts
@@ -45,20 +45,23 @@ export const createMockState = (
 
 // Helper to create a state with a user for user-related tests
 export const createStateWithUser = (
-  userOverrides: Partial<wizardState['users'][0]> = {},
+  userOverrides: Partial<wizardState['system']['users'][0]> = {},
 ): RootState =>
   createMockState({
-    users: [
-      {
-        name: 'testuser',
-        password: '',
-        ssh_key: '',
-        groups: [],
-        isAdministrator: false,
-        hasPassword: false,
-        ...userOverrides,
-      },
-    ],
+    system: {
+      ...wizardInitialState.system,
+      users: [
+        {
+          name: 'testuser',
+          password: '',
+          ssh_key: '',
+          groups: [],
+          isAdministrator: false,
+          hasPassword: false,
+          ...userOverrides,
+        },
+      ],
+    },
   });
 
 // Helper to create a state with partitions for filesystem tests

--- a/src/store/slices/wizard/tests/output.test.ts
+++ b/src/store/slices/wizard/tests/output.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BootcDistributionItem } from '@/store/api/backend';
+import {
+  addImageType,
+  changeArchitecture,
+  changeBootcDistributions,
+  changeDistribution,
+  changeImageSource,
+  changeImageTypes,
+  changeIsoPayloadReference,
+  initialState,
+  removeImageType,
+  selectArchitecture,
+  selectBootcDistributions,
+  selectDistribution,
+  selectImageSource,
+  selectImageTypes,
+  selectIsoPayloadReference,
+  wizardReducer,
+  type wizardState,
+} from '@/store/slices/wizard';
+
+import { createMockState } from './mockWizardState';
+
+describe('output reducers', () => {
+  describe('changeImageSource', () => {
+    it('should update image source', () => {
+      const result = wizardReducer(
+        initialState,
+        changeImageSource('quay.io/org/image:latest'),
+      );
+
+      expect(result.output.imageSource).toBe('quay.io/org/image:latest');
+    });
+
+    it('should clear image source with undefined', () => {
+      const stateWithSource: wizardState = {
+        ...initialState,
+        output: {
+          ...initialState.output,
+          imageSource: 'quay.io/org/image:latest',
+        },
+      };
+
+      const result = wizardReducer(
+        stateWithSource,
+        changeImageSource(undefined),
+      );
+
+      expect(result.output.imageSource).toBeUndefined();
+    });
+  });
+
+  describe('changeIsoPayloadReference', () => {
+    it('should update iso payload reference', () => {
+      const result = wizardReducer(
+        initialState,
+        changeIsoPayloadReference('registry.example.org/payload:latest'),
+      );
+
+      expect(result.output.isoPayloadReference).toBe(
+        'registry.example.org/payload:latest',
+      );
+    });
+
+    it('should clear iso payload reference with undefined', () => {
+      const stateWithRef: wizardState = {
+        ...initialState,
+        output: {
+          ...initialState.output,
+          isoPayloadReference: 'registry.example.org/payload:latest',
+        },
+      };
+
+      const result = wizardReducer(
+        stateWithRef,
+        changeIsoPayloadReference(undefined),
+      );
+
+      expect(result.output.isoPayloadReference).toBeUndefined();
+    });
+  });
+
+  describe('changeBootcDistributions', () => {
+    it('should update bootc distributions', () => {
+      const distributions = [
+        {
+          distro: 'rhel-10',
+          name: 'distro-1',
+          reference: 'ref-1',
+          type: 'guest-image',
+          arch: 'x86_64',
+        },
+      ] satisfies BootcDistributionItem[];
+
+      const result = wizardReducer(
+        initialState,
+        changeBootcDistributions(distributions),
+      );
+
+      expect(result.output.bootcDistributions).toEqual(distributions);
+    });
+  });
+
+  describe('changeArchitecture', () => {
+    it('should update architecture under output', () => {
+      const result = wizardReducer(initialState, changeArchitecture('aarch64'));
+
+      expect(result.output.architecture).toBe('aarch64');
+    });
+  });
+
+  describe('changeDistribution', () => {
+    it('should update distribution under output', () => {
+      const result = wizardReducer(initialState, changeDistribution('rhel-9'));
+
+      expect(result.output.distribution).toBe('rhel-9');
+    });
+  });
+
+  describe('addImageType', () => {
+    it('should add an image type under output', () => {
+      const result = wizardReducer(initialState, addImageType('aws'));
+
+      expect(result.output.imageTypes).toContain('aws');
+      expect(result.output.imageTypes).toHaveLength(1);
+    });
+
+    it('should not add duplicate image types', () => {
+      let state = wizardReducer(initialState, addImageType('aws'));
+      state = wizardReducer(state, addImageType('aws'));
+
+      expect(state.output.imageTypes).toEqual(['aws']);
+    });
+  });
+
+  describe('removeImageType', () => {
+    it('should remove an existing image type from output', () => {
+      const stateWithTypes: wizardState = {
+        ...initialState,
+        output: {
+          ...initialState.output,
+          imageTypes: ['aws', 'gcp', 'azure'],
+        },
+      };
+
+      const result = wizardReducer(stateWithTypes, removeImageType('gcp'));
+
+      expect(result.output.imageTypes).toEqual(['aws', 'azure']);
+    });
+  });
+
+  describe('changeImageTypes', () => {
+    it('should replace all image types under output', () => {
+      const stateWithTypes: wizardState = {
+        ...initialState,
+        output: {
+          ...initialState.output,
+          imageTypes: ['aws', 'gcp'],
+        },
+      };
+
+      const result = wizardReducer(
+        stateWithTypes,
+        changeImageTypes(['azure', 'vsphere']),
+      );
+
+      expect(result.output.imageTypes).toEqual(['azure', 'vsphere']);
+    });
+
+    it('should clear isoPayloadReference when bootable-container-iso is not selected', () => {
+      const stateWithIso: wizardState = {
+        ...initialState,
+        output: {
+          ...initialState.output,
+          imageTypes: ['bootable-container-iso'],
+          isoPayloadReference: 'registry.example.org/payload:latest',
+        },
+      };
+
+      const result = wizardReducer(
+        stateWithIso,
+        changeImageTypes(['guest-image']),
+      );
+
+      expect(result.output.isoPayloadReference).toBeUndefined();
+    });
+
+    it('should preserve isoPayloadReference when bootable-container-iso is selected', () => {
+      const stateWithIso: wizardState = {
+        ...initialState,
+        output: {
+          ...initialState.output,
+          imageTypes: ['bootable-container-iso'],
+          isoPayloadReference: 'registry.example.org/payload:latest',
+        },
+      };
+
+      const result = wizardReducer(
+        stateWithIso,
+        changeImageTypes(['bootable-container-iso', 'guest-image']),
+      );
+
+      expect(result.output.isoPayloadReference).toBe(
+        'registry.example.org/payload:latest',
+      );
+    });
+  });
+});
+
+describe('output selectors', () => {
+  describe('selectImageSource', () => {
+    it('should return imageSource from output', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageSource: 'quay.io/org/image:latest',
+        },
+      });
+
+      expect(selectImageSource(state)).toBe('quay.io/org/image:latest');
+    });
+
+    it('should return undefined when not set', () => {
+      const state = createMockState({});
+
+      expect(selectImageSource(state)).toBeUndefined();
+    });
+  });
+
+  describe('selectIsoPayloadReference', () => {
+    it('should return isoPayloadReference from output', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          isoPayloadReference: 'registry.example.org/payload:latest',
+        },
+      });
+
+      expect(selectIsoPayloadReference(state)).toBe(
+        'registry.example.org/payload:latest',
+      );
+    });
+  });
+
+  describe('selectBootcDistributions', () => {
+    it('should return bootcDistributions from output', () => {
+      const distributions = [
+        {
+          distro: 'rhel-10',
+          name: 'distro-1',
+          reference: 'ref-1',
+          type: 'guest-image',
+          arch: 'x86_64',
+        },
+      ] satisfies BootcDistributionItem[];
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          bootcDistributions: distributions,
+        },
+      });
+
+      expect(selectBootcDistributions(state)).toEqual(distributions);
+    });
+  });
+
+  describe('selectArchitecture', () => {
+    it('should return architecture from output', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          architecture: 'aarch64',
+        },
+      });
+
+      expect(selectArchitecture(state)).toBe('aarch64');
+    });
+  });
+
+  describe('selectDistribution', () => {
+    it('should return distribution from output', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          distribution: 'rhel-9',
+        },
+      });
+
+      expect(selectDistribution(state)).toBe('rhel-9');
+    });
+  });
+
+  describe('selectImageTypes', () => {
+    it('should return imageTypes from output', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: ['aws', 'gcp'],
+        },
+      });
+
+      expect(selectImageTypes(state)).toEqual(['aws', 'gcp']);
+    });
+  });
+});

--- a/src/store/slices/wizard/tests/selectors.test.ts
+++ b/src/store/slices/wizard/tests/selectors.test.ts
@@ -1,26 +1,50 @@
 import { describe, expect, it } from 'vitest';
 
-import { selectBlueprintMode, selectIsImageMode } from '@/store/slices/wizard';
+import {
+  initialState,
+  selectBlueprintMode,
+  selectIsImageMode,
+} from '@/store/slices/wizard';
 
 import { createMockState } from './mockWizardState';
 
 describe('wizard selectors', () => {
   describe('selectIsImageMode (computed selector)', () => {
     it('should return true when blueprintMode is "image"', () => {
-      const state = createMockState({ blueprintMode: 'image' });
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'image' },
+        },
+      });
 
       expect(selectIsImageMode(state)).toBe(true);
     });
 
     it('should return false when blueprintMode is "package"', () => {
-      const state = createMockState({ blueprintMode: 'package' });
+      const state = createMockState({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'package' },
+        },
+      });
 
       expect(selectIsImageMode(state)).toBe(false);
     });
 
     it('should be derived from selectBlueprintMode', () => {
-      const imageState = createMockState({ blueprintMode: 'image' });
-      const packageState = createMockState({ blueprintMode: 'package' });
+      const imageState = createMockState({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'image' },
+        },
+      });
+      const packageState = createMockState({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'package' },
+        },
+      });
 
       // Verify the relationship between the base selector and derived selector
       expect(selectBlueprintMode(imageState)).toBe('image');

--- a/src/store/slices/wizard/tests/services.test.ts
+++ b/src/store/slices/wizard/tests/services.test.ts
@@ -21,15 +21,18 @@ describe('services reducers', () => {
       it('should add a service to enabled list', () => {
         const result = wizardReducer(initialState, addEnabledService('httpd'));
 
-        expect(result.services.enabled).toContain('httpd');
+        expect(result.system.services.enabled).toContain('httpd');
       });
 
       it('should not add duplicate services', () => {
         const stateWithService: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            enabled: ['httpd'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              enabled: ['httpd'],
+            },
           },
         };
 
@@ -38,7 +41,7 @@ describe('services reducers', () => {
           addEnabledService('httpd'),
         );
 
-        expect(result.services.enabled).toEqual(['httpd']);
+        expect(result.system.services.enabled).toEqual(['httpd']);
       });
 
       it('should add multiple different services', () => {
@@ -46,7 +49,11 @@ describe('services reducers', () => {
         state = wizardReducer(state, addEnabledService('sshd'));
         state = wizardReducer(state, addEnabledService('nginx'));
 
-        expect(state.services.enabled).toEqual(['httpd', 'sshd', 'nginx']);
+        expect(state.system.services.enabled).toEqual([
+          'httpd',
+          'sshd',
+          'nginx',
+        ]);
       });
     });
 
@@ -54,9 +61,12 @@ describe('services reducers', () => {
       it('should remove a service from enabled list', () => {
         const stateWithServices: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            enabled: ['httpd', 'sshd', 'nginx'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              enabled: ['httpd', 'sshd', 'nginx'],
+            },
           },
         };
 
@@ -65,15 +75,18 @@ describe('services reducers', () => {
           removeEnabledService('sshd'),
         );
 
-        expect(result.services.enabled).toEqual(['httpd', 'nginx']);
+        expect(result.system.services.enabled).toEqual(['httpd', 'nginx']);
       });
 
       it('should do nothing when service not found', () => {
         const stateWithServices: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            enabled: ['httpd'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              enabled: ['httpd'],
+            },
           },
         };
 
@@ -82,7 +95,7 @@ describe('services reducers', () => {
           removeEnabledService('nonexistent'),
         );
 
-        expect(result.services.enabled).toEqual(['httpd']);
+        expect(result.system.services.enabled).toEqual(['httpd']);
       });
     });
 
@@ -90,9 +103,12 @@ describe('services reducers', () => {
       it('should replace all enabled services', () => {
         const stateWithServices: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            enabled: ['httpd', 'sshd'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              enabled: ['httpd', 'sshd'],
+            },
           },
         };
 
@@ -101,15 +117,18 @@ describe('services reducers', () => {
           changeEnabledServices(['nginx', 'postgresql']),
         );
 
-        expect(result.services.enabled).toEqual(['nginx', 'postgresql']);
+        expect(result.system.services.enabled).toEqual(['nginx', 'postgresql']);
       });
 
       it('should set empty array', () => {
         const stateWithServices: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            enabled: ['httpd', 'sshd'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              enabled: ['httpd', 'sshd'],
+            },
           },
         };
 
@@ -118,7 +137,7 @@ describe('services reducers', () => {
           changeEnabledServices([]),
         );
 
-        expect(result.services.enabled).toEqual([]);
+        expect(result.system.services.enabled).toEqual([]);
       });
     });
   });
@@ -131,15 +150,18 @@ describe('services reducers', () => {
           addMaskedService('firewalld'),
         );
 
-        expect(result.services.masked).toContain('firewalld');
+        expect(result.system.services.masked).toContain('firewalld');
       });
 
       it('should not add duplicate services', () => {
         const stateWithService: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            masked: ['firewalld'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              masked: ['firewalld'],
+            },
           },
         };
 
@@ -148,7 +170,7 @@ describe('services reducers', () => {
           addMaskedService('firewalld'),
         );
 
-        expect(result.services.masked).toEqual(['firewalld']);
+        expect(result.system.services.masked).toEqual(['firewalld']);
       });
     });
 
@@ -156,9 +178,12 @@ describe('services reducers', () => {
       it('should remove a service from masked list', () => {
         const stateWithServices: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            masked: ['firewalld', 'iptables'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              masked: ['firewalld', 'iptables'],
+            },
           },
         };
 
@@ -167,7 +192,7 @@ describe('services reducers', () => {
           removeMaskedService('firewalld'),
         );
 
-        expect(result.services.masked).toEqual(['iptables']);
+        expect(result.system.services.masked).toEqual(['iptables']);
       });
     });
 
@@ -175,9 +200,12 @@ describe('services reducers', () => {
       it('should replace all masked services', () => {
         const stateWithServices: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            masked: ['firewalld'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              masked: ['firewalld'],
+            },
           },
         };
 
@@ -186,7 +214,7 @@ describe('services reducers', () => {
           changeMaskedServices(['iptables', 'nftables']),
         );
 
-        expect(result.services.masked).toEqual(['iptables', 'nftables']);
+        expect(result.system.services.masked).toEqual(['iptables', 'nftables']);
       });
     });
   });
@@ -196,15 +224,18 @@ describe('services reducers', () => {
       it('should add a service to disabled list', () => {
         const result = wizardReducer(initialState, addDisabledService('cups'));
 
-        expect(result.services.disabled).toContain('cups');
+        expect(result.system.services.disabled).toContain('cups');
       });
 
       it('should not add duplicate services', () => {
         const stateWithService: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            disabled: ['cups'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              disabled: ['cups'],
+            },
           },
         };
 
@@ -213,7 +244,7 @@ describe('services reducers', () => {
           addDisabledService('cups'),
         );
 
-        expect(result.services.disabled).toEqual(['cups']);
+        expect(result.system.services.disabled).toEqual(['cups']);
       });
     });
 
@@ -221,9 +252,12 @@ describe('services reducers', () => {
       it('should remove a service from disabled list', () => {
         const stateWithServices: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            disabled: ['cups', 'bluetooth'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              disabled: ['cups', 'bluetooth'],
+            },
           },
         };
 
@@ -232,7 +266,7 @@ describe('services reducers', () => {
           removeDisabledService('cups'),
         );
 
-        expect(result.services.disabled).toEqual(['bluetooth']);
+        expect(result.system.services.disabled).toEqual(['bluetooth']);
       });
     });
 
@@ -240,9 +274,12 @@ describe('services reducers', () => {
       it('should replace all disabled services', () => {
         const stateWithServices: wizardState = {
           ...initialState,
-          services: {
-            ...initialState.services,
-            disabled: ['cups'],
+          system: {
+            ...initialState.system,
+            services: {
+              ...initialState.system.services,
+              disabled: ['cups'],
+            },
           },
         };
 
@@ -251,7 +288,10 @@ describe('services reducers', () => {
           changeDisabledServices(['bluetooth', 'avahi-daemon']),
         );
 
-        expect(result.services.disabled).toEqual(['bluetooth', 'avahi-daemon']);
+        expect(result.system.services.disabled).toEqual([
+          'bluetooth',
+          'avahi-daemon',
+        ]);
       });
     });
   });
@@ -262,9 +302,9 @@ describe('services reducers', () => {
       state = wizardReducer(state, addMaskedService('firewalld'));
       state = wizardReducer(state, addDisabledService('cups'));
 
-      expect(state.services.enabled).toEqual(['httpd']);
-      expect(state.services.masked).toEqual(['firewalld']);
-      expect(state.services.disabled).toEqual(['cups']);
+      expect(state.system.services.enabled).toEqual(['httpd']);
+      expect(state.system.services.masked).toEqual(['firewalld']);
+      expect(state.system.services.disabled).toEqual(['cups']);
     });
 
     it('should allow same service name in different categories', () => {
@@ -273,9 +313,9 @@ describe('services reducers', () => {
       state = wizardReducer(state, addMaskedService('test'));
       state = wizardReducer(state, addDisabledService('test'));
 
-      expect(state.services.enabled).toContain('test');
-      expect(state.services.masked).toContain('test');
-      expect(state.services.disabled).toContain('test');
+      expect(state.system.services.enabled).toContain('test');
+      expect(state.system.services.masked).toContain('test');
+      expect(state.system.services.disabled).toContain('test');
     });
   });
 });

--- a/src/store/slices/wizard/tests/users.test.ts
+++ b/src/store/slices/wizard/tests/users.test.ts
@@ -20,7 +20,10 @@ import {
 
 const createUserState = (users: UserWithAdditionalInfo[]): wizardState => ({
   ...initialState,
-  users,
+  system: {
+    ...initialState.system,
+    users,
+  },
 });
 
 const createDefaultUser = (
@@ -40,10 +43,10 @@ describe('user reducers', () => {
     it('should add a new user with default values', () => {
       const result = wizardReducer(initialState, addUser());
 
-      expect(result.users).toHaveLength(1);
-      expect(result.users[0].name).toBe('');
-      expect(result.users[0].groups).toEqual([]);
-      expect(result.users[0].isAdministrator).toBe(false);
+      expect(result.system.users).toHaveLength(1);
+      expect(result.system.users[0].name).toBe('');
+      expect(result.system.users[0].groups).toEqual([]);
+      expect(result.system.users[0].isAdministrator).toBe(false);
     });
 
     it('should add multiple users', () => {
@@ -51,7 +54,7 @@ describe('user reducers', () => {
       state = wizardReducer(state, addUser());
       state = wizardReducer(state, addUser());
 
-      expect(state.users).toHaveLength(3);
+      expect(state.system.users).toHaveLength(3);
     });
   });
 
@@ -65,9 +68,9 @@ describe('user reducers', () => {
 
       const result = wizardReducer(state, removeUser(1));
 
-      expect(result.users).toHaveLength(2);
-      expect(result.users[0].name).toBe('user1');
-      expect(result.users[1].name).toBe('user3');
+      expect(result.system.users).toHaveLength(2);
+      expect(result.system.users[0].name).toBe('user1');
+      expect(result.system.users[1].name).toBe('user3');
     });
 
     it('should handle removing last user', () => {
@@ -75,7 +78,7 @@ describe('user reducers', () => {
 
       const result = wizardReducer(state, removeUser(0));
 
-      expect(result.users).toHaveLength(0);
+      expect(result.system.users).toHaveLength(0);
     });
   });
 
@@ -88,7 +91,7 @@ describe('user reducers', () => {
         setUserNameByIndex({ index: 0, name: 'newname' }),
       );
 
-      expect(result.users[0].name).toBe('newname');
+      expect(result.system.users[0].name).toBe('newname');
     });
   });
 
@@ -102,7 +105,7 @@ describe('user reducers', () => {
         setUserPasswordByIndex({ index: 0, password: FAKE_PASSWORD }),
       );
 
-      expect(result.users[0].password).toBe(FAKE_PASSWORD);
+      expect(result.system.users[0].password).toBe(FAKE_PASSWORD);
     });
   });
 
@@ -115,7 +118,7 @@ describe('user reducers', () => {
         setUserSshKeyByIndex({ index: 0, sshKey: 'ssh-rsa AAAAB...' }),
       );
 
-      expect(result.users[0].ssh_key).toBe('ssh-rsa AAAAB...');
+      expect(result.system.users[0].ssh_key).toBe('ssh-rsa AAAAB...');
     });
   });
 
@@ -128,8 +131,8 @@ describe('user reducers', () => {
         setUserAdministratorByIndex({ index: 0, isAdministrator: true }),
       );
 
-      expect(result.users[0].isAdministrator).toBe(true);
-      expect(result.users[0].groups).toContain('wheel');
+      expect(result.system.users[0].isAdministrator).toBe(true);
+      expect(result.system.users[0].groups).toContain('wheel');
     });
 
     it('should remove wheel group when unsetting administrator', () => {
@@ -145,9 +148,9 @@ describe('user reducers', () => {
         setUserAdministratorByIndex({ index: 0, isAdministrator: false }),
       );
 
-      expect(result.users[0].isAdministrator).toBe(false);
-      expect(result.users[0].groups).not.toContain('wheel');
-      expect(result.users[0].groups).toContain('developers');
+      expect(result.system.users[0].isAdministrator).toBe(false);
+      expect(result.system.users[0].groups).not.toContain('wheel');
+      expect(result.system.users[0].groups).toContain('developers');
     });
 
     it('should preserve other groups when toggling administrator', () => {
@@ -160,14 +163,18 @@ describe('user reducers', () => {
         setUserAdministratorByIndex({ index: 0, isAdministrator: true }),
       );
 
-      expect(result.users[0].groups).toEqual(['developers', 'docker', 'wheel']);
+      expect(result.system.users[0].groups).toEqual([
+        'developers',
+        'docker',
+        'wheel',
+      ]);
 
       result = wizardReducer(
         result,
         setUserAdministratorByIndex({ index: 0, isAdministrator: false }),
       );
 
-      expect(result.users[0].groups).toEqual(['developers', 'docker']);
+      expect(result.system.users[0].groups).toEqual(['developers', 'docker']);
     });
   });
 
@@ -180,7 +187,7 @@ describe('user reducers', () => {
         addGroupToUserByUserIndex({ index: 0, group: 'developers' }),
       );
 
-      expect(result.users[0].groups).toContain('developers');
+      expect(result.system.users[0].groups).toContain('developers');
     });
 
     it('should not add duplicate groups', () => {
@@ -193,7 +200,7 @@ describe('user reducers', () => {
         addGroupToUserByUserIndex({ index: 0, group: 'developers' }),
       );
 
-      expect(result.users[0].groups).toEqual(['developers']);
+      expect(result.system.users[0].groups).toEqual(['developers']);
     });
 
     it('should set isAdministrator to true when adding wheel group', () => {
@@ -204,8 +211,8 @@ describe('user reducers', () => {
         addGroupToUserByUserIndex({ index: 0, group: 'wheel' }),
       );
 
-      expect(result.users[0].groups).toContain('wheel');
-      expect(result.users[0].isAdministrator).toBe(true);
+      expect(result.system.users[0].groups).toContain('wheel');
+      expect(result.system.users[0].isAdministrator).toBe(true);
     });
   });
 
@@ -220,7 +227,7 @@ describe('user reducers', () => {
         removeGroupFromUserByIndex({ index: 0, group: 'developers' }),
       );
 
-      expect(result.users[0].groups).toEqual(['docker']);
+      expect(result.system.users[0].groups).toEqual(['docker']);
     });
 
     it('should set isAdministrator to false when removing wheel group', () => {
@@ -236,8 +243,8 @@ describe('user reducers', () => {
         removeGroupFromUserByIndex({ index: 0, group: 'wheel' }),
       );
 
-      expect(result.users[0].groups).not.toContain('wheel');
-      expect(result.users[0].isAdministrator).toBe(false);
+      expect(result.system.users[0].groups).not.toContain('wheel');
+      expect(result.system.users[0].isAdministrator).toBe(false);
     });
 
     it('should do nothing when removing non-existent group', () => {
@@ -250,7 +257,7 @@ describe('user reducers', () => {
         removeGroupFromUserByIndex({ index: 0, group: 'nonexistent' }),
       );
 
-      expect(result.users[0].groups).toEqual(['developers']);
+      expect(result.system.users[0].groups).toEqual(['developers']);
     });
   });
 });
@@ -261,10 +268,10 @@ describe('user group reducers', () => {
       const result = wizardReducer(initialState, addUserGroup());
 
       // Initial state has one empty group, so this adds a second
-      expect(result.userGroups.length).toBeGreaterThan(
-        initialState.userGroups.length,
+      expect(result.system.groups.length).toBeGreaterThan(
+        initialState.system.groups.length,
       );
-      const newGroup = result.userGroups[result.userGroups.length - 1];
+      const newGroup = result.system.groups[result.system.groups.length - 1];
       expect(newGroup.name).toBe('');
       expect(newGroup.gid).toBeDefined();
     });
@@ -274,7 +281,7 @@ describe('user group reducers', () => {
       state = wizardReducer(state, addUserGroup());
 
       // Filter out groups with GIDs
-      const groupsWithGids = state.userGroups.filter(
+      const groupsWithGids = state.system.groups.filter(
         (g) => g.gid !== undefined,
       );
       const gids = groupsWithGids.map((g) => g.gid);
@@ -292,12 +299,15 @@ describe('user group reducers', () => {
     it('should skip already used GIDs', () => {
       const stateWithExistingGid: wizardState = {
         ...initialState,
-        userGroups: [{ name: 'existing', gid: 1000 }],
+        system: {
+          ...initialState.system,
+          groups: [{ name: 'existing', gid: 1000 }],
+        },
       };
 
       const result = wizardReducer(stateWithExistingGid, addUserGroup());
 
-      const newGroup = result.userGroups[result.userGroups.length - 1];
+      const newGroup = result.system.groups[result.system.groups.length - 1];
       expect(newGroup.gid).toBe(1001);
     });
   });
@@ -306,7 +316,10 @@ describe('user group reducers', () => {
     it('should update group name', () => {
       const state: wizardState = {
         ...initialState,
-        userGroups: [{ name: '', gid: 1000 }],
+        system: {
+          ...initialState.system,
+          groups: [{ name: '', gid: 1000 }],
+        },
       };
 
       const result = wizardReducer(
@@ -314,13 +327,16 @@ describe('user group reducers', () => {
         setUserGroupNameByIndex({ index: 0, name: 'developers' }),
       );
 
-      expect(result.userGroups[0].name).toBe('developers');
+      expect(result.system.groups[0].name).toBe('developers');
     });
 
     it('should trim whitespace from name', () => {
       const state: wizardState = {
         ...initialState,
-        userGroups: [{ name: '', gid: 1000 }],
+        system: {
+          ...initialState.system,
+          groups: [{ name: '', gid: 1000 }],
+        },
       };
 
       const result = wizardReducer(
@@ -328,13 +344,16 @@ describe('user group reducers', () => {
         setUserGroupNameByIndex({ index: 0, name: '  developers  ' }),
       );
 
-      expect(result.userGroups[0].name).toBe('developers');
+      expect(result.system.groups[0].name).toBe('developers');
     });
 
     it('should remove GID when name is set to empty', () => {
       const state: wizardState = {
         ...initialState,
-        userGroups: [{ name: 'developers', gid: 1000 }],
+        system: {
+          ...initialState.system,
+          groups: [{ name: 'developers', gid: 1000 }],
+        },
       };
 
       const result = wizardReducer(
@@ -342,14 +361,17 @@ describe('user group reducers', () => {
         setUserGroupNameByIndex({ index: 0, name: '' }),
       );
 
-      expect(result.userGroups[0].name).toBe('');
-      expect(result.userGroups[0].gid).toBeUndefined();
+      expect(result.system.groups[0].name).toBe('');
+      expect(result.system.groups[0].gid).toBeUndefined();
     });
 
     it('should assign GID when name is set on group without GID', () => {
       const state: wizardState = {
         ...initialState,
-        userGroups: [{ name: '' }],
+        system: {
+          ...initialState.system,
+          groups: [{ name: '' }],
+        },
       };
 
       const result = wizardReducer(
@@ -357,8 +379,8 @@ describe('user group reducers', () => {
         setUserGroupNameByIndex({ index: 0, name: 'developers' }),
       );
 
-      expect(result.userGroups[0].name).toBe('developers');
-      expect(result.userGroups[0].gid).toBeGreaterThanOrEqual(1000);
+      expect(result.system.groups[0].name).toBe('developers');
+      expect(result.system.groups[0].gid).toBeGreaterThanOrEqual(1000);
     });
   });
 
@@ -366,18 +388,21 @@ describe('user group reducers', () => {
     it('should remove user group at index', () => {
       const state: wizardState = {
         ...initialState,
-        userGroups: [
-          { name: 'group1', gid: 1000 },
-          { name: 'group2', gid: 1001 },
-          { name: 'group3', gid: 1002 },
-        ],
+        system: {
+          ...initialState.system,
+          groups: [
+            { name: 'group1', gid: 1000 },
+            { name: 'group2', gid: 1001 },
+            { name: 'group3', gid: 1002 },
+          ],
+        },
       };
 
       const result = wizardReducer(state, removeUserGroup(1));
 
-      expect(result.userGroups).toHaveLength(2);
-      expect(result.userGroups[0].name).toBe('group1');
-      expect(result.userGroups[1].name).toBe('group3');
+      expect(result.system.groups).toHaveLength(2);
+      expect(result.system.groups[0].name).toBe('group1');
+      expect(result.system.groups[1].name).toBe('group3');
     });
   });
 });

--- a/src/store/slices/wizard/tests/wizardSlice.test.ts
+++ b/src/store/slices/wizard/tests/wizardSlice.test.ts
@@ -20,9 +20,12 @@ describe('wizardSlice core reducers', () => {
     it('should reset state to initial state', () => {
       const modifiedState: wizardState = {
         ...initialState,
-        distribution: 'rhel-8',
-        architecture: 'aarch64',
-        imageTypes: ['aws', 'gcp'],
+        output: {
+          ...initialState.output,
+          distribution: 'rhel-8',
+          architecture: 'aarch64',
+          imageTypes: ['aws', 'gcp'],
+        },
         system: {
           ...initialState.system,
           hostname: 'modified-hostname',
@@ -96,8 +99,11 @@ describe('wizardSlice core reducers', () => {
     it('should load provided state', () => {
       const stateToLoad: wizardState = {
         ...initialState,
-        distribution: 'rhel-9',
-        architecture: 'aarch64',
+        output: {
+          ...initialState.output,
+          distribution: 'rhel-9',
+          architecture: 'aarch64',
+        },
         system: {
           ...initialState.system,
           hostname: 'loaded-hostname',
@@ -106,8 +112,8 @@ describe('wizardSlice core reducers', () => {
 
       const result = wizardReducer(initialState, loadWizardState(stateToLoad));
 
-      expect(result.distribution).toBe('rhel-9');
-      expect(result.architecture).toBe('aarch64');
+      expect(result.output.distribution).toBe('rhel-9');
+      expect(result.output.architecture).toBe('aarch64');
       expect(result.system.hostname).toBe('loaded-hostname');
     });
 
@@ -150,7 +156,7 @@ describe('wizardSlice core reducers', () => {
     it('should update distribution', () => {
       const result = wizardReducer(initialState, changeDistribution('rhel-9'));
 
-      expect(result.distribution).toBe('rhel-9');
+      expect(result.output.distribution).toBe('rhel-9');
     });
   });
 
@@ -158,7 +164,7 @@ describe('wizardSlice core reducers', () => {
     it('should update architecture', () => {
       const result = wizardReducer(initialState, changeArchitecture('aarch64'));
 
-      expect(result.architecture).toBe('aarch64');
+      expect(result.output.architecture).toBe('aarch64');
     });
   });
 
@@ -167,8 +173,8 @@ describe('wizardSlice core reducers', () => {
       it('should add an image type to empty array', () => {
         const result = wizardReducer(initialState, addImageType('aws'));
 
-        expect(result.imageTypes).toContain('aws');
-        expect(result.imageTypes).toHaveLength(1);
+        expect(result.output.imageTypes).toContain('aws');
+        expect(result.output.imageTypes).toHaveLength(1);
       });
 
       it('should add multiple image types', () => {
@@ -176,14 +182,14 @@ describe('wizardSlice core reducers', () => {
         state = wizardReducer(state, addImageType('gcp'));
         state = wizardReducer(state, addImageType('azure'));
 
-        expect(state.imageTypes).toEqual(['aws', 'gcp', 'azure']);
+        expect(state.output.imageTypes).toEqual(['aws', 'gcp', 'azure']);
       });
 
       it('should not add duplicate image types', () => {
         let state = wizardReducer(initialState, addImageType('aws'));
         state = wizardReducer(state, addImageType('aws'));
 
-        expect(state.imageTypes).toEqual(['aws']);
+        expect(state.output.imageTypes).toEqual(['aws']);
       });
     });
 
@@ -191,23 +197,29 @@ describe('wizardSlice core reducers', () => {
       it('should remove an existing image type', () => {
         const stateWithTypes: wizardState = {
           ...initialState,
-          imageTypes: ['aws', 'gcp', 'azure'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['aws', 'gcp', 'azure'],
+          },
         };
 
         const result = wizardReducer(stateWithTypes, removeImageType('gcp'));
 
-        expect(result.imageTypes).toEqual(['aws', 'azure']);
+        expect(result.output.imageTypes).toEqual(['aws', 'azure']);
       });
 
       it('should do nothing when removing non-existent type', () => {
         const stateWithTypes: wizardState = {
           ...initialState,
-          imageTypes: ['aws', 'gcp'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['aws', 'gcp'],
+          },
         };
 
         const result = wizardReducer(stateWithTypes, removeImageType('azure'));
 
-        expect(result.imageTypes).toEqual(['aws', 'gcp']);
+        expect(result.output.imageTypes).toEqual(['aws', 'gcp']);
       });
     });
 
@@ -215,7 +227,10 @@ describe('wizardSlice core reducers', () => {
       it('should replace all image types', () => {
         const stateWithTypes: wizardState = {
           ...initialState,
-          imageTypes: ['aws', 'gcp'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['aws', 'gcp'],
+          },
         };
 
         const result = wizardReducer(
@@ -223,25 +238,31 @@ describe('wizardSlice core reducers', () => {
           changeImageTypes(['azure', 'vsphere']),
         );
 
-        expect(result.imageTypes).toEqual(['azure', 'vsphere']);
+        expect(result.output.imageTypes).toEqual(['azure', 'vsphere']);
       });
 
       it('should set empty array', () => {
         const stateWithTypes: wizardState = {
           ...initialState,
-          imageTypes: ['aws', 'gcp'],
+          output: {
+            ...initialState.output,
+            imageTypes: ['aws', 'gcp'],
+          },
         };
 
         const result = wizardReducer(stateWithTypes, changeImageTypes([]));
 
-        expect(result.imageTypes).toEqual([]);
+        expect(result.output.imageTypes).toEqual([]);
       });
 
       it('should clear isoPayloadReference when bootable-container-iso is not selected', () => {
         const stateWithIso: wizardState = {
           ...initialState,
-          imageTypes: ['bootable-container-iso'],
-          isoPayloadReference: 'registry.example.org/payload:latest',
+          output: {
+            ...initialState.output,
+            imageTypes: ['bootable-container-iso'],
+            isoPayloadReference: 'registry.example.org/payload:latest',
+          },
         };
 
         const result = wizardReducer(
@@ -249,7 +270,7 @@ describe('wizardSlice core reducers', () => {
           changeImageTypes(['guest-image']),
         );
 
-        expect(result.isoPayloadReference).toBeUndefined();
+        expect(result.output.isoPayloadReference).toBeUndefined();
       });
     });
   });

--- a/src/store/slices/wizard/tests/wizardSlice.test.ts
+++ b/src/store/slices/wizard/tests/wizardSlice.test.ts
@@ -23,7 +23,10 @@ describe('wizardSlice core reducers', () => {
         distribution: 'rhel-8',
         architecture: 'aarch64',
         imageTypes: ['aws', 'gcp'],
-        hostname: 'modified-hostname',
+        system: {
+          ...initialState.system,
+          hostname: 'modified-hostname',
+        },
       };
 
       const result = wizardReducer(modifiedState, initializeWizard());
@@ -34,21 +37,24 @@ describe('wizardSlice core reducers', () => {
     it('should reset users array to empty', () => {
       const stateWithUsers: wizardState = {
         ...initialState,
-        users: [
-          {
-            name: 'user1',
-            password: 'pass',
-            ssh_key: 'key',
-            groups: ['wheel'],
-            isAdministrator: true,
-            hasPassword: true,
-          },
-        ],
+        system: {
+          ...initialState.system,
+          users: [
+            {
+              name: 'user1',
+              password: 'pass',
+              ssh_key: 'key',
+              groups: ['wheel'],
+              isAdministrator: true,
+              hasPassword: true,
+            },
+          ],
+        },
       };
 
       const result = wizardReducer(stateWithUsers, initializeWizard());
 
-      expect(result.users).toEqual([]);
+      expect(result.system.users).toEqual([]);
     });
 
     it('should reset partitions to empty arrays', () => {
@@ -92,42 +98,51 @@ describe('wizardSlice core reducers', () => {
         ...initialState,
         distribution: 'rhel-9',
         architecture: 'aarch64',
-        hostname: 'loaded-hostname',
+        system: {
+          ...initialState.system,
+          hostname: 'loaded-hostname',
+        },
       };
 
       const result = wizardReducer(initialState, loadWizardState(stateToLoad));
 
       expect(result.distribution).toBe('rhel-9');
       expect(result.architecture).toBe('aarch64');
-      expect(result.hostname).toBe('loaded-hostname');
+      expect(result.system.hostname).toBe('loaded-hostname');
     });
 
     it('should completely replace existing state', () => {
       const existingState: wizardState = {
         ...initialState,
-        hostname: 'existing-hostname',
-        users: [
-          {
-            name: 'existinguser',
-            password: '',
-            ssh_key: '',
-            groups: [],
-            isAdministrator: false,
-            hasPassword: false,
-          },
-        ],
+        system: {
+          ...initialState.system,
+          hostname: 'existing-hostname',
+          users: [
+            {
+              name: 'existinguser',
+              password: '',
+              ssh_key: '',
+              groups: [],
+              isAdministrator: false,
+              hasPassword: false,
+            },
+          ],
+        },
       };
 
       const newState: wizardState = {
         ...initialState,
-        hostname: 'new-hostname',
-        users: [],
+        system: {
+          ...initialState.system,
+          hostname: 'new-hostname',
+          users: [],
+        },
       };
 
       const result = wizardReducer(existingState, loadWizardState(newState));
 
-      expect(result.hostname).toBe('new-hostname');
-      expect(result.users).toEqual([]);
+      expect(result.system.hostname).toBe('new-hostname');
+      expect(result.system.users).toEqual([]);
     });
   });
 
@@ -243,23 +258,26 @@ describe('wizardSlice core reducers', () => {
     it('should reset languages and keyboard', () => {
       const stateWithLocale: wizardState = {
         ...initialState,
-        locale: {
-          languages: ['en_US.UTF-8', 'fr_FR.UTF-8'],
-          keyboard: 'us',
+        system: {
+          ...initialState.system,
+          locale: {
+            languages: ['en_US.UTF-8', 'fr_FR.UTF-8'],
+            keyboard: 'us',
+          },
         },
       };
 
       const result = wizardReducer(stateWithLocale, clearLocale());
 
-      expect(result.locale.languages).toEqual([]);
-      expect(result.locale.keyboard).toBe('');
+      expect(result.system.locale.languages).toEqual([]);
+      expect(result.system.locale.keyboard).toBe('');
     });
 
     it('should be a no-op on already empty locale state', () => {
       const result = wizardReducer(initialState, clearLocale());
 
-      expect(result.locale.languages).toEqual([]);
-      expect(result.locale.keyboard).toBe('');
+      expect(result.system.locale.languages).toEqual([]);
+      expect(result.system.locale.keyboard).toBe('');
     });
   });
 
@@ -267,23 +285,26 @@ describe('wizardSlice core reducers', () => {
     it('should reset timezone and ntpservers', () => {
       const stateWithTimezone: wizardState = {
         ...initialState,
-        timezone: {
-          timezone: 'America/New_York',
-          ntpservers: ['0.pool.ntp.org', '1.pool.ntp.org'],
+        system: {
+          ...initialState.system,
+          timezone: {
+            timezone: 'America/New_York',
+            ntpservers: ['0.pool.ntp.org', '1.pool.ntp.org'],
+          },
         },
       };
 
       const result = wizardReducer(stateWithTimezone, clearTimezone());
 
-      expect(result.timezone.timezone).toBe('');
-      expect(result.timezone.ntpservers).toEqual([]);
+      expect(result.system.timezone.timezone).toBe('');
+      expect(result.system.timezone.ntpservers).toEqual([]);
     });
 
     it('should be a no-op on already empty timezone state', () => {
       const result = wizardReducer(initialState, clearTimezone());
 
-      expect(result.timezone.timezone).toBe('');
-      expect(result.timezone.ntpservers).toEqual([]);
+      expect(result.system.timezone.timezone).toBe('');
+      expect(result.system.timezone.ntpservers).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
Wizard slice: phase 2 — nest remaining state domains

## Summary

Continues the wizard slice restructuring started in #4539 and #4544 by nesting the remaining top-level state (`details`, `output`, `system`) under submodule keys.

## Changes

- Nest blueprint metadata and wizard mode under a `details` submodule key, moving `wizardMode`, `blueprintMode`, `blueprintName`, `blueprintDescription`, and `metadata` into `details`
- Nest image output configuration under an `output` submodule key, moving `architecture`, `distribution`, `imageTypes`, `imageSource`, `bootcDistributions`, and `isoPayloadReference` into `output`
- Nest system configuration under a `system` submodule key, moving `services`, `kernel`, `locale`, `timezone`, `hostname`, `firewall`, `firstBoot`, `users`, and `userGroups` into `system`
- Update all selectors, reducers, request mappers, and component tests to use the new nested state paths
- Add dedicated unit tests for the `details` and `output` submodules


JIRA: [HMS-10847](https://issues.redhat.com/browse/HMS-10847)

[HMS-10847]: https://redhat.atlassian.net/browse/HMS-10847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ