### PR TITLE
Extract details subslice from wizard slice (HMS-10889)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -130,7 +130,10 @@ module.exports = defineConfig([
         {
           patterns: [
             {
-              group: ['@/store/slices/wizard/filesystem/*.ts'],
+              group: [
+                '@/store/slices/wizard/details/*',
+                '@/store/slices/wizard/filesystem/*.ts',
+              ],
               message:
                 'Import from @/store/slices/wizard instead. Direct imports into slice internals bypass the barrel and fragment createSelector memoization caches.',
             },

--- a/src/Components/CreateImageWizard/steps/Details/tests/Details.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/tests/Details.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { initialState } from '@/store/slices/wizard';
+import { combinedInitialState as initialState } from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
 import { clearWithWait, createUser, typeWithWait } from '@/test/testUtils';
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -10,6 +10,7 @@ import {
   changeArchitecture,
   changeBlueprintName,
   changeImageSource,
+  generateDefaultName,
   selectArchitecture,
   selectBlueprintName,
   selectDistribution,
@@ -25,8 +26,6 @@ import ImageSourceSelect from './components/ImageSourceSelect';
 import ReleaseLifecycle from './components/ReleaseLifecycle';
 import ReleaseSelect from './components/ReleaseSelect';
 import TargetEnvironment from './components/TargetEnvironment';
-
-import { generateDefaultName } from '../../utilities/useGenerateDefaultName';
 
 const ImageOutputStep = () => {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/BlueprintMode.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/BlueprintMode.test.tsx
@@ -1,6 +1,6 @@
 import { screen } from '@testing-library/react';
 
-import { initialState } from '@/store/slices/wizard';
+import { combinedInitialState as initialState } from '@/store/slices/wizard';
 import { createUser } from '@/test/testUtils';
 
 import { renderBlueprintMode, toggleBlueprintMode } from './helpers';

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageOutput.test.tsx
@@ -1,7 +1,10 @@
 import { screen } from '@testing-library/react';
 
 import { CENTOS_9, FEDORA_44, RHEL_10, RHEL_8, RHEL_9 } from '@/constants';
-import { initialState, selectBlueprintName } from '@/store/slices/wizard';
+import {
+  combinedInitialState as initialState,
+  selectBlueprintName,
+} from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
 import { clickWithWait, createUser, fetchMock } from '@/test/testUtils';
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -4,7 +4,7 @@ import { screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import {
-  initialState,
+  combinedInitialState as initialState,
   selectDistribution,
   selectImageSource as selectImageSourceState,
 } from '@/store/slices/wizard';

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/TargetEnvironment.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/TargetEnvironment.test.tsx
@@ -2,7 +2,10 @@ import { screen } from '@testing-library/react';
 
 import { RHEL_10 } from '@/constants';
 import { Distributions } from '@/store/api/backend';
-import { initialState, selectImageTypes } from '@/store/slices/wizard';
+import {
+  combinedInitialState as initialState,
+  selectImageTypes,
+} from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
 import {
   clickWithWait,

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { RHEL_10 } from '@/constants';
-import { initialState } from '@/store/slices/wizard';
+import { combinedInitialState as initialState } from '@/store/slices/wizard';
 import {
   clickWithWait,
   renderWithRedux,

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { screen } from '@testing-library/react';
 
 import { RHEL_10, X86_64 } from '@/constants';
-import { initialState } from '@/store/slices/wizard';
+import { combinedInitialState as initialState } from '@/store/slices/wizard';
 import { renderWithRedux } from '@/test/testUtils';
 
 import { adminUser, userGroups } from '../../AdvancedSettings/tests/mocks';

--- a/src/store/slices/wizard/details/index.ts
+++ b/src/store/slices/wizard/details/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/store/slices/wizard/details/index.ts
+++ b/src/store/slices/wizard/details/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './utilities';

--- a/src/store/slices/wizard/details/index.ts
+++ b/src/store/slices/wizard/details/index.ts
@@ -1,3 +1,4 @@
+export * from './selectors';
 export { initialState as detailsState } from './state';
 export * from './types';
 export * from './utilities';

--- a/src/store/slices/wizard/details/index.ts
+++ b/src/store/slices/wizard/details/index.ts
@@ -1,2 +1,3 @@
+export { initialState as detailsState } from './state';
 export * from './types';
 export * from './utilities';

--- a/src/store/slices/wizard/details/index.ts
+++ b/src/store/slices/wizard/details/index.ts
@@ -1,4 +1,5 @@
 export * from './selectors';
+export * from './slice';
 export { initialState as detailsState } from './state';
 export * from './types';
 export * from './utilities';

--- a/src/store/slices/wizard/details/selectors.ts
+++ b/src/store/slices/wizard/details/selectors.ts
@@ -1,0 +1,37 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import { RootState } from '@/store';
+
+export const selectWizardMode = (state: RootState) => {
+  return state.wizard.details.mode;
+};
+
+export const selectBlueprintMode = (state: RootState) => {
+  return state.wizard.details.blueprint.mode;
+};
+
+export const selectBlueprintId = (state: RootState) => {
+  return state.wizard.details.blueprintId;
+};
+
+export const selectBlueprintName = (state: RootState) => {
+  return state.wizard.details.blueprint.name;
+};
+
+export const selectIsCustomName = (state: RootState) => {
+  return state.wizard.details.blueprint.isCustomName;
+};
+
+export const selectMetadata = (state: RootState) => {
+  return state.wizard.details.metadata;
+};
+
+export const selectBlueprintDescription = (state: RootState) => {
+  return state.wizard.details.blueprint.description;
+};
+
+// Derived selector for checking if we're in image mode
+export const selectIsImageMode = createSelector(
+  [selectBlueprintMode],
+  (mode) => mode === 'image',
+);

--- a/src/store/slices/wizard/details/slice.ts
+++ b/src/store/slices/wizard/details/slice.ts
@@ -1,0 +1,49 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { initialState } from './state';
+import { BlueprintModeOptions } from './types';
+
+import { initializeWizard, loadWizardState } from '../actions';
+
+export const detailsSlice = createSlice({
+  name: 'wizard/details',
+  initialState,
+  reducers: {
+    changeBlueprintMode: (
+      state,
+      action: PayloadAction<BlueprintModeOptions>,
+    ) => {
+      state.blueprint.mode = action.payload;
+    },
+    changeBlueprintName: (state, action: PayloadAction<string>) => {
+      state.blueprint.name = action.payload;
+    },
+    setIsCustomName: (state) => {
+      state.blueprint.isCustomName = true;
+    },
+    changeBlueprintDescription: (state, action: PayloadAction<string>) => {
+      state.blueprint.description = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // we need to add these cases so that the submodule slice also
+      // reacts to the top-level initialize and loadWizardState calls
+      .addCase(initializeWizard, () => initialState)
+      .addCase(
+        loadWizardState,
+        // Payload may lack `details` if loading a blueprint serialised before
+        // this subslice existed, so fall back defensively despite the type.
+        (_state, action) =>
+          (action.payload as Partial<typeof action.payload>).details ??
+          initialState,
+      );
+  },
+});
+
+export const {
+  changeBlueprintMode,
+  changeBlueprintName,
+  setIsCustomName,
+  changeBlueprintDescription,
+} = detailsSlice.actions;

--- a/src/store/slices/wizard/details/state.ts
+++ b/src/store/slices/wizard/details/state.ts
@@ -1,0 +1,14 @@
+import { RHEL_10, X86_64 } from '@/constants';
+
+import { DetailsSlice } from './types';
+import { generateDefaultName } from './utilities';
+
+export const initialState: DetailsSlice = {
+  mode: 'create',
+  blueprint: {
+    name: generateDefaultName(RHEL_10, X86_64),
+    isCustomName: false,
+    description: '',
+    mode: 'package',
+  },
+};

--- a/src/store/slices/wizard/details/tests/details.test.ts
+++ b/src/store/slices/wizard/details/tests/details.test.ts
@@ -17,9 +17,8 @@ import {
   selectMetadata,
   selectWizardMode,
   setIsCustomName,
-} from '@/store/slices/wizard';
-
-import { createMockState } from './mockWizardState';
+} from '..';
+import { createMockState } from '../../tests/mockWizardState';
 
 describe('details submodule', () => {
   describe('reducers', () => {

--- a/src/store/slices/wizard/details/types.ts
+++ b/src/store/slices/wizard/details/types.ts
@@ -1,0 +1,19 @@
+export type WizardModeOptions = 'create' | 'edit';
+
+export type BlueprintModeOptions = 'image' | 'package';
+
+export type DetailsSlice = {
+  blueprintId?: string;
+  mode: WizardModeOptions;
+  blueprint: {
+    name: string;
+    isCustomName: boolean;
+    description: string;
+    mode: BlueprintModeOptions;
+  };
+  metadata?: {
+    parent_id: string | null;
+    exported_at: string;
+    is_on_prem: boolean;
+  };
+};

--- a/src/store/slices/wizard/details/utilities.ts
+++ b/src/store/slices/wizard/details/utilities.ts
@@ -1,5 +1,8 @@
 import { Distributions, ImageRequest } from '@/store/api/backend';
 
+// TODO: this can be converted into a derived selector once we've
+// moved all the other wizard slices to their own submodule, it's
+// too complicated to do now
 export const generateDefaultName = (
   distribution: Distributions,
   arch: ImageRequest['architecture'],

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -3,4 +3,5 @@ export * from './slice';
 export * from './types';
 
 // submodules
+export * from './details';
 export * from './filesystem';

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -28,7 +28,7 @@ import isRhel from '@/Utilities/isRhel';
 import { yyyyMMddFormat } from '@/Utilities/time';
 
 import { initializeWizard, loadWizardState } from './actions';
-import { BlueprintModeOptions, detailsState } from './details';
+import { detailsSlice, detailsState } from './details';
 import { filesystemSlice, filesystemState } from './filesystem';
 import {
   CombinedWizardState,
@@ -50,7 +50,6 @@ export const MIN_REGULAR_GID = 1000;
 export const MAX_REGULAR_GID = 60000;
 
 export const initialState: WizardState = {
-  details: detailsState,
   output: {
     bootcDistributions: [],
     architecture: X86_64,
@@ -466,12 +465,6 @@ export const wizardSlice = createSlice({
     changeProxy: (state, action: PayloadAction<string | undefined>) => {
       state.registration.proxy = action.payload;
     },
-    changeBlueprintMode: (
-      state,
-      action: PayloadAction<BlueprintModeOptions>,
-    ) => {
-      state.details.blueprint.mode = action.payload;
-    },
     changeImageSource: (
       state,
       action: PayloadAction<ImageSource | undefined>,
@@ -808,15 +801,6 @@ export const wizardSlice = createSlice({
     changeKeyboard: (state, action: PayloadAction<string>) => {
       state.system.locale.keyboard = action.payload;
     },
-    changeBlueprintName: (state, action: PayloadAction<string>) => {
-      state.details.blueprint.name = action.payload;
-    },
-    setIsCustomName: (state) => {
-      state.details.blueprint.isCustomName = true;
-    },
-    changeBlueprintDescription: (state, action: PayloadAction<string>) => {
-      state.details.blueprint.description = action.payload;
-    },
     setFirstBootScript: (state, action: PayloadAction<string>) => {
       state.system.firstBoot.script = action.payload;
     },
@@ -1136,7 +1120,6 @@ export const {
   changeServerUrl,
   changeBaseUrl,
   changeProxy,
-  changeBlueprintMode,
   changeImageSource,
   changeIsoPayloadReference,
   changeBootcDistributions,
@@ -1189,9 +1172,6 @@ export const {
   clearLanguages,
   clearLocale,
   changeKeyboard,
-  changeBlueprintName,
-  setIsCustomName,
-  changeBlueprintDescription,
   setFirstBootScript,
   changeEnabledServices,
   addEnabledService,
@@ -1245,6 +1225,7 @@ export const {
 // to temporarily change the slice shape, which is not ideal
 export const combinedInitialState: CombinedWizardState = {
   ...initialState,
+  details: detailsState,
   filesystem: filesystemState,
 };
 
@@ -1255,6 +1236,7 @@ export const wizardReducer: Reducer<CombinedWizardState> = (state, action) => {
   );
   return {
     ...coreState,
+    details: detailsSlice.reducer(state?.details, action),
     filesystem: filesystemSlice.reducer(state?.filesystem, action),
   };
 };

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -29,9 +29,9 @@ import isRhel from '@/Utilities/isRhel';
 import { yyyyMMddFormat } from '@/Utilities/time';
 
 import { initializeWizard, loadWizardState } from './actions';
+import { BlueprintModeOptions } from './details';
 import { filesystemSlice, filesystemState } from './filesystem';
 import {
-  BlueprintModeOptions,
   CombinedWizardState,
   ComplianceType,
   ImageSource,

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -28,7 +28,7 @@ import isRhel from '@/Utilities/isRhel';
 import { yyyyMMddFormat } from '@/Utilities/time';
 
 import { initializeWizard, loadWizardState } from './actions';
-import { BlueprintModeOptions, generateDefaultName } from './details';
+import { BlueprintModeOptions, detailsState } from './details';
 import { filesystemSlice, filesystemState } from './filesystem';
 import {
   CombinedWizardState,
@@ -50,15 +50,7 @@ export const MIN_REGULAR_GID = 1000;
 export const MAX_REGULAR_GID = 60000;
 
 export const initialState: WizardState = {
-  details: {
-    mode: 'create',
-    blueprint: {
-      name: generateDefaultName(RHEL_10, X86_64),
-      isCustomName: false,
-      description: '',
-      mode: 'package',
-    },
-  },
+  details: detailsState,
   output: {
     bootcDistributions: [],
     architecture: X86_64,

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -11,7 +11,6 @@ import {
   GroupWithRepositoryInfo,
   IBPackageWithRepositoryInfo,
 } from '@/Components/CreateImageWizard/steps/Packages/packagesTypes';
-import { generateDefaultName } from '@/Components/CreateImageWizard/utilities/useGenerateDefaultName';
 import { RHEL_10, X86_64 } from '@/constants';
 import type { RootState } from '@/store';
 import type {
@@ -29,7 +28,7 @@ import isRhel from '@/Utilities/isRhel';
 import { yyyyMMddFormat } from '@/Utilities/time';
 
 import { initializeWizard, loadWizardState } from './actions';
-import { BlueprintModeOptions } from './details';
+import { BlueprintModeOptions, generateDefaultName } from './details';
 import { filesystemSlice, filesystemState } from './filesystem';
 import {
   CombinedWizardState,

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -157,14 +157,6 @@ export const selectServerUrl = (state: RootState) => {
   return state.wizard.registration.serverUrl;
 };
 
-export const selectWizardMode = (state: RootState) => {
-  return state.wizard.details.mode;
-};
-
-export const selectBlueprintMode = (state: RootState) => {
-  return state.wizard.details.blueprint.mode;
-};
-
 export const selectImageSource = (state: RootState) => {
   return state.wizard.output.imageSource;
 };
@@ -175,10 +167,6 @@ export const selectIsoPayloadReference = (state: RootState) => {
 
 export const selectBootcDistributions = (state: RootState) => {
   return state.wizard.output.bootcDistributions;
-};
-
-export const selectBlueprintId = (state: RootState) => {
-  return state.wizard.details.blueprintId;
 };
 
 export const selectBaseUrl = (state: RootState) => {
@@ -371,22 +359,6 @@ export const selectKeyboard = (state: RootState) => {
   return state.wizard.system.locale.keyboard;
 };
 
-export const selectBlueprintName = (state: RootState) => {
-  return state.wizard.details.blueprint.name;
-};
-
-export const selectIsCustomName = (state: RootState) => {
-  return state.wizard.details.blueprint.isCustomName;
-};
-
-export const selectMetadata = (state: RootState) => {
-  return state.wizard.details.metadata;
-};
-
-export const selectBlueprintDescription = (state: RootState) => {
-  return state.wizard.details.blueprint.description;
-};
-
 export const selectFirstBootScript = (state: RootState) => {
   return state.wizard.system.firstBoot.script;
 };
@@ -455,12 +427,6 @@ export const selectFirewallEnabled = createSelector(
     if (firewall.services.disabled.length > 0) return true;
     return false;
   },
-);
-
-// Derived selector for checking if we're in image mode
-export const selectIsImageMode = createSelector(
-  [selectBlueprintMode],
-  (mode) => mode === 'image',
 );
 
 export const selectAapTlsConfigured = createSelector(

--- a/src/store/slices/wizard/tests/details.test.ts
+++ b/src/store/slices/wizard/tests/details.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  combinedInitialState as initialState,
+  wizardReducer,
+} from '@/store/slices/wizard';
+
+import {
   changeBlueprintDescription,
   changeBlueprintMode,
   changeBlueprintName,
-  type CombinedWizardState,
-  combinedInitialState as initialState,
-  loadWizardState,
   selectBlueprintDescription,
   selectBlueprintId,
   selectBlueprintMode,
@@ -15,7 +17,6 @@ import {
   selectMetadata,
   selectWizardMode,
   setIsCustomName,
-  wizardReducer,
 } from '@/store/slices/wizard';
 
 import { createMockState } from './mockWizardState';
@@ -50,42 +51,6 @@ describe('details submodule', () => {
       const result = wizardReducer(initialState, changeBlueprintMode('image'));
 
       expect(result.details.blueprint.mode).toBe('image');
-    });
-
-    it('loadWizardState should load full state including details', () => {
-      const stateToLoad: CombinedWizardState = {
-        ...initialState,
-        details: {
-          ...initialState.details,
-          blueprintId: 'test-id-123',
-          mode: 'edit',
-          blueprint: {
-            name: 'loaded-blueprint',
-            isCustomName: true,
-            description: 'loaded description',
-            mode: 'image',
-          },
-          metadata: {
-            parent_id: 'parent-123',
-            exported_at: '2024-01-01',
-            is_on_prem: true,
-          },
-        },
-      };
-
-      const result = wizardReducer(initialState, loadWizardState(stateToLoad));
-
-      expect(result.details.blueprintId).toBe('test-id-123');
-      expect(result.details.mode).toBe('edit');
-      expect(result.details.blueprint.name).toBe('loaded-blueprint');
-      expect(result.details.blueprint.isCustomName).toBe(true);
-      expect(result.details.blueprint.description).toBe('loaded description');
-      expect(result.details.blueprint.mode).toBe('image');
-      expect(result.details.metadata).toEqual({
-        parent_id: 'parent-123',
-        exported_at: '2024-01-01',
-        is_on_prem: true,
-      });
     });
   });
 

--- a/src/store/slices/wizard/tests/selectors.test.ts
+++ b/src/store/slices/wizard/tests/selectors.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  initialState,
+  combinedInitialState as initialState,
   selectBlueprintMode,
   selectIsImageMode,
 } from '@/store/slices/wizard';

--- a/src/store/slices/wizard/tests/wizardSlice.test.ts
+++ b/src/store/slices/wizard/tests/wizardSlice.test.ts
@@ -117,6 +117,16 @@ describe('wizardSlice core reducers', () => {
             unit: 'GiB',
           },
         },
+        details: {
+          ...initialState.details,
+          mode: 'edit',
+          blueprintId: 'bp-123',
+          blueprint: {
+            ...initialState.details.blueprint,
+            name: 'loaded-blueprint',
+            mode: 'image',
+          },
+        },
       };
 
       const result = wizardReducer(initialState, loadWizardState(stateToLoad));
@@ -126,6 +136,10 @@ describe('wizardSlice core reducers', () => {
       expect(result.system.hostname).toBe('loaded-hostname');
       expect(result.filesystem.mode).toBe('advanced');
       expect(result.filesystem.disk.minsize).toBe('20');
+      expect(result.details.mode).toBe('edit');
+      expect(result.details.blueprintId).toBe('bp-123');
+      expect(result.details.blueprint.name).toBe('loaded-blueprint');
+      expect(result.details.blueprint.mode).toBe('image');
     });
 
     it('should completely replace existing state', () => {
@@ -171,6 +185,17 @@ describe('wizardSlice core reducers', () => {
       const result = wizardReducer(initialState, loadWizardState(stateToLoad));
 
       expect(result.filesystem).toEqual(initialState.filesystem);
+    });
+
+    it('loadWizardState should fall back to initialState when details is missing', () => {
+      const stateToLoad = {
+        ...initialState,
+        details: undefined,
+      } as unknown as CombinedWizardState;
+
+      const result = wizardReducer(initialState, loadWizardState(stateToLoad));
+
+      expect(result.details).toEqual(initialState.details);
     });
   });
 

--- a/src/store/slices/wizard/types.ts
+++ b/src/store/slices/wizard/types.ts
@@ -20,11 +20,8 @@ import {
 import { ApiRepositoryResponseRead } from '@/store/api/contentSources';
 import { ActivationKeys } from '@/store/api/rhsm';
 
+import { DetailsSlice } from './details';
 import { FilesystemSlice } from './filesystem';
-
-type WizardModeOptions = 'create' | 'edit';
-
-export type BlueprintModeOptions = 'image' | 'package';
 
 export type ImageSource = string;
 
@@ -85,21 +82,7 @@ export type UserGroup = {
 };
 
 export type WizardState = {
-  details: {
-    blueprintId?: string;
-    mode: WizardModeOptions;
-    blueprint: {
-      name: string;
-      isCustomName: boolean;
-      description: string;
-      mode: BlueprintModeOptions;
-    };
-    metadata?: {
-      parent_id: string | null;
-      exported_at: string;
-      is_on_prem: boolean;
-    };
-  };
+  details: DetailsSlice;
   output: {
     imageSource?: ImageSource | undefined;
     isoPayloadReference?: string | undefined;

--- a/src/store/slices/wizard/types.ts
+++ b/src/store/slices/wizard/types.ts
@@ -82,7 +82,6 @@ export type UserGroup = {
 };
 
 export type WizardState = {
-  details: DetailsSlice;
   output: {
     imageSource?: ImageSource | undefined;
     isoPayloadReference?: string | undefined;
@@ -184,4 +183,7 @@ export type WizardState = {
   };
 };
 
-export type CombinedWizardState = WizardState & { filesystem: FilesystemSlice };
+export type CombinedWizardState = WizardState & {
+  details: DetailsSlice;
+  filesystem: FilesystemSlice;
+};


### PR DESCRIPTION
Extract details subslice from wizard slice

## Summary

Extracts the "details" concerns (blueprint name, description, mode, metadata) from the monolithic wizard slice into a dedicated `details/` submodule, following the same pattern established by the `filesystem/` extraction.

## Changes

- Extract `DetailsSlice` type, `WizardModeOptions`, and `BlueprintModeOptions` into `details/types.ts`, removing them from the parent slice
- Move `generateDefaultName` utility into `details/utilities.ts` (renamed from `useGenerateDefaultName`) with a TODO for future conversion to a derived selector
- Create `detailsSlice` with its own reducers and `extraReducers` for `initializeWizard`/`loadWizardState`, including a defensive fallback for payloads missing the `details` key
- Move all 7 details selectors and 4 reducers into the submodule with a barrel re-export to keep consumer imports stable
- Add ESLint boundary rule restricting direct imports into `details/` internals, and co-locate submodule tests following the filesystem precedent


JIRA: [HMS-10889](https://issues.redhat.com/browse/HMS-10889)

[HMS-10889]: https://redhat.atlassian.net/browse/HMS-10889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ