### PR TITLE
Fix blueprint import failing with duplicate custom repositories (HMS-10697)

### DIFF
--- a/playwright/Customizations/Repositories.spec.ts
+++ b/playwright/Customizations/Repositories.spec.ts
@@ -108,10 +108,8 @@ test('Create blueprint with repository and test edit mode removal', async ({
   });
 
   await test.step('Remove repository and verify warning modal', async () => {
-    const removeButton = frame.getByRole('button', {
-      name: /remove repository/i,
-    });
-    await removeButton.click();
+    const repoRow = frame.getByRole('row', { name: repositoryName });
+    await repoRow.getByRole('button', { name: /remove repository/i }).click();
 
     await expect(frame.getByText(/Are you sure?/)).toBeVisible();
 

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -31,6 +31,7 @@ import {
   ApiRepositoryImportResponseRead,
   ApiRepositoryRequest,
   useBulkImportRepositoriesMutation,
+  useLazyListRepositoriesQuery,
 } from '@/store/api/contentSources';
 import { selectIsOnPremise } from '@/store/slices/env';
 import { CombinedWizardState, loadWizardState } from '@/store/slices/wizard';
@@ -74,6 +75,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
   const [isCheckedImportRepos, setIsCheckedImportRepos] = React.useState(true);
   const addNotification = useAddNotification();
   const [importRepositories] = useBulkImportRepositoriesMutation();
+  const [listRepositories] = useLazyListRepositoriesQuery();
 
   const handleFileInputChange = (_event: DropEvent, file: File) => {
     setFileContent('');
@@ -83,53 +85,103 @@ export const ImportBlueprintModal: React.FunctionComponent<
   async function handleRepositoryImport(
     blueprintExportedResponse: BlueprintExportResponse,
   ): Promise<CustomRepository[] | undefined> {
-    if (isCheckedImportRepos && blueprintExportedResponse.content_sources) {
-      const customRepositories: ApiRepositoryRequest[] =
-        blueprintExportedResponse.content_sources.map(
-          (item) => item as ApiRepositoryRequest,
-        );
+    if (!isCheckedImportRepos || !blueprintExportedResponse.content_sources) {
+      return;
+    }
 
-      try {
-        const result = await importRepositories({
-          body: customRepositories,
-        }).unwrap();
-        if (Array.isArray(result)) {
-          const importedRepositoryNames: string[] = [];
-          const newCustomRepos: CustomRepository[] = [];
-          result.forEach((repository) => {
-            const contentSourcesRepo =
-              repository as ApiRepositoryImportResponseRead;
-            if (contentSourcesRepo.uuid) {
-              newCustomRepos.push(
-                ...mapToCustomRepositories(contentSourcesRepo),
-              );
-            }
-            if (repository.warnings?.length === 0 && repository.url) {
-              importedRepositoryNames.push(repository.url);
-              return;
-            }
-            addNotification({
-              variant: 'warning',
-              title: 'Failed to import custom repositories',
-              description: JSON.stringify(repository.warnings),
-            });
-          });
+    const contentSources =
+      blueprintExportedResponse.content_sources as ApiRepositoryRequest[];
+    const allUrls = contentSources
+      .map((cs) => cs.url)
+      .filter((url): url is string => !!url);
 
-          if (importedRepositoryNames.length !== 0) {
-            addNotification({
-              variant: 'info',
-              title: 'Successfully imported custom repositories',
-              description: importedRepositoryNames.join(', '),
-            });
-          }
-          return newCustomRepos;
+    if (allUrls.length === 0) {
+      return;
+    }
+
+    // Look up which repos already exist in the user's content sources
+    const existingCustomRepos: CustomRepository[] = [];
+    const existingUrls = new Set<string>();
+
+    try {
+      const listResult = await listRepositories({
+        url: allUrls.join(','),
+        limit: allUrls.length,
+      }).unwrap();
+
+      for (const repo of listResult.data ?? []) {
+        if (repo.url) {
+          existingUrls.add(repo.url);
         }
-      } catch {
+        existingCustomRepos.push(...mapToCustomRepositories(repo));
+      }
+
+      if (existingUrls.size > 0) {
         addNotification({
-          variant: 'danger',
-          title: 'Custom repositories import failed',
+          variant: 'info',
+          title: 'Custom repositories already exist',
+          description: [...existingUrls].join(', '),
         });
       }
+    } catch (error) {
+      // If the lookup fails, fall through and try to import all repos
+      // eslint-disable-next-line no-console
+      console.error('Failed to look up existing repositories:', error);
+    }
+
+    // Filter to only repos that don't already exist
+    const newContentSources = contentSources.filter(
+      (cs: ApiRepositoryRequest) => !cs.url || !existingUrls.has(cs.url),
+    );
+
+    if (newContentSources.length === 0) {
+      return existingCustomRepos;
+    }
+
+    // Import only the genuinely new repos
+    try {
+      const result = await importRepositories({
+        body: newContentSources,
+      }).unwrap();
+      if (Array.isArray(result)) {
+        const importedRepositoryNames: string[] = [];
+        const newCustomRepos: CustomRepository[] = [];
+        result.forEach((repository) => {
+          const contentSourcesRepo =
+            repository as ApiRepositoryImportResponseRead;
+          if (contentSourcesRepo.uuid) {
+            newCustomRepos.push(...mapToCustomRepositories(contentSourcesRepo));
+          }
+          if (repository.warnings?.length === 0 && repository.url) {
+            importedRepositoryNames.push(repository.url);
+            return;
+          }
+          addNotification({
+            variant: 'warning',
+            title: 'Failed to import custom repositories',
+            description: JSON.stringify(repository.warnings),
+          });
+        });
+
+        if (importedRepositoryNames.length !== 0) {
+          addNotification({
+            variant: 'info',
+            title: 'Successfully imported custom repositories',
+            description: importedRepositoryNames.join(', '),
+          });
+        }
+        return [...existingCustomRepos, ...newCustomRepos];
+      }
+    } catch {
+      addNotification({
+        variant: 'danger',
+        title: 'Custom repositories import failed',
+      });
+    }
+
+    // If bulk import failed, still return any existing repos we found
+    if (existingCustomRepos.length > 0) {
+      return existingCustomRepos;
     }
   }
 

--- a/src/Components/Blueprints/tests/ImportBlueprintModal.test.tsx
+++ b/src/Components/Blueprints/tests/ImportBlueprintModal.test.tsx
@@ -1,0 +1,337 @@
+import React from 'react';
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { server } from '@/test/mocks/server';
+import { renderWithRedux } from '@/test/testUtils';
+
+import {
+  createBlueprintJson,
+  createFetchHandler,
+  existingRepo,
+  fetchMock,
+} from './mocks';
+
+import { ImportBlueprintModal } from '../ImportBlueprintModal';
+
+fetchMock.enableMocks();
+
+const mockAddNotification = vi.fn();
+vi.mock(
+  '@redhat-cloud-services/frontend-components-notifications/hooks',
+  () => ({
+    useAddNotification: () => mockAddNotification,
+  }),
+);
+
+beforeAll(() => {
+  server.close();
+});
+
+afterAll(() => {
+  server.listen();
+});
+
+beforeEach(() => {
+  fetchMock.mockResponse(createFetchHandler());
+  mockAddNotification.mockClear();
+  // The component calls console.error when listRepositories fails.
+  // The global test setup throws on console.error, so we suppress it here.
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  fetchMock.resetMocks();
+  vi.restoreAllMocks();
+});
+
+const renderModal = () => {
+  const setShowImportModal = vi.fn();
+  return renderWithRedux(
+    <ImportBlueprintModal setShowImportModal={setShowImportModal} isOpen />,
+  );
+};
+
+const uploadBlueprintFile = async (content: string) => {
+  const user = userEvent.setup();
+  const fileInput: HTMLElement | null =
+    document.querySelector('input[type="file"]');
+
+  if (!fileInput) {
+    throw new Error('File input not found');
+  }
+
+  const file = new File([content], 'blueprint.json', {
+    type: 'application/json',
+  });
+  await waitFor(() => user.upload(fileInput, file));
+};
+
+describe('ImportBlueprintModal repository import', () => {
+  test('does not import repos when checkbox is unchecked', async () => {
+    const user = userEvent.setup();
+    const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
+
+    fetchMock.mockResponse(
+      createFetchHandler({
+        list: { repositories: [] },
+        bulkImport: { response: [] },
+      }),
+    );
+
+    renderModal();
+
+    // Uncheck the "import repositories" checkbox
+    const checkbox = screen.getByRole('checkbox', {
+      name: /import custom repositories/i,
+    });
+    await user.click(checkbox);
+
+    await uploadBlueprintFile(
+      createBlueprintJson([{ url: newRepoUrl, name: 'brand-new-repo' }]),
+    );
+
+    // Wait for the blueprint to be parsed
+    const reviewButton = await screen.findByRole('button', {
+      name: /review and finish/i,
+    });
+    await waitFor(() => expect(reviewButton).toBeEnabled());
+
+    // No repository-related notifications should fire
+    expect(mockAddNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('repositories'),
+      }),
+    );
+
+    // No repository API calls should have been made
+    const repoCalls = fetchMock.mock.calls.filter(([url]) =>
+      typeof url === 'string' ? url.includes('/repositories') : false,
+    );
+    expect(repoCalls).toHaveLength(0);
+  });
+
+  test('imports all repos when none already exist', async () => {
+    const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
+    const importedRepo = {
+      uuid: 'new-uuid-1',
+      url: newRepoUrl,
+      name: 'brand-new-repo',
+      warnings: [],
+    };
+
+    fetchMock.mockResponse(
+      createFetchHandler({
+        list: { repositories: [] },
+        bulkImport: { response: [importedRepo] },
+      }),
+    );
+
+    renderModal();
+    await uploadBlueprintFile(
+      createBlueprintJson([{ url: newRepoUrl, name: 'brand-new-repo' }]),
+    );
+
+    await waitFor(() => {
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'info',
+          title: 'Successfully imported custom repositories',
+        }),
+      );
+    });
+
+    // Should NOT show "already exist" notification
+    expect(mockAddNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Custom repositories already exist',
+      }),
+    );
+  });
+
+  test('skips import when all repos already exist', async () => {
+    fetchMock.mockResponse(
+      createFetchHandler({
+        list: { repositories: [existingRepo] },
+      }),
+    );
+
+    renderModal();
+    await uploadBlueprintFile(
+      createBlueprintJson([{ url: existingRepo.url! }]),
+    );
+
+    await waitFor(() => {
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'info',
+          title: 'Custom repositories already exist',
+        }),
+      );
+    });
+
+    // Should NOT show a successful import notification (no bulk import happened)
+    expect(mockAddNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Successfully imported custom repositories',
+      }),
+    );
+  });
+
+  test('imports only new repos when some already exist', async () => {
+    const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
+    const importedRepo = {
+      uuid: 'new-uuid-1',
+      url: newRepoUrl,
+      name: 'brand-new-repo',
+      warnings: [],
+    };
+
+    fetchMock.mockResponse(
+      createFetchHandler({
+        list: { repositories: [existingRepo] },
+        bulkImport: { response: [importedRepo] },
+      }),
+    );
+
+    renderModal();
+    await uploadBlueprintFile(
+      createBlueprintJson([
+        { url: existingRepo.url! },
+        { url: newRepoUrl, name: 'brand-new-repo' },
+      ]),
+    );
+
+    // Should show "already exist" notification for the existing repo
+    await waitFor(() => {
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'info',
+          title: 'Custom repositories already exist',
+          description: existingRepo.url,
+        }),
+      );
+    });
+
+    // Should also show success notification for the newly imported repo
+    await waitFor(() => {
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'info',
+          title: 'Successfully imported custom repositories',
+        }),
+      );
+    });
+  });
+
+  test('falls through to import all when listRepositories fails', async () => {
+    const repoUrl = 'http://some.repo.example.com/x86_64/';
+    const importedRepo = {
+      uuid: 'imported-uuid',
+      url: repoUrl,
+      name: 'some-repo',
+      warnings: [],
+    };
+
+    fetchMock.mockResponse(
+      createFetchHandler({
+        list: { shouldFail: true },
+        bulkImport: { response: [importedRepo] },
+      }),
+    );
+
+    renderModal();
+    await uploadBlueprintFile(
+      createBlueprintJson([{ url: repoUrl, name: 'some-repo' }]),
+    );
+
+    // Should import successfully despite list failure
+    await waitFor(() => {
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'info',
+          title: 'Successfully imported custom repositories',
+        }),
+      );
+    });
+
+    // Should have logged the error
+    // eslint-disable-next-line no-console
+    expect(console.error).toHaveBeenCalledWith(
+      'Failed to look up existing repositories:',
+      expect.anything(),
+    );
+  });
+
+  test('returns early when content_sources have no URLs', async () => {
+    renderModal();
+    await uploadBlueprintFile(
+      JSON.stringify({
+        name: 'test-blueprint',
+        description: 'Test',
+        distribution: 'rhel-9',
+        customizations: { packages: [] },
+        image_requests: [
+          {
+            architecture: 'x86_64',
+            image_type: 'guest-image',
+            upload_request: { type: 'aws.s3', options: {} },
+          },
+        ],
+        content_sources: [{ name: 'no-url-repo' }],
+      }),
+    );
+
+    // Wait for the blueprint to be parsed — the Review button should become enabled
+    const reviewButton = await screen.findByRole('button', {
+      name: /review and finish/i,
+    });
+    await waitFor(() => expect(reviewButton).toBeEnabled());
+
+    // No repository-related notifications should fire
+    expect(mockAddNotification).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.stringContaining('repositories'),
+      }),
+    );
+  });
+
+  test('returns existing repos when bulk import fails', async () => {
+    fetchMock.mockResponse(
+      createFetchHandler({
+        list: { repositories: [existingRepo] },
+        bulkImport: { shouldFail: true },
+      }),
+    );
+
+    const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
+    renderModal();
+    await uploadBlueprintFile(
+      createBlueprintJson([
+        { url: existingRepo.url! },
+        { url: newRepoUrl, name: 'brand-new-repo' },
+      ]),
+    );
+
+    // Should show "already exist" notification
+    await waitFor(() => {
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'info',
+          title: 'Custom repositories already exist',
+        }),
+      );
+    });
+
+    // Should show import failure notification
+    await waitFor(() => {
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: 'danger',
+          title: 'Custom repositories import failed',
+        }),
+      );
+    });
+  });
+});

--- a/src/Components/Blueprints/tests/mocks/fixtures.ts
+++ b/src/Components/Blueprints/tests/mocks/fixtures.ts
@@ -1,0 +1,48 @@
+import type { ApiRepositoryResponseRead } from '@/store/api/contentSources';
+
+export const existingRepo: ApiRepositoryResponseRead = {
+  uuid: 'existing-uuid-1',
+  name: 'existing-repo',
+  url: 'http://existing.repo.example.com/x86_64/',
+  distribution_versions: ['9'],
+  distribution_arch: 'x86_64',
+  status: 'Valid',
+  gpg_key: '',
+  metadata_verification: false,
+  module_hotfixes: false,
+};
+
+export const anotherExistingRepo: ApiRepositoryResponseRead = {
+  uuid: 'existing-uuid-2',
+  name: 'another-existing-repo',
+  url: 'http://another-existing.repo.example.com/x86_64/',
+  distribution_versions: ['9'],
+  distribution_arch: 'x86_64',
+  status: 'Valid',
+  gpg_key: '',
+  metadata_verification: false,
+  module_hotfixes: false,
+};
+
+export const createBlueprintJson = (
+  contentSources: { url: string; name?: string }[],
+) =>
+  JSON.stringify({
+    name: 'test-blueprint',
+    description: 'Test blueprint',
+    distribution: 'rhel-9',
+    customizations: {
+      packages: [],
+    },
+    image_requests: [
+      {
+        architecture: 'x86_64',
+        image_type: 'guest-image',
+        upload_request: { type: 'aws.s3', options: {} },
+      },
+    ],
+    content_sources: contentSources.map((cs) => ({
+      url: cs.url,
+      name: cs.name ?? cs.url,
+    })),
+  });

--- a/src/Components/Blueprints/tests/mocks/handlers.ts
+++ b/src/Components/Blueprints/tests/mocks/handlers.ts
@@ -1,0 +1,79 @@
+import type { ApiRepositoryResponseRead } from '@/store/api/contentSources';
+import {
+  composeHandlers,
+  CONTENT_SOURCES_URL,
+  createBlueprintsHandler,
+  createRepositoriesHandler,
+  type FetchHandler,
+  fetchMock,
+  type FetchRequest,
+} from '@/test/testUtils';
+
+export { fetchMock };
+
+type BulkImportOverrides = {
+  response?: object[];
+  shouldFail?: boolean;
+};
+
+type ListOverrides = {
+  repositories?: ApiRepositoryResponseRead[];
+  shouldFail?: boolean;
+};
+
+type FetchHandlerOverrides = {
+  bulkImport?: BulkImportOverrides;
+  list?: ListOverrides;
+};
+
+const createBulkImportHandler = (
+  overrides: BulkImportOverrides = {},
+): FetchHandler => {
+  const { response = [], shouldFail = false } = overrides;
+
+  return ({ url, method }: FetchRequest) => {
+    if (
+      url.startsWith(CONTENT_SOURCES_URL + '/repositories/bulk_import') &&
+      method === 'POST'
+    ) {
+      if (shouldFail) {
+        throw new Error('Bulk import failed');
+      }
+      return JSON.stringify(response);
+    }
+    return null;
+  };
+};
+
+const createListRepositoriesHandler = (
+  overrides: ListOverrides = {},
+): FetchHandler => {
+  if (overrides.shouldFail) {
+    return ({ url, method }: FetchRequest) => {
+      if (
+        url.startsWith(CONTENT_SOURCES_URL + '/repositories') &&
+        !url.includes('bulk_import') &&
+        method === 'GET'
+      ) {
+        throw new Error('List repositories failed');
+      }
+      return null;
+    };
+  }
+
+  return createRepositoriesHandler({
+    repositories: overrides.repositories,
+  });
+};
+
+export const createFetchHandler = (
+  overrides: FetchHandlerOverrides = {},
+): FetchHandler => {
+  return composeHandlers(
+    createBulkImportHandler(overrides.bulkImport),
+    createListRepositoriesHandler(overrides.list),
+    createBlueprintsHandler(),
+  );
+};
+
+export const createDefaultFetchHandler = createFetchHandler();

--- a/src/Components/Blueprints/tests/mocks/index.ts
+++ b/src/Components/Blueprints/tests/mocks/index.ts
@@ -1,0 +1,2 @@
+export * from './fixtures';
+export * from './handlers';

--- a/src/Components/CreateImageWizard/steps/Repositories/components/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/Repositories.tsx
@@ -125,13 +125,38 @@ const Repositories = () => {
     { refetchOnMountOrArgChange: false, skip: isTemplateSelected },
   );
 
+  const requiredUrls = useMemo(
+    () => requiredRedHatRepos(arch, version) || [],
+    [arch, version],
+  );
+
+  const { data: { data: requiredReposData = [] } = {} } =
+    useListRepositoriesQuery(
+      {
+        url: requiredUrls.join(','),
+        limit: requiredUrls.length,
+      },
+      { skip: requiredUrls.length === 0 || isTemplateSelected },
+    );
+
   const requiredRedHatRepoUUIDs = useMemo(() => {
-    const requiredUrls = requiredRedHatRepos(arch, version) || [];
-    return previousReposData
-      .filter((repo) => requiredUrls.includes(repo.url!))
-      .map((repo) => repo.uuid!)
+    // First try to find the required repos in the previousReposData
+    // (works when initialSelectedState is empty since the API returns all repos)
+    const fromPrevious = previousReposData
+      .filter((repo) => repo.url && requiredUrls.includes(repo.url))
+      .map((repo) => repo.uuid)
       .filter((uuid): uuid is string => !!uuid);
-  }, [arch, version, previousReposData]);
+
+    if (fromPrevious.length > 0) {
+      return fromPrevious;
+    }
+
+    // Fall back to the dedicated URL query when previousReposData is
+    // filtered by UUID and doesn't include the required repos
+    return requiredReposData
+      .map((repo) => repo.uuid)
+      .filter((uuid): uuid is string => !!uuid);
+  }, [previousReposData, requiredUrls, requiredReposData]);
 
   const hasReposToShow =
     selected.size > 0 || requiredRedHatRepoUUIDs.length > 0;

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -36,7 +36,10 @@ import {
   User,
   VolumeGroup,
 } from '@/store/api/backend';
-import { ApiRepositoryImportResponseRead } from '@/store/api/contentSources';
+import {
+  ApiRepositoryImportResponseRead,
+  ApiRepositoryResponseRead,
+} from '@/store/api/contentSources';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
   CombinedWizardState,
@@ -686,7 +689,7 @@ export const mapRequestToState = (
 };
 
 export function mapToCustomRepositories(
-  repo: ApiRepositoryImportResponseRead,
+  repo: ApiRepositoryImportResponseRead | ApiRepositoryResponseRead,
 ): CustomRepository[] {
   if (!repo.uuid) return [];
   return [

--- a/src/store/api/contentSources/index.ts
+++ b/src/store/api/contentSources/index.ts
@@ -33,3 +33,6 @@ export const {
   useListTemplatesQuery,
   useGetTemplateQuery,
 } = hostedQueries;
+
+// Lazy hooks from the API instance (not exported by codegen)
+export const { useLazyListRepositoriesQuery } = hostedQueries.contentSourcesApi;

--- a/src/test/testUtils/fetchMock.ts
+++ b/src/test/testUtils/fetchMock.ts
@@ -99,9 +99,17 @@ export const createRepositoriesHandler = (
 
       let filteredRepos = repositories;
 
+      const urlParam = urlObj.searchParams.get('url');
+      if (urlParam) {
+        const urls = urlParam.split(',');
+        filteredRepos = filteredRepos.filter((repo) =>
+          urls.includes(repo.url || ''),
+        );
+      }
+
       if (uuidParam) {
         const uuids = uuidParam.split(',');
-        filteredRepos = repositories.filter((repo) =>
+        filteredRepos = filteredRepos.filter((repo) =>
           uuids.includes(repo.uuid || ''),
         );
       }


### PR DESCRIPTION
## Summary

Fix blueprint import failing when custom repositories already exist in the user's content sources. The `bulk_import` endpoint errors if any repo URLs are duplicates, causing the entire repository import to fail silently. This PR pre-filters existing repos so only genuinely new ones are sent to `bulk_import`.

## Changes

- Query existing repositories by URL before calling `bulk_import`, partitioning into existing vs new repos
- Only send genuinely new repos to the `bulk_import` endpoint, avoiding the duplicate URL error
- Widen `mapToCustomRepositories` to accept both list and import response types, enabling reuse for existing repo mapping
- Export `useLazyListRepositoriesQuery` from the content sources API for imperative repo lookups
- Gracefully return already-existing repos even if the bulk import of new repos fails
