### PR TITLE
api: update the url for the image-builder-crc openapi schema (HMS-10870)

### DIFF
--- a/api/config/imageBuilder.ts
+++ b/api/config/imageBuilder.ts
@@ -2,7 +2,7 @@ import type { ConfigFile } from '@rtk-query/codegen-openapi';
 
 const config: ConfigFile = {
   schemaFile:
-    'https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml',
+    'https://raw.githubusercontent.com/osbuild/image-builder-crc/main/internal/v1/api.yaml',
   apiFile: '../../src/store/api/backend/hosted/emptyImageBuilderApi.ts',
   apiImport: 'emptyImageBuilderApi',
   outputFile: '../../src/store/api/backend/hosted/imageBuilderApi.ts',


### PR DESCRIPTION
We recently renamed merged our `images` and `image-builder-cli` repo and moved it to `image-builder`, so the url no longer resolves. We need to update it to `image-builder-crc`.

JIRA: [HMS-10870](https://issues.redhat.com/browse/HMS-10870)

[HMS-10870]: https://redhat.atlassian.net/browse/HMS-10870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ