### PR TITLE
formatting: format all config files in the repo (HMS-10871)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,4 +9,17 @@ coverage/
 # Vendored
 cockpit/public/
 
+# github directory
+.github/
+
+package.json
 package-lock.json
+
+# all yaml files
+*.yml
+*.yaml
+**/*.yml
+**/*.yaml
+
+# all markdown files
+*.md

--- a/api/config/contentSources.ts
+++ b/api/config/contentSources.ts
@@ -2,7 +2,8 @@ import type { ConfigFile } from '@rtk-query/codegen-openapi';
 
 const config: ConfigFile = {
   schemaFile: 'https://console.redhat.com/api/content-sources/v1/openapi.json',
-  apiFile: '../../src/store/api/contentSources/hosted/emptyContentSourcesApi.ts',
+  apiFile:
+    '../../src/store/api/contentSources/hosted/emptyContentSourcesApi.ts',
   apiImport: 'emptyContentSourcesApi',
   outputFile: '../../src/store/api/contentSources/hosted/contentSourcesApi.ts',
   exportName: 'contentSourcesApi',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,8 @@ const globals = require('globals');
 const prettierConfig = require('eslint-config-prettier');
 
 module.exports = defineConfig([
-  { // Ignore programatically generated files
+  {
+    // Ignore programatically generated files
     ignores: [
       '**/mockServiceWorker.js',
       '**/imageBuilderApi.ts',
@@ -25,30 +26,35 @@ module.exports = defineConfig([
     ],
   },
 
-  { // Base config for js/ts files
+  {
+    // Base config for js/ts files
     files: ['**/*.{js,ts,jsx,tsx}'],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {
-        project: ['./tsconfig.json', './tsconfig.vitest.json', './playwright/tsconfig.json']
+        project: [
+          './tsconfig.json',
+          './tsconfig.vitest.json',
+          './playwright/tsconfig.json',
+        ],
       },
       globals: {
         ...globals.browser,
         // node
-        'JSX': 'readonly',
-        'process': 'readonly',
-        '__dirname': 'readonly',
-        'require': 'readonly',
+        JSX: 'readonly',
+        process: 'readonly',
+        __dirname: 'readonly',
+        require: 'readonly',
         // vitest
-        'describe': 'readonly',
-        'it': 'readonly',
-        'test': 'readonly',
-        'expect': 'readonly',
-        'vi': 'readonly',
-        'beforeAll': 'readonly',
-        'beforeEach': 'readonly',
-        'afterAll': 'readonly',
-        'afterEach': 'readonly'
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        vi: 'readonly',
+        beforeAll: 'readonly',
+        beforeEach: 'readonly',
+        afterAll: 'readonly',
+        afterEach: 'readonly',
       },
     },
     plugins: {
@@ -68,33 +74,46 @@ module.exports = defineConfig([
       ...pluginReactRedux.configs.recommended.rules,
       ...pluginJsxA11y.configs.recommended.rules,
       ...fecConfig.rules,
-      'import/order': ['error', {
-        groups: ['builtin', 'external', 'internal', 'sibling', 'parent', 'index'],
-        alphabetize: {
-          order: 'asc',
-          caseInsensitive: true
-        },
-        'newlines-between': 'always',
-        pathGroups: [
-          // ensures the import of React is always on top
-          {
-            pattern: 'react',
-            group: 'builtin',
-            position: 'before'
+      'import/order': [
+        'error',
+        {
+          groups: [
+            'builtin',
+            'external',
+            'internal',
+            'sibling',
+            'parent',
+            'index',
+          ],
+          alphabetize: {
+            order: 'asc',
+            caseInsensitive: true,
           },
-          {
-            pattern: '@/**',
-            group: 'internal',
-            position: 'before'
-          }
-        ],
-        pathGroupsExcludedImportTypes: ['react']
-      }],
-      'sort-imports': ['error', {
-        ignoreCase: true,
-        ignoreDeclarationSort: true,
-        ignoreMemberSort: false,
-      }],
+          'newlines-between': 'always',
+          pathGroups: [
+            // ensures the import of React is always on top
+            {
+              pattern: 'react',
+              group: 'builtin',
+              position: 'before',
+            },
+            {
+              pattern: '@/**',
+              group: 'internal',
+              position: 'before',
+            },
+          ],
+          pathGroupsExcludedImportTypes: ['react'],
+        },
+      ],
+      'sort-imports': [
+        'error',
+        {
+          ignoreCase: true,
+          ignoreDeclarationSort: true,
+          ignoreMemberSort: false,
+        },
+      ],
       'no-duplicate-imports': 'error',
       // NOTE: we can enable this after the revamp and after summit. We can live with
       // the mixture of alias imports and relative imports. We can then enable the warning
@@ -111,28 +130,32 @@ module.exports = defineConfig([
         {
           patterns: [
             {
-              group: [
-                '@/store/slices/wizard/filesystem/*.ts',
-              ],
+              group: ['@/store/slices/wizard/filesystem/*.ts'],
               message:
                 'Import from @/store/slices/wizard instead. Direct imports into slice internals bypass the barrel and fragment createSelector memoization caches.',
             },
           ],
         },
       ],
-      'prefer-const': ['error', {
-        destructuring: 'any',
-      }],
+      'prefer-const': [
+        'error',
+        {
+          destructuring: 'any',
+        },
+      ],
       'no-console': 'error',
-      'eqeqeq': 'error',
+      eqeqeq: 'error',
       'array-callback-return': 'warn',
-      '@typescript-eslint/ban-ts-comment': ['error', {
-        'ts-expect-error': 'allow-with-description',
-        'ts-ignore': 'allow-with-description',
-        'ts-nocheck': true,
-        'ts-check': true,
-        minimumDescriptionLength: 5,
-      }],
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        {
+          'ts-expect-error': 'allow-with-description',
+          'ts-ignore': 'allow-with-description',
+          'ts-nocheck': true,
+          'ts-check': true,
+          minimumDescriptionLength: 5,
+        },
+      ],
       '@typescript-eslint/ban-types': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'error',
@@ -155,7 +178,8 @@ module.exports = defineConfig([
     },
   },
 
-  { // Override for test files
+  {
+    // Override for test files
     files: ['src/test/**/*.{ts,tsx}'],
     plugins: {
       'jest-dom': jestDom,
@@ -166,11 +190,12 @@ module.exports = defineConfig([
       ...pluginTestingLibrary.configs.react.rules,
       'react/display-name': 'off',
       'react/prop-types': 'off',
-      'testing-library/no-debugging-utils': 'error'
+      'testing-library/no-debugging-utils': 'error',
     },
   },
 
-  { // Override for Playwright tests
+  {
+    // Override for Playwright tests
     files: ['playwright/**/*.ts'],
     plugins: {
       playwright: pluginPlaywright,
@@ -182,8 +207,8 @@ module.exports = defineConfig([
       'playwright/no-skipped-test': [
         'error',
         {
-          'allowConditional': true
-        }
+          allowConditional: true,
+        },
       ],
       '@typescript-eslint/await-thenable': 'error',
       '@typescript-eslint/no-floating-promises': 'error',

--- a/fec.config.js
+++ b/fec.config.js
@@ -9,7 +9,7 @@ const plugins = [];
 
 function add_define(key, value) {
   const definePluginIndex = plugins.findIndex(
-    (plugin) => plugin instanceof webpack.DefinePlugin
+    (plugin) => plugin instanceof webpack.DefinePlugin,
   );
   if (definePluginIndex !== -1) {
     const definePlugin = plugins[definePluginIndex];
@@ -24,7 +24,7 @@ function add_define(key, value) {
     plugins.push(
       new webpack.DefinePlugin({
         [key]: JSON.stringify(value),
-      })
+      }),
     );
   }
 }
@@ -47,7 +47,7 @@ if (process.env.ENABLE_SENTRY) {
         project: 'image-builder-rhel',
         release,
       }),
-    })
+    }),
   );
 }
 
@@ -115,11 +115,11 @@ module.exports = {
       './RootApp': path.resolve(__dirname, './src/AppEntry.tsx'),
       './ImageBuilderWidget': path.resolve(
         __dirname,
-        './src/Components/Widgets/image-builder-widget.tsx'
+        './src/Components/Widgets/image-builder-widget.tsx',
       ),
     },
     shared: [{ 'react-router-dom': { singleton: true, version: '*' } }],
     exclude: ['react-router-dom'],
   },
-  frontendCRDPath: path.resolve(__dirname, './deploy/frontend-clowder.yml')
+  frontendCRDPath: path.resolve(__dirname, './deploy/frontend-clowder.yml'),
 };

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
   "scripts": {
     "lint": "eslint src playwright --fix --cache",
     "lint:check": "eslint src playwright",
-    "format": "prettier --write src playwright",
-    "format:check": "prettier --check src playwright",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "start": "fec dev-proxy",
     "start:stage": "fec dev-proxy --clouddotEnv=stage",
     "start:prod": "fec dev-proxy --clouddotEnv=prod",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,7 +54,7 @@ export default defineConfig({
     },
     {
       name: 'Boot tests',
-      testMatch: /.*\.boot\.ts/, 
+      testMatch: /.*\.boot\.ts/,
       // Retry 2 times because it's still cheaper than
       // rerunning the whole job
       retries: process.env.CI ? 2 : 0,
@@ -64,6 +64,6 @@ export default defineConfig({
         storageState: '.auth/user.json',
       },
       dependencies: ['Setup'],
-    }
+    },
   ],
 });

--- a/renovate.json
+++ b/renovate.json
@@ -1,21 +1,15 @@
 {
-    "extends": [
-        "github>konflux-ci/mintmaker//config/renovate/renovate.json"
-    ],
-    "schedule": [
-        "on Monday after 3am and before 10am"
-    ],
-    "ignorePaths": [
-        ".pre-commit-config.yaml"
-    ],
-    "packageRules": [
+  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+  "schedule": ["on Monday after 3am and before 10am"],
+  "ignorePaths": [".pre-commit-config.yaml"],
+  "packageRules": [
     {
-        "description": "Disable all npm dependency updates",
-        "matchManagers": ["npm"],
-        "enabled": false
+      "description": "Disable all npm dependency updates",
+      "matchManagers": ["npm"],
+      "enabled": false
     }
-    ],
-    "lockFileMaintenance": {
-        "enabled": false
-    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  }
 }

--- a/scripts/check-vulnerable-packages.js
+++ b/scripts/check-vulnerable-packages.js
@@ -10,7 +10,11 @@ const { PackageURL } = require('packageurl-js');
 
 // Parse deny-packages from config
 function loadDeniedPackages() {
-  const configPath = path.join(process.cwd(), '.github', 'dependency-review-config.yml');
+  const configPath = path.join(
+    process.cwd(),
+    '.github',
+    'dependency-review-config.yml',
+  );
 
   if (!fs.existsSync(configPath)) {
     console.error('Error: .github/dependency-review-config.yml not found');
@@ -26,7 +30,12 @@ function loadDeniedPackages() {
       inDenyPackages = true;
       continue;
     }
-    if (inDenyPackages && line[0] !== ' ' && line[0] !== '-' && line.trim() !== '') {
+    if (
+      inDenyPackages &&
+      line[0] !== ' ' &&
+      line[0] !== '-' &&
+      line.trim() !== ''
+    ) {
       break;
     }
     if (inDenyPackages && line.trim().startsWith('- ')) {
@@ -69,7 +78,9 @@ function checkPackages() {
   for (const purlString of deniedPackages) {
     try {
       const purl = PackageURL.fromString(purlString);
-      const fullName = purl.namespace ? `${purl.namespace}/${purl.name}` : purl.name;
+      const fullName = purl.namespace
+        ? `${purl.namespace}/${purl.name}`
+        : purl.name;
       if (!compromisedByName.has(fullName)) {
         compromisedByName.set(fullName, []);
       }
@@ -109,7 +120,7 @@ function checkPackages() {
           name,
           info.version,
           null,
-          null
+          null,
         );
 
         // Convert to string and check if it's in the denied list
@@ -120,14 +131,14 @@ function checkPackages() {
         if (deniedPackages.has(purlString)) {
           found.push({
             purl: purlString,
-            displayName: displayName
+            displayName: displayName,
           });
         } else if (compromisedByName.has(fullName)) {
           // Package exists but at a different version
           if (!differentVersions.has(fullName)) {
             differentVersions.set(fullName, {
               installed: new Set(),
-              compromised: compromisedByName.get(fullName)
+              compromised: compromisedByName.get(fullName),
             });
           }
           differentVersions.get(fullName).installed.add(info.version);
@@ -140,24 +151,34 @@ function checkPackages() {
   }
 
   if (packageLock.packages) scan(packageLock.packages);
-  
+
   // Report results
   if (found.length > 0) {
     console.error(`\n❌ Found ${found.length} compromised package(s):`);
-    found.forEach(pkg => console.error(`  - ${pkg.displayName}`));
-    console.error('\nThese packages are from a supply chain attack. DO NOT MERGE!');
-    console.error('See: https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack\n');
+    found.forEach((pkg) => console.error(`  - ${pkg.displayName}`));
+    console.error(
+      '\nThese packages are from a supply chain attack. DO NOT MERGE!',
+    );
+    console.error(
+      'See: https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack\n',
+    );
     process.exit(1);
   } else {
-    console.log(`✅ No compromised packages detected (checked ${deniedPackages.size} packages)`);
-    
+    console.log(
+      `✅ No compromised packages detected (checked ${deniedPackages.size} packages)`,
+    );
+
     // Show packages with different versions if any
     if (differentVersions.size > 0) {
-      console.log(`\nℹ️  Found ${differentVersions.size} package(s) at different (safe) versions:`);
+      console.log(
+        `\nℹ️  Found ${differentVersions.size} package(s) at different (safe) versions:`,
+      );
       for (const [pkgName, versions] of differentVersions.entries()) {
         const installedList = Array.from(versions.installed).sort().join(', ');
         const compromisedList = versions.compromised.join(', ');
-        console.log(`  - ${pkgName}@${installedList} ✓ (compromised: ${compromisedList})`);
+        console.log(
+          `  - ${pkgName}@${installedList} ✓ (compromised: ${compromisedList})`,
+        );
       }
     }
   }

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,11 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "types": [
-      "node",
-      "vitest/globals",
-      "@testing-library/jest-dom"
-    ]
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["./src/**/*.test.ts", "./src/**/*.test.tsx", "./src/test"],
   "exclude": ["./playwright"]


### PR DESCRIPTION
It's super annoying working on config files and then prettier formats them automatically. It makes it trickier to only commit the relevant changes. Let's just format all the config files in one go and then update the script to fix the config files too.

JIRA: [HMS-10871](https://issues.redhat.com/browse/HMS-10871)

[HMS-10871]: https://redhat.atlassian.net/browse/HMS-10871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ