### PR TITLE
Extract compliance submodule from wizard slice (HMS-10888)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -131,6 +131,7 @@ module.exports = defineConfig([
           patterns: [
             {
               group: [
+                '@/store/slices/wizard/compliance/*',
                 '@/store/slices/wizard/details/*',
                 '@/store/slices/wizard/filesystem/*.ts',
               ],

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -20,6 +20,7 @@ import {
   changeFips,
   changeFscMode,
   clearKernelAppend,
+  removeBetaFromRelease,
   selectCompliancePolicyID,
   selectCompliancePolicyTitle,
   selectDistribution,
@@ -28,8 +29,6 @@ import {
 } from '@/store/slices/wizard';
 
 import { useSelectorHandlers } from './useSelectorHandlers';
-
-import { removeBetaFromRelease } from '../removeBetaFromRelease';
 
 type ComplianceSelectOptionValueType = {
   policyID?: string;

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileDetails.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileDetails.tsx
@@ -18,11 +18,10 @@ import {
 } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
 import {
+  removeBetaFromRelease,
   selectComplianceProfileID,
   selectDistribution,
 } from '@/store/slices/wizard';
-
-import { removeBetaFromRelease } from '../removeBetaFromRelease';
 
 const ProfileDetails = (): JSX.Element => {
   const releaseRaw = useAppSelector(selectDistribution);

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -30,6 +30,7 @@ import {
   changeFips,
   changeFscMode,
   clearKernelAppend,
+  removeBetaFromRelease,
   selectComplianceProfileID,
   selectComplianceType,
   selectDistribution,
@@ -37,8 +38,6 @@ import {
 } from '@/store/slices/wizard';
 
 import { useSelectorHandlers } from './useSelectorHandlers';
-
-import { removeBetaFromRelease } from '../removeBetaFromRelease';
 
 type OScapSelectOptionValueType = {
   profileID?: DistributionProfileItem;

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -46,6 +46,7 @@ import {
   changeMaskedServices,
   clearKernelAppend,
   ComplianceType,
+  removeBetaFromRelease,
   removePackage,
   selectCompliancePolicyID,
   selectComplianceProfileID,
@@ -67,7 +68,6 @@ import PolicySelector from './components/PolicySelector';
 import OpenScapProfileDetails from './components/ProfileDetails';
 import ProfileSelector from './components/ProfileSelector';
 
-import { removeBetaFromRelease } from '../../../../store/slices/wizard/compliance/utilities';
 import ExternalLinkButton from '../../utilities/ExternalLinkButton';
 
 const OscapContent = () => {

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -66,8 +66,8 @@ import PolicyDetails from './components/PolicyDetails';
 import PolicySelector from './components/PolicySelector';
 import OpenScapProfileDetails from './components/ProfileDetails';
 import ProfileSelector from './components/ProfileSelector';
-import { removeBetaFromRelease } from './removeBetaFromRelease';
 
+import { removeBetaFromRelease } from '../../../../store/slices/wizard/compliance/utilities';
 import ExternalLinkButton from '../../utilities/ExternalLinkButton';
 
 const OscapContent = () => {

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -39,13 +39,13 @@ import {
 import { ApiRepositoryImportResponseRead } from '@/store/api/contentSources';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
+  combinedInitialState,
   CombinedWizardState,
   ComplianceType,
   convertToBytes,
   DiskPartition,
   FilesystemMode,
   FilesystemPartition,
-  initialState,
   parseSizeUnit,
   RegistrationType,
   selectAapCallbackUrl,
@@ -435,7 +435,8 @@ function commonRequestToState(
     .options as AzureUploadRequestOptions;
 
   const arch =
-    request.image_requests[0]?.architecture ?? initialState.output.architecture;
+    request.image_requests[0]?.architecture ??
+    combinedInitialState.output.architecture;
   if (!['x86_64', 'aarch64'].includes(arch)) {
     throw new Error(`image type: ${arch} has no implementation yet`);
   }
@@ -496,7 +497,7 @@ function commonRequestToState(
               },
             }
           : {
-              ...initialState.compliance,
+              ...combinedInitialState.compliance,
               fips: {
                 enabled: request.customizations.fips?.enabled || false,
               },
@@ -544,7 +545,7 @@ function commonRequestToState(
       // the user can pick the correct distro in the wizard.
       distribution:
         getLatestRelease(request.distribution) ??
-        initialState.output.distribution,
+        combinedInitialState.output.distribution,
       imageSource: 'bootc' in request ? request.bootc?.reference : undefined,
       isoPayloadReference: request.bootc?.iso_payload_reference,
       imageTypes: request.image_requests.map((image) => image.image_type),
@@ -616,7 +617,7 @@ function commonRequestToState(
         ? {
             script: getFirstBootScript(request.customizations.files),
           }
-        : initialState.system.firstBoot,
+        : combinedInitialState.system.firstBoot,
       users:
         request.customizations.users?.map((user) => ({
           name: user.name,
@@ -774,7 +775,7 @@ export const mapBlueprintExportToState = (
       metadata: getMetadata(blueprint.metadata),
     },
     registration: {
-      ...initialState.registration,
+      ...combinedInitialState.registration,
       aap: {
         enabled: blueprint.customizations.aap_registration !== undefined,
         callbackUrl:

--- a/src/store/slices/wizard/compliance/index.ts
+++ b/src/store/slices/wizard/compliance/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/src/store/slices/wizard/compliance/index.ts
+++ b/src/store/slices/wizard/compliance/index.ts
@@ -1,2 +1,3 @@
 export { initialState as complianceState } from './state';
 export * from './types';
+export * from './utilities';

--- a/src/store/slices/wizard/compliance/index.ts
+++ b/src/store/slices/wizard/compliance/index.ts
@@ -1,1 +1,2 @@
+export { initialState as complianceState } from './state';
 export * from './types';

--- a/src/store/slices/wizard/compliance/index.ts
+++ b/src/store/slices/wizard/compliance/index.ts
@@ -1,3 +1,4 @@
+export * from './selectors';
 export { initialState as complianceState } from './state';
 export * from './types';
 export * from './utilities';

--- a/src/store/slices/wizard/compliance/index.ts
+++ b/src/store/slices/wizard/compliance/index.ts
@@ -1,4 +1,5 @@
 export * from './selectors';
+export * from './slice';
 export { initialState as complianceState } from './state';
 export * from './types';
 export * from './utilities';

--- a/src/store/slices/wizard/compliance/selectors.ts
+++ b/src/store/slices/wizard/compliance/selectors.ts
@@ -1,0 +1,21 @@
+import { RootState } from '@/store';
+
+export const selectComplianceProfileID = (state: RootState) => {
+  return state.wizard.compliance.profileID;
+};
+
+export const selectCompliancePolicyID = (state: RootState) => {
+  return state.wizard.compliance.policyID;
+};
+
+export const selectCompliancePolicyTitle = (state: RootState) => {
+  return state.wizard.compliance.policyTitle;
+};
+
+export const selectComplianceType = (state: RootState) => {
+  return state.wizard.compliance.type;
+};
+
+export const selectFips = (state: RootState) => {
+  return state.wizard.compliance.fips;
+};

--- a/src/store/slices/wizard/compliance/slice.ts
+++ b/src/store/slices/wizard/compliance/slice.ts
@@ -1,0 +1,50 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { initialState } from './state';
+import { ComplianceSlice, ComplianceType } from './types';
+
+import { initializeWizard, loadWizardState } from '../actions';
+
+export const complianceSlice = createSlice({
+  name: 'wizard/compliance',
+  initialState,
+  reducers: {
+    changeComplianceType: (state, action: PayloadAction<ComplianceType>) => {
+      state.type = action.payload;
+    },
+    setCompliancePolicy: (
+      state,
+      action: PayloadAction<Pick<ComplianceSlice, 'policyID' | 'policyTitle'>>,
+    ) => {
+      state.policyID = action.payload.policyID;
+      state.policyTitle = action.payload.policyTitle;
+    },
+    setOscapProfile: (state, action: PayloadAction<string | undefined>) => {
+      state.profileID = action.payload;
+    },
+    changeFips: (state, action: PayloadAction<boolean>) => {
+      state.fips.enabled = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // we need to add these cases so that the submodule slice also
+      // reacts to the top-level initialize and loadWizardState calls
+      .addCase(initializeWizard, () => initialState)
+      .addCase(
+        loadWizardState,
+        // Payload may lack `compliance` if loading a blueprint serialised before
+        // this subslice existed, so fall back defensively despite the type.
+        (_state, action) =>
+          (action.payload as Partial<typeof action.payload>).compliance ??
+          initialState,
+      );
+  },
+});
+
+export const {
+  setCompliancePolicy,
+  setOscapProfile,
+  changeComplianceType,
+  changeFips,
+} = complianceSlice.actions;

--- a/src/store/slices/wizard/compliance/state.ts
+++ b/src/store/slices/wizard/compliance/state.ts
@@ -1,0 +1,11 @@
+import { ComplianceSlice } from './types';
+
+export const initialState: ComplianceSlice = {
+  type: 'none',
+  policyID: undefined,
+  profileID: undefined,
+  policyTitle: undefined,
+  fips: {
+    enabled: false,
+  },
+};

--- a/src/store/slices/wizard/compliance/tests/compliance.test.ts
+++ b/src/store/slices/wizard/compliance/tests/compliance.test.ts
@@ -1,10 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { describe, expect, it } from 'vitest';
 
+import { combinedInitialState, wizardReducer } from '@/store/slices/wizard';
+
 import {
   changeComplianceType,
   changeFips,
-  combinedInitialState,
   selectCompliancePolicyID,
   selectCompliancePolicyTitle,
   selectComplianceProfileID,
@@ -12,10 +13,8 @@ import {
   selectFips,
   setCompliancePolicy,
   setOscapProfile,
-  wizardReducer,
-} from '@/store/slices/wizard';
-
-import { createMockState } from './mockWizardState';
+} from '..';
+import { createMockState } from '../../tests/mockWizardState';
 
 const createStore = (overrides: Partial<typeof combinedInitialState> = {}) =>
   configureStore({

--- a/src/store/slices/wizard/compliance/types.ts
+++ b/src/store/slices/wizard/compliance/types.ts
@@ -1,0 +1,11 @@
+export type ComplianceType = 'none' | 'openscap' | 'compliance';
+
+export type ComplianceSlice = {
+  type: ComplianceType;
+  policyID: string | undefined;
+  profileID: string | undefined;
+  policyTitle: string | undefined;
+  fips: {
+    enabled: boolean;
+  };
+};

--- a/src/store/slices/wizard/compliance/utilities.ts
+++ b/src/store/slices/wizard/compliance/utilities.ts
@@ -3,6 +3,8 @@ import { Distributions } from '@/store/api/backend';
 
 // The beta releases won't have any oscap profiles associated with them,
 // so just use the ones from the major release.
+// TODO: this can be moved to a derived selector once we've finished breaking
+// up the wizard slice into sub slices
 export const removeBetaFromRelease = (dist: Distributions): Distributions => {
   switch (dist) {
     case RHEL_10_BETA:

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -3,5 +3,6 @@ export * from './slice';
 export * from './types';
 
 // submodules
+export * from './compliance/';
 export * from './details';
 export * from './filesystem';

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -28,11 +28,11 @@ import isRhel from '@/Utilities/isRhel';
 import { yyyyMMddFormat } from '@/Utilities/time';
 
 import { initializeWizard, loadWizardState } from './actions';
+import { ComplianceType } from './compliance';
 import { detailsSlice, detailsState } from './details';
 import { filesystemSlice, filesystemState } from './filesystem';
 import {
   CombinedWizardState,
-  ComplianceType,
   ImageSource,
   RegistrationType,
   UserAdministratorPayload,

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -28,7 +28,7 @@ import isRhel from '@/Utilities/isRhel';
 import { yyyyMMddFormat } from '@/Utilities/time';
 
 import { initializeWizard, loadWizardState } from './actions';
-import { ComplianceType } from './compliance';
+import { complianceState, ComplianceType } from './compliance';
 import { detailsSlice, detailsState } from './details';
 import { filesystemSlice, filesystemState } from './filesystem';
 import {
@@ -93,15 +93,7 @@ export const initialState: WizardState = {
       skipTlsVerification: undefined,
     },
   },
-  compliance: {
-    type: 'none',
-    policyID: undefined,
-    profileID: undefined,
-    policyTitle: undefined,
-    fips: {
-      enabled: false,
-    },
-  },
+  compliance: complianceState,
   content: {
     repositories: {
       customRepositories: [],

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -256,22 +256,6 @@ export const selectAapTlsConfirmation = (state: RootState) => {
   return state.wizard.registration.aap.skipTlsVerification;
 };
 
-export const selectComplianceProfileID = (state: RootState) => {
-  return state.wizard.compliance.profileID;
-};
-
-export const selectCompliancePolicyID = (state: RootState) => {
-  return state.wizard.compliance.policyID;
-};
-
-export const selectCompliancePolicyTitle = (state: RootState) => {
-  return state.wizard.compliance.policyTitle;
-};
-
-export const selectComplianceType = (state: RootState) => {
-  return state.wizard.compliance.type;
-};
-
 export const selectUseLatest = (state: RootState) => {
   return state.wizard.content.snapshotting.useLatest;
 };
@@ -368,10 +352,6 @@ export const selectHostname = (state: RootState) => {
 
 export const selectFirewall = (state: RootState) => {
   return state.wizard.system.firewall;
-};
-
-export const selectFips = (state: RootState) => {
-  return state.wizard.compliance.fips;
 };
 
 export const selectVerifiedLocaleLangpacks = (state: RootState) => {

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -28,7 +28,7 @@ import isRhel from '@/Utilities/isRhel';
 import { yyyyMMddFormat } from '@/Utilities/time';
 
 import { initializeWizard, loadWizardState } from './actions';
-import { complianceState, ComplianceType } from './compliance';
+import { complianceSlice, complianceState } from './compliance';
 import { detailsSlice, detailsState } from './details';
 import { filesystemSlice, filesystemState } from './filesystem';
 import {
@@ -93,7 +93,6 @@ export const initialState: WizardState = {
       skipTlsVerification: undefined,
     },
   },
-  compliance: complianceState,
   content: {
     repositories: {
       customRepositories: [],
@@ -579,22 +578,6 @@ export const wizardSlice = createSlice({
     changeOrgId: (state, action: PayloadAction<string>) => {
       state.registration.orgId = action.payload;
     },
-    changeComplianceType: (state, action: PayloadAction<ComplianceType>) => {
-      state.compliance.type = action.payload;
-    },
-    setCompliancePolicy: (
-      state,
-      action: PayloadAction<{
-        policyID: string | undefined;
-        policyTitle: string | undefined;
-      }>,
-    ) => {
-      state.compliance.policyID = action.payload.policyID;
-      state.compliance.policyTitle = action.payload.policyTitle;
-    },
-    setOscapProfile: (state, action: PayloadAction<string | undefined>) => {
-      state.compliance.profileID = action.payload;
-    },
     changeUseLatest: (state, action: PayloadAction<boolean>) => {
       if (!action.payload && state.content.snapshotting.snapshotDate === '') {
         state.content.snapshotting.snapshotDate = `${yyyyMMddFormat(new Date())}T00:00:00.000Z`;
@@ -1071,9 +1054,6 @@ export const wizardSlice = createSlice({
         (_, index) => index !== action.payload,
       );
     },
-    changeFips: (state, action: PayloadAction<boolean>) => {
-      state.compliance.fips.enabled = action.payload;
-    },
     setVerifiedLocaleLangpacks: (state, action: PayloadAction<string[]>) => {
       state.content.verifiedLocaleLangpacks = action.payload;
     },
@@ -1116,9 +1096,6 @@ export const {
   changeRegistrationType,
   changeActivationKey,
   changeOrgId,
-  setCompliancePolicy,
-  setOscapProfile,
-  changeComplianceType,
   changeUseLatest,
   changeSnapshotDate,
   changeTemplate,
@@ -1185,7 +1162,6 @@ export const {
   addGroupToUserByUserIndex,
   removeGroupFromUserByIndex,
   changeRedHatRepositories,
-  changeFips,
   setVerifiedLocaleLangpacks,
 } = wizardSlice.actions;
 
@@ -1197,6 +1173,7 @@ export const {
 // to temporarily change the slice shape, which is not ideal
 export const combinedInitialState: CombinedWizardState = {
   ...initialState,
+  compliance: complianceState,
   details: detailsState,
   filesystem: filesystemState,
 };
@@ -1208,6 +1185,7 @@ export const wizardReducer: Reducer<CombinedWizardState> = (state, action) => {
   );
   return {
     ...coreState,
+    compliance: complianceSlice.reducer(state?.compliance, action),
     details: detailsSlice.reducer(state?.details, action),
     filesystem: filesystemSlice.reducer(state?.filesystem, action),
   };

--- a/src/store/slices/wizard/tests/compliance.test.ts
+++ b/src/store/slices/wizard/tests/compliance.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   changeComplianceType,
   changeFips,
-  initialState,
+  combinedInitialState,
   selectCompliancePolicyID,
   selectCompliancePolicyTitle,
   selectComplianceProfileID,
@@ -12,23 +12,23 @@ import {
   selectFips,
   setCompliancePolicy,
   setOscapProfile,
-  wizardSlice,
+  wizardReducer,
 } from '@/store/slices/wizard';
 
 import { createMockState } from './mockWizardState';
 
-const createStore = (overrides: Partial<typeof initialState> = {}) =>
+const createStore = (overrides: Partial<typeof combinedInitialState> = {}) =>
   configureStore({
-    reducer: { wizard: wizardSlice.reducer },
+    reducer: { wizard: wizardReducer },
     preloadedState: {
-      wizard: { ...initialState, ...overrides },
+      wizard: { ...combinedInitialState, ...overrides },
     },
   });
 
 describe('compliance submodule', () => {
   describe('initial state', () => {
     it('has compliance nested with type, policyID, profileID, policyTitle, and fips', () => {
-      const state = initialState;
+      const state = combinedInitialState;
 
       expect(state.compliance).toEqual({
         type: 'none',
@@ -42,12 +42,14 @@ describe('compliance submodule', () => {
     });
 
     it('does not have a top-level fips key', () => {
-      expect(initialState).not.toHaveProperty('fips');
+      expect(combinedInitialState).not.toHaveProperty('fips');
     });
 
     it('does not have complianceType inside compliance (uses type instead)', () => {
-      expect(initialState.compliance).not.toHaveProperty('complianceType');
-      expect(initialState.compliance).toHaveProperty('type');
+      expect(combinedInitialState.compliance).not.toHaveProperty(
+        'complianceType',
+      );
+      expect(combinedInitialState.compliance).toHaveProperty('type');
     });
   });
 
@@ -55,7 +57,7 @@ describe('compliance submodule', () => {
     it('selectComplianceType reads from compliance.type', () => {
       const state = createMockState({
         compliance: {
-          ...initialState.compliance,
+          ...combinedInitialState.compliance,
           type: 'openscap',
         },
       });
@@ -66,7 +68,7 @@ describe('compliance submodule', () => {
     it('selectCompliancePolicyID reads from compliance.policyID', () => {
       const state = createMockState({
         compliance: {
-          ...initialState.compliance,
+          ...combinedInitialState.compliance,
           policyID: 'policy-123',
         },
       });
@@ -77,7 +79,7 @@ describe('compliance submodule', () => {
     it('selectComplianceProfileID reads from compliance.profileID', () => {
       const state = createMockState({
         compliance: {
-          ...initialState.compliance,
+          ...combinedInitialState.compliance,
           profileID: 'profile-456',
         },
       });
@@ -88,7 +90,7 @@ describe('compliance submodule', () => {
     it('selectCompliancePolicyTitle reads from compliance.policyTitle', () => {
       const state = createMockState({
         compliance: {
-          ...initialState.compliance,
+          ...combinedInitialState.compliance,
           policyTitle: 'My Policy',
         },
       });
@@ -99,7 +101,7 @@ describe('compliance submodule', () => {
     it('selectFips reads from compliance.fips', () => {
       const state = createMockState({
         compliance: {
-          ...initialState.compliance,
+          ...combinedInitialState.compliance,
           fips: { enabled: true },
         },
       });

--- a/src/store/slices/wizard/tests/wizardSlice.test.ts
+++ b/src/store/slices/wizard/tests/wizardSlice.test.ts
@@ -117,6 +117,12 @@ describe('wizardSlice core reducers', () => {
             unit: 'GiB',
           },
         },
+        compliance: {
+          ...initialState.compliance,
+          type: 'openscap',
+          profileID: 'xccdf_org.ssgproject.content_profile_cis',
+          fips: { enabled: true },
+        },
         details: {
           ...initialState.details,
           mode: 'edit',
@@ -136,6 +142,11 @@ describe('wizardSlice core reducers', () => {
       expect(result.system.hostname).toBe('loaded-hostname');
       expect(result.filesystem.mode).toBe('advanced');
       expect(result.filesystem.disk.minsize).toBe('20');
+      expect(result.compliance.type).toBe('openscap');
+      expect(result.compliance.profileID).toBe(
+        'xccdf_org.ssgproject.content_profile_cis',
+      );
+      expect(result.compliance.fips.enabled).toBe(true);
       expect(result.details.mode).toBe('edit');
       expect(result.details.blueprintId).toBe('bp-123');
       expect(result.details.blueprint.name).toBe('loaded-blueprint');
@@ -185,6 +196,17 @@ describe('wizardSlice core reducers', () => {
       const result = wizardReducer(initialState, loadWizardState(stateToLoad));
 
       expect(result.filesystem).toEqual(initialState.filesystem);
+    });
+
+    it('loadWizardState should fall back to initialState when compliance is missing', () => {
+      const stateToLoad = {
+        ...initialState,
+        compliance: undefined,
+      } as unknown as CombinedWizardState;
+
+      const result = wizardReducer(initialState, loadWizardState(stateToLoad));
+
+      expect(result.compliance).toEqual(initialState.compliance);
     });
 
     it('loadWizardState should fall back to initialState when details is missing', () => {

--- a/src/store/slices/wizard/types.ts
+++ b/src/store/slices/wizard/types.ts
@@ -127,7 +127,6 @@ export type WizardState = {
       skipTlsVerification: boolean | undefined;
     };
   };
-  compliance: ComplianceSlice;
   content: {
     repositories: {
       customRepositories: CustomRepository[];
@@ -175,6 +174,7 @@ export type WizardState = {
 };
 
 export type CombinedWizardState = WizardState & {
+  compliance: ComplianceSlice;
   details: DetailsSlice;
   filesystem: FilesystemSlice;
 };

--- a/src/store/slices/wizard/types.ts
+++ b/src/store/slices/wizard/types.ts
@@ -20,6 +20,7 @@ import {
 import { ApiRepositoryResponseRead } from '@/store/api/contentSources';
 import { ActivationKeys } from '@/store/api/rhsm';
 
+import { ComplianceSlice } from './compliance';
 import { DetailsSlice } from './details';
 import { FilesystemSlice } from './filesystem';
 
@@ -32,8 +33,6 @@ export type RegistrationType =
   | 'register-now-rhc'
   | 'register-satellite'
   | 'register-aap';
-
-export type ComplianceType = 'none' | 'openscap' | 'compliance';
 
 export type UserWithAdditionalInfo = {
   [K in keyof User]-?: NonNullable<User[K]>;
@@ -128,15 +127,7 @@ export type WizardState = {
       skipTlsVerification: boolean | undefined;
     };
   };
-  compliance: {
-    type: ComplianceType;
-    policyID: string | undefined;
-    profileID: string | undefined;
-    policyTitle: string | undefined;
-    fips: {
-      enabled: boolean;
-    };
-  };
+  compliance: ComplianceSlice;
   content: {
     repositories: {
       customRepositories: CustomRepository[];


### PR DESCRIPTION
Extract compliance submodule from wizard slice

## Summary

Third in the series of wizard slice decompositions (after filesystem and details). Extracts compliance state, reducers, selectors, and types into a self-contained submodule under `store/slices/wizard/compliance/`.

## Changes

- Extract compliance types, initial state, selectors, reducers, and `removeBetaFromRelease` utility into `store/slices/wizard/compliance/` following the established four-file layout
- Add `extraReducers` for `initializeWizard` and `loadWizardState` with a defensive fallback for blueprints serialized before this subslice existed
- Co-locate compliance tests and add reducer + `loadWizardState` fallback coverage
- Add ESLint `no-restricted-imports` rule to enforce barrel imports for the compliance submodule
- Update all consumer imports (`Oscap`, `requestMapper`) to use the `@/store/slices/wizard` barrel


JIRA: [HMS-10888](https://issues.redhat.com/browse/HMS-10888)

[HMS-10888]: https://redhat.atlassian.net/browse/HMS-10888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ