### PR TITLE
Wizard/Review: Hide user groups section when empty (HMS-10873)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/UserGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/UserGroups.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { Flex } from '@patternfly/react-core';
 
 import { useAppSelector } from '@/store/hooks';
-import { selectUserGroups } from '@/store/slices/wizard';
+import { selectNonEmptyUserGroups } from '@/store/slices/wizard';
 
 import { FlexColumn, ReviewGroup } from '../../shared';
 import { Hideable } from '../../types';
 
 export const UserGroups = ({ shouldHide }: Hideable) => {
-  const userGroups = useAppSelector(selectUserGroups);
+  const userGroups = useAppSelector(selectNonEmptyUserGroups);
 
   if (shouldHide || userGroups.length === 0) {
     return null;

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -346,6 +346,11 @@ export const selectUserGroups = (state: RootState) => {
   return state.wizard.system.groups;
 };
 
+export const selectNonEmptyUserGroups = createSelector(
+  [selectUserGroups],
+  (groups) => groups.filter((group) => group.name.trim() || group.gid),
+);
+
 export const selectKernel = (state: RootState) => {
   return state.wizard.system.kernel;
 };


### PR DESCRIPTION
The user groups was previously rendered on the Review step when empty, this fixes the issue.

JIRA: [HMS-10873](https://issues.redhat.com/browse/HMS-10873)

[HMS-10873]: https://redhat.atlassian.net/browse/HMS-10873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ