### PR TITLE
Wizard/Review: Hide systemd services group when empty (HMS-10874)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Services.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Services.tsx
@@ -38,7 +38,10 @@ export const Services = ({
     [services, oscapServices],
   );
 
-  if (shouldHide) {
+  const isCustomized =
+    enabled.length > 0 || disabled.length > 0 || masked.length > 0;
+
+  if (shouldHide || !isCustomized) {
     return null;
   }
 

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -715,7 +715,7 @@ describe('AdvancedSettingsOverview', () => {
   });
 
   describe('Services', () => {
-    test('displays all service sections with empty messages by default', () => {
+    test('hides services section when no services configured', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
@@ -734,10 +734,15 @@ describe('AdvancedSettingsOverview', () => {
         },
       );
 
-      expect(screen.getByText('Enabled systemd services')).toBeInTheDocument();
-      expect(screen.getByText('Disabled systemd services')).toBeInTheDocument();
-      expect(screen.getByText('Masked systemd services')).toBeInTheDocument();
-      expect(screen.getAllByText('No services selected')).toHaveLength(3);
+      expect(
+        screen.queryByText('Enabled systemd services'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Disabled systemd services'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Masked systemd services'),
+      ).not.toBeInTheDocument();
     });
 
     test('displays enabled services', () => {


### PR DESCRIPTION
This hides the systems service group on the review page when there were no services specified.

JIRA: [HMS-10874](https://issues.redhat.com/browse/HMS-10874)

[HMS-10874]: https://redhat.atlassian.net/browse/HMS-10874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ