### PR TITLE
ImportBlueprintModal: extract duplicated test data into fixtures (HMS-10886)

### DIFF
--- a/src/Components/Blueprints/tests/ImportBlueprintModal.test.tsx
+++ b/src/Components/Blueprints/tests/ImportBlueprintModal.test.tsx
@@ -11,6 +11,8 @@ import {
   createFetchHandler,
   existingRepo,
   fetchMock,
+  importedNewRepo,
+  newRepoUrl,
 } from './mocks';
 
 import { ImportBlueprintModal } from '../ImportBlueprintModal';
@@ -71,7 +73,6 @@ const uploadBlueprintFile = async (content: string) => {
 describe('ImportBlueprintModal repository import', () => {
   test('does not import repos when checkbox is unchecked', async () => {
     const user = userEvent.setup();
-    const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
 
     fetchMock.mockResponse(
       createFetchHandler({
@@ -113,18 +114,10 @@ describe('ImportBlueprintModal repository import', () => {
   });
 
   test('imports all repos when none already exist', async () => {
-    const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
-    const importedRepo = {
-      uuid: 'new-uuid-1',
-      url: newRepoUrl,
-      name: 'brand-new-repo',
-      warnings: [],
-    };
-
     fetchMock.mockResponse(
       createFetchHandler({
         list: { repositories: [] },
-        bulkImport: { response: [importedRepo] },
+        bulkImport: { response: [importedNewRepo] },
       }),
     );
 
@@ -180,18 +173,10 @@ describe('ImportBlueprintModal repository import', () => {
   });
 
   test('imports only new repos when some already exist', async () => {
-    const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
-    const importedRepo = {
-      uuid: 'new-uuid-1',
-      url: newRepoUrl,
-      name: 'brand-new-repo',
-      warnings: [],
-    };
-
     fetchMock.mockResponse(
       createFetchHandler({
         list: { repositories: [existingRepo] },
-        bulkImport: { response: [importedRepo] },
+        bulkImport: { response: [importedNewRepo] },
       }),
     );
 
@@ -305,7 +290,6 @@ describe('ImportBlueprintModal repository import', () => {
       }),
     );
 
-    const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
     renderModal();
     await uploadBlueprintFile(
       createBlueprintJson([

--- a/src/Components/Blueprints/tests/mocks/fixtures.ts
+++ b/src/Components/Blueprints/tests/mocks/fixtures.ts
@@ -24,6 +24,15 @@ export const anotherExistingRepo: ApiRepositoryResponseRead = {
   module_hotfixes: false,
 };
 
+export const newRepoUrl = 'http://brand-new.repo.example.com/x86_64/';
+
+export const importedNewRepo = {
+  uuid: 'new-uuid-1',
+  url: newRepoUrl,
+  name: 'brand-new-repo',
+  warnings: [],
+};
+
 export const createBlueprintJson = (
   contentSources: { url: string; name?: string }[],
 ) =>


### PR DESCRIPTION
## Summary

Follow-up to #4553 — addresses review feedback by extracting duplicated test data into shared fixtures.

## Changes

- Extract `newRepoUrl` and `importedNewRepo` into `mocks/fixtures.ts` to eliminate repeated declarations across ImportBlueprintModal tests


JIRA: [HMS-10886](https://issues.redhat.com/browse/HMS-10886)

[HMS-10886]: https://redhat.atlassian.net/browse/HMS-10886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ