### PR TITLE
vitest: Migrate edit tests to co-located vitest mocked tests (HMS-10880)

### DIFF
--- a/src/Components/CreateImageWizard/tests/EditMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/EditMode.test.tsx
@@ -1,17 +1,35 @@
 import { screen, within } from '@testing-library/react';
+import { vi } from 'vitest';
 
-import { renderEditMode } from './wizardTestUtils';
+import { composeHandlers, createArchitecturesHandler } from '@/test/testUtils';
 
-import { mockBlueprintIds } from '../../fixtures/blueprints';
+import { renderEditMode } from './helpers';
+import {
+  createBlueprintHandler,
+  fetchMock,
+  mockArchitectures,
+  mockBlueprint,
+  mockBlueprintId,
+} from './mocks';
 
-describe('EditImageWizard', () => {
+describe('EditMode', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchMock.enableMocks();
+    fetchMock.mockResponse(
+      composeHandlers(
+        createArchitecturesHandler({ architectures: mockArchitectures }),
+        createBlueprintHandler({ blueprint: mockBlueprint }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    fetchMock.disableMocks();
   });
 
   test('should enable all navigation items in edit mode', async () => {
-    const id = mockBlueprintIds['darkChocolate'];
-    await renderEditMode(id);
+    await renderEditMode(mockBlueprintId);
 
     const heading = await screen.findByRole('heading', {
       name: /review image configuration/i,
@@ -33,7 +51,6 @@ describe('EditImageWizard', () => {
       name: /review/i,
     });
 
-    // Assert that all validation items are enabled
     expect(heading).toBeInTheDocument();
     expect(baseNavItem).toBeEnabled();
     expect(contentNavItem).toBeEnabled();

--- a/src/Components/CreateImageWizard/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/tests/helpers.tsx
@@ -9,18 +9,25 @@ import { RootState, serviceMiddleware, serviceReducer } from '@/store';
 
 import CreateImageWizard from '../CreateImageWizard';
 
-export const renderWithQueryParams = async (
-  queryString: string = '',
+type RenderWizardOptions = {
+  preloadedState?: Partial<RootState>;
+  initialRoute?: string;
+  waitForHeading?: RegExp;
+};
+
+const renderWizard = async (
+  options: RenderWizardOptions = {},
 ): Promise<{ store: EnhancedStore<RootState> }> => {
+  const {
+    preloadedState = {},
+    initialRoute = '/insights/image-builder/',
+    waitForHeading,
+  } = options;
+
   const store = configureStore({
     reducer: serviceReducer,
     middleware: serviceMiddleware,
-    preloadedState: {
-      wizardModal: {
-        isModalOpen: true,
-        mode: 'create' as const,
-      },
-    },
+    preloadedState,
   });
 
   const routes = [
@@ -31,7 +38,7 @@ export const renderWithQueryParams = async (
   ];
 
   const router = createMemoryRouter(routes, {
-    initialEntries: [`/insights/image-builder${queryString}`],
+    initialEntries: [initialRoute],
   });
 
   render(
@@ -45,17 +52,32 @@ export const renderWithQueryParams = async (
     </Provider>,
   );
 
-  await screen.findByRole('heading', { name: /image output/i });
+  if (waitForHeading) {
+    await screen.findByRole('heading', { name: waitForHeading });
+  }
 
   return { store };
+};
+
+export const renderWithQueryParams = async (
+  queryString: string = '',
+): Promise<{ store: EnhancedStore<RootState> }> => {
+  return renderWizard({
+    preloadedState: {
+      wizardModal: {
+        isModalOpen: true,
+        mode: 'create' as const,
+      },
+    },
+    initialRoute: `/insights/image-builder${queryString}`,
+    waitForHeading: /image output/i,
+  });
 };
 
 export const renderEditMode = async (
   blueprintId: string,
 ): Promise<{ store: EnhancedStore<RootState> }> => {
-  const store = configureStore({
-    reducer: serviceReducer,
-    middleware: serviceMiddleware,
+  return renderWizard({
     preloadedState: {
       wizardModal: {
         isModalOpen: true,
@@ -69,31 +91,7 @@ export const renderEditMode = async (
         versionFilter: 'latest' as const,
       },
     },
+    initialRoute: '/insights/image-builder/',
+    waitForHeading: /review image configuration/i,
   });
-
-  const routes = [
-    {
-      path: 'insights/image-builder/',
-      element: <CreateImageWizard />,
-    },
-  ];
-
-  const router = createMemoryRouter(routes, {
-    initialEntries: ['/insights/image-builder/'],
-  });
-
-  render(
-    <Provider store={store}>
-      <RouterProvider
-        router={router}
-        future={{
-          v7_startTransition: true,
-        }}
-      />
-    </Provider>,
-  );
-
-  await screen.findByRole('heading', { name: /review image configuration/i });
-
-  return { store };
 };

--- a/src/Components/CreateImageWizard/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/tests/helpers.tsx
@@ -49,3 +49,51 @@ export const renderWithQueryParams = async (
 
   return { store };
 };
+
+export const renderEditMode = async (
+  blueprintId: string,
+): Promise<{ store: EnhancedStore<RootState> }> => {
+  const store = configureStore({
+    reducer: serviceReducer,
+    middleware: serviceMiddleware,
+    preloadedState: {
+      wizardModal: {
+        isModalOpen: true,
+        mode: 'edit' as const,
+      },
+      blueprints: {
+        selectedBlueprintId: blueprintId,
+        searchInput: undefined,
+        offset: 0,
+        limit: 10,
+        versionFilter: 'latest' as const,
+      },
+    },
+  });
+
+  const routes = [
+    {
+      path: 'insights/image-builder/',
+      element: <CreateImageWizard />,
+    },
+  ];
+
+  const router = createMemoryRouter(routes, {
+    initialEntries: ['/insights/image-builder/'],
+  });
+
+  render(
+    <Provider store={store}>
+      <RouterProvider
+        router={router}
+        future={{
+          v7_startTransition: true,
+        }}
+      />
+    </Provider>,
+  );
+
+  await screen.findByRole('heading', { name: /review image configuration/i });
+
+  return { store };
+};

--- a/src/Components/CreateImageWizard/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/tests/mocks/fixtures.ts
@@ -1,4 +1,5 @@
-import { Architectures } from '@/store/api/backend';
+import { RHEL_9 } from '@/constants';
+import { Architectures, GetBlueprintApiResponse } from '@/store/api/backend';
 
 export const mockArchitectures: Record<string, Architectures> = {
   'rhel-8': [
@@ -37,4 +38,28 @@ export const mockArchitectures: Record<string, Architectures> = {
       repositories: [],
     },
   ],
+};
+
+export const mockBlueprintId = '677b010b-e95e-4694-9813-d11d847f1bfc';
+
+export const mockBlueprint: GetBlueprintApiResponse = {
+  id: mockBlueprintId,
+  name: 'Test Blueprint',
+  description: 'Test blueprint for edit mode',
+  distribution: RHEL_9,
+  image_requests: [
+    {
+      architecture: 'x86_64',
+      image_type: 'guest-image',
+      upload_request: {
+        type: 'aws.s3',
+        options: {},
+      },
+    },
+  ],
+  customizations: {},
+  lint: {
+    errors: [],
+    warnings: [],
+  },
 };

--- a/src/Components/CreateImageWizard/tests/mocks/handlers.ts
+++ b/src/Components/CreateImageWizard/tests/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { GetBlueprintApiResponse } from '@/store/api/backend';
 import {
   composeHandlers,
   createArchitecturesHandler,
@@ -24,6 +25,26 @@ export const createSourcesHandler = (): FetchHandler => {
       return JSON.stringify({ data: [] });
     }
     return null;
+  };
+};
+
+export type BlueprintHandlerOptions = {
+  blueprint: GetBlueprintApiResponse;
+};
+
+export const createBlueprintHandler = (
+  options: BlueprintHandlerOptions,
+): FetchHandler => {
+  const { blueprint } = options;
+
+  return ({ url, method }) => {
+    const blueprintMatch = url.match(/\/blueprints\/([^/?]+)/);
+    if (!blueprintMatch || method !== 'GET') {
+      return null;
+    }
+
+    const requestedId = blueprintMatch[1];
+    return requestedId === blueprint.id ? JSON.stringify(blueprint) : null;
   };
 };
 

--- a/src/Components/CreateImageWizard/tests/mocks/index.ts
+++ b/src/Components/CreateImageWizard/tests/mocks/index.ts
@@ -1,2 +1,8 @@
-export * from './fixtures';
-export * from './handlers';
+export { mockArchitectures, mockBlueprint, mockBlueprintId } from './fixtures';
+export {
+  createActivationKeysHandler,
+  createBlueprintHandler,
+  createDefaultFetchHandler,
+  createSourcesHandler,
+  fetchMock,
+} from './handlers';


### PR DESCRIPTION
This removes the old msw based tests for the edit mode and create new suite based on vitest mocking.

JIRA: [HMS-10880](https://issues.redhat.com/browse/HMS-10880)

[HMS-10880]: https://redhat.atlassian.net/browse/HMS-10880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ