### PR TITLE
playwright: Fix tsconfig (HMS-10881)

### DIFF
--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "@playwright/test"]
+    "types": ["node", "@playwright/test"],
+    "rootDir": "."
   },
   "include": ["./**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Set `rootDir` to scope the config just to the `playwright/` directory. This prevents looking at parent directories when determining output structure and resolves a config error.

JIRA: [HMS-10881](https://issues.redhat.com/browse/HMS-10881)

[HMS-10881]: https://redhat.atlassian.net/browse/HMS-10881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ