### PR TITLE
deps: Remove more unused dependencies (HMS-10882)

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
-const CopyPlugin = require('copy-webpack-plugin');
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 const webpack = require('webpack');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@redhat-cloud-services/frontend-components-utilities": "7.4.0",
         "@redhat-cloud-services/types": "3.6.0",
         "@reduxjs/toolkit": "2.12.0",
-        "@scalprum/react-core": "0.11.3",
         "@sentry/webpack-plugin": "5.3.0",
         "@unleash/proxy-client-react": "5.0.1",
         "jwt-decode": "4.0.0",
@@ -59,7 +58,6 @@
         "chart.js": "4.5.1",
         "chartjs-adapter-moment": "1.0.1",
         "chartjs-plugin-annotation": "3.1.0",
-        "copy-webpack-plugin": "14.0.0",
         "css-loader": "7.1.4",
         "eslint": "9.39.2",
         "eslint-config-prettier": "10.1.8",
@@ -71,9 +69,7 @@
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-react-redux": "4.2.2",
         "eslint-plugin-testing-library": "7.16.2",
-        "git-revision-webpack-plugin": "5.0.0",
         "globals": "17.6.0",
-        "history": "5.3.0",
         "identity-obj-proxy": "3.0.0",
         "jsdom": "26.1.0",
         "madge": "8.0.0",
@@ -85,7 +81,6 @@
         "postcss-scss": "4.0.9",
         "prettier": "3.8.4",
         "react-chartjs-2": "5.3.1",
-        "redux-mock-store": "1.5.5",
         "sass": "1.100.0",
         "sass-loader": "17.0.0",
         "stylelint": "17.13.0",
@@ -98,8 +93,7 @@
         "vitest": "4.1.8",
         "vitest-canvas-mock": "1.1.4",
         "vitest-fetch-mock": "0.4.5",
-        "webpack-bundle-analyzer": "5.3.0",
-        "whatwg-fetch": "3.6.20"
+        "webpack-bundle-analyzer": "5.3.0"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -8944,40 +8938,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-webpack-plugin": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-14.0.0.tgz",
-      "integrity": "sha512-3JLW90aBGeaTLpM7mYQKpnVdgsUZRExY55giiZgLuX/xTQRUs1dOCwbBnWnvY6Q6rfZoXMNwzOQJCSZPppfqXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "glob-parent": "^6.0.1",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^4.2.0",
-        "serialize-javascript": "^7.0.3",
-        "tinyglobby": "^0.2.12"
-      },
-      "engines": {
-        "node": ">= 20.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
-      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
@@ -12312,16 +12272,6 @@
         "hermes-estree": "0.25.1"
       }
     },
-    "node_modules/history": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
-      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.7.6"
-      }
-    },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
@@ -14660,13 +14610,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -17385,19 +17328,6 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
-    },
-    "node_modules/redux-mock-store": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.5.tgz",
-      "integrity": "sha512-YxX+ofKUTQkZE4HbhYG4kKGr7oCTJfB0GLy7bSeqx86GLpGirrbUWstMnqXkqHNaQpcnbMGbof2dYs5KsPE6Zg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.isplainobject": "^4.0.6"
-      },
-      "peerDependencies": {
-        "redux": "*"
-      }
     },
     "node_modules/redux-promise-middleware": {
       "version": "6.2.0",
@@ -21803,13 +21733,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@redhat-cloud-services/frontend-components-utilities": "7.4.0",
     "@redhat-cloud-services/types": "3.6.0",
     "@reduxjs/toolkit": "2.12.0",
-    "@scalprum/react-core": "0.11.3",
     "@sentry/webpack-plugin": "5.3.0",
     "@unleash/proxy-client-react": "5.0.1",
     "jwt-decode": "4.0.0",
@@ -57,7 +56,6 @@
     "chart.js": "4.5.1",
     "chartjs-adapter-moment": "1.0.1",
     "chartjs-plugin-annotation": "3.1.0",
-    "copy-webpack-plugin": "14.0.0",
     "css-loader": "7.1.4",
     "eslint": "9.39.2",
     "eslint-config-prettier": "10.1.8",
@@ -69,9 +67,7 @@
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-react-redux": "4.2.2",
     "eslint-plugin-testing-library": "7.16.2",
-    "git-revision-webpack-plugin": "5.0.0",
     "globals": "17.6.0",
-    "history": "5.3.0",
     "identity-obj-proxy": "3.0.0",
     "jsdom": "26.1.0",
     "madge": "8.0.0",
@@ -83,7 +79,6 @@
     "postcss-scss": "4.0.9",
     "prettier": "3.8.4",
     "react-chartjs-2": "5.3.1",
-    "redux-mock-store": "1.5.5",
     "sass": "1.100.0",
     "sass-loader": "17.0.0",
     "stylelint": "17.13.0",
@@ -96,8 +91,7 @@
     "vitest": "4.1.8",
     "vitest-canvas-mock": "1.1.4",
     "vitest-fetch-mock": "0.4.5",
-    "webpack-bundle-analyzer": "5.3.0",
-    "whatwg-fetch": "3.6.20"
+    "webpack-bundle-analyzer": "5.3.0"
   },
   "scripts": {
     "lint": "eslint src playwright --fix --cache",


### PR DESCRIPTION
This removes following dependencies:
- `@scalprum/react-core` - Micro-frontend orchestration library (transitive dependency of `@redhat-cloud-services/frontend-components`)
- `copy-webpack-plugin` - Webpack plugin for copying files during build (unused)
- `git-revision-webpack-plugin` - Webpack plugin for injecting git commit info into builds (transitive dependency of `@redhat-cloud-services/frontend-components-config`)
- `history` - Browser history management library (unused - react-router-dom has its own history implementation)
- `redux-mock-store` - Mock Redux store for testing (unused in tests)
- `whatwg-fetch` - Polyfill for fetch API (unused - modern browsers have native fetch)

All removed packages are either:
- Transitive dependencies (still available via other packages)
- Completely unused in the codebase

JIRA: [HMS-10882](https://issues.redhat.com/browse/HMS-10882)

[HMS-10882]: https://redhat.atlassian.net/browse/HMS-10882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ