### PR TITLE
ESLint: Fix config and errors (HMS-10892)

### DIFF
--- a/cockpit/webpack.config.ts
+++ b/cockpit/webpack.config.ts
@@ -1,6 +1,8 @@
 const path = require('path');
+
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const webpack = require('webpack'); // Add this line
+const webpack = require('webpack');
+
 const [mode, devtool] =
   process.env.NODE_ENV === 'production'
     ? ['production', 'source-map']

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,17 +1,17 @@
 const js = require('@eslint/js');
-const tseslint = require('typescript-eslint');
+const fecConfig = require('@redhat-cloud-services/eslint-config-redhat-cloud-services');
+const { defineConfig } = require('eslint/config');
+const prettierConfig = require('eslint-config-prettier');
+const pluginImport = require('eslint-plugin-import');
+const jestDom = require('eslint-plugin-jest-dom');
+const pluginJsxA11y = require('eslint-plugin-jsx-a11y');
+const pluginPlaywright = require('eslint-plugin-playwright');
 const pluginReact = require('eslint-plugin-react');
 const pluginReactHooks = require('eslint-plugin-react-hooks');
 const pluginReactRedux = require('eslint-plugin-react-redux');
-const pluginImport = require('eslint-plugin-import');
-const fecConfig = require('@redhat-cloud-services/eslint-config-redhat-cloud-services');
-const pluginJsxA11y = require('eslint-plugin-jsx-a11y');
-const jestDom = require('eslint-plugin-jest-dom');
 const pluginTestingLibrary = require('eslint-plugin-testing-library');
-const pluginPlaywright = require('eslint-plugin-playwright');
-const { defineConfig } = require('eslint/config');
 const globals = require('globals');
-const prettierConfig = require('eslint-config-prettier');
+const tseslint = require('typescript-eslint');
 
 module.exports = defineConfig([
   {
@@ -169,6 +169,7 @@ module.exports = defineConfig([
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
         },
       ],
       'react-hooks/set-state-in-effect': 'warn', // TODO address issues and enable the rule

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,8 +15,15 @@ const prettierConfig = require('eslint-config-prettier');
 
 module.exports = defineConfig([
   {
-    // Ignore programatically generated files
+    // Ignore programatically generated files and build artifacts
     ignores: [
+      // Build outputs
+      'dist/**',
+      'cockpit/public/**',
+      '.cache/**',
+      'playwright-report/**',
+      'pkg/**',
+      // Generated API code
       '**/mockServiceWorker.js',
       '**/imageBuilderApi.ts',
       '**/hosted/contentSourcesApi.ts',
@@ -31,20 +38,10 @@ module.exports = defineConfig([
     files: ['**/*.{js,ts,jsx,tsx}'],
     languageOptions: {
       parser: tseslint.parser,
-      parserOptions: {
-        project: [
-          './tsconfig.json',
-          './tsconfig.vitest.json',
-          './playwright/tsconfig.json',
-        ],
-      },
       globals: {
         ...globals.browser,
-        // node
+        ...globals.node,
         JSX: 'readonly',
-        process: 'readonly',
-        __dirname: 'readonly',
-        require: 'readonly',
         // vitest
         describe: 'readonly',
         it: 'readonly',
@@ -166,8 +163,6 @@ module.exports = defineConfig([
       '@typescript-eslint/ban-types': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'error',
-      '@typescript-eslint/no-require-imports': 'error',
-      '@typescript-eslint/no-unnecessary-condition': 'error',
       'no-unused-vars': 'off', // disable js rule in favor of @typescript-eslint's rule
       '@typescript-eslint/no-unused-vars': [
         'error',
@@ -182,6 +177,26 @@ module.exports = defineConfig([
       react: {
         version: 'detect', // Automatically detect React version
       },
+    },
+  },
+
+  {
+    // TypeScript parser with project for source files only
+    files: ['src/**/*.{js,ts,jsx,tsx}', 'playwright/**/*.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: [
+          './tsconfig.json',
+          './tsconfig.vitest.json',
+          './playwright/tsconfig.json',
+        ],
+      },
+    },
+    rules: {
+      // Type-aware rules that require parserOptions.project
+      '@typescript-eslint/no-require-imports': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'error',
     },
   },
 

--- a/fec.config.js
+++ b/fec.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');

--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
     "webpack-bundle-analyzer": "5.3.0"
   },
   "scripts": {
-    "lint": "eslint src playwright --fix --cache",
-    "lint:check": "eslint src playwright",
+    "lint": "eslint . --fix --cache",
+    "lint:check": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "start": "fec dev-proxy",

--- a/scripts/check-vulnerable-packages.js
+++ b/scripts/check-vulnerable-packages.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 
 /**
  * Check for compromised packages from .github/dependency-review-config.yml
@@ -6,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const { PackageURL } = require('packageurl-js');
 
 // Parse deny-packages from config
@@ -50,7 +52,7 @@ function loadDeniedPackages() {
           // Store the normalized purl string
           deniedPackages.add(purl.toString());
         }
-      } catch (error) {
+      } catch (_error) {
         console.warn(`Warning: Invalid purl format: ${purlString}`);
       }
     }
@@ -85,7 +87,7 @@ function checkPackages() {
         compromisedByName.set(fullName, []);
       }
       compromisedByName.get(fullName).push(purl.version);
-    } catch (error) {
+    } catch (_error) {
       continue;
     }
   }
@@ -143,7 +145,7 @@ function checkPackages() {
           }
           differentVersions.get(fullName).installed.add(info.version);
         }
-      } catch (error) {
+      } catch (_error) {
         // Skip packages that can't be parsed as purl
         continue;
       }


### PR DESCRIPTION
The TypeScript parser with `parserOptions.project` was being applied to all files including config files like `eslint.config.js`, but those files aren't included in any tsconfig.

This splits the configuration so only source files in `src/` and `playwright/` get the TypeScript parser with project checking, while config files are linted with basic rules.

Type-aware rules that require project checking were moved to only apply where the parser is configured.

All errors in files with linting failing on non-relevant parser were fixed and the npm run script was updated.

JIRA: [HMS-10892](https://issues.redhat.com/browse/HMS-10892)

[HMS-10892]: https://redhat.atlassian.net/browse/HMS-10892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ