### PR TITLE
src: Add vitest lint rules to co-locates tests (HMS-10893)

### DIFF
--- a/cockpit/webpack.config.ts
+++ b/cockpit/webpack.config.ts
@@ -1,6 +1,8 @@
 const path = require('path');
+
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const webpack = require('webpack'); // Add this line
+const webpack = require('webpack');
+
 const [mode, devtool] =
   process.env.NODE_ENV === 'production'
     ? ['production', 'source-map']

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,17 +1,17 @@
 const js = require('@eslint/js');
-const tseslint = require('typescript-eslint');
+const fecConfig = require('@redhat-cloud-services/eslint-config-redhat-cloud-services');
+const { defineConfig } = require('eslint/config');
+const prettierConfig = require('eslint-config-prettier');
+const pluginImport = require('eslint-plugin-import');
+const jestDom = require('eslint-plugin-jest-dom');
+const pluginJsxA11y = require('eslint-plugin-jsx-a11y');
+const pluginPlaywright = require('eslint-plugin-playwright');
 const pluginReact = require('eslint-plugin-react');
 const pluginReactHooks = require('eslint-plugin-react-hooks');
 const pluginReactRedux = require('eslint-plugin-react-redux');
-const pluginImport = require('eslint-plugin-import');
-const fecConfig = require('@redhat-cloud-services/eslint-config-redhat-cloud-services');
-const pluginJsxA11y = require('eslint-plugin-jsx-a11y');
-const jestDom = require('eslint-plugin-jest-dom');
 const pluginTestingLibrary = require('eslint-plugin-testing-library');
-const pluginPlaywright = require('eslint-plugin-playwright');
-const { defineConfig } = require('eslint/config');
 const globals = require('globals');
-const prettierConfig = require('eslint-config-prettier');
+const tseslint = require('typescript-eslint');
 
 module.exports = defineConfig([
   {
@@ -169,6 +169,7 @@ module.exports = defineConfig([
         {
           argsIgnorePattern: '^_',
           varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
         },
       ],
       'react-hooks/set-state-in-effect': 'warn', // TODO address issues and enable the rule

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,8 +15,15 @@ const prettierConfig = require('eslint-config-prettier');
 
 module.exports = defineConfig([
   {
-    // Ignore programatically generated files
+    // Ignore programatically generated files and build artifacts
     ignores: [
+      // Build outputs
+      'dist/**',
+      'cockpit/public/**',
+      '.cache/**',
+      'playwright-report/**',
+      'pkg/**',
+      // Generated API code
       '**/mockServiceWorker.js',
       '**/imageBuilderApi.ts',
       '**/hosted/contentSourcesApi.ts',
@@ -31,20 +38,10 @@ module.exports = defineConfig([
     files: ['**/*.{js,ts,jsx,tsx}'],
     languageOptions: {
       parser: tseslint.parser,
-      parserOptions: {
-        project: [
-          './tsconfig.json',
-          './tsconfig.vitest.json',
-          './playwright/tsconfig.json',
-        ],
-      },
       globals: {
         ...globals.browser,
-        // node
+        ...globals.node,
         JSX: 'readonly',
-        process: 'readonly',
-        __dirname: 'readonly',
-        require: 'readonly',
         // vitest
         describe: 'readonly',
         it: 'readonly',
@@ -166,8 +163,6 @@ module.exports = defineConfig([
       '@typescript-eslint/ban-types': 'off',
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/no-unsafe-function-type': 'error',
-      '@typescript-eslint/no-require-imports': 'error',
-      '@typescript-eslint/no-unnecessary-condition': 'error',
       'no-unused-vars': 'off', // disable js rule in favor of @typescript-eslint's rule
       '@typescript-eslint/no-unused-vars': [
         'error',
@@ -182,6 +177,26 @@ module.exports = defineConfig([
       react: {
         version: 'detect', // Automatically detect React version
       },
+    },
+  },
+
+  {
+    // TypeScript parser with project for source files only
+    files: ['src/**/*.{js,ts,jsx,tsx}', 'playwright/**/*.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: [
+          './tsconfig.json',
+          './tsconfig.vitest.json',
+          './playwright/tsconfig.json',
+        ],
+      },
+    },
+    rules: {
+      // Type-aware rules that require parserOptions.project
+      '@typescript-eslint/no-require-imports': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'error',
     },
   },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -202,8 +202,12 @@ module.exports = defineConfig([
   },
 
   {
-    // Override for test files
-    files: ['src/test/**/*.{ts,tsx}'],
+    // Override for test files (legacy integration tests + co-located unit tests)
+    files: [
+      'src/test/**/*.{ts,tsx}',
+      '**/*.test.{ts,tsx}',
+      '**/tests/**/*.{ts,tsx}',
+    ],
     plugins: {
       'jest-dom': jestDom,
       'testing-library': pluginTestingLibrary,

--- a/fec.config.js
+++ b/fec.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');

--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
     "webpack-bundle-analyzer": "5.3.0"
   },
   "scripts": {
-    "lint": "eslint src playwright --fix --cache",
-    "lint:check": "eslint src playwright",
+    "lint": "eslint . --fix --cache",
+    "lint:check": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "start": "fec dev-proxy",

--- a/scripts/check-vulnerable-packages.js
+++ b/scripts/check-vulnerable-packages.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 
 /**
  * Check for compromised packages from .github/dependency-review-config.yml
@@ -6,6 +7,7 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const { PackageURL } = require('packageurl-js');
 
 // Parse deny-packages from config
@@ -50,7 +52,7 @@ function loadDeniedPackages() {
           // Store the normalized purl string
           deniedPackages.add(purl.toString());
         }
-      } catch (error) {
+      } catch (_error) {
         console.warn(`Warning: Invalid purl format: ${purlString}`);
       }
     }
@@ -85,7 +87,7 @@ function checkPackages() {
         compromisedByName.set(fullName, []);
       }
       compromisedByName.get(fullName).push(purl.version);
-    } catch (error) {
+    } catch (_error) {
       continue;
     }
   }
@@ -143,7 +145,7 @@ function checkPackages() {
           }
           differentVersions.get(fullName).installed.add(info.version);
         }
-      } catch (error) {
+      } catch (_error) {
         // Skip packages that can't be parsed as purl
         continue;
       }

--- a/src/Components/Blueprints/tests/ImportBlueprintModal.test.tsx
+++ b/src/Components/Blueprints/tests/ImportBlueprintModal.test.tsx
@@ -58,6 +58,8 @@ const renderModal = () => {
 const uploadBlueprintFile = async (content: string) => {
   const user = userEvent.setup();
   const fileInput: HTMLElement | null =
+    // PatternFly FileUpload doesn't expose the file input via Testing Library queries
+    // eslint-disable-next-line testing-library/no-node-access
     document.querySelector('input[type="file"]');
 
   if (!fileInput) {

--- a/src/Components/CreateImageWizard/steps/FirstBoot/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/tests/helpers.tsx
@@ -24,6 +24,8 @@ export const uploadScript = async (
   let fileInput: HTMLInputElement | null = null;
 
   await waitFor(() => {
+    // PatternFly FileUpload doesn't expose the file input via Testing Library queries
+    // eslint-disable-next-line testing-library/no-node-access
     fileInput = document.querySelector<HTMLInputElement>('input[type="file"]');
     if (!fileInput) {
       throw new Error('File input not found');

--- a/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
@@ -892,7 +892,7 @@ describe('Packages Component', () => {
       const testLibOption = await screen.findByRole('option', {
         name: /test-lib/i,
       });
-      expect(testLibOption).not.toBeDisabled();
+      expect(testLibOption).toBeEnabled();
 
       // Clicking the disabled option should not remove the package
       await clickWithWait(user, aideOption);
@@ -980,12 +980,12 @@ describe('Packages Component', () => {
       const testLibOption = await screen.findByRole('option', {
         name: /test-lib/i,
       });
-      expect(testLibOption).not.toBeDisabled();
+      expect(testLibOption).toBeEnabled();
 
       const testPkgOption = await screen.findByRole('option', {
         name: /testPkg/i,
       });
-      expect(testPkgOption).not.toBeDisabled();
+      expect(testPkgOption).toBeEnabled();
 
       // Clicking the selected package should remove it
       await clickWithWait(user, testLibOption);
@@ -1033,7 +1033,7 @@ describe('Packages Component', () => {
 
       // aide is required but not yet selected, so it should NOT be disabled
       const aideOption = await screen.findByRole('option', { name: /aide/i });
-      expect(aideOption).not.toBeDisabled();
+      expect(aideOption).toBeEnabled();
 
       // Select it — should be addable
       await clickWithWait(user, aideOption);

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable testing-library/no-node-access */
+// PatternFly Label components render text in child spans with color classes on the parent.
+// Tests need .closest() to access the label element for class assertions.
 import React from 'react';
 
 import { screen } from '@testing-library/react';

--- a/src/Components/CreateImageWizard/steps/Review/components/Content/tests/Content.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/Content/tests/Content.test.tsx
@@ -111,7 +111,9 @@ describe('ContentOverview', () => {
           },
         },
       );
-
+      // PatternFly Label components render text in child spans with color classes on the parent.
+      // Tests need .closest() to access the label element for class assertions.
+      // eslint-disable-next-line testing-library/no-node-access
       const label = screen.getByText('vim').closest('.pf-v6-c-label');
       expect(label).toHaveClass('pf-m-blue');
     });
@@ -140,6 +142,9 @@ describe('ContentOverview', () => {
         },
       );
 
+      // PatternFly Label components render text in child spans with color classes on the parent.
+      // Tests need .closest() to access the label element for class assertions.
+      // eslint-disable-next-line testing-library/no-node-access
       const label = screen.getByText('aide').closest('.pf-v6-c-label');
       // Grey is the default color, so no color modifier class is applied
       expect(label).not.toHaveClass('pf-m-blue');
@@ -171,7 +176,11 @@ describe('ContentOverview', () => {
         },
       );
 
+      // PatternFly Label components render text in child spans with color classes on the parent.
+      // Tests need .closest() to access the label element for class assertions.
+      // eslint-disable-next-line testing-library/no-node-access
       const aideLabel = screen.getByText('aide').closest('.pf-v6-c-label');
+      // eslint-disable-next-line testing-library/no-node-access
       const vimLabel = screen.getByText('vim').closest('.pf-v6-c-label');
 
       // Oscap packages use grey (default), user packages use blue


### PR DESCRIPTION
This adds the co-located tests to to the vitest rules override section in the ESLint config.

Errors were also fixed or commented out with a reason why.

Rebased on https://github.com/osbuild/image-builder-frontend/pull/4573

JIRA: [HMS-10893](https://issues.redhat.com/browse/HMS-10893)

[HMS-10893]: https://redhat.atlassian.net/browse/HMS-10893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ