### PR TITLE
cockpit/tsconfig: Add `rootDir` to resolve IDE diagnostics error (HMS-10896)

### DIFF
--- a/cockpit/tsconfig.json
+++ b/cockpit/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "rootDir": "..",
     "baseUrl": ".",
     "paths": {
       "@/*": ["../src/*"],


### PR DESCRIPTION
Fix TypeScript error by setting rootDir: ".." in cockpit/tsconfig.json. The Cockpit build compiles TypeScript from parent directories (../src for app code, ../pkg/lib for Cockpit modules), so TypeScript requires an explicit rootDir to acknowledge this cross-directory compilation.

JIRA: [HMS-10896](https://issues.redhat.com/browse/HMS-10896)

[HMS-10896]: https://redhat.atlassian.net/browse/HMS-10896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ