### PR TITLE
Resolve org ID once at app init instead of per-blueprint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,56 @@
 import React, { useEffect } from 'react';
 
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import NotificationsProvider from '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider';
 import '@patternfly/patternfly/patternfly-addons.css';
 
 import { Router } from './Router';
+import { useAppDispatch } from './store/hooks';
+import { changeOrgId } from './store/slices/wizard';
 
-const App = () => {
-  const { hideGlobalFilter, updateDocumentTitle } = useChrome();
+const AppContent = () => {
+  const { auth, hideGlobalFilter, updateDocumentTitle } = useChrome();
+  const dispatch = useAppDispatch();
+  const addNotification = useAddNotification();
+  const getUser = auth.getUser;
 
   useEffect(() => {
     updateDocumentTitle('Images');
     hideGlobalFilter(true);
   }, [hideGlobalFilter, updateDocumentTitle]);
 
+  useEffect(() => {
+    // the org id never changes, let's just get
+    // this on app init rather than every time
+    // the user creates a blueprint
+    const resolveOrgId = async () => {
+      const userData = await getUser();
+      const orgId = userData?.identity.internal?.org_id;
+      if (orgId) {
+        dispatch(changeOrgId(orgId));
+        return;
+      }
+      throw new Error('Unable to determine organization ID');
+    };
+
+    resolveOrgId().catch(() => {
+      addNotification({
+        variant: 'danger',
+        title:
+          'Unable to determine your organization ID. Some features may not work correctly.',
+      });
+    });
+  }, [getUser, dispatch, addNotification]);
+
+  return <Router />;
+};
+
+const App = () => {
   return (
     <React.Fragment>
       <NotificationsProvider>
-        <Router />
+        <AppContent />
       </NotificationsProvider>
     </React.Fragment>
   );

--- a/src/Components/CreateImageWizard/components/ReviewWizardFooter.tsx
+++ b/src/Components/CreateImageWizard/components/ReviewWizardFooter.tsx
@@ -9,12 +9,9 @@ import {
   WizardFooterWrapper,
 } from '@patternfly/react-core';
 import { MenuToggleElement } from '@patternfly/react-core/dist/esm/components/MenuToggle/MenuToggle';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useStore } from 'react-redux';
 
 import { selectSelectedBlueprintId } from '@/store/slices/blueprint';
-import { selectIsOnPremise } from '@/store/slices/env';
-import { selectOrgId } from '@/store/slices/wizard';
 import { selectWizardModalMode } from '@/store/slices/wizardModal';
 
 import {
@@ -40,8 +37,6 @@ const ReviewWizardFooter = () => {
 
   const { isSuccess: isUpdateSuccess, reset: resetUpdate } =
     useUpdateBlueprintMutation({ fixedCacheKey: 'updateBlueprintKey' });
-  const { auth } = useChrome();
-  const isOnPremise = useAppSelector(selectIsOnPremise);
   const mode = useAppSelector(selectWizardModalMode);
   const blueprintId = useAppSelector(selectSelectedBlueprintId);
   const [isOpen, setIsOpen] = useState(false);
@@ -50,7 +45,6 @@ const ReviewWizardFooter = () => {
     setIsOpen(!isOpen);
   };
   const isValid = useIsBlueprintValid();
-  const orgId = useAppSelector(selectOrgId);
 
   useEffect(() => {
     if (isUpdateSuccess || isCreateSuccess) {
@@ -60,15 +54,8 @@ const ReviewWizardFooter = () => {
     }
   }, [isUpdateSuccess, isCreateSuccess, resetCreate, resetUpdate, close]);
 
-  const getBlueprintPayload = async () => {
-    if (!isOnPremise) {
-      const userData = await auth.getUser();
-      const orgId = userData?.identity.internal?.org_id;
-      const requestBody = orgId && mapRequestFromState(store, orgId);
-      return requestBody;
-    }
-
-    return mapRequestFromState(store, orgId ?? '');
+  const getBlueprintPayload = () => {
+    return mapRequestFromState(store);
   };
 
   const isEditMode = mode === 'edit';

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Aws/tests/AwsTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Aws/tests/AwsTarget.test.tsx
@@ -41,8 +41,6 @@ const createStoreWithAwsState = (
   });
 };
 
-const MOCK_ORG_ID = '5';
-
 describe('AWS Component', () => {
   describe('Rendering', () => {
     test('displays step components', async () => {
@@ -233,10 +231,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
@@ -267,10 +262,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.image_requests[0].upload_request.type).toBe('aws');
     expect(request.image_requests[0].image_type).toBe('aws');
@@ -288,10 +280,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('share_with_accounts', ['111222333444']);
@@ -309,10 +298,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.image_requests[0].architecture).toBe('x86_64');
   });
@@ -329,10 +315,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.customizations.subscription).toBeUndefined();
   });

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
@@ -48,8 +48,6 @@ const createStoreWithAzureState = (
   });
 };
 
-const MOCK_ORG_ID = '5';
-
 describe('Azure Component', () => {
   describe('Rendering', () => {
     test('displays step components', async () => {
@@ -360,10 +358,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
@@ -398,10 +393,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.image_requests).toHaveLength(1);
     expect(request.image_requests[0].image_type).toBe('azure');
@@ -429,10 +421,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.image_requests[0].upload_request.type).toBe('azure');
     expect(request.image_requests[0].image_type).toBe('azure');
@@ -451,10 +440,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('resource_group', '');
@@ -473,10 +459,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toEqual({
@@ -500,10 +483,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.image_requests[0].architecture).toBe('x86_64');
   });
@@ -521,10 +501,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.customizations.subscription).toBeUndefined();
   });

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/tests/GcpTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/tests/GcpTarget.test.tsx
@@ -43,8 +43,6 @@ const createStoreWithGcpState = (
   });
 };
 
-const MOCK_ORG_ID = '5';
-
 describe('GCP Component', () => {
   describe('Rendering', () => {
     test('displays step components', async () => {
@@ -304,10 +302,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
@@ -337,10 +332,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('share_with_accounts', [
@@ -359,10 +351,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('share_with_accounts', [
@@ -381,10 +370,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('share_with_accounts', [
@@ -403,10 +389,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.image_requests[0].upload_request.type).toBe('gcp');
     expect(request.image_requests[0].image_type).toBe('gcp');
@@ -423,10 +406,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.image_requests[0].architecture).toBe('x86_64');
   });
@@ -442,10 +422,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.customizations.subscription).toBeUndefined();
   });

--- a/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
@@ -501,8 +501,6 @@ const createStoreWithRepositoriesState = (
   });
 };
 
-const MOCK_ORG_ID = '5';
-
 describe('Request Payload Generation', () => {
   test('generates correct custom_repositories from state', () => {
     const store = createStoreWithRepositoriesState({
@@ -535,10 +533,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.customizations.custom_repositories).toHaveLength(1);
     expect(request.customizations.custom_repositories![0]).toEqual({
@@ -579,10 +574,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.customizations.payload_repositories).toHaveLength(1);
     expect(request.customizations.payload_repositories![0]).toEqual({
@@ -624,10 +616,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.customizations.custom_repositories![0].module_hotfixes).toBe(
       true,
@@ -647,10 +636,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.customizations.custom_repositories).toBeUndefined();
     expect(request.customizations.payload_repositories).toBeUndefined();
@@ -678,10 +664,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(
       request.customizations.custom_repositories![0].baseurl,
@@ -720,10 +703,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(
-      store,
-      MOCK_ORG_ID,
-    ) as CreateBlueprintRequest;
+    const request = mapRequestFromState(store) as CreateBlueprintRequest;
 
     expect(request.customizations.custom_repositories).toHaveLength(2);
     expect(request.customizations.payload_repositories).toHaveLength(2);

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -34,9 +34,10 @@ import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import { createAnalytics } from '../../../../../Utilities/analytics';
 
 type CreateDropdownProps = {
-  getBlueprintPayload: () => Promise<
-    '' | CreateBlueprintRequest | ComposerCreateBlueprintRequest | undefined
-  >;
+  getBlueprintPayload: () =>
+    | CreateBlueprintRequest
+    | ComposerCreateBlueprintRequest
+    | undefined;
   setIsOpen: (isOpen: boolean) => void;
   isDisabled: boolean;
 };

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -27,9 +27,10 @@ import { useAppSelector } from '../../../../../store/hooks';
 import { createAnalytics } from '../../../../../Utilities/analytics';
 
 type EditDropdownProps = {
-  getBlueprintPayload: () => Promise<
-    '' | CreateBlueprintRequest | ComposerCreateBlueprintRequest | undefined
-  >;
+  getBlueprintPayload: () =>
+    | CreateBlueprintRequest
+    | ComposerCreateBlueprintRequest
+    | undefined;
   setIsOpen: (isOpen: boolean) => void;
   blueprintId: string;
   isDisabled: boolean;

--- a/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
@@ -9,12 +9,10 @@ import {
   WizardFooterWrapper,
 } from '@patternfly/react-core';
 import { MenuToggleElement } from '@patternfly/react-core/dist/esm/components/MenuToggle/MenuToggle';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useStore } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { selectIsOnPremise, selectPathResolver } from '@/store/slices/env';
-import { selectOrgId } from '@/store/slices/wizard';
+import { selectPathResolver } from '@/store/slices/env';
 
 import { CreateSaveAndBuildBtn, CreateSaveButton } from './CreateDropdown';
 import { EditSaveAndBuildBtn, EditSaveButton } from './EditDropdown';
@@ -35,8 +33,6 @@ const ReviewWizardFooter = () => {
   // initialize the server store with the data from RTK query
   const { isSuccess: isUpdateSuccess, reset: resetUpdate } =
     useUpdateBlueprintMutation({ fixedCacheKey: 'updateBlueprintKey' });
-  const { auth } = useChrome();
-  const isOnPremise = useAppSelector(selectIsOnPremise);
   const resolvePath = useAppSelector(selectPathResolver);
   const { composeId } = useParams();
   const [isOpen, setIsOpen] = useState(false);
@@ -46,7 +42,6 @@ const ReviewWizardFooter = () => {
   };
   const navigate = useNavigate();
   const isValid = useIsBlueprintValid();
-  const orgId = useAppSelector(selectOrgId);
 
   useEffect(() => {
     if (isUpdateSuccess || isCreateSuccess) {
@@ -56,15 +51,8 @@ const ReviewWizardFooter = () => {
     }
   }, [isUpdateSuccess, isCreateSuccess, resetCreate, resetUpdate, navigate]);
 
-  const getBlueprintPayload = async () => {
-    if (!isOnPremise) {
-      const userData = await auth.getUser();
-      const orgId = userData?.identity.internal?.org_id;
-      const requestBody = orgId && mapRequestFromState(store, orgId);
-      return requestBody;
-    }
-
-    return mapRequestFromState(store, orgId ?? '');
+  const getBlueprintPayload = () => {
+    return mapRequestFromState(store);
   };
 
   return (

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -99,6 +99,7 @@ import {
   selectMetadata,
   selectModules,
   selectNtpServers,
+  selectOrgId,
   selectPackageGroups,
   selectPackages,
   selectPartitioningMode,
@@ -143,17 +144,15 @@ import {
 /**
  * This function maps the wizard state to a valid CreateBlueprint request object
  * @param {Store} store redux store
- * @param {string} orgID organization ID
  *
  * @returns {CreateBlueprintRequest} blueprint creation request payload
  */
 export const mapRequestFromState = (
   store: Store,
-  orgID: string,
 ): CreateBlueprintRequest | ComposerCreateBlueprintRequest => {
   const state = store.getState();
   const imageRequests = getImageRequests(state);
-  const customizations = getCustomizations(state, orgID);
+  const customizations = getCustomizations(state);
   const isImageMode = selectIsImageMode(state);
   const imageSource = selectImageSource(state);
 
@@ -964,7 +963,7 @@ const getImageOptions = (
   return {};
 };
 
-const getCustomizations = (state: RootState, orgID: string): Customizations => {
+const getCustomizations = (state: RootState): Customizations => {
   const satCert = selectSatelliteCaCertificate(state);
   const files: File[] = [];
   if (selectFirstBootScript(state)) {
@@ -1002,7 +1001,7 @@ const getCustomizations = (state: RootState, orgID: string): Customizations => {
     containers: undefined,
     directories: undefined,
     files: files.length > 0 ? files : undefined,
-    subscription: getSubscription(state, orgID),
+    subscription: getSubscription(state),
     packages: getPackages(state),
     enabled_modules: getModules(state),
     payload_repositories: getPayloadRepositories(state),
@@ -1227,10 +1226,7 @@ const getTimezone = (state: RootState) => {
   };
 };
 
-const getSubscription = (
-  state: RootState,
-  orgID: string,
-): Subscription | undefined => {
+const getSubscription = (state: RootState): Subscription | undefined => {
   const registrationType = selectRegistrationType(state);
   const activationKey = selectActivationKey(state);
 
@@ -1247,9 +1243,14 @@ const getSubscription = (
     );
   }
 
+  const orgId = selectOrgId(state);
+  if (!orgId) {
+    return undefined;
+  }
+
   const initialSubscription = {
     'activation-key': activationKey,
-    organization: Number(orgID),
+    organization: Number(orgId),
     'server-url': selectServerUrl(state),
     'base-url': selectBaseUrl(state),
     insights_client_proxy: selectProxy(state),

--- a/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
+++ b/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
@@ -203,7 +203,7 @@ describe('round-trip: mapRequestToState + mapRequestFromState', () => {
       const response = toBlueprintResponse(expectedRequest);
       const wizardState = mapRequestToState(response);
       const store = createTestStore(wizardState);
-      const result = stripUndefined(mapRequestFromState(store, 'test-org-id'));
+      const result = stripUndefined(mapRequestFromState(store));
       expect(result).toEqual(expectedRequest);
     },
   );


### PR DESCRIPTION
Resolve org ID once at app init instead of per-blueprint

## Summary

Moves org ID resolution from the blueprint creation path to a one-time fetch at app startup. The org ID never changes during a session, so fetching it repeatedly on every blueprint save was unnecessary complexity that also forced `getBlueprintPayload` to be async.

## Changes

- Resolve org ID in `App.tsx` on mount via `auth.getUser()`, store it in Redux, and surface a notification on failure
- Read org ID from state inside `requestMapper` via `selectOrgId` instead of accepting it as a parameter
- Simplify `getBlueprintPayload` in both footer components from async to sync by removing the inline `auth.getUser()` call
- Simplify test setup across target and repository tests by removing `useChrome`/`auth` mocking that is no longer needed
