### PR TITLE
Wizard: always enable Next and Review buttons (HMS-10658)

### DIFF
--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -324,7 +324,7 @@ registrationModes.forEach(
             await registrationCommandInput.blur();
             await expect(
               frame.getByRole('button', { name: 'Review image' }),
-            ).toBeDisabled();
+            ).toBeEnabled();
             await expect(
               frame.getByText('Invalid or missing token'),
             ).toBeVisible();

--- a/playwright/Customizations/TargetEnvironments/Azure.spec.ts
+++ b/playwright/Customizations/TargetEnvironments/Azure.spec.ts
@@ -38,7 +38,7 @@ test('Create a blueprint with Azure target', async ({ page, cleanup }) => {
     const reviewImageButton = frame.getByRole('button', {
       name: 'Review image',
     });
-    await expect(reviewImageButton).toBeDisabled();
+    await expect(reviewImageButton).toBeEnabled();
 
     const tenantInput = frame.getByRole('textbox', {
       name: /azure tenant guid/i,

--- a/playwright/Customizations/UsersAndGroups.spec.ts
+++ b/playwright/Customizations/UsersAndGroups.spec.ts
@@ -234,11 +234,11 @@ test('Create a blueprint with Users customization', async ({
     // Test 4: Empty username with password filled
     await usernameInputs.nth(4).fill('');
     await passwordInputs.nth(4).fill('password123');
-    // Next and Review image buttons should be disabled due to validation errors
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    // Next and Review image buttons should be enabled (validation happens on click)
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await expect(
       frame.getByRole('button', { name: 'Review image' }),
-    ).toBeDisabled();
+    ).toBeEnabled();
 
     // Test 5: Invalid group name with spaces
     await expect(

--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -56,7 +56,7 @@ test('Import a blueprint with invalid customization', async ({
     await expect(
       frame.getByText(/Duplicate mount points/i).first(),
     ).toBeVisible();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     const closeRootButton = frame
       .locator('td:nth-child(5) > .pf-v6-c-button')
       .first();
@@ -70,16 +70,16 @@ test('Import a blueprint with invalid customization', async ({
 
   await test.step('Fix timezone and locale errors on Advanced settings', async () => {
     await expect(frame.getByText('Includes duplicate NTP')).toBeVisible();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove ntp/' }).first().click();
 
     await expect(frame.getByText('Unknown languages: random:')).toBeVisible();
     await expect(frame.getByText('Duplicated languages: af_ZA.')).toBeVisible();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove language' }).last().click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove language' }).last().click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
   });
 
   await test.step('Fix firewall errors on Advanced settings', async () => {
@@ -95,22 +95,22 @@ test('Import a blueprint with invalid customization', async ({
     await expect(
       frame.getByText('Includes duplicate disabled services: service2'),
     ).toBeVisible();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame
       .getByRole('button', { name: 'Remove 2020:port' })
       .first()
       .click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame
       .getByRole('button', { name: 'Remove service1' })
       .first()
       .click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame
       .getByRole('button', { name: 'Remove service2' })
       .first()
       .click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
   });
 
   await test.step('Fix systemd errors on Advanced settings', async () => {
@@ -124,11 +124,11 @@ test('Import a blueprint with invalid customization', async ({
       frame.getByText('Includes duplicate disabled services: sssd'),
     ).toBeVisible();
     await expect(frame.getByText('Includes duplicate masked')).toBeVisible();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove auditd' }).first().click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove sssd' }).first().click();
-    await expect(frame.getByRole('button', { name: 'Next' })).toBeDisabled();
+    await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove masked' }).first().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Review image' }).click();

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -478,7 +478,7 @@ const CreateImageWizard = () => {
           footer={
             <CustomWizardFooter
               disableBack={true}
-              disableNext={baseSettingsHasErrors}
+              hasErrors={baseSettingsHasErrors}
               isOnPremise={isOnPremise}
             />
           }
@@ -535,7 +535,7 @@ const CreateImageWizard = () => {
             restrictions.packages.shouldHide
           }
           footer={
-            <CustomWizardFooter disableNext={false} isOnPremise={isOnPremise} />
+            <CustomWizardFooter hasErrors={false} isOnPremise={isOnPremise} />
           }
         >
           <Form onSubmit={handleFormSubmit}>
@@ -575,7 +575,7 @@ const CreateImageWizard = () => {
           }
           footer={
             <CustomWizardFooter
-              disableNext={advancedSettingsHasErrors}
+              hasErrors={advancedSettingsHasErrors}
               isOnPremise={isOnPremise}
             />
           }

--- a/src/Components/CreateImageWizard/ValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInput.tsx
@@ -14,6 +14,9 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 
+import { useAppSelector } from '@/store/hooks';
+import { selectForceShowErrors } from '@/store/slices/wizard';
+
 import type { StepValidation } from './utilities/useValidation';
 
 type ValidatedTextInputPropTypes = Omit<
@@ -65,13 +68,14 @@ export const ValidatedInputAndTextArea = ({
 }: ValidationInputProp) => {
   const errorMessage = stepValidation.errors[fieldName] || '';
   const hasError = errorMessage !== '';
+  const forceShowErrors = useAppSelector(selectForceShowErrors);
 
   const [isPristine, setIsPristine] = useState(!value);
   const validated = getValidationState(
     isPristine,
     errorMessage,
     isRequired,
-    forceErrorDisplay,
+    forceErrorDisplay || forceShowErrors,
   );
 
   const handleBlur = () => {
@@ -173,17 +177,16 @@ export const ValidatedInput = ({
   ...props
 }: ValidatedTextInputPropTypes) => {
   const [isPristine, setIsPristine] = useState(!value ? true : false);
+  const forceShowErrors = useAppSelector(selectForceShowErrors);
   const ariaLabel = props['aria-label'];
 
   const handleBlur = () => {
     setIsPristine(false);
   };
 
-  const validated = isPristine
-    ? undefined
-    : validator(value)
-      ? 'success'
-      : 'error';
+  const showError = forceShowErrors && !validator(value);
+  const validated =
+    showError || (!isPristine && !validator(value)) ? 'error' : undefined;
 
   return (
     <>
@@ -208,7 +211,7 @@ export const ValidatedInput = ({
           </TextInputGroupUtilities>
         )}
       </TextInputGroup>
-      {!isPristine && !validator(value) && (
+      {validated === 'error' && (
         <HelperText>
           <HelperTextItem variant='error'>{helperText}</HelperTextItem>
         </HelperText>

--- a/src/Components/CreateImageWizard/components/CustomWizardFooter.tsx
+++ b/src/Components/CreateImageWizard/components/CustomWizardFooter.tsx
@@ -7,27 +7,71 @@ import {
   WizardFooterWrapper,
 } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { flushSync } from 'react-dom';
 
 import { AMPLITUDE_MODULE_NAME } from '@/constants';
+import { useAppDispatch } from '@/store/hooks';
+import {
+  resetForceShowErrors,
+  setForceShowErrors,
+} from '@/store/slices/wizard';
+
+import { scrollToFirstError } from '../utilities/scrollToFirstError';
 
 type CustomWizardFooterPropType = {
   disableBack?: boolean;
-  disableNext: boolean;
+  hasErrors: boolean;
   beforeNext?: () => boolean;
   isOnPremise: boolean;
 };
 
 export const CustomWizardFooter = ({
   disableBack,
-  disableNext,
+  hasErrors,
   beforeNext,
   isOnPremise,
 }: CustomWizardFooterPropType) => {
   const { goToNextStep, goToPrevStep, goToStepById, close, activeStep } =
     useWizardContext();
   const { analytics } = useChrome();
+  const dispatch = useAppDispatch();
   const reviewAndFinishBtnID = 'wizard-review-and-finish-btn';
   const cancelBtnID = 'wizard-cancel-btn';
+
+  const handleNext = () => {
+    if (hasErrors) {
+      flushSync(() => {
+        dispatch(setForceShowErrors());
+      });
+      scrollToFirstError();
+      return;
+    }
+    if (!beforeNext || beforeNext()) {
+      dispatch(resetForceShowErrors());
+      goToNextStep();
+    }
+  };
+
+  const handleReview = () => {
+    if (hasErrors) {
+      flushSync(() => {
+        dispatch(setForceShowErrors());
+      });
+      scrollToFirstError();
+      return;
+    }
+    if (!beforeNext || beforeNext()) {
+      if (!isOnPremise) {
+        analytics.track(`${AMPLITUDE_MODULE_NAME} - Button Clicked`, {
+          module: AMPLITUDE_MODULE_NAME,
+          button_id: reviewAndFinishBtnID,
+          active_step_id: activeStep.id,
+        });
+      }
+      dispatch(resetForceShowErrors());
+      goToStepById('review-step');
+    }
+  };
 
   return (
     <WizardFooterWrapper>
@@ -38,35 +82,17 @@ export const CustomWizardFooter = ({
         <Button
           variant='secondary'
           onClick={() => {
+            dispatch(resetForceShowErrors());
             goToPrevStep();
           }}
           isDisabled={disableBack || false}
         >
           Back
         </Button>
-        <Button
-          variant='secondary'
-          onClick={() => {
-            if (!beforeNext || beforeNext()) goToNextStep();
-          }}
-          isDisabled={disableNext}
-        >
+        <Button variant='secondary' onClick={handleNext}>
           Next
         </Button>
-        <Button
-          variant='primary'
-          onClick={() => {
-            if (!isOnPremise) {
-              analytics.track(`${AMPLITUDE_MODULE_NAME} - Button Clicked`, {
-                module: AMPLITUDE_MODULE_NAME,
-                button_id: reviewAndFinishBtnID,
-                active_step_id: activeStep.id,
-              });
-            }
-            if (!beforeNext || beforeNext()) goToStepById('review-step');
-          }}
-          isDisabled={disableNext}
-        >
+        <Button variant='primary' onClick={handleReview}>
           Review image
         </Button>
         <Button

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -5,6 +5,9 @@ import {
   Content,
   EmptyState,
   FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
   Spinner,
   Tooltip,
 } from '@patternfly/react-core';
@@ -23,6 +26,7 @@ import {
   changeRegistrationType,
   selectArchitecture,
   selectDistribution,
+  selectForceShowErrors,
   selectImageTypes,
   selectIsImageMode,
   selectIsOnlyNetworkInstallerSelected,
@@ -70,6 +74,7 @@ const TargetEnvironment = () => {
   const isOtherEnvironmentSelected = useAppSelector(
     selectIsOtherEnvironmentSelected,
   );
+  const forceShowErrors = useAppSelector(selectForceShowErrors);
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: environments,
@@ -192,6 +197,15 @@ const TargetEnvironment = () => {
           ? 'Select a target environment for this image.'
           : 'Select one or more target environments for this image.'}
       </Content>
+      {forceShowErrors && environments.length === 0 && (
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem variant='error'>
+              Select at least one target environment.
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
+      )}
 
       {publicClouds.length > 0 && (
         <FormGroup

--- a/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
@@ -67,8 +67,6 @@ describe('ImportMode', () => {
     const clickNext = () => clickWithWait(user, nextButton);
 
     await selectGuestImage(user);
-    await clickNext();
-
     await selectRegisterLater(user);
     await clickNext();
 
@@ -139,8 +137,6 @@ describe('ImportMode', () => {
     const clickNext = () => clickWithWait(user, nextButton);
 
     await selectGuestImage(user);
-    await clickNext();
-
     await selectRegisterLater(user);
     await clickNext();
 

--- a/src/Components/CreateImageWizard/utilities/scrollToFirstError.ts
+++ b/src/Components/CreateImageWizard/utilities/scrollToFirstError.ts
@@ -1,0 +1,11 @@
+export const scrollToFirstError = (): boolean => {
+  const errorEl = document.querySelector('.pf-m-error');
+  if (errorEl) {
+    errorEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    const parent = errorEl.closest('.pf-v6-c-form-group, [role="group"]');
+    const input = parent?.querySelector('input, textarea, select');
+    if (input instanceof HTMLElement) input.focus();
+    return true;
+  }
+  return false;
+};

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -12,3 +12,4 @@ export * from './filesystem';
 export * from './output';
 export * from './registration';
 export * from './system';
+export * from './validation';

--- a/src/store/slices/wizard/parsers.ts
+++ b/src/store/slices/wizard/parsers.ts
@@ -12,6 +12,7 @@ import { parseOutputFromRequest } from './output';
 import { parseRegistrationFromRequest } from './registration';
 import type { WizardState } from './slice';
 import { parseSystemFromRequest } from './system';
+import { validationState } from './validation';
 
 export const parseStateFromRequest = (
   request: Request | Blueprint,
@@ -24,4 +25,5 @@ export const parseStateFromRequest = (
   output: parseOutputFromRequest(request),
   cloudProviders: parseCloudProvidersFromRequest(request),
   registration: parseRegistrationFromRequest(request),
+  validation: validationState,
 });

--- a/src/store/slices/wizard/slice.ts
+++ b/src/store/slices/wizard/slice.ts
@@ -8,6 +8,7 @@ import { filesystemSlice, filesystemState } from './filesystem';
 import { outputSlice, outputState } from './output';
 import { registrationSlice, registrationState } from './registration';
 import { systemSlice, systemState } from './system';
+import { validationSlice, validationState } from './validation';
 
 export const wizardReducer = combineSlices({
   cloudProviders: cloudProvidersSlice.reducer,
@@ -18,6 +19,7 @@ export const wizardReducer = combineSlices({
   output: outputSlice.reducer,
   registration: registrationSlice.reducer,
   system: systemSlice.reducer,
+  validation: validationSlice.reducer,
 });
 
 export type WizardState = ReturnType<typeof wizardReducer>;
@@ -31,4 +33,5 @@ export const initialState: WizardState = {
   output: outputState,
   registration: registrationState,
   system: systemState,
+  validation: validationState,
 };

--- a/src/store/slices/wizard/validation/index.ts
+++ b/src/store/slices/wizard/validation/index.ts
@@ -1,0 +1,4 @@
+export * from './selectors';
+export * from './slice';
+export { initialState as validationState } from './state';
+export * from './types';

--- a/src/store/slices/wizard/validation/selectors.ts
+++ b/src/store/slices/wizard/validation/selectors.ts
@@ -1,0 +1,5 @@
+import { RootState } from '@/store';
+
+export const selectForceShowErrors = (state: RootState) => {
+  return state.wizard.validation.forceShowErrors;
+};

--- a/src/store/slices/wizard/validation/slice.ts
+++ b/src/store/slices/wizard/validation/slice.ts
@@ -1,0 +1,31 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { initialState } from './state';
+
+import { initializeWizard, loadWizardState } from '../actions';
+
+export const validationSlice = createSlice({
+  name: 'wizard/validation',
+  initialState,
+  reducers: {
+    setForceShowErrors: (state) => {
+      state.forceShowErrors = true;
+    },
+    resetForceShowErrors: (state) => {
+      state.forceShowErrors = false;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(initializeWizard, () => initialState)
+      .addCase(
+        loadWizardState,
+        (_state, action) =>
+          (action.payload as Partial<typeof action.payload>).validation ??
+          initialState,
+      );
+  },
+});
+
+export const { setForceShowErrors, resetForceShowErrors } =
+  validationSlice.actions;

--- a/src/store/slices/wizard/validation/state.ts
+++ b/src/store/slices/wizard/validation/state.ts
@@ -1,0 +1,5 @@
+import { ValidationSlice } from './types';
+
+export const initialState: ValidationSlice = {
+  forceShowErrors: false,
+};

--- a/src/store/slices/wizard/validation/types.ts
+++ b/src/store/slices/wizard/validation/types.ts
@@ -1,0 +1,3 @@
+export type ValidationSlice = {
+  forceShowErrors: boolean;
+};


### PR DESCRIPTION
  Instead of disabling Next/Review when validation fails, keep them
  enabled and scroll to the first error on click. Create/Save buttons
  on the Review step behave the same way:
  always clickable, but navigate back to the first error step when validation fails.

  A new ValidationContext forces pristine fields to reveal their
  errors so the user sees exactly what needs fixing.

  Note: The activation key loading fix (stop blocking Next while
  the activation key query is in flight) will be submitted in a
  separate PR.
JIRA :HMS-10658
