### PR TITLE
Prepare store types for request mapper migration

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -15,7 +15,6 @@ import { useTargetEnvironmentCategories } from '@/Hooks';
 import { rhsmApi } from '@/store/api';
 import {
   BootcDistributionItem,
-  ImageTypes,
   useGetArchitecturesQuery,
   useGetDistributionsQuery,
 } from '@/store/api/backend';
@@ -35,6 +34,7 @@ import {
   selectImageTypes,
   selectIsImageMode,
   selectIsoPayloadReference,
+  SupportedImageTypes,
 } from '@/store/slices/wizard';
 
 import Aws from './Aws';
@@ -177,7 +177,7 @@ const TargetEnvironment = () => {
   const { privateClouds, publicClouds, miscFormats } =
     useTargetEnvironmentCategories(supportedEnvironments);
 
-  const handleToggleEnvironment = (environment: ImageTypes) => {
+  const handleToggleEnvironment = (environment: SupportedImageTypes) => {
     if (environments.includes(environment)) {
       switch (environment) {
         case 'aws':
@@ -195,7 +195,7 @@ const TargetEnvironment = () => {
     }
   };
 
-  const handleSelectSingleEnvironment = (environment: ImageTypes) => {
+  const handleSelectSingleEnvironment = (environment: SupportedImageTypes) => {
     dispatch(changeImageTypes([environment]));
   };
 

--- a/src/Components/CreateImageWizard/steps/Repositories/components/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/Repositories.tsx
@@ -28,6 +28,8 @@ import {
   changeCustomRepositories,
   changePayloadRepositories,
   changeRedHatRepositories,
+  convertSchemaToIBCustomRepo,
+  convertSchemaToIBPayloadRepo,
   selectArchitecture,
   selectCustomRepositories,
   selectDistribution,
@@ -60,8 +62,6 @@ import RepositoryUnavailable from './RepositoryUnavailable';
 import UploadRepositoryLabel from './UploadRepositoryLabel';
 
 import {
-  convertSchemaToIBCustomRepo,
-  convertSchemaToIBPayloadRepo,
   excludeEUSReposFilter,
   getReadableArchitecture,
   getReadableVersions,

--- a/src/Components/CreateImageWizard/steps/Repositories/repositoriesUtilities.ts
+++ b/src/Components/CreateImageWizard/steps/Repositories/repositoriesUtilities.ts
@@ -1,5 +1,4 @@
 import { ContentOrigin } from '@/constants';
-import { CustomRepository, Repository } from '@/store/api/backend';
 import {
   ApiRepositoryParameterResponse,
   ApiRepositoryResponse,
@@ -10,50 +9,6 @@ import {
   convertStringToDate,
   timestampToDisplayString,
 } from '@/Utilities/time';
-
-export const convertSchemaToIBCustomRepo = (
-  repo: ApiRepositoryResponseRead,
-) => {
-  const imageBuilderRepo: CustomRepository = {
-    id: repo.uuid!,
-    name: repo.name,
-    baseurl: repo.origin === ContentOrigin.UPLOAD ? undefined : [repo.url!],
-    check_gpg: false,
-  };
-  // only include the flag if enabled
-  if (repo.module_hotfixes) {
-    imageBuilderRepo.module_hotfixes = repo.module_hotfixes;
-  }
-  if (repo.gpg_key) {
-    imageBuilderRepo.gpgkey = [repo.gpg_key];
-    imageBuilderRepo.check_gpg = true;
-    imageBuilderRepo.check_repo_gpg = repo.metadata_verification;
-  }
-
-  return imageBuilderRepo;
-};
-
-export const convertSchemaToIBPayloadRepo = (
-  repo: ApiRepositoryResponseRead,
-) => {
-  const imageBuilderRepo: Repository = {
-    id: repo.uuid!,
-    baseurl: repo.origin === ContentOrigin.UPLOAD ? undefined : repo.url!,
-    rhsm: false,
-    check_gpg: false,
-  };
-  // only include the flag if enabled
-  if (repo.module_hotfixes) {
-    imageBuilderRepo.module_hotfixes = repo.module_hotfixes;
-  }
-  if (repo.gpg_key) {
-    imageBuilderRepo.gpgkey = repo.gpg_key;
-    imageBuilderRepo.check_gpg = true;
-    imageBuilderRepo.check_repo_gpg = repo.metadata_verification;
-  }
-
-  return imageBuilderRepo;
-};
 
 export const getLastIntrospection = (
   repoIntrospections: ApiRepositoryResponse['last_introspection_time'],

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -44,6 +44,8 @@ import { selectIsOnPremise } from '@/store/slices/env';
 import {
   AwsShareMethod,
   ComplianceType,
+  convertSchemaToIBCustomRepo,
+  convertSchemaToIBPayloadRepo,
   convertToBytes,
   DiskPartition,
   FilesystemMode,
@@ -136,10 +138,6 @@ import {
   SATELLITE_SERVICE_PATH,
 } from '../../../constants';
 import { RootState } from '../../../store';
-import {
-  convertSchemaToIBCustomRepo,
-  convertSchemaToIBPayloadRepo,
-} from '../steps/Repositories/repositoriesUtilities';
 
 /**
  * This function maps the wizard state to a valid CreateBlueprint request object

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -53,6 +53,7 @@ import {
   GcpAccountType,
   initialState,
   isRhel,
+  isSupportedImageType,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
@@ -547,7 +548,10 @@ function commonRequestToState(
         initialState.output.distribution,
       imageSource: 'bootc' in request ? request.bootc?.reference : undefined,
       isoPayloadReference: request.bootc?.iso_payload_reference,
-      imageTypes: request.image_requests.map((image) => image.image_type),
+      // Edge types are managed by a separate workflow; exclude them from this wizard
+      imageTypes: request.image_requests
+        .map((image) => image.image_type)
+        .filter(isSupportedImageType),
       bootcDistributions: [],
     },
     cloudProviders: {

--- a/src/store/slices/wizard/content/index.ts
+++ b/src/store/slices/wizard/content/index.ts
@@ -2,3 +2,4 @@ export * from './selectors';
 export * from './slice';
 export { initialState as contentState } from './state';
 export * from './types';
+export * from './utilities';

--- a/src/store/slices/wizard/content/utilities.ts
+++ b/src/store/slices/wizard/content/utilities.ts
@@ -1,0 +1,47 @@
+import { ContentOrigin } from '@/constants';
+import { CustomRepository, Repository } from '@/store/api/backend';
+import { ApiRepositoryResponseRead } from '@/store/api/contentSources';
+
+export const convertSchemaToIBCustomRepo = (
+  repo: ApiRepositoryResponseRead,
+) => {
+  const imageBuilderRepo: CustomRepository = {
+    id: repo.uuid!,
+    name: repo.name,
+    baseurl: repo.origin === ContentOrigin.UPLOAD ? undefined : [repo.url!],
+    check_gpg: false,
+  };
+  // only include the flag if enabled
+  if (repo.module_hotfixes) {
+    imageBuilderRepo.module_hotfixes = repo.module_hotfixes;
+  }
+  if (repo.gpg_key) {
+    imageBuilderRepo.gpgkey = [repo.gpg_key];
+    imageBuilderRepo.check_gpg = true;
+    imageBuilderRepo.check_repo_gpg = repo.metadata_verification;
+  }
+
+  return imageBuilderRepo;
+};
+
+export const convertSchemaToIBPayloadRepo = (
+  repo: ApiRepositoryResponseRead,
+) => {
+  const imageBuilderRepo: Repository = {
+    id: repo.uuid!,
+    baseurl: repo.origin === ContentOrigin.UPLOAD ? undefined : repo.url!,
+    rhsm: false,
+    check_gpg: false,
+  };
+  // only include the flag if enabled
+  if (repo.module_hotfixes) {
+    imageBuilderRepo.module_hotfixes = repo.module_hotfixes;
+  }
+  if (repo.gpg_key) {
+    imageBuilderRepo.gpgkey = repo.gpg_key;
+    imageBuilderRepo.check_gpg = true;
+    imageBuilderRepo.check_repo_gpg = repo.metadata_verification;
+  }
+
+  return imageBuilderRepo;
+};

--- a/src/store/slices/wizard/output/slice.ts
+++ b/src/store/slices/wizard/output/slice.ts
@@ -4,11 +4,10 @@ import {
   BootcDistributionItem,
   Distributions,
   ImageRequest,
-  ImageTypes,
 } from '@/store/api/backend';
 
 import { initialState } from './state';
-import { ImageSource } from './types';
+import { ImageSource, SupportedImageTypes } from './types';
 
 import { initializeWizard, loadWizardState } from '../actions';
 
@@ -43,19 +42,19 @@ export const outputSlice = createSlice({
     changeDistribution: (state, action: PayloadAction<Distributions>) => {
       state.distribution = action.payload;
     },
-    addImageType: (state, action: PayloadAction<ImageTypes>) => {
+    addImageType: (state, action: PayloadAction<SupportedImageTypes>) => {
       // Remove (if present) before adding to avoid duplicates
       state.imageTypes = state.imageTypes.filter(
         (imageType) => imageType !== action.payload,
       );
       state.imageTypes.push(action.payload);
     },
-    removeImageType: (state, action: PayloadAction<ImageTypes>) => {
+    removeImageType: (state, action: PayloadAction<SupportedImageTypes>) => {
       state.imageTypes = state.imageTypes.filter(
         (imageType) => imageType !== action.payload,
       );
     },
-    changeImageTypes: (state, action: PayloadAction<ImageTypes[]>) => {
+    changeImageTypes: (state, action: PayloadAction<SupportedImageTypes[]>) => {
       state.imageTypes = action.payload;
       // isoPayloadReference is only relevant for bootable-container-iso,
       // clear it when that image type is no longer selected

--- a/src/store/slices/wizard/output/tests/typeguards.test.ts
+++ b/src/store/slices/wizard/output/tests/typeguards.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { isPrivateCloud, isPublicCloud, isRhel } from '../typeguards';
+import {
+  isEdgeType,
+  isPrivateCloud,
+  isPublicCloud,
+  isRhel,
+  isSupportedImageType,
+} from '../typeguards';
 
 describe('isRhel', () => {
   it.each(['rhel-8', 'rhel-9', 'rhel-9-beta', 'rhel-10', 'rhel-10-beta'])(
@@ -53,4 +59,44 @@ describe('isPrivateCloud', () => {
       expect(isPrivateCloud(env)).toBe(false);
     },
   );
+});
+
+describe('isEdgeType', () => {
+  it.each([
+    'edge-commit',
+    'edge-installer',
+    'rhel-edge-commit',
+    'rhel-edge-installer',
+  ])('returns true for %s', (env) => {
+    expect(isEdgeType(env)).toBe(true);
+  });
+
+  it.each(['aws', 'guest-image', 'vsphere', 'iso'])(
+    'returns false for %s',
+    (env) => {
+      expect(isEdgeType(env)).toBe(false);
+    },
+  );
+});
+
+describe('isSupportedImageType', () => {
+  it.each(['aws', 'ami', 'azure', 'gcp', 'vsphere', 'guest-image'])(
+    'returns true for supported type %s',
+    (env) => {
+      expect(isSupportedImageType(env)).toBe(true);
+    },
+  );
+
+  it.each([
+    'edge-commit',
+    'edge-installer',
+    'rhel-edge-commit',
+    'rhel-edge-installer',
+  ])('returns false for edge type %s', (env) => {
+    expect(isSupportedImageType(env)).toBe(false);
+  });
+
+  it('returns false for arbitrary strings', () => {
+    expect(isSupportedImageType('not-a-real-type')).toBe(false);
+  });
 });

--- a/src/store/slices/wizard/output/typeguards.ts
+++ b/src/store/slices/wizard/output/typeguards.ts
@@ -2,14 +2,17 @@ import { targetOptions } from '@/constants';
 import { ImageTypes } from '@/store/api/backend/hosted';
 
 import {
+  EDGE_TYPES,
   PRIVATE_CLOUD_TYPES,
   PUBLIC_CLOUD_TYPES,
   RHEL_DISTRIBUTIONS,
 } from './constants';
 import type {
+  EdgeType,
   PrivateCloudType,
   PublicCloudType,
   RhelDistribution,
+  SupportedImageTypes,
 } from './types';
 
 export const isImageType = (key: string): key is ImageTypes => {
@@ -28,4 +31,14 @@ export const isPublicCloud = (env: string): env is PublicCloudType => {
 
 export const isPrivateCloud = (env: string): env is PrivateCloudType => {
   return (PRIVATE_CLOUD_TYPES as readonly string[]).includes(env);
+};
+
+export const isEdgeType = (env: string): env is EdgeType => {
+  return (EDGE_TYPES as readonly string[]).includes(env);
+};
+
+export const isSupportedImageType = (
+  env: string,
+): env is SupportedImageTypes => {
+  return isImageType(env) && !isEdgeType(env);
 };

--- a/src/store/slices/wizard/output/types.ts
+++ b/src/store/slices/wizard/output/types.ts
@@ -16,9 +16,11 @@ export type PublicCloudType = (typeof PUBLIC_CLOUD_TYPES)[number];
 export type PrivateCloudType = (typeof PRIVATE_CLOUD_TYPES)[number];
 export type EdgeType = (typeof EDGE_TYPES)[number];
 
+export type SupportedImageTypes = Exclude<ImageTypes, EdgeType>;
+
 export type MiscFormatType = Exclude<
-  ImageTypes,
-  PublicCloudType | PrivateCloudType | EdgeType
+  SupportedImageTypes,
+  PublicCloudType | PrivateCloudType
 >;
 
 export type ImageSource = string;
@@ -31,5 +33,5 @@ export type OutputSlice = {
   bootcDistributions: BootcDistributionItem[];
   architecture: ImageRequest['architecture'];
   distribution: Distributions;
-  imageTypes: ImageTypes[];
+  imageTypes: SupportedImageTypes[];
 };


### PR DESCRIPTION
Prepare store types for request mapper migration

## Summary

Establishes type-safe boundaries around edge image types and relocates repo conversion logic to the store layer, preparing the ground for moving the request mapper into the store.

## Changes

- Introduce `SupportedImageTypes = Exclude<ImageTypes, EdgeType>` and narrow the output slice's `imageTypes` field and action payloads to reject edge types at compile time
- Add `isEdgeType` and `isSupportedImageType` type guards with full test coverage, composing existing guards for DRY narrowing
- Filter edge types from blueprints on load in `requestMapper` so the wizard only operates on supported types
- Move `convertSchemaToIBCustomRepo` and `convertSchemaToIBPayloadRepo` from component utilities to `src/store/slices/wizard/content/utilities.ts` — pure data transforms belong at the store boundary, not in React components
