### PR TITLE
Extract customization mappers into co-located composable mappers

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -43,8 +43,6 @@ import { selectIsOnPremise } from '@/store/slices/env';
 import {
   AwsShareMethod,
   ComplianceType,
-  convertSchemaToIBCustomRepo,
-  convertSchemaToIBPayloadRepo,
   convertToBytes,
   DiskPartition,
   FilesystemMode,
@@ -54,6 +52,7 @@ import {
   isRhel,
   isSupportedImageType,
   mapComplianceCustomizations,
+  mapContentCustomizations,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
@@ -74,7 +73,6 @@ import {
   selectBlueprintDescription,
   selectBlueprintName,
   selectBootcDistributions,
-  selectCustomRepositories,
   selectDiskMinsize,
   selectDiskPartitions,
   selectDiskType,
@@ -95,15 +93,10 @@ import {
   selectKeyboard,
   selectLanguages,
   selectMetadata,
-  selectModules,
   selectNtpServers,
   selectOrgId,
-  selectPackageGroups,
-  selectPackages,
   selectPartitioningMode,
-  selectPayloadRepositories,
   selectProxy,
-  selectRecommendedRepositories,
   selectRegistrationType,
   selectSatelliteCaCertificate,
   selectSatelliteRegistrationCommand,
@@ -116,7 +109,6 @@ import {
   selectUseLatest,
   selectUserGroups,
   selectUsers,
-  selectVerifiedLocaleLangpacks,
   Units,
   UserWithAdditionalInfo,
   WizardState,
@@ -997,10 +989,8 @@ const getCustomizations = (state: RootState): Customizations => {
     directories: undefined,
     files: files.length > 0 ? files : undefined,
     subscription: getSubscription(state),
-    packages: getPackages(state),
-    enabled_modules: getModules(state),
-    payload_repositories: getPayloadRepositories(state),
-    custom_repositories: getCustomRepositories(state),
+    // packages, modules, payload repos + custom repos
+    ...mapContentCustomizations(state),
     // fips + openscap
     ...mapComplianceCustomizations(state),
     disk: getDisk(state),
@@ -1164,31 +1154,6 @@ const getFileSystem = (state: RootState): Filesystem[] | undefined => {
   return undefined;
 };
 
-const getPackages = (state: RootState) => {
-  const packages = selectPackages(state);
-  const groups = selectPackageGroups(state);
-  const verifiedLocaleLangpacks = selectVerifiedLocaleLangpacks(state);
-  const packageNames = new Set(packages.map((pkg) => pkg.name));
-  for (const pkg of verifiedLocaleLangpacks) {
-    packageNames.add(pkg);
-  }
-  const list = [...packageNames].concat(groups.map((grp) => '@' + grp.name));
-
-  if (list.length > 0) {
-    return list;
-  }
-  return undefined;
-};
-
-const getModules = (state: RootState) => {
-  const modules = selectModules(state);
-
-  if (modules.length > 0) {
-    return modules;
-  }
-  return undefined;
-};
-
 const getTimezone = (state: RootState) => {
   const timezone = selectTimezone(state);
   const ntpservers = selectNtpServers(state);
@@ -1285,48 +1250,6 @@ const getFirewall = (state: RootState) => {
   }
 
   return Object.keys(firewall).length > 0 ? firewall : undefined;
-};
-
-const getCustomRepositories = (state: RootState) => {
-  const customRepositories = selectCustomRepositories(state).map((cr) => {
-    return {
-      ...cr,
-      baseurl: cr.baseurl && cr.baseurl.length !== 0 ? cr.baseurl : undefined,
-    } as CustomRepository;
-  });
-
-  const recommendedRepositories = selectRecommendedRepositories(state);
-
-  const customAndRecommendedRepositories = [...customRepositories];
-
-  for (const repo in recommendedRepositories) {
-    customAndRecommendedRepositories.push(
-      convertSchemaToIBCustomRepo(recommendedRepositories[repo]),
-    );
-  }
-
-  if (customAndRecommendedRepositories.length === 0) {
-    return undefined;
-  }
-  return customAndRecommendedRepositories;
-};
-
-const getPayloadRepositories = (state: RootState) => {
-  const payloadRepositories = selectPayloadRepositories(state);
-  const recommendedRepositories = selectRecommendedRepositories(state);
-
-  const payloadAndRecommendedRepositories = [...payloadRepositories];
-
-  for (const repo in recommendedRepositories) {
-    payloadAndRecommendedRepositories.push(
-      convertSchemaToIBPayloadRepo(recommendedRepositories[repo]),
-    );
-  }
-
-  if (payloadAndRecommendedRepositories.length === 0) {
-    return undefined;
-  }
-  return payloadAndRecommendedRepositories;
 };
 
 const getKernel = (state: RootState) => {

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -2,7 +2,6 @@ import { Store } from 'redux';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
-  AapRegistration,
   AwsUploadRequestOptions,
   AzureUploadRequestOptions,
   BlueprintExportResponse,
@@ -29,7 +28,6 @@ import {
   OpenScapCompliance,
   OpenScapProfile,
   Services,
-  Subscription,
   UploadTypes,
   User,
   VolumeGroup,
@@ -53,15 +51,10 @@ import {
   mapContentCustomizations,
   mapFileCustomizations,
   mapFilesystemCustomizations,
+  mapRegistrationCustomizations,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
-  selectAapCallbackUrl,
-  selectAapEnabled,
-  selectAapHostConfigKey,
-  selectAapTlsCertificateAuthority,
-  selectAapTlsConfirmation,
-  selectActivationKey,
   selectArchitecture,
   selectAwsAccountId,
   selectAwsRegion,
@@ -69,7 +62,6 @@ import {
   selectAzureResourceGroup,
   selectAzureSubscriptionId,
   selectAzureTenantId,
-  selectBaseUrl,
   selectBlueprintDescription,
   selectBlueprintName,
   selectBootcDistributions,
@@ -87,11 +79,6 @@ import {
   selectLanguages,
   selectMetadata,
   selectNtpServers,
-  selectOrgId,
-  selectProxy,
-  selectRegistrationType,
-  selectSatelliteCaCertificate,
-  selectServerUrl,
   selectServices,
   selectSnapshotDate,
   selectTemplate,
@@ -776,29 +763,6 @@ const getFirstBootScript = (files?: File[]): string => {
   return firstBootFile?.data ? atob(firstBootFile.data) : '';
 };
 
-const getAapRegistration = (state: RootState): AapRegistration | undefined => {
-  const enabled = selectAapEnabled(state);
-  if (!enabled) {
-    return undefined;
-  }
-
-  const callbackUrl = selectAapCallbackUrl(state);
-  const hostConfigKey = selectAapHostConfigKey(state);
-  const tlsCertificateAuthority = selectAapTlsCertificateAuthority(state);
-  const skipTlsVerification = selectAapTlsConfirmation(state);
-
-  if (!callbackUrl && !hostConfigKey && !tlsCertificateAuthority) {
-    return undefined;
-  }
-
-  return {
-    ansible_callback_url: callbackUrl || '',
-    host_config_key: hostConfigKey || '',
-    tls_certificate_authority: tlsCertificateAuthority || undefined,
-    skip_tls_verification: skipTlsVerification || undefined,
-  };
-};
-
 const getImageRequests = (
   state: RootState,
 ): ImageRequest[] | ComposerImageRequest[] => {
@@ -938,13 +902,13 @@ const getImageOptions = (
 };
 
 const getCustomizations = (state: RootState): Customizations => {
-  const satCert = selectSatelliteCaCertificate(state);
   return {
     containers: undefined,
     directories: undefined,
     // first boot & satellite use file customizations
     ...mapFileCustomizations(state),
-    subscription: getSubscription(state),
+    // subscription, aap_registration + cacerts
+    ...mapRegistrationCustomizations(state),
     // packages, modules, payload repos + custom repos
     ...mapContentCustomizations(state),
     // fips + openscap
@@ -962,13 +926,6 @@ const getCustomizations = (state: RootState): Customizations => {
     installation_device: undefined,
     fdo: undefined,
     ignition: undefined,
-    cacerts:
-      satCert && selectRegistrationType(state) === 'register-satellite'
-        ? {
-            pem_certs: [satCert],
-          }
-        : undefined,
-    aap_registration: getAapRegistration(state),
   };
 };
 
@@ -1060,46 +1017,6 @@ const getTimezone = (state: RootState) => {
     timezone: timezone ? timezone : undefined,
     ntpservers: ntpservers && ntpservers.length > 0 ? ntpservers : undefined,
   };
-};
-
-const getSubscription = (state: RootState): Subscription | undefined => {
-  const registrationType = selectRegistrationType(state);
-  const activationKey = selectActivationKey(state);
-
-  if (
-    registrationType === 'register-later' ||
-    registrationType === 'register-satellite'
-  ) {
-    return undefined;
-  }
-
-  if (activationKey === undefined) {
-    throw new Error(
-      'Activation key unexpectedly undefined while generating subscription customization',
-    );
-  }
-
-  const orgId = selectOrgId(state);
-  if (!orgId) {
-    return undefined;
-  }
-
-  const initialSubscription = {
-    'activation-key': activationKey,
-    organization: Number(orgId),
-    'server-url': selectServerUrl(state),
-    'base-url': selectBaseUrl(state),
-    insights_client_proxy: selectProxy(state),
-  };
-
-  switch (registrationType) {
-    case 'register-now-rhc':
-      return { ...initialSubscription, insights: true, rhc: true };
-    case 'register-now-insights':
-      return { ...initialSubscription, insights: true, rhc: false };
-    case 'register-now':
-      return { ...initialSubscription, insights: false, rhc: false };
-  }
 };
 
 const getLocale = (state: RootState) => {

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -21,15 +21,12 @@ import {
   Filesystem,
   FilesystemTyped,
   GcpUploadRequestOptions,
-  Group,
   ImageRequest,
   ImageTypes,
   LogicalVolume,
   OpenScapCompliance,
   OpenScapProfile,
-  Services,
   UploadTypes,
-  User,
   VolumeGroup,
 } from '@/store/api/backend';
 import {
@@ -52,6 +49,7 @@ import {
   mapFileCustomizations,
   mapFilesystemCustomizations,
   mapRegistrationCustomizations,
+  mapSystemCustomizations,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
@@ -66,29 +64,18 @@ import {
   selectBlueprintName,
   selectBootcDistributions,
   selectDistribution,
-  selectFirewall,
   selectGcpAccountType,
   selectGcpEmail,
-  selectHostname,
   selectImageSource,
   selectImageTypes,
   selectIsImageMode,
   selectIsoPayloadReference,
-  selectKernel,
-  selectKeyboard,
-  selectLanguages,
   selectMetadata,
-  selectNtpServers,
-  selectServices,
   selectSnapshotDate,
   selectTemplate,
   selectTemplateName,
-  selectTimezone,
   selectUseLatest,
-  selectUserGroups,
-  selectUsers,
   Units,
-  UserWithAdditionalInfo,
   WizardState,
 } from '@/store/slices/wizard';
 
@@ -915,171 +902,10 @@ const getCustomizations = (state: RootState): Customizations => {
     ...mapComplianceCustomizations(state),
     // disk, filesystem + partition mode
     ...mapFilesystemCustomizations(state),
-    users: getUsers(state),
-    services: getServices(state),
-    hostname: selectHostname(state) || undefined,
-    kernel: getKernel(state),
-    groups: getUserGroups(state),
-    timezone: getTimezone(state),
-    locale: getLocale(state),
-    firewall: getFirewall(state),
+    // users, groups, services, hostname, kernel, timezone, locale + firewall
+    ...mapSystemCustomizations(state),
     installation_device: undefined,
     fdo: undefined,
     ignition: undefined,
   };
-};
-
-const getServices = (state: RootState): Services | undefined => {
-  const services = selectServices(state);
-  const enabledSvcs = services.enabled;
-  if (
-    enabledSvcs.length === 0 &&
-    services.masked.length === 0 &&
-    services.disabled.length === 0
-  ) {
-    return undefined;
-  }
-
-  return {
-    enabled: enabledSvcs.length ? enabledSvcs : undefined,
-    masked: services.masked.length ? services.masked : undefined,
-    disabled: services.disabled.length ? services.disabled : undefined,
-  };
-};
-
-const getUsers = (state: RootState): User[] | undefined => {
-  const users = selectUsers(state);
-
-  if (users.length === 0) {
-    return undefined;
-  }
-
-  const arrayUsers = users
-    .filter(
-      (user: UserWithAdditionalInfo) =>
-        user.name || user.password || user.ssh_key || user.groups.length > 0,
-    )
-    .map((user: UserWithAdditionalInfo) => {
-      const result: User = {
-        name: user.name,
-      };
-      if (user.password !== '') {
-        result.password = user.password;
-      }
-      if (user.ssh_key !== '') {
-        result.ssh_key = user.ssh_key;
-      }
-      if (user.groups.length > 0) {
-        result.groups = user.groups;
-      }
-      result.hasPassword = user.hasPassword || user.password !== '';
-      return result as User;
-    });
-
-  return arrayUsers.length > 0 ? arrayUsers : undefined;
-};
-
-const getUserGroups = (state: RootState): Group[] | undefined => {
-  const userGroups = selectUserGroups(state);
-
-  if (userGroups.length === 0) {
-    return undefined;
-  }
-
-  const arrayGroups = userGroups
-    .filter((group) => group.name && group.name.trim() !== '')
-    .map((group) => {
-      const result: Group = {
-        name: group.name,
-      };
-      if (group.gid !== undefined) {
-        result.gid = group.gid;
-      }
-      return result;
-    });
-
-  return arrayGroups.length > 0 ? arrayGroups : undefined;
-};
-
-const getTimezone = (state: RootState) => {
-  const timezone = selectTimezone(state);
-  const ntpservers = selectNtpServers(state);
-  const isImageMode = selectIsImageMode(state);
-
-  if (isImageMode) {
-    return undefined;
-  }
-
-  if (!timezone && ntpservers?.length === 0) {
-    return undefined;
-  }
-  return {
-    timezone: timezone ? timezone : undefined,
-    ntpservers: ntpservers && ntpservers.length > 0 ? ntpservers : undefined,
-  };
-};
-
-const getLocale = (state: RootState) => {
-  const languages = selectLanguages(state);
-  const keyboard = selectKeyboard(state);
-  const isImageMode = selectIsImageMode(state);
-
-  if (isImageMode) {
-    return undefined;
-  }
-
-  if (languages?.length === 0 && !keyboard) {
-    return undefined;
-  }
-  return {
-    languages: languages && languages.length > 0 ? languages : undefined,
-    keyboard: keyboard ? keyboard : undefined,
-  };
-};
-
-const getFirewall = (state: RootState) => {
-  const ports = selectFirewall(state).ports;
-  const services = selectFirewall(state).services;
-
-  const firewall = {};
-
-  if (ports.length > 0) {
-    Object.assign(firewall, { ports: ports });
-  }
-
-  if (services.enabled.length > 0 || services.disabled.length > 0) {
-    Object.assign(firewall, {
-      services: {
-        enabled: services.enabled.length > 0 ? services.enabled : undefined,
-        disabled: services.disabled.length > 0 ? services.disabled : undefined,
-      },
-    });
-  }
-
-  return Object.keys(firewall).length > 0 ? firewall : undefined;
-};
-
-const getKernel = (state: RootState) => {
-  const kernel = selectKernel(state);
-  const kernelAppendString = selectKernel(state).append.join(' ');
-
-  const kernelRequest = {};
-
-  if (!kernel.name && kernel.append.length === 0) {
-    return undefined;
-  }
-
-  if (kernel.name) {
-    Object.assign(kernelRequest, {
-      name: kernel.name,
-    });
-  }
-
-  if (kernelAppendString !== '') {
-    Object.assign(kernelRequest, {
-      append: kernelAppendString,
-    });
-  }
-
-  return Object.keys(kernelRequest).length > 0 ? kernelRequest : undefined;
 };

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -890,8 +890,6 @@ const getImageOptions = (
 
 const getCustomizations = (state: RootState): Customizations => {
   return {
-    containers: undefined,
-    directories: undefined,
     // first boot & satellite use file customizations
     ...mapFileCustomizations(state),
     // subscription, aap_registration + cacerts
@@ -904,8 +902,5 @@ const getCustomizations = (state: RootState): Customizations => {
     ...mapFilesystemCustomizations(state),
     // users, groups, services, hostname, kernel, timezone, locale + firewall
     ...mapSystemCustomizations(state),
-    installation_device: undefined,
-    fdo: undefined,
-    ignition: undefined,
   };
 };

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -13,7 +13,6 @@ import {
   ComposerImageRequest,
   ComposerUploadTypes,
   CreateBlueprintRequest,
-  Customizations,
   CustomRepository,
   DistributionProfileItem,
   Distributions,
@@ -44,12 +43,7 @@ import {
   initialState,
   isRhel,
   isSupportedImageType,
-  mapComplianceCustomizations,
-  mapContentCustomizations,
-  mapFileCustomizations,
-  mapFilesystemCustomizations,
-  mapRegistrationCustomizations,
-  mapSystemCustomizations,
+  mapCustomizations,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
@@ -100,7 +94,6 @@ export const mapRequestFromState = (
 ): CreateBlueprintRequest | ComposerCreateBlueprintRequest => {
   const state = store.getState();
   const imageRequests = getImageRequests(state);
-  const customizations = getCustomizations(state);
   const isImageMode = selectIsImageMode(state);
   const imageSource = selectImageSource(state);
 
@@ -142,7 +135,7 @@ export const mapRequestFromState = (
     distribution: selectDistribution(state),
     bootc: bootcBody,
     image_requests: imageRequests,
-    customizations,
+    ...mapCustomizations(state),
   };
 };
 
@@ -886,21 +879,4 @@ const getImageOptions = (
     }
   }
   return {};
-};
-
-const getCustomizations = (state: RootState): Customizations => {
-  return {
-    // first boot & satellite use file customizations
-    ...mapFileCustomizations(state),
-    // subscription, aap_registration + cacerts
-    ...mapRegistrationCustomizations(state),
-    // packages, modules, payload repos + custom repos
-    ...mapContentCustomizations(state),
-    // fips + openscap
-    ...mapComplianceCustomizations(state),
-    // disk, filesystem + partition mode
-    ...mapFilesystemCustomizations(state),
-    // users, groups, services, hostname, kernel, timezone, locale + firewall
-    ...mapSystemCustomizations(state),
-  };
 };

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -51,6 +51,7 @@ import {
   isSupportedImageType,
   mapComplianceCustomizations,
   mapContentCustomizations,
+  mapFileCustomizations,
   mapFilesystemCustomizations,
   PackageRepository,
   parseSizeUnit,
@@ -74,7 +75,6 @@ import {
   selectBootcDistributions,
   selectDistribution,
   selectFirewall,
-  selectFirstBootScript,
   selectGcpAccountType,
   selectGcpEmail,
   selectHostname,
@@ -91,7 +91,6 @@ import {
   selectProxy,
   selectRegistrationType,
   selectSatelliteCaCertificate,
-  selectSatelliteRegistrationCommand,
   selectServerUrl,
   selectServices,
   selectSnapshotDate,
@@ -108,15 +107,11 @@ import {
 
 import {
   CENTOS_9,
-  FIRST_BOOT_SERVICE_DATA,
   FIRSTBOOT_PATH,
-  FIRSTBOOT_SERVICE_PATH,
   RHEL_10,
   RHEL_8,
   RHEL_9,
   SATELLITE_PATH,
-  SATELLITE_SERVICE_DATA,
-  SATELLITE_SERVICE_PATH,
 } from '../../../constants';
 import { RootState } from '../../../store';
 
@@ -944,42 +939,11 @@ const getImageOptions = (
 
 const getCustomizations = (state: RootState): Customizations => {
   const satCert = selectSatelliteCaCertificate(state);
-  const files: File[] = [];
-  if (selectFirstBootScript(state)) {
-    files.push({
-      path: FIRSTBOOT_SERVICE_PATH,
-      data: FIRST_BOOT_SERVICE_DATA,
-      data_encoding: 'base64',
-      ensure_parents: true,
-    });
-    files.push({
-      path: FIRSTBOOT_PATH,
-      data: btoa(selectFirstBootScript(state)),
-      data_encoding: 'base64',
-      mode: '0774',
-      ensure_parents: true,
-    });
-  }
-  const satCmd = selectSatelliteRegistrationCommand(state);
-  if (satCmd && selectRegistrationType(state) === 'register-satellite') {
-    files.push({
-      path: SATELLITE_SERVICE_PATH,
-      data: SATELLITE_SERVICE_DATA,
-      data_encoding: 'base64',
-      ensure_parents: true,
-    });
-    files.push({
-      path: SATELLITE_PATH,
-      data: btoa(satCmd),
-      mode: '0774',
-      data_encoding: 'base64',
-      ensure_parents: true,
-    });
-  }
   return {
     containers: undefined,
     directories: undefined,
-    files: files.length > 0 ? files : undefined,
+    // first boot & satellite use file customizations
+    ...mapFileCustomizations(state),
     subscription: getSubscription(state),
     // packages, modules, payload repos + custom repos
     ...mapContentCustomizations(state),

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -16,7 +16,6 @@ import {
   CreateBlueprintRequest,
   Customizations,
   CustomRepository,
-  Disk,
   DistributionProfileItem,
   Distributions,
   File,
@@ -43,7 +42,6 @@ import { selectIsOnPremise } from '@/store/slices/env';
 import {
   AwsShareMethod,
   ComplianceType,
-  convertToBytes,
   DiskPartition,
   FilesystemMode,
   FilesystemPartition,
@@ -53,6 +51,7 @@ import {
   isSupportedImageType,
   mapComplianceCustomizations,
   mapContentCustomizations,
+  mapFilesystemCustomizations,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
@@ -73,15 +72,9 @@ import {
   selectBlueprintDescription,
   selectBlueprintName,
   selectBootcDistributions,
-  selectDiskMinsize,
-  selectDiskPartitions,
-  selectDiskType,
-  selectDiskUnit,
   selectDistribution,
-  selectFilesystemPartitions,
   selectFirewall,
   selectFirstBootScript,
-  selectFscMode,
   selectGcpAccountType,
   selectGcpEmail,
   selectHostname,
@@ -95,7 +88,6 @@ import {
   selectMetadata,
   selectNtpServers,
   selectOrgId,
-  selectPartitioningMode,
   selectProxy,
   selectRegistrationType,
   selectSatelliteCaCertificate,
@@ -993,8 +985,8 @@ const getCustomizations = (state: RootState): Customizations => {
     ...mapContentCustomizations(state),
     // fips + openscap
     ...mapComplianceCustomizations(state),
-    disk: getDisk(state),
-    filesystem: getFileSystem(state),
+    // disk, filesystem + partition mode
+    ...mapFilesystemCustomizations(state),
     users: getUsers(state),
     services: getServices(state),
     hostname: selectHostname(state) || undefined,
@@ -1006,7 +998,6 @@ const getCustomizations = (state: RootState): Customizations => {
     installation_device: undefined,
     fdo: undefined,
     ignition: undefined,
-    partitioning_mode: selectPartitioningMode(state),
     cacerts:
       satCert && selectRegistrationType(state) === 'register-satellite'
         ? {
@@ -1087,71 +1078,6 @@ const getUserGroups = (state: RootState): Group[] | undefined => {
     });
 
   return arrayGroups.length > 0 ? arrayGroups : undefined;
-};
-
-const getDisk = (state: RootState): Disk | undefined => {
-  const fscMode = selectFscMode(state);
-  const minsize = selectDiskMinsize(state);
-  const unit = selectDiskUnit(state);
-  const partitions = selectDiskPartitions(state);
-  const diskPartitions = partitions.map((partition) => {
-    if (partition.type === 'lvm') {
-      return {
-        minsize: partition.min_size + ' ' + partition.unit,
-        name: partition.name,
-        type: partition.type,
-        logical_volumes: partition.logical_volumes.map((lv) => {
-          return {
-            minsize: lv.min_size + ' ' + lv.unit,
-            name: lv.name,
-            fs_type: lv.fs_type,
-            mountpoint: lv.mountpoint,
-          };
-        }),
-      };
-    }
-
-    if (partition.type === 'btrfs') {
-      return {
-        minsize: partition.min_size + ' ' + partition.unit,
-        type: partition.type,
-        subvolumes: partition.subvolumes,
-      };
-    }
-
-    return {
-      minsize: partition.min_size + ' ' + partition.unit,
-      fs_type: partition.fs_type,
-      mountpoint: partition.mountpoint,
-      type: partition.type,
-    };
-  });
-
-  if (fscMode === 'advanced') {
-    return {
-      type: selectDiskType(state),
-      minsize: minsize ? minsize + ' ' + unit : undefined,
-      partitions: diskPartitions,
-    };
-  }
-
-  return undefined;
-};
-
-const getFileSystem = (state: RootState): Filesystem[] | undefined => {
-  const fscMode = selectFscMode(state);
-
-  if (fscMode === 'basic') {
-    const partitions = selectFilesystemPartitions(state);
-    const fileSystem = partitions.map((partition) => {
-      return {
-        min_size: convertToBytes(partition.min_size, partition.unit),
-        mountpoint: partition.mountpoint,
-      };
-    });
-    return fileSystem;
-  }
-  return undefined;
 };
 
 const getTimezone = (state: RootState) => {

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -27,7 +27,6 @@ import {
   ImageRequest,
   ImageTypes,
   LogicalVolume,
-  OpenScap,
   OpenScapCompliance,
   OpenScapProfile,
   Services,
@@ -54,6 +53,7 @@ import {
   initialState,
   isRhel,
   isSupportedImageType,
+  mapComplianceCustomizations,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
@@ -74,9 +74,6 @@ import {
   selectBlueprintDescription,
   selectBlueprintName,
   selectBootcDistributions,
-  selectCompliancePolicyID,
-  selectComplianceProfileID,
-  selectComplianceType,
   selectCustomRepositories,
   selectDiskMinsize,
   selectDiskPartitions,
@@ -84,7 +81,6 @@ import {
   selectDiskUnit,
   selectDistribution,
   selectFilesystemPartitions,
-  selectFips,
   selectFirewall,
   selectFirstBootScript,
   selectFscMode,
@@ -1005,7 +1001,8 @@ const getCustomizations = (state: RootState): Customizations => {
     enabled_modules: getModules(state),
     payload_repositories: getPayloadRepositories(state),
     custom_repositories: getCustomRepositories(state),
-    openscap: getOpenscap(state),
+    // fips + openscap
+    ...mapComplianceCustomizations(state),
     disk: getDisk(state),
     filesystem: getFileSystem(state),
     users: getUsers(state),
@@ -1020,7 +1017,6 @@ const getCustomizations = (state: RootState): Customizations => {
     fdo: undefined,
     ignition: undefined,
     partitioning_mode: selectPartitioningMode(state),
-    fips: getFips(state),
     cacerts:
       satCert && selectRegistrationType(state) === 'register-satellite'
         ? {
@@ -1047,20 +1043,6 @@ const getServices = (state: RootState): Services | undefined => {
     masked: services.masked.length ? services.masked : undefined,
     disabled: services.disabled.length ? services.disabled : undefined,
   };
-};
-
-const getOpenscap = (state: RootState): OpenScap | undefined => {
-  const complianceType = selectComplianceType(state);
-  const profile = selectComplianceProfileID(state);
-  const policy = selectCompliancePolicyID(state);
-
-  if (complianceType === 'openscap' && profile) {
-    return { profile_id: profile };
-  }
-  if (complianceType === 'compliance' && policy) {
-    return { policy_id: policy };
-  }
-  return undefined;
 };
 
 const getUsers = (state: RootState): User[] | undefined => {
@@ -1345,18 +1327,6 @@ const getPayloadRepositories = (state: RootState) => {
     return undefined;
   }
   return payloadAndRecommendedRepositories;
-};
-
-const getFips = (state: RootState) => {
-  const fips = selectFips(state);
-
-  if (!fips.enabled) {
-    return undefined;
-  }
-
-  return {
-    enabled: fips.enabled,
-  };
 };
 
 const getKernel = (state: RootState) => {

--- a/src/store/slices/wizard/compliance/index.ts
+++ b/src/store/slices/wizard/compliance/index.ts
@@ -1,3 +1,4 @@
+export * from './mappers';
 export * from './selectors';
 export * from './slice';
 export { initialState as complianceState } from './state';

--- a/src/store/slices/wizard/compliance/mappers.ts
+++ b/src/store/slices/wizard/compliance/mappers.ts
@@ -1,0 +1,40 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import {
+  selectCompliancePolicyID,
+  selectComplianceProfileID,
+  selectComplianceType,
+  selectFips,
+} from './selectors';
+
+const mapOpenscap = createSelector(
+  [selectComplianceType, selectComplianceProfileID, selectCompliancePolicyID],
+  (mode, profile, policy) => {
+    if (mode === 'openscap' && profile) {
+      return { openscap: { profile_id: profile } };
+    }
+
+    if (mode === 'compliance' && policy) {
+      return { openscap: { policy_id: policy } };
+    }
+
+    return undefined;
+  },
+);
+
+const mapFips = createSelector([selectFips], (fips) => {
+  if (!fips.enabled) {
+    return undefined;
+  }
+
+  return {
+    fips: {
+      enabled: fips.enabled,
+    },
+  };
+});
+
+export const mapComplianceCustomizations = createSelector(
+  [mapOpenscap, mapFips],
+  (oscap, fips) => ({ ...oscap, ...fips }),
+);

--- a/src/store/slices/wizard/compliance/tests/mappers.test.ts
+++ b/src/store/slices/wizard/compliance/tests/mappers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockState } from '../../tests/mockWizardState';
+import { mapComplianceCustomizations } from '../mappers';
+import { initialState } from '../state';
+import type { ComplianceSlice } from '../types';
+
+const createState = (overrides: Partial<ComplianceSlice> = {}) =>
+  createMockState({
+    compliance: { ...initialState, ...overrides },
+  });
+
+describe('mapComplianceCustomizations', () => {
+  it('returns empty object when compliance type is none', () => {
+    const state = createState();
+    expect(mapComplianceCustomizations(state)).toEqual({});
+  });
+
+  it('returns openscap with profile_id for openscap type', () => {
+    const state = createState({
+      type: 'openscap',
+      profileID: 'xccdf_org.ssgproject.content_profile_cis',
+    });
+    expect(mapComplianceCustomizations(state)).toEqual({
+      openscap: {
+        profile_id: 'xccdf_org.ssgproject.content_profile_cis',
+      },
+    });
+  });
+
+  it('returns openscap with policy_id for compliance type', () => {
+    const state = createState({
+      type: 'compliance',
+      policyID: 'policy-123',
+    });
+    expect(mapComplianceCustomizations(state)).toEqual({
+      openscap: {
+        policy_id: 'policy-123',
+      },
+    });
+  });
+
+  it('returns undefined openscap when openscap type has no profile', () => {
+    const state = createState({ type: 'openscap' });
+    expect(mapComplianceCustomizations(state)).toEqual({});
+  });
+
+  it('returns undefined openscap when compliance type has no policy', () => {
+    const state = createState({ type: 'compliance' });
+    expect(mapComplianceCustomizations(state)).toEqual({});
+  });
+
+  it('returns fips when enabled', () => {
+    const state = createState({ fips: { enabled: true } });
+    expect(mapComplianceCustomizations(state)).toEqual({
+      fips: { enabled: true },
+    });
+  });
+
+  it('omits fips key when disabled', () => {
+    const state = createState({ fips: { enabled: false } });
+    const result = mapComplianceCustomizations(state);
+    expect(result).not.toHaveProperty('fips');
+  });
+
+  it('returns both openscap and fips when both are set', () => {
+    const state = createState({
+      type: 'openscap',
+      profileID: 'xccdf_org.ssgproject.content_profile_cis',
+      fips: { enabled: true },
+    });
+    expect(mapComplianceCustomizations(state)).toEqual({
+      openscap: {
+        profile_id: 'xccdf_org.ssgproject.content_profile_cis',
+      },
+      fips: { enabled: true },
+    });
+  });
+});

--- a/src/store/slices/wizard/content/index.ts
+++ b/src/store/slices/wizard/content/index.ts
@@ -1,3 +1,4 @@
+export * from './mappers';
 export * from './selectors';
 export * from './slice';
 export { initialState as contentState } from './state';

--- a/src/store/slices/wizard/content/mappers.ts
+++ b/src/store/slices/wizard/content/mappers.ts
@@ -1,0 +1,96 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import type { CustomRepository } from '@/store/api/backend';
+
+import {
+  selectCustomRepositories,
+  selectModules,
+  selectPackageGroups,
+  selectPackages,
+  selectPayloadRepositories,
+  selectRecommendedRepositories,
+  selectVerifiedLocaleLangpacks,
+} from './selectors';
+import {
+  convertSchemaToIBCustomRepo,
+  convertSchemaToIBPayloadRepo,
+} from './utilities';
+
+const mapPackages = createSelector(
+  [selectPackages, selectPackageGroups, selectVerifiedLocaleLangpacks],
+  (packages, groups, langpacks) => {
+    const packageNames = new Set(packages.map((pkg) => pkg.name));
+    for (const pkg of langpacks) {
+      packageNames.add(pkg);
+    }
+
+    const list = [...packageNames].concat(groups.map((grp) => '@' + grp.name));
+
+    if (list.length > 0) {
+      return { packages: list };
+    }
+
+    return undefined;
+  },
+);
+
+const mapModules = createSelector([selectModules], (modules) => {
+  if (modules.length > 0) {
+    return { enabled_modules: modules };
+  }
+
+  return undefined;
+});
+
+const mapCustomRepos = createSelector(
+  [selectCustomRepositories, selectRecommendedRepositories],
+  (customRepositories, recommendedRepositories) => {
+    const cleaned = customRepositories.map((cr) => {
+      return {
+        ...cr,
+        baseurl: cr.baseurl && cr.baseurl.length !== 0 ? cr.baseurl : undefined,
+      } as CustomRepository;
+    });
+
+    const combined = [...cleaned];
+
+    for (const repo in recommendedRepositories) {
+      combined.push(convertSchemaToIBCustomRepo(recommendedRepositories[repo]));
+    }
+
+    if (combined.length === 0) {
+      return undefined;
+    }
+
+    return { custom_repositories: combined };
+  },
+);
+
+const mapPayloadRepos = createSelector(
+  [selectPayloadRepositories, selectRecommendedRepositories],
+  (payloadRepositories, recommendedRepositories) => {
+    const combined = [...payloadRepositories];
+
+    for (const repo in recommendedRepositories) {
+      combined.push(
+        convertSchemaToIBPayloadRepo(recommendedRepositories[repo]),
+      );
+    }
+
+    if (combined.length === 0) {
+      return undefined;
+    }
+
+    return { payload_repositories: combined };
+  },
+);
+
+export const mapContentCustomizations = createSelector(
+  [mapPackages, mapModules, mapCustomRepos, mapPayloadRepos],
+  (packages, modules, customRepositories, payloadRepositories) => ({
+    ...packages,
+    ...modules,
+    ...customRepositories,
+    ...payloadRepositories,
+  }),
+);

--- a/src/store/slices/wizard/content/tests/mappers.test.ts
+++ b/src/store/slices/wizard/content/tests/mappers.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockState } from '../../tests/mockWizardState';
+import { mapContentCustomizations } from '../mappers';
+import { initialState } from '../state';
+import type { ContentSlice } from '../types';
+
+const createState = (overrides: Partial<ContentSlice> = {}) =>
+  createMockState({
+    content: { ...initialState, ...overrides },
+  });
+
+describe('mapContentCustomizations', () => {
+  it('returns empty object when content is default', () => {
+    const state = createState();
+    expect(mapContentCustomizations(state)).toEqual({});
+  });
+
+  describe('packages', () => {
+    it('includes packages when present', () => {
+      const state = createState({
+        packages: [
+          { name: 'vim', summary: 'editor', repository: 'distro' },
+          { name: 'curl', summary: 'transfer', repository: 'distro' },
+        ],
+      });
+      const result = mapContentCustomizations(state);
+      expect(result.packages).toEqual(expect.arrayContaining(['vim', 'curl']));
+    });
+
+    it('prefixes groups with @', () => {
+      const state = createState({
+        groups: [
+          {
+            name: 'development',
+            description: 'dev tools',
+            repository: 'distro',
+          },
+        ],
+      });
+      const result = mapContentCustomizations(state);
+      expect(result.packages).toContain('@development');
+    });
+
+    it('deduplicates packages and langpacks', () => {
+      const state = createState({
+        packages: [{ name: 'glibc', summary: '', repository: 'distro' }],
+        verifiedLocaleLangpacks: ['glibc', 'langpack-en'],
+      });
+      const result = mapContentCustomizations(state);
+      expect(result.packages).toEqual(
+        expect.arrayContaining(['glibc', 'langpack-en']),
+      );
+      const glibcCount = result.packages!.filter(
+        (p: string) => p === 'glibc',
+      ).length;
+      expect(glibcCount).toBe(1);
+    });
+
+    it('omits packages key when none are set', () => {
+      const state = createState();
+      expect(mapContentCustomizations(state)).not.toHaveProperty('packages');
+    });
+  });
+
+  describe('modules', () => {
+    it('includes enabled_modules when present', () => {
+      const state = createState({
+        enabledModules: [{ name: 'nodejs', stream: '18' }],
+      });
+      expect(mapContentCustomizations(state)).toEqual(
+        expect.objectContaining({
+          enabled_modules: [{ name: 'nodejs', stream: '18' }],
+        }),
+      );
+    });
+
+    it('omits enabled_modules key when empty', () => {
+      const state = createState();
+      expect(mapContentCustomizations(state)).not.toHaveProperty(
+        'enabled_modules',
+      );
+    });
+  });
+
+  describe('repositories', () => {
+    it('includes custom_repositories with cleaned baseurl', () => {
+      const state = createState({
+        repositories: {
+          ...initialState.repositories,
+          customRepositories: [
+            {
+              id: 'repo-1',
+              name: 'My Repo',
+              baseurl: ['https://example.com/repo'],
+              check_gpg: false,
+            },
+          ],
+        },
+      });
+      const result = mapContentCustomizations(state);
+      expect(result.custom_repositories).toEqual([
+        {
+          id: 'repo-1',
+          name: 'My Repo',
+          baseurl: ['https://example.com/repo'],
+          check_gpg: false,
+        },
+      ]);
+    });
+
+    it('sets baseurl to undefined when empty array', () => {
+      const state = createState({
+        repositories: {
+          ...initialState.repositories,
+          customRepositories: [
+            {
+              id: 'repo-1',
+              name: 'My Repo',
+              baseurl: [],
+              check_gpg: false,
+            },
+          ],
+        },
+      });
+      const result = mapContentCustomizations(state);
+      expect(result.custom_repositories![0].baseurl).toBeUndefined();
+    });
+
+    it('omits custom_repositories key when empty', () => {
+      const state = createState();
+      expect(mapContentCustomizations(state)).not.toHaveProperty(
+        'custom_repositories',
+      );
+    });
+
+    it('omits payload_repositories key when empty', () => {
+      const state = createState();
+      expect(mapContentCustomizations(state)).not.toHaveProperty(
+        'payload_repositories',
+      );
+    });
+
+    it('includes payload_repositories when present', () => {
+      const state = createState({
+        repositories: {
+          ...initialState.repositories,
+          payloadRepositories: [
+            {
+              baseurl: 'https://example.com/payload',
+              rhsm: false,
+              check_gpg: false,
+            },
+          ],
+        },
+      });
+      const result = mapContentCustomizations(state);
+      expect(result.payload_repositories).toHaveLength(1);
+    });
+  });
+});

--- a/src/store/slices/wizard/filesystem/index.ts
+++ b/src/store/slices/wizard/filesystem/index.ts
@@ -1,3 +1,4 @@
+export * from './mappers';
 export * from './selectors';
 export * from './slice';
 export { initialState as filesystemState } from './state';

--- a/src/store/slices/wizard/filesystem/mappers.ts
+++ b/src/store/slices/wizard/filesystem/mappers.ts
@@ -1,0 +1,107 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import {
+  selectDiskMinsize,
+  selectDiskPartitions,
+  selectDiskType,
+  selectDiskUnit,
+  selectFilesystemPartitions,
+  selectFscMode,
+  selectPartitioningMode,
+} from './selectors';
+import { convertToBytes } from './utilities';
+
+const mapDisk = createSelector(
+  [
+    selectFscMode,
+    selectDiskMinsize,
+    selectDiskUnit,
+    selectDiskPartitions,
+    selectDiskType,
+  ],
+  (fscMode, minsize, unit, partitions, diskType) => {
+    if (fscMode !== 'advanced') {
+      return undefined;
+    }
+
+    const diskPartitions = partitions.map((partition) => {
+      if (partition.type === 'lvm') {
+        return {
+          minsize: partition.min_size + ' ' + partition.unit,
+          name: partition.name,
+          type: partition.type,
+          logical_volumes: partition.logical_volumes.map((lv) => {
+            return {
+              minsize: lv.min_size + ' ' + lv.unit,
+              name: lv.name,
+              fs_type: lv.fs_type,
+              mountpoint: lv.mountpoint,
+            };
+          }),
+        };
+      }
+
+      if (partition.type === 'btrfs') {
+        return {
+          minsize: partition.min_size + ' ' + partition.unit,
+          type: partition.type,
+          subvolumes: partition.subvolumes,
+        };
+      }
+
+      return {
+        minsize: partition.min_size + ' ' + partition.unit,
+        fs_type: partition.fs_type,
+        mountpoint: partition.mountpoint,
+        type: partition.type,
+      };
+    });
+
+    return {
+      disk: {
+        type: diskType,
+        minsize: minsize ? minsize + ' ' + unit : undefined,
+        partitions: diskPartitions,
+      },
+    };
+  },
+);
+
+const mapFilesystem = createSelector(
+  [selectFscMode, selectFilesystemPartitions],
+  (fscMode, partitions) => {
+    if (fscMode === 'basic') {
+      const filesystem = partitions.map((partition) => {
+        return {
+          min_size: convertToBytes(partition.min_size, partition.unit),
+          mountpoint: partition.mountpoint,
+        };
+      });
+      return { filesystem };
+    }
+
+    return undefined;
+  },
+);
+
+const mapPartitioningMode = createSelector(
+  [selectPartitioningMode],
+  (partitioningMode) => {
+    if (!partitioningMode) {
+      return undefined;
+    }
+
+    return {
+      partitioning_mode: partitioningMode,
+    };
+  },
+);
+
+export const mapFilesystemCustomizations = createSelector(
+  [mapDisk, mapFilesystem, mapPartitioningMode],
+  (disk, filesystem, partitionMode) => ({
+    ...disk,
+    ...filesystem,
+    ...partitionMode,
+  }),
+);

--- a/src/store/slices/wizard/filesystem/tests/mappers.test.ts
+++ b/src/store/slices/wizard/filesystem/tests/mappers.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockState } from '../../tests/mockWizardState';
+import { mapFilesystemCustomizations } from '../mappers';
+import { initialState } from '../state';
+import type { FilesystemSlice } from '../types';
+
+const createState = (overrides: Partial<FilesystemSlice> = {}) =>
+  createMockState({
+    filesystem: { ...initialState, ...overrides },
+  });
+
+describe('mapFilesystemCustomizations', () => {
+  it('returns empty object for automatic mode', () => {
+    const state = createState();
+    expect(mapFilesystemCustomizations(state)).toEqual({});
+  });
+
+  describe('basic mode (filesystem)', () => {
+    it('returns filesystem partitions with converted sizes', () => {
+      const state = createState({
+        mode: 'basic',
+        fileSystem: {
+          partitions: [
+            { id: '1', mountpoint: '/', min_size: '10', unit: 'GiB' },
+            { id: '2', mountpoint: '/home', min_size: '5', unit: 'GiB' },
+          ],
+        },
+      });
+      const result = mapFilesystemCustomizations(state);
+      expect(result.filesystem).toEqual([
+        { min_size: 10737418240, mountpoint: '/' },
+        { min_size: 5368709120, mountpoint: '/home' },
+      ]);
+    });
+
+    it('omits disk key in basic mode', () => {
+      const state = createState({
+        mode: 'basic',
+        fileSystem: {
+          partitions: [
+            { id: '1', mountpoint: '/', min_size: '10', unit: 'GiB' },
+          ],
+        },
+      });
+      expect(mapFilesystemCustomizations(state)).not.toHaveProperty('disk');
+    });
+  });
+
+  describe('advanced mode (disk)', () => {
+    it('returns disk with plain partitions', () => {
+      const state = createState({
+        mode: 'advanced',
+        disk: {
+          minsize: '50',
+          unit: 'GiB',
+          type: 'gpt',
+          partitions: [
+            {
+              id: '1',
+              min_size: '10',
+              unit: 'GiB',
+              fs_type: 'ext4',
+              mountpoint: '/',
+              type: 'plain',
+            },
+          ],
+        },
+      });
+      const result = mapFilesystemCustomizations(state);
+      expect(result.disk).toEqual({
+        type: 'gpt',
+        minsize: '50 GiB',
+        partitions: [
+          {
+            minsize: '10 GiB',
+            fs_type: 'ext4',
+            mountpoint: '/',
+            type: 'plain',
+          },
+        ],
+      });
+    });
+
+    it('returns disk with lvm partitions including logical volumes', () => {
+      const state = createState({
+        mode: 'advanced',
+        disk: {
+          minsize: '',
+          unit: 'GiB',
+          type: 'gpt',
+          partitions: [
+            {
+              id: '1',
+              min_size: '20',
+              unit: 'GiB',
+              type: 'lvm',
+              name: 'myvg',
+              logical_volumes: [
+                {
+                  id: 'lv1',
+                  min_size: '10',
+                  unit: 'GiB',
+                  name: 'root',
+                  fs_type: 'ext4',
+                  mountpoint: '/',
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const result = mapFilesystemCustomizations(state);
+      expect(result.disk!.partitions[0]).toEqual({
+        minsize: '20 GiB',
+        name: 'myvg',
+        type: 'lvm',
+        logical_volumes: [
+          {
+            minsize: '10 GiB',
+            name: 'root',
+            fs_type: 'ext4',
+            mountpoint: '/',
+          },
+        ],
+      });
+    });
+
+    it('returns disk with btrfs partitions', () => {
+      const state = createState({
+        mode: 'advanced',
+        disk: {
+          minsize: '',
+          unit: 'GiB',
+          type: 'gpt',
+          partitions: [
+            {
+              id: '1',
+              min_size: '30',
+              unit: 'GiB',
+              type: 'btrfs',
+              subvolumes: [{ name: 'root', mountpoint: '/' }],
+            },
+          ],
+        },
+      });
+      const result = mapFilesystemCustomizations(state);
+      expect(result.disk!.partitions[0]).toEqual({
+        minsize: '30 GiB',
+        type: 'btrfs',
+        subvolumes: [{ name: 'root', mountpoint: '/' }],
+      });
+    });
+
+    it('sets disk minsize to undefined when empty', () => {
+      const state = createState({
+        mode: 'advanced',
+        disk: {
+          minsize: '',
+          unit: 'GiB',
+          type: 'gpt',
+          partitions: [],
+        },
+      });
+      const result = mapFilesystemCustomizations(state);
+      expect(result.disk!.minsize).toBeUndefined();
+    });
+
+    it('omits filesystem key in advanced mode', () => {
+      const state = createState({
+        mode: 'advanced',
+        disk: {
+          minsize: '',
+          unit: 'GiB',
+          type: 'gpt',
+          partitions: [],
+        },
+      });
+      expect(mapFilesystemCustomizations(state)).not.toHaveProperty(
+        'filesystem',
+      );
+    });
+  });
+
+  describe('partitioning mode', () => {
+    it('includes partitioning_mode when set', () => {
+      const state = createState({ partitioningMode: 'auto-lvm' });
+      expect(mapFilesystemCustomizations(state)).toEqual(
+        expect.objectContaining({
+          partitioning_mode: 'auto-lvm',
+        }),
+      );
+    });
+
+    it('omits partitioning_mode when undefined', () => {
+      const state = createState({ partitioningMode: undefined });
+      expect(mapFilesystemCustomizations(state)).not.toHaveProperty(
+        'partitioning_mode',
+      );
+    });
+  });
+});

--- a/src/store/slices/wizard/index.ts
+++ b/src/store/slices/wizard/index.ts
@@ -1,4 +1,5 @@
 export * from './actions';
+export * from './mappers';
 export * from './slice';
 
 // submodules

--- a/src/store/slices/wizard/mappers.ts
+++ b/src/store/slices/wizard/mappers.ts
@@ -1,7 +1,17 @@
+// These selectors use createSelector for its declarative composition,
+// not memoization. Each mapper produces a fragment of the API request
+// body, composed bottom-up from slice selectors into the full
+// customizations object.
 import { createSelector } from '@reduxjs/toolkit';
 
-import { mapSatelliteFiles } from './registration';
-import { mapFirstbootFiles } from './system';
+import { mapComplianceCustomizations } from './compliance';
+import { mapContentCustomizations } from './content';
+import { mapFilesystemCustomizations } from './filesystem';
+import {
+  mapRegistrationCustomizations,
+  mapSatelliteFiles,
+} from './registration';
+import { mapFirstbootFiles, mapSystemCustomizations } from './system';
 
 export const mapFileCustomizations = createSelector(
   [mapSatelliteFiles, mapFirstbootFiles],
@@ -12,4 +22,31 @@ export const mapFileCustomizations = createSelector(
 
     return { files: [...satellite, ...firstboot] };
   },
+);
+
+export const mapCustomizations = createSelector(
+  [
+    mapFileCustomizations,
+    mapRegistrationCustomizations,
+    mapContentCustomizations,
+    mapComplianceCustomizations,
+    mapFilesystemCustomizations,
+    mapSystemCustomizations,
+  ],
+  (files, subscription, content, compliance, filesystem, system) => ({
+    customizations: {
+      // first boot & satellite use file customizations
+      ...files,
+      // subscription, aap_registration + cacerts
+      ...subscription,
+      // packages, modules, payload repos + custom repos
+      ...content,
+      // fips + openscap
+      ...compliance,
+      // disk, filesystem + partition mode
+      ...filesystem,
+      // users, groups, services, hostname, kernel, timezone, locale + firewall
+      ...system,
+    },
+  }),
 );

--- a/src/store/slices/wizard/mappers.ts
+++ b/src/store/slices/wizard/mappers.ts
@@ -1,0 +1,15 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import { mapSatelliteFiles } from './registration';
+import { mapFirstbootFiles } from './system';
+
+export const mapFileCustomizations = createSelector(
+  [mapSatelliteFiles, mapFirstbootFiles],
+  (satellite, firstboot) => {
+    if (satellite.length === 0 && firstboot.length === 0) {
+      return undefined;
+    }
+
+    return { files: [...satellite, ...firstboot] };
+  },
+);

--- a/src/store/slices/wizard/registration/index.ts
+++ b/src/store/slices/wizard/registration/index.ts
@@ -1,3 +1,4 @@
+export * from './mappers';
 export * from './constants';
 export * from './selectors';
 export * from './slice';

--- a/src/store/slices/wizard/registration/mappers.ts
+++ b/src/store/slices/wizard/registration/mappers.ts
@@ -8,9 +8,132 @@ import {
 import type { File } from '@/store/api/backend';
 
 import {
+  selectAapCallbackUrl,
+  selectAapEnabled,
+  selectAapHostConfigKey,
+  selectAapTlsCertificateAuthority,
+  selectAapTlsConfirmation,
+  selectActivationKey,
+  selectBaseUrl,
+  selectOrgId,
+  selectProxy,
   selectRegistrationType,
+  selectSatelliteCaCertificate,
   selectSatelliteRegistrationCommand,
+  selectServerUrl,
 } from './selectors';
+
+const mapSubscription = createSelector(
+  [
+    selectRegistrationType,
+    selectActivationKey,
+    selectOrgId,
+    selectServerUrl,
+    selectBaseUrl,
+    selectProxy,
+  ],
+  (registrationType, activationKey, orgId, serverUrl, baseUrl, proxy) => {
+    if (
+      registrationType === 'register-later' ||
+      registrationType === 'register-satellite'
+    ) {
+      return undefined;
+    }
+
+    // this is existing behaviour, but maybe we should return
+    // undefined instead, since this is a bit of an anti-pattern
+    if (activationKey === undefined) {
+      throw new Error(
+        'Activation key unexpectedly undefined while generating subscription customization',
+      );
+    }
+
+    if (!orgId || isNaN(Number(orgId))) {
+      return undefined;
+    }
+
+    const subscription = {
+      'activation-key': activationKey,
+      organization: Number(orgId),
+      'server-url': serverUrl,
+      'base-url': baseUrl,
+      insights_client_proxy: proxy,
+      insights: false,
+      rhc: false,
+    };
+
+    if (registrationType === 'register-now') {
+      return { subscription };
+    }
+
+    if (registrationType === 'register-now-insights') {
+      return {
+        subscription: { ...subscription, insights: true },
+      };
+    }
+
+    if (registrationType === 'register-now-rhc') {
+      return {
+        subscription: { ...subscription, insights: true, rhc: true },
+      };
+    }
+
+    return undefined;
+  },
+);
+
+const mapAap = createSelector(
+  [
+    selectAapEnabled,
+    selectAapCallbackUrl,
+    selectAapHostConfigKey,
+    selectAapTlsCertificateAuthority,
+    selectAapTlsConfirmation,
+  ],
+  (
+    enabled,
+    callbackUrl,
+    hostConfigKey,
+    tlsCertificateAuthority,
+    skipTlsVerification,
+  ) => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    if (!callbackUrl && !hostConfigKey && !tlsCertificateAuthority) {
+      return undefined;
+    }
+
+    return {
+      aap_registration: {
+        ansible_callback_url: callbackUrl || '',
+        host_config_key: hostConfigKey || '',
+        tls_certificate_authority: tlsCertificateAuthority || undefined,
+        skip_tls_verification: skipTlsVerification || undefined,
+      },
+    };
+  },
+);
+
+const mapCaCerts = createSelector(
+  [selectRegistrationType, selectSatelliteCaCertificate],
+  (registrationType, cacert) => {
+    if (registrationType !== 'register-satellite') {
+      return undefined;
+    }
+
+    if (!cacert) {
+      return undefined;
+    }
+
+    return {
+      cacerts: {
+        pem_certs: [cacert],
+      },
+    };
+  },
+);
 
 // this needs to be exported because other slices
 // also have file customizations
@@ -39,4 +162,9 @@ export const mapSatelliteFiles = createSelector(
       },
     ];
   },
+);
+
+export const mapRegistrationCustomizations = createSelector(
+  [mapSubscription, mapCaCerts, mapAap],
+  (subscription, cacerts, aap) => ({ ...subscription, ...cacerts, ...aap }),
 );

--- a/src/store/slices/wizard/registration/mappers.ts
+++ b/src/store/slices/wizard/registration/mappers.ts
@@ -1,0 +1,42 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import {
+  SATELLITE_PATH,
+  SATELLITE_SERVICE_DATA,
+  SATELLITE_SERVICE_PATH,
+} from '@/constants';
+import type { File } from '@/store/api/backend';
+
+import {
+  selectRegistrationType,
+  selectSatelliteRegistrationCommand,
+} from './selectors';
+
+// this needs to be exported because other slices
+// also have file customizations
+export const mapSatelliteFiles = createSelector(
+  [selectSatelliteRegistrationCommand, selectRegistrationType],
+  (satCmd, registrationType): File[] => {
+    if (!satCmd || registrationType !== 'register-satellite') {
+      return [];
+    }
+
+    // TODO: we really should figure out how to handle this
+    // lower down in the stack rather than the frontend
+    return [
+      {
+        path: SATELLITE_SERVICE_PATH,
+        data: SATELLITE_SERVICE_DATA,
+        data_encoding: 'base64',
+        ensure_parents: true,
+      },
+      {
+        path: SATELLITE_PATH,
+        data: btoa(satCmd),
+        mode: '0774',
+        data_encoding: 'base64',
+        ensure_parents: true,
+      },
+    ];
+  },
+);

--- a/src/store/slices/wizard/registration/tests/mappers.test.ts
+++ b/src/store/slices/wizard/registration/tests/mappers.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockState } from '../../tests/mockWizardState';
+import { mapRegistrationCustomizations, mapSatelliteFiles } from '../mappers';
+import { initialState } from '../state';
+import type { RegistrationSlice } from '../types';
+
+const createState = (overrides: Partial<RegistrationSlice> = {}) =>
+  createMockState({
+    registration: { ...initialState, ...overrides },
+  });
+
+describe('mapRegistrationCustomizations', () => {
+  describe('subscription', () => {
+    it('returns subscription for register-now-rhc', () => {
+      const state = createState({
+        type: 'register-now-rhc',
+        activationKey: 'my-key',
+        orgId: '123',
+        serverUrl: 'https://server.example.com',
+        baseUrl: 'https://base.example.com',
+      });
+      const result = mapRegistrationCustomizations(state);
+      expect(result.subscription).toEqual(
+        expect.objectContaining({
+          'activation-key': 'my-key',
+          organization: 123,
+          insights: true,
+          rhc: true,
+        }),
+      );
+    });
+
+    it('returns subscription for register-now-insights', () => {
+      const state = createState({
+        type: 'register-now-insights',
+        activationKey: 'my-key',
+        orgId: '456',
+      });
+      const result = mapRegistrationCustomizations(state);
+      expect(result.subscription).toEqual(
+        expect.objectContaining({
+          insights: true,
+          rhc: false,
+        }),
+      );
+    });
+
+    it('returns subscription for register-now', () => {
+      const state = createState({
+        type: 'register-now',
+        activationKey: 'my-key',
+        orgId: '789',
+      });
+      const result = mapRegistrationCustomizations(state);
+      expect(result.subscription).toEqual(
+        expect.objectContaining({
+          insights: false,
+          rhc: false,
+        }),
+      );
+    });
+
+    it('omits subscription for register-later', () => {
+      const state = createState({ type: 'register-later' });
+      expect(mapRegistrationCustomizations(state)).not.toHaveProperty(
+        'subscription',
+      );
+    });
+
+    it('omits subscription for register-satellite', () => {
+      const state = createState({ type: 'register-satellite' });
+      expect(mapRegistrationCustomizations(state)).not.toHaveProperty(
+        'subscription',
+      );
+    });
+
+    it('omits subscription when orgId is missing', () => {
+      const state = createState({
+        type: 'register-now-rhc',
+        activationKey: 'my-key',
+        orgId: undefined,
+      });
+      expect(mapRegistrationCustomizations(state)).not.toHaveProperty(
+        'subscription',
+      );
+    });
+
+    it('omits subscription when orgId is not numeric', () => {
+      const state = createState({
+        type: 'register-now-rhc',
+        activationKey: 'my-key',
+        orgId: 'not-a-number',
+      });
+      expect(mapRegistrationCustomizations(state)).not.toHaveProperty(
+        'subscription',
+      );
+    });
+
+    it('throws when activation key is undefined for register-now type', () => {
+      const state = createState({
+        type: 'register-now-rhc',
+        activationKey: undefined,
+        orgId: '123',
+      });
+      expect(() => mapRegistrationCustomizations(state)).toThrow(
+        'Activation key unexpectedly undefined',
+      );
+    });
+  });
+
+  describe('aap_registration', () => {
+    it('returns aap_registration when enabled with callback url', () => {
+      const state = createState({
+        type: 'register-later',
+        aap: {
+          enabled: true,
+          callbackUrl: 'https://aap.example.com/callback',
+          hostConfigKey: 'config-key',
+          tlsCertificateAuthority: undefined,
+          skipTlsVerification: undefined,
+        },
+      });
+      const result = mapRegistrationCustomizations(state);
+      expect(result.aap_registration).toEqual({
+        ansible_callback_url: 'https://aap.example.com/callback',
+        host_config_key: 'config-key',
+        tls_certificate_authority: undefined,
+        skip_tls_verification: undefined,
+      });
+    });
+
+    it('omits aap_registration when disabled', () => {
+      const state = createState({
+        type: 'register-later',
+        aap: { ...initialState.aap, enabled: false },
+      });
+      expect(mapRegistrationCustomizations(state)).not.toHaveProperty(
+        'aap_registration',
+      );
+    });
+
+    it('omits aap_registration when enabled but no fields set', () => {
+      const state = createState({
+        type: 'register-later',
+        aap: {
+          enabled: true,
+          callbackUrl: undefined,
+          hostConfigKey: undefined,
+          tlsCertificateAuthority: undefined,
+          skipTlsVerification: undefined,
+        },
+      });
+      expect(mapRegistrationCustomizations(state)).not.toHaveProperty(
+        'aap_registration',
+      );
+    });
+  });
+
+  describe('cacerts', () => {
+    it('returns cacerts for satellite registration with cert', () => {
+      const state = createState({
+        type: 'register-satellite',
+        satelliteRegistration: {
+          command: 'sat-cmd',
+          caCert: 'PEM-CERT-DATA',
+        },
+      });
+      const result = mapRegistrationCustomizations(state);
+      expect(result.cacerts).toEqual({
+        pem_certs: ['PEM-CERT-DATA'],
+      });
+    });
+
+    it('omits cacerts when not satellite registration', () => {
+      const state = createState({
+        type: 'register-later',
+        satelliteRegistration: {
+          command: undefined,
+          caCert: 'PEM-CERT-DATA',
+        },
+      });
+      expect(mapRegistrationCustomizations(state)).not.toHaveProperty(
+        'cacerts',
+      );
+    });
+
+    it('omits cacerts when satellite registration has no cert', () => {
+      const state = createState({
+        type: 'register-satellite',
+        satelliteRegistration: {
+          command: 'sat-cmd',
+          caCert: undefined,
+        },
+      });
+      expect(mapRegistrationCustomizations(state)).not.toHaveProperty(
+        'cacerts',
+      );
+    });
+  });
+});
+
+describe('mapSatelliteFiles', () => {
+  it('returns files for satellite registration with command', () => {
+    const state = createState({
+      type: 'register-satellite',
+      satelliteRegistration: {
+        command: 'satellite-register --org=123',
+        caCert: undefined,
+      },
+    });
+    const result = mapSatelliteFiles(state);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ data_encoding: 'base64' }),
+      ]),
+    );
+  });
+
+  it('returns empty array when not satellite registration', () => {
+    const state = createState({
+      type: 'register-now-rhc',
+      satelliteRegistration: {
+        command: 'satellite-register --org=123',
+        caCert: undefined,
+      },
+    });
+    expect(mapSatelliteFiles(state)).toEqual([]);
+  });
+
+  it('returns empty array when no command set', () => {
+    const state = createState({
+      type: 'register-satellite',
+      satelliteRegistration: {
+        command: undefined,
+        caCert: undefined,
+      },
+    });
+    expect(mapSatelliteFiles(state)).toEqual([]);
+  });
+});

--- a/src/store/slices/wizard/system/index.ts
+++ b/src/store/slices/wizard/system/index.ts
@@ -1,3 +1,4 @@
+export * from './mappers';
 export * from './constants';
 export * from './selectors';
 export * from './slice';

--- a/src/store/slices/wizard/system/mappers.ts
+++ b/src/store/slices/wizard/system/mappers.ts
@@ -5,9 +5,239 @@ import {
   FIRSTBOOT_PATH,
   FIRSTBOOT_SERVICE_PATH,
 } from '@/constants';
-import type { File } from '@/store/api/backend';
+import type { File, Group, User } from '@/store/api/backend';
 
-import { selectFirstBootScript } from './selectors';
+import {
+  selectFirewall,
+  selectFirstBootScript,
+  selectHostname,
+  selectKernel,
+  selectKeyboard,
+  selectLanguages,
+  selectNtpServers,
+  selectServices,
+  selectTimezone,
+  selectUserGroups,
+  selectUsers,
+} from './selectors';
+import { UserWithAdditionalInfo } from './types';
+
+import { selectIsImageMode } from '../details';
+
+const mapUsers = createSelector([selectUsers], (users) => {
+  if (users.length === 0) {
+    return undefined;
+  }
+
+  const customizationUsers = users
+    .filter(
+      (user: UserWithAdditionalInfo) =>
+        user.name || user.password || user.ssh_key || user.groups.length > 0,
+    )
+    .map((user: UserWithAdditionalInfo) => {
+      const result: User = {
+        name: user.name,
+      };
+      if (user.password !== '') {
+        result.password = user.password;
+      }
+      if (user.ssh_key !== '') {
+        result.ssh_key = user.ssh_key;
+      }
+      if (user.groups.length > 0) {
+        result.groups = user.groups;
+      }
+      result.hasPassword = user.hasPassword || user.password !== '';
+      return result as User;
+    });
+
+  if (customizationUsers.length === 0) {
+    return undefined;
+  }
+
+  return {
+    users: customizationUsers,
+  };
+});
+
+const mapGroups = createSelector([selectUserGroups], (groups) => {
+  if (groups.length === 0) {
+    return undefined;
+  }
+
+  const customizationGroups = groups
+    .filter((group) => group.name && group.name.trim() !== '')
+    .map((group) => {
+      const result: Group = {
+        name: group.name,
+      };
+      if (group.gid !== undefined) {
+        result.gid = group.gid;
+      }
+      return result;
+    });
+
+  if (customizationGroups.length === 0) {
+    return undefined;
+  }
+
+  return {
+    groups: customizationGroups,
+  };
+});
+
+const mapServices = createSelector([selectServices], (services) => {
+  if (
+    services.enabled.length === 0 &&
+    services.masked.length === 0 &&
+    services.disabled.length === 0
+  ) {
+    return undefined;
+  }
+
+  return {
+    services: {
+      enabled: services.enabled.length ? services.enabled : undefined,
+      masked: services.masked.length ? services.masked : undefined,
+      disabled: services.disabled.length ? services.disabled : undefined,
+    },
+  };
+});
+
+const mapHostname = createSelector([selectHostname], (hostname) => {
+  if (!hostname) {
+    return undefined;
+  }
+
+  return { hostname };
+});
+
+const mapKernel = createSelector([selectKernel], (kernel) => {
+  const kernelAppendString = kernel.append.join(' ');
+
+  const kernelRequest = {};
+
+  if (!kernel.name && kernel.append.length === 0) {
+    return undefined;
+  }
+
+  if (kernel.name) {
+    Object.assign(kernelRequest, {
+      name: kernel.name,
+    });
+  }
+
+  if (kernelAppendString !== '') {
+    Object.assign(kernelRequest, {
+      append: kernelAppendString,
+    });
+  }
+
+  if (Object.keys(kernelRequest).length === 0) {
+    return undefined;
+  }
+
+  return {
+    kernel: kernelRequest,
+  };
+});
+
+const mapTimezoneField = createSelector([selectTimezone], (timezone) => {
+  if (!timezone) {
+    return undefined;
+  }
+
+  return { timezone };
+});
+
+const mapNtpServersField = createSelector([selectNtpServers], (ntpservers) => {
+  if (ntpservers?.length === 0) {
+    return undefined;
+  }
+
+  return { ntpservers };
+});
+
+const mapTimezone = createSelector(
+  [mapTimezoneField, mapNtpServersField, selectIsImageMode],
+  (timezone, ntpservers, isImageMode) => {
+    if (isImageMode) {
+      return undefined;
+    }
+
+    if (!timezone && !ntpservers) {
+      return undefined;
+    }
+
+    return {
+      timezone: {
+        ...timezone,
+        ...ntpservers,
+      },
+    };
+  },
+);
+
+const mapLanguagesField = createSelector([selectLanguages], (languages) => {
+  if (languages?.length === 0) {
+    return undefined;
+  }
+
+  return { languages };
+});
+
+const mapKeyboardField = createSelector([selectKeyboard], (keyboard) => {
+  if (!keyboard) {
+    return undefined;
+  }
+
+  return { keyboard };
+});
+
+const mapLocale = createSelector(
+  [mapLanguagesField, mapKeyboardField, selectIsImageMode],
+  (languages, keyboard, isImageMode) => {
+    if (isImageMode) {
+      return undefined;
+    }
+
+    if (!languages && !keyboard) {
+      return undefined;
+    }
+
+    return {
+      locale: {
+        ...languages,
+        ...keyboard,
+      },
+    };
+  },
+);
+
+const mapFirewall = createSelector([selectFirewall], (firewall) => {
+  const ports = firewall.ports;
+  const services = firewall.services;
+  const fw = {};
+
+  if (ports.length > 0) {
+    Object.assign(fw, { ports: ports });
+  }
+
+  if (services.enabled.length > 0 || services.disabled.length > 0) {
+    Object.assign(fw, {
+      services: {
+        enabled: services.enabled.length > 0 ? services.enabled : undefined,
+        disabled: services.disabled.length > 0 ? services.disabled : undefined,
+      },
+    });
+  }
+
+  if (Object.keys(fw).length === 0) {
+    return undefined;
+  }
+
+  return { firewall: fw };
+});
 
 // this needs to be exported because other slices
 // also have file customizations
@@ -36,4 +266,27 @@ export const mapFirstbootFiles = createSelector(
       },
     ];
   },
+);
+
+export const mapSystemCustomizations = createSelector(
+  [
+    mapUsers,
+    mapGroups,
+    mapServices,
+    mapHostname,
+    mapKernel,
+    mapTimezone,
+    mapLocale,
+    mapFirewall,
+  ],
+  (users, groups, services, hostname, kernel, timezone, locale, firewall) => ({
+    ...users,
+    ...groups,
+    ...services,
+    ...hostname,
+    ...kernel,
+    ...timezone,
+    ...locale,
+    ...firewall,
+  }),
 );

--- a/src/store/slices/wizard/system/mappers.ts
+++ b/src/store/slices/wizard/system/mappers.ts
@@ -1,0 +1,39 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import {
+  FIRST_BOOT_SERVICE_DATA,
+  FIRSTBOOT_PATH,
+  FIRSTBOOT_SERVICE_PATH,
+} from '@/constants';
+import type { File } from '@/store/api/backend';
+
+import { selectFirstBootScript } from './selectors';
+
+// this needs to be exported because other slices
+// also have file customizations
+export const mapFirstbootFiles = createSelector(
+  [selectFirstBootScript],
+  (firstbootScript): File[] => {
+    if (!firstbootScript) {
+      return [];
+    }
+
+    // TODO: we really should figure out how to handle this
+    // lower down in the stack rather than the frontend
+    return [
+      {
+        path: FIRSTBOOT_SERVICE_PATH,
+        data: FIRST_BOOT_SERVICE_DATA,
+        data_encoding: 'base64',
+        ensure_parents: true,
+      },
+      {
+        path: FIRSTBOOT_PATH,
+        data: btoa(firstbootScript),
+        data_encoding: 'base64',
+        mode: '0774',
+        ensure_parents: true,
+      },
+    ];
+  },
+);

--- a/src/store/slices/wizard/system/tests/mappers.test.ts
+++ b/src/store/slices/wizard/system/tests/mappers.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockState } from '../../tests/mockWizardState';
+import { mapFirstbootFiles, mapSystemCustomizations } from '../mappers';
+import { initialState } from '../state';
+import type { SystemSlice } from '../types';
+
+const createState = (overrides: Partial<SystemSlice> = {}) =>
+  createMockState({
+    system: { ...initialState, ...overrides },
+  });
+
+describe('mapSystemCustomizations', () => {
+  it('includes locale for default state (default language is C.UTF-8)', () => {
+    const state = createState();
+    expect(mapSystemCustomizations(state)).toEqual({
+      locale: { languages: ['C.UTF-8'] },
+    });
+  });
+
+  describe('users', () => {
+    it('includes users with name and ssh key', () => {
+      const state = createState({
+        users: [
+          {
+            name: 'admin',
+            password: '',
+            ssh_key: 'ssh-rsa AAAA...',
+            groups: ['wheel'],
+            isAdministrator: true,
+            hasPassword: false,
+          },
+        ],
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.users).toEqual([
+        expect.objectContaining({
+          name: 'admin',
+          ssh_key: 'ssh-rsa AAAA...',
+          groups: ['wheel'],
+        }),
+      ]);
+    });
+
+    it('omits empty password and ssh_key fields', () => {
+      const state = createState({
+        users: [
+          {
+            name: 'testuser',
+            password: '',
+            ssh_key: '',
+            groups: [],
+            isAdministrator: false,
+            hasPassword: false,
+          },
+        ],
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.users![0]).not.toHaveProperty('password');
+      expect(result.users![0]).not.toHaveProperty('ssh_key');
+      expect(result.users![0]).not.toHaveProperty('groups');
+    });
+
+    it('filters out users with no name, password, ssh_key, or groups', () => {
+      const state = createState({
+        users: [
+          {
+            name: '',
+            password: '',
+            ssh_key: '',
+            groups: [],
+            isAdministrator: false,
+            hasPassword: false,
+          },
+        ],
+      });
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('users');
+    });
+
+    it('omits users key when no users', () => {
+      const state = createState({ users: [] });
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('users');
+    });
+  });
+
+  describe('groups', () => {
+    it('includes groups with name', () => {
+      const state = createState({
+        groups: [{ name: 'developers', gid: 1001 }],
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.groups).toEqual([{ name: 'developers', gid: 1001 }]);
+    });
+
+    it('filters out groups with empty name', () => {
+      const state = createState({
+        groups: [{ name: '' }],
+      });
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('groups');
+    });
+
+    it('omits gid when not set', () => {
+      const state = createState({
+        groups: [{ name: 'mygroup' }],
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.groups![0]).not.toHaveProperty('gid');
+    });
+  });
+
+  describe('services', () => {
+    it('includes services when enabled list is populated', () => {
+      const state = createState({
+        services: {
+          enabled: ['httpd', 'sshd'],
+          masked: [],
+          disabled: [],
+        },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.services).toEqual({
+        enabled: ['httpd', 'sshd'],
+        masked: undefined,
+        disabled: undefined,
+      });
+    });
+
+    it('includes services when disabled list is populated', () => {
+      const state = createState({
+        services: {
+          enabled: [],
+          masked: [],
+          disabled: ['firewalld'],
+        },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.services).toEqual({
+        enabled: undefined,
+        masked: undefined,
+        disabled: ['firewalld'],
+      });
+    });
+
+    it('omits services key when all lists are empty', () => {
+      const state = createState();
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('services');
+    });
+  });
+
+  describe('hostname', () => {
+    it('includes hostname when set', () => {
+      const state = createState({ hostname: 'my-host' });
+      expect(mapSystemCustomizations(state)).toEqual(
+        expect.objectContaining({ hostname: 'my-host' }),
+      );
+    });
+
+    it('omits hostname when empty', () => {
+      const state = createState({ hostname: '' });
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('hostname');
+    });
+  });
+
+  describe('kernel', () => {
+    it('includes kernel with name', () => {
+      const state = createState({
+        kernel: { name: 'kernel-rt', append: [] },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.kernel).toEqual({ name: 'kernel-rt' });
+    });
+
+    it('includes kernel with append string', () => {
+      const state = createState({
+        kernel: { name: '', append: ['nosmt', 'quiet'] },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.kernel).toEqual({ append: 'nosmt quiet' });
+    });
+
+    it('includes both name and append when set', () => {
+      const state = createState({
+        kernel: { name: 'kernel-rt', append: ['nosmt'] },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.kernel).toEqual({ name: 'kernel-rt', append: 'nosmt' });
+    });
+
+    it('omits kernel when no name or append', () => {
+      const state = createState({
+        kernel: { name: '', append: [] },
+      });
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('kernel');
+    });
+  });
+
+  describe('timezone', () => {
+    it('includes timezone when set', () => {
+      const state = createState({
+        timezone: { timezone: 'UTC', ntpservers: [] },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.timezone).toEqual({ timezone: 'UTC' });
+    });
+
+    it('includes ntpservers when set', () => {
+      const state = createState({
+        timezone: { timezone: '', ntpservers: ['pool.ntp.org'] },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.timezone).toEqual({ ntpservers: ['pool.ntp.org'] });
+    });
+
+    it('omits timezone when both empty', () => {
+      const state = createState();
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('timezone');
+    });
+
+    it('omits timezone in image mode', () => {
+      const state = createMockState({
+        system: {
+          ...initialState,
+          timezone: { timezone: 'UTC', ntpservers: ['pool.ntp.org'] },
+        },
+        details: {
+          blueprint: {
+            name: 'test',
+            description: '',
+            isCustomName: false,
+            mode: 'image',
+          },
+          mode: 'create',
+        },
+      });
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('timezone');
+    });
+  });
+
+  describe('locale', () => {
+    it('includes languages when set', () => {
+      const state = createState({
+        locale: { languages: ['en_US.UTF-8'], keyboard: '' },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.locale).toEqual({ languages: ['en_US.UTF-8'] });
+    });
+
+    it('includes keyboard when set', () => {
+      const state = createState({
+        locale: { languages: [], keyboard: 'us' },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.locale).toEqual({ keyboard: 'us' });
+    });
+
+    it('omits locale when both empty', () => {
+      const state = createState({
+        locale: { languages: [], keyboard: '' },
+      });
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('locale');
+    });
+
+    it('omits locale in image mode', () => {
+      const state = createMockState({
+        system: {
+          ...initialState,
+          locale: { languages: ['en_US.UTF-8'], keyboard: 'us' },
+        },
+        details: {
+          blueprint: {
+            name: 'test',
+            description: '',
+            isCustomName: false,
+            mode: 'image',
+          },
+          mode: 'create',
+        },
+      });
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('locale');
+    });
+  });
+
+  describe('firewall', () => {
+    it('includes firewall with ports', () => {
+      const state = createState({
+        firewall: {
+          ports: ['8080:tcp', '443:tcp'],
+          services: { enabled: [], disabled: [] },
+        },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.firewall).toEqual({
+        ports: ['8080:tcp', '443:tcp'],
+      });
+    });
+
+    it('includes firewall with services', () => {
+      const state = createState({
+        firewall: {
+          ports: [],
+          services: { enabled: ['ssh'], disabled: ['telnet'] },
+        },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.firewall).toEqual({
+        services: { enabled: ['ssh'], disabled: ['telnet'] },
+      });
+    });
+
+    it('includes firewall services when only enabled is set', () => {
+      const state = createState({
+        firewall: {
+          ports: [],
+          services: { enabled: ['ssh'], disabled: [] },
+        },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.firewall).toEqual({
+        services: { enabled: ['ssh'] },
+      });
+    });
+
+    it('includes firewall services when only disabled is set', () => {
+      const state = createState({
+        firewall: {
+          ports: [],
+          services: { enabled: [], disabled: ['telnet'] },
+        },
+      });
+      const result = mapSystemCustomizations(state);
+      expect(result.firewall).toEqual({
+        services: { disabled: ['telnet'] },
+      });
+    });
+
+    it('omits firewall when empty', () => {
+      const state = createState();
+      expect(mapSystemCustomizations(state)).not.toHaveProperty('firewall');
+    });
+  });
+});
+
+describe('mapFirstbootFiles', () => {
+  it('returns files when firstboot script is set', () => {
+    const state = createState({
+      firstBoot: { script: 'echo hello' },
+    });
+    const result = mapFirstbootFiles(state);
+    expect(result).toHaveLength(2);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ data_encoding: 'base64' }),
+      ]),
+    );
+  });
+
+  it('returns empty array when no firstboot script', () => {
+    const state = createState();
+    expect(mapFirstbootFiles(state)).toEqual([]);
+  });
+});

--- a/src/store/slices/wizard/tests/mappers.test.ts
+++ b/src/store/slices/wizard/tests/mappers.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import { initialState } from '@/store/slices/wizard';
+
+import { createMockState } from './mockWizardState';
+
+import { mapFileCustomizations } from '../mappers';
+
+describe('mapFileCustomizations', () => {
+  it('returns undefined when no files are contributed', () => {
+    const state = createMockState({});
+    expect(mapFileCustomizations(state)).toBeUndefined();
+  });
+
+  it('returns files with firstboot entries when script is set', () => {
+    const state = createMockState({
+      system: {
+        ...initialState.system,
+        firstBoot: { script: 'echo hello' },
+      },
+    });
+    const result = mapFileCustomizations(state);
+    expect(result).toBeDefined();
+    expect(result!.files).toHaveLength(2);
+    expect(result!.files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ data_encoding: 'base64' }),
+      ]),
+    );
+  });
+
+  it('returns files with satellite entries when satellite registration is configured', () => {
+    const state = createMockState({
+      registration: {
+        ...initialState.registration,
+        type: 'register-satellite',
+        satelliteRegistration: {
+          command: 'satellite-register --org=123',
+          caCert: undefined,
+        },
+      },
+    });
+    const result = mapFileCustomizations(state);
+    expect(result).toBeDefined();
+    expect(result!.files).toHaveLength(2);
+  });
+
+  it('returns combined files when both firstboot and satellite are set', () => {
+    const state = createMockState({
+      system: {
+        ...initialState.system,
+        firstBoot: { script: 'echo hello' },
+      },
+      registration: {
+        ...initialState.registration,
+        type: 'register-satellite',
+        satelliteRegistration: {
+          command: 'satellite-register --org=123',
+          caCert: undefined,
+        },
+      },
+    });
+    const result = mapFileCustomizations(state);
+    expect(result).toBeDefined();
+    expect(result!.files).toHaveLength(4);
+  });
+
+  it('does not include satellite files when registration type is not satellite', () => {
+    const state = createMockState({
+      registration: {
+        ...initialState.registration,
+        type: 'register-now-rhc',
+        satelliteRegistration: {
+          command: 'satellite-register --org=123',
+          caCert: undefined,
+        },
+      },
+    });
+    expect(mapFileCustomizations(state)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Decompose the monolithic `getCustomizations` function from `requestMapper.ts` into co-located, composable mappers per wizard subslice. Each mapper produces a fragment of the API request body, composed bottom-up into the full customizations object using `createSelector` for its declarative composition.

## Changes

- Extract domain-specific mappers (`mappers.ts`) into compliance, content, filesystem, registration, and system subslices, co-located with their slice state
- Add a wizard-level `mapFileCustomizations` composer for cross-domain file customizations (satellite + firstboot) and a top-level `mapCustomizations` that aggregates all domain fragments
- Add co-located unit tests for each mapper covering happy paths, edge cases, and empty/undefined boundary conditions (~1100 lines of new test coverage)
- Remove ~500 lines of inline customization logic from `requestMapper.ts`, replacing it with a single composed mapper call
