### PR TITLE
actions: Add a check for pinned dependencies (HMS-10932)

### DIFF
--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -71,3 +71,25 @@ jobs:
           echo "✓ No manual API changes."
           exit 0
         fi
+
+  pinned-versions:
+    name: Pinned Dependencies Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Check for unpinned dependencies
+      run: |
+        UNPINNED=$(grep -F '": "^' package.json || true)
+        if [ -n "$UNPINNED" ]; then
+          echo
+          echo "✗ Found unpinned dependencies (using '^' prefix):"
+          echo "$UNPINNED"
+          echo
+          echo "Pin versions for reproducible builds and explicit Dependabot PRs."
+          echo "With '^', updates happen silently during npm install."
+          exit 1
+        else
+          echo
+          echo "✓ All dependencies are pinned."
+          exit 0
+        fi


### PR DESCRIPTION
This adds a check that will look for unpinned dependencies and throw an error if any found.

Dependabot would create a PR for every update with pinned versions. With the '^' thingie only major version bumps get a PR, the rest of the updates happens silently on `npm i`.

JIRA: [HMS-10932](https://issues.redhat.com/browse/HMS-10932)

[HMS-10932]: https://redhat.atlassian.net/browse/HMS-10932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ