### PR TITLE
ImagesTable: Combine blueprints and images in rows (HMS-10910)

### DIFF
--- a/src/Components/ImagesTable/NewImagesTable.tsx
+++ b/src/Components/ImagesTable/NewImagesTable.tsx
@@ -42,6 +42,9 @@ import { useAppSelector } from '../../store/hooks';
 const NewImagesTable = () => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
+  const [selectedBlueprintId, setSelectedBlueprintId] = useState<
+    string | undefined
+  >(undefined);
 
   const effectiveBlueprintId = useEffectiveBlueprintId();
   const blueprintSearchInput =
@@ -54,6 +57,10 @@ const NewImagesTable = () => {
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
   const isOnPremise = useAppSelector(selectIsOnPremise);
+
+  const handleBlueprintSelect = (id: string) => {
+    setSelectedBlueprintId((prev) => (prev === id ? undefined : id));
+  };
 
   const searchParamsGetBlueprints: GetBlueprintsApiArg = {
     limit: 100,
@@ -262,6 +269,12 @@ const NewImagesTable = () => {
               style={{ minWidth: itemCount === 0 ? '30px' : 'auto' }}
               aria-label='Details expandable'
             />
+            <Th
+              select={{
+                onSelect: () => {},
+                isSelected: false,
+              }}
+            />
             <Th>Name</Th>
             <Th>Last updated</Th>
             <Th>Operating system</Th>
@@ -290,6 +303,8 @@ const NewImagesTable = () => {
                 blueprint={item.blueprint}
                 rowIndex={rowIndex}
                 key={`blueprint-${item.blueprint.id}`}
+                onSelect={handleBlueprintSelect}
+                isSelected={selectedBlueprintId === item.blueprint.id}
               />
             );
           } else {
@@ -298,6 +313,8 @@ const NewImagesTable = () => {
                 compose={item.compose}
                 rowIndex={rowIndex}
                 key={`compose-${item.compose.id}`}
+                onSelect={handleBlueprintSelect}
+                isSelected={selectedBlueprintId === item.compose.id}
               />
             );
           }

--- a/src/Components/ImagesTable/NewImagesTable.tsx
+++ b/src/Components/ImagesTable/NewImagesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import {
   Alert,
@@ -143,6 +143,58 @@ const NewImagesTable = () => {
 
   const blueprints = blueprintsData?.data || [];
 
+  let composes = data?.data;
+  if (effectiveBlueprintId && blueprintVersionFilter === 'latest') {
+    composes = composes?.filter((compose) => {
+      return compose.blueprint_version === selectedBlueprintVersion;
+    });
+  }
+
+  // TODO: Add server-side search parameter to the composes API endpoint
+  // This filters composes on the client-side because the API doesn't
+  // support searching through composes by their name
+  // We're limited to filtering only within the fetched 100 composes
+  if (blueprintSearchInput && composes) {
+    const searchLower = blueprintSearchInput.toLowerCase();
+    composes = composes.filter((compose) => {
+      const imageName = compose.image_name || compose.id;
+      return imageName.toLowerCase().includes(searchLower);
+    });
+  }
+
+  const { paginatedItems, itemCount } = useMemo(() => {
+    const blueprintIdsWithComposes = new Set(
+      composes?.map((compose) => compose.blueprint_id).filter(Boolean) ?? [],
+    );
+    const blueprintsWithoutComposes = blueprints.filter(
+      (blueprint) => !blueprintIdsWithComposes.has(blueprint.id),
+    );
+
+    const combinedItems = [
+      ...blueprintsWithoutComposes.map((blueprint) => ({
+        type: 'blueprint' as const,
+        blueprint,
+        date: blueprint.last_modified_at,
+      })),
+      ...(composes?.map((compose) => ({
+        type: 'compose' as const,
+        compose,
+        date: compose.created_at,
+      })) ?? []),
+    ];
+
+    combinedItems.sort(
+      (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+    );
+
+    const totalItems = combinedItems.length;
+    const startIndex = (page - 1) * perPage;
+    const endIndex = startIndex + perPage;
+    const paginatedItems = combinedItems.slice(startIndex, endIndex);
+
+    return { paginatedItems, itemCount: totalItems };
+  }, [blueprints, composes, page, perPage]);
+
   useEffect(() => {
     if (!isOnPremise) {
       const orgId = userData?.identity.internal?.org_id;
@@ -202,56 +254,6 @@ const NewImagesTable = () => {
       </Bullseye>
     );
   }
-
-  let composes = data?.data;
-  if (effectiveBlueprintId && blueprintVersionFilter === 'latest') {
-    composes = composes?.filter((compose) => {
-      return compose.blueprint_version === selectedBlueprintVersion;
-    });
-  }
-
-  // TODO: Add server-side search parameter to the composes API endpoint
-  // This filters composes on the client-side because the API doesn't
-  // support searching through composes by their name
-  // We're limited to filtering only within the fetched 100 composes
-  if (blueprintSearchInput && composes) {
-    const searchLower = blueprintSearchInput.toLowerCase();
-    composes = composes.filter((compose) => {
-      const imageName = compose.image_name || compose.id;
-      return imageName.toLowerCase().includes(searchLower);
-    });
-  }
-
-  const blueprintIdsWithComposes = new Set(
-    composes?.map((compose) => compose.blueprint_id).filter(Boolean) ?? [],
-  );
-  const blueprintsWithoutComposes = blueprints.filter(
-    (blueprint) => !blueprintIdsWithComposes.has(blueprint.id),
-  );
-
-  const combinedItems = [
-    ...blueprintsWithoutComposes.map((blueprint) => ({
-      type: 'blueprint' as const,
-      blueprint,
-      date: blueprint.last_modified_at,
-    })),
-    ...(composes?.map((compose) => ({
-      type: 'compose' as const,
-      compose,
-      date: compose.created_at,
-    })) ?? []),
-  ];
-
-  combinedItems.sort(
-    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
-  );
-
-  const totalItems = combinedItems.length;
-  const startIndex = (page - 1) * perPage;
-  const endIndex = startIndex + perPage;
-  const paginatedItems = combinedItems.slice(startIndex, endIndex);
-
-  const itemCount = totalItems;
 
   return (
     <PageSection>

--- a/src/Components/ImagesTable/NewImagesTable.tsx
+++ b/src/Components/ImagesTable/NewImagesTable.tsx
@@ -203,6 +203,18 @@ const NewImagesTable = () => {
     });
   }
 
+  // TODO: Add server-side search parameter to the composes API endpoint
+  // This filters composes on the client-side because the API doesn't
+  // support searching through composes by their name
+  // We're limited to filtering only within the fetched 100 composes
+  if (blueprintSearchInput && composes) {
+    const searchLower = blueprintSearchInput.toLowerCase();
+    composes = composes.filter((compose) => {
+      const imageName = compose.image_name || compose.id;
+      return imageName.toLowerCase().includes(searchLower);
+    });
+  }
+
   const blueprintIdsWithComposes = new Set(
     composes?.map((compose) => compose.blueprint_id).filter(Boolean) ?? [],
   );

--- a/src/Components/ImagesTable/NewImagesTable.tsx
+++ b/src/Components/ImagesTable/NewImagesTable.tsx
@@ -35,6 +35,7 @@ import { selectIsOnPremise } from '@/store/slices/env';
 import ImagesEmptyState from './components/EmptyState';
 import NewImagesTableToolbar from './components/NewImagesTableToolbar';
 import { ImagesTableRow } from './components/Row';
+import BlueprintTableRow from './components/Row/components/BlueprintTableRow';
 
 import {
   PAGINATION_LIMIT,
@@ -70,6 +71,9 @@ const NewImagesTable = () => {
   if (blueprintSearchInput) {
     searchParamsGetBlueprints.search = blueprintSearchInput;
   }
+
+  const { data: blueprintsData, isLoading: isLoadingBlueprints } =
+    useGetBlueprintsQuery(searchParamsGetBlueprints);
 
   const { selectedBlueprintVersion } = useGetBlueprintsQuery(
     searchParamsGetBlueprints,
@@ -133,9 +137,12 @@ const NewImagesTable = () => {
     ? isBlueprintsSuccess
     : isComposesSuccess;
   const isError = effectiveBlueprintId ? isBlueprintsError : isComposesError;
-  const isLoading = effectiveBlueprintId
-    ? isLoadingBlueprintsCompose
-    : isLoadingComposes;
+  const isLoading =
+    isLoadingComposes ||
+    isLoadingBlueprints ||
+    (effectiveBlueprintId && isLoadingBlueprintsCompose);
+
+  const blueprints = blueprintsData?.data || [];
 
   useEffect(() => {
     if (!isOnPremise) {
@@ -214,7 +221,7 @@ const NewImagesTable = () => {
         setPage={setPage}
         onPerPageSelect={onPerPageSelect}
       />
-      <Table variant='compact' data-testid='images-table'>
+      <Table data-testid='images-table'>
         <Thead>
           <Tr>
             <Th
@@ -230,7 +237,7 @@ const NewImagesTable = () => {
             <Th aria-label='Actions menu' />
           </Tr>
         </Thead>
-        {itemCount === 0 && (
+        {itemCount === 0 && blueprints.length === 0 && (
           <Tbody>
             <Tr>
               <Td colSpan={12}>
@@ -242,11 +249,20 @@ const NewImagesTable = () => {
           </Tbody>
         )}
 
+        {blueprints.map((blueprint, rowIndex) => (
+          <BlueprintTableRow
+            blueprint={blueprint}
+            rowIndex={rowIndex}
+            key={blueprint.id}
+          />
+        ))}
+
         {composes?.map((compose, rowIndex) => {
+          const adjustedRowIndex = rowIndex + blueprints.length;
           return (
             <ImagesTableRow
               compose={compose}
-              rowIndex={rowIndex}
+              rowIndex={adjustedRowIndex}
               key={compose.id}
             />
           );

--- a/src/Components/ImagesTable/NewImagesTable.tsx
+++ b/src/Components/ImagesTable/NewImagesTable.tsx
@@ -27,8 +27,6 @@ import {
   selectBlueprintSearchInput,
   selectBlueprintVersionFilter,
   selectBlueprintVersionFilterAPI,
-  selectLimit,
-  selectOffset,
 } from '@/store/slices/blueprint';
 import { selectIsOnPremise } from '@/store/slices/env';
 
@@ -37,11 +35,7 @@ import NewImagesTableToolbar from './components/NewImagesTableToolbar';
 import { ImagesTableRow } from './components/Row';
 import BlueprintTableRow from './components/Row/components/BlueprintTableRow';
 
-import {
-  PAGINATION_LIMIT,
-  PAGINATION_OFFSET,
-  SEARCH_INPUT,
-} from '../../constants';
+import { SEARCH_INPUT } from '../../constants';
 import { useEffectiveBlueprintId, useGetUser } from '../../Hooks';
 import { useAppSelector } from '../../store/hooks';
 
@@ -56,16 +50,14 @@ const NewImagesTable = () => {
   const blueprintVersionFilterAPI = useAppSelector(
     selectBlueprintVersionFilterAPI,
   );
-  const blueprintsOffset = useAppSelector(selectOffset) || PAGINATION_OFFSET;
-  const blueprintsLimit = useAppSelector(selectLimit) || PAGINATION_LIMIT;
 
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
   const isOnPremise = useAppSelector(selectIsOnPremise);
 
   const searchParamsGetBlueprints: GetBlueprintsApiArg = {
-    limit: blueprintsLimit,
-    offset: blueprintsOffset,
+    limit: 100,
+    offset: 0,
   };
 
   if (blueprintSearchInput) {
@@ -120,8 +112,8 @@ const NewImagesTable = () => {
     isLoading: isLoadingComposes,
   } = useGetComposesQuery(
     {
-      limit: perPage,
-      offset: perPage * (page - 1),
+      limit: 100,
+      offset: 0,
       ignoreImageTypes: [
         'rhel-edge-commit',
         'rhel-edge-installer',
@@ -210,7 +202,37 @@ const NewImagesTable = () => {
       return compose.blueprint_version === selectedBlueprintVersion;
     });
   }
-  const itemCount = data?.meta.count || 0;
+
+  const blueprintIdsWithComposes = new Set(
+    composes?.map((compose) => compose.blueprint_id).filter(Boolean) ?? [],
+  );
+  const blueprintsWithoutComposes = blueprints.filter(
+    (blueprint) => !blueprintIdsWithComposes.has(blueprint.id),
+  );
+
+  const combinedItems = [
+    ...blueprintsWithoutComposes.map((blueprint) => ({
+      type: 'blueprint' as const,
+      blueprint,
+      date: blueprint.last_modified_at,
+    })),
+    ...(composes?.map((compose) => ({
+      type: 'compose' as const,
+      compose,
+      date: compose.created_at,
+    })) ?? []),
+  ];
+
+  combinedItems.sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
+
+  const totalItems = combinedItems.length;
+  const startIndex = (page - 1) * perPage;
+  const endIndex = startIndex + perPage;
+  const paginatedItems = combinedItems.slice(startIndex, endIndex);
+
+  const itemCount = totalItems;
 
   return (
     <PageSection>
@@ -237,7 +259,7 @@ const NewImagesTable = () => {
             <Th aria-label='Actions menu' />
           </Tr>
         </Thead>
-        {itemCount === 0 && blueprints.length === 0 && (
+        {itemCount === 0 && (
           <Tbody>
             <Tr>
               <Td colSpan={12}>
@@ -249,23 +271,24 @@ const NewImagesTable = () => {
           </Tbody>
         )}
 
-        {blueprints.map((blueprint, rowIndex) => (
-          <BlueprintTableRow
-            blueprint={blueprint}
-            rowIndex={rowIndex}
-            key={blueprint.id}
-          />
-        ))}
-
-        {composes?.map((compose, rowIndex) => {
-          const adjustedRowIndex = rowIndex + blueprints.length;
-          return (
-            <ImagesTableRow
-              compose={compose}
-              rowIndex={adjustedRowIndex}
-              key={compose.id}
-            />
-          );
+        {paginatedItems.map((item, rowIndex) => {
+          if (item.type === 'blueprint') {
+            return (
+              <BlueprintTableRow
+                blueprint={item.blueprint}
+                rowIndex={rowIndex}
+                key={`blueprint-${item.blueprint.id}`}
+              />
+            );
+          } else {
+            return (
+              <ImagesTableRow
+                compose={item.compose}
+                rowIndex={rowIndex}
+                key={`compose-${item.compose.id}`}
+              />
+            );
+          }
         })}
       </Table>
       <Toolbar className='pf-v6-u-mb-xl'>

--- a/src/Components/ImagesTable/NewImagesTable.tsx
+++ b/src/Components/ImagesTable/NewImagesTable.tsx
@@ -289,7 +289,7 @@ const NewImagesTable = () => {
         {itemCount === 0 && (
           <Tbody>
             <Tr>
-              <Td colSpan={12}>
+              <Td colSpan={9}>
                 <ImagesEmptyState
                   selectedBlueprint={effectiveBlueprintId || ''}
                 />

--- a/src/Components/ImagesTable/components/ImagesFilter.tsx
+++ b/src/Components/ImagesTable/components/ImagesFilter.tsx
@@ -9,17 +9,18 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 
-const filterOptions = [
-  { value: 'name', label: 'Name' },
-  { value: 'latest', label: 'Last updated' },
-  { value: 'system', label: 'Operating system' },
-  { value: 'target', label: 'Target environment' },
-  { value: 'status', label: 'Status' },
-];
+import { filterOptions } from '../constants';
 
-const ImagesFilter = () => {
+type ImagesFilterProps = {
+  filterCategory: string;
+  setFilterCategory: (category: string) => void;
+};
+
+const ImagesFilter = ({
+  filterCategory,
+  setFilterCategory,
+}: ImagesFilterProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [filterCategory, setFilterCategory] = useState('name');
 
   const onToggleClick = () => {
     setIsOpen(!isOpen);

--- a/src/Components/ImagesTable/components/NewImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/components/NewImagesTableToolbar.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   Button,
   Pagination,
-  TextInput,
+  SearchInput,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -14,9 +14,14 @@ import {
   RhUiRedoIcon,
 } from '@patternfly/react-icons';
 
+import { setBlueprintSearchInput } from '@/store/slices/blueprint';
+
 import ImagesFilter from './ImagesFilter';
 
+import { useAppDispatch } from '../../../store/hooks';
+import useDebounce from '../../../Utilities/useDebounce';
 import { DeleteBlueprintModal } from '../../Blueprints/DeleteBlueprintModal';
+import { filterOptions } from '../constants';
 
 type NewImagesTableToolbarProps = {
   itemCount: number;
@@ -39,7 +44,32 @@ const NewImagesTableToolbar: React.FC<NewImagesTableToolbarProps> = ({
   setPage,
   onPerPageSelect,
 }: NewImagesTableToolbarProps) => {
+  const dispatch = useAppDispatch();
+
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [filterCategory, setFilterCategory] = useState('name');
+  const [searchValue, setSearchValue] = useState('');
+
+  const debouncedSearchValue = useDebounce(searchValue);
+
+  const selectedFilter = filterOptions.find(
+    (option) => option.value === filterCategory,
+  );
+  const placeholder = selectedFilter
+    ? `Find by ${selectedFilter.label.toLowerCase()}`
+    : 'Find';
+
+  useEffect(() => {
+    // TODO - only name is implemented for now
+    if (filterCategory === 'name') {
+      dispatch(
+        setBlueprintSearchInput(
+          debouncedSearchValue.length > 0 ? debouncedSearchValue : undefined,
+        ),
+      );
+      setPage(1);
+    }
+  }, [debouncedSearchValue, filterCategory, dispatch, setPage]);
 
   return (
     <>
@@ -50,13 +80,18 @@ const NewImagesTableToolbar: React.FC<NewImagesTableToolbarProps> = ({
       <Toolbar>
         <ToolbarContent>
           <ToolbarItem>
-            <ImagesFilter />
+            <ImagesFilter
+              filterCategory={filterCategory}
+              setFilterCategory={setFilterCategory}
+            />
           </ToolbarItem>
           <ToolbarItem>
-            <TextInput
-              aria-label='Image filter input'
-              placeholder='Find by ...'
-              isDisabled
+            <SearchInput
+              placeholder={placeholder}
+              value={searchValue}
+              onChange={(_event, value) => setSearchValue(value)}
+              onClear={() => setSearchValue('')}
+              isDisabled={filterCategory !== 'name'}
             />
           </ToolbarItem>
           <ToolbarItem>

--- a/src/Components/ImagesTable/components/Row/components/AwsRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/AwsRow.tsx
@@ -12,9 +12,16 @@ import { AwsTarget } from '../../Target';
 type AwsRowPropTypes = {
   compose: ComposesResponseItem;
   rowIndex: number;
+  onSelect?: (id: string) => void;
+  isSelected?: boolean;
 };
 
-const AwsRow = ({ compose, rowIndex }: AwsRowPropTypes) => {
+const AwsRow = ({
+  compose,
+  rowIndex,
+  onSelect,
+  isSelected,
+}: AwsRowPropTypes) => {
   const target = <AwsTarget />;
   const status = <CloudStatus compose={compose} />;
   const instance = <AWSLaunchModal compose={compose} />;
@@ -28,6 +35,8 @@ const AwsRow = ({ compose, rowIndex }: AwsRowPropTypes) => {
       target={target}
       instance={instance}
       details={details}
+      {...(onSelect && { onSelect })}
+      {...(isSelected !== undefined && { isSelected })}
     />
   );
 };

--- a/src/Components/ImagesTable/components/Row/components/AwsS3Row.tsx
+++ b/src/Components/ImagesTable/components/Row/components/AwsS3Row.tsx
@@ -13,9 +13,16 @@ import { ExpiringStatus } from '../../Status';
 type AwsS3RowPropTypes = {
   compose: ComposesResponseItem;
   rowIndex: number;
+  onSelect?: (id: string) => void;
+  isSelected?: boolean;
 };
 
-const AwsS3Row = ({ compose, rowIndex }: AwsS3RowPropTypes) => {
+const AwsS3Row = ({
+  compose,
+  rowIndex,
+  onSelect,
+  isSelected,
+}: AwsS3RowPropTypes) => {
   const hoursToExpiration = computeHoursToExpiration(compose.created_at);
   const awsS3ExpirationTime = AWS_S3_EXPIRATION_TIME_IN_HOURS;
   const isExpired = hoursToExpiration >= awsS3ExpirationTime;
@@ -37,6 +44,8 @@ const AwsS3Row = ({ compose, rowIndex }: AwsS3RowPropTypes) => {
       details={details}
       instance={instance}
       status={status}
+      {...(onSelect && { onSelect })}
+      {...(isSelected !== undefined && { isSelected })}
     />
   );
 };

--- a/src/Components/ImagesTable/components/Row/components/AzureRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/AzureRow.tsx
@@ -11,9 +11,16 @@ import { CloudStatus } from '../../Status';
 type AzureRowPropTypes = {
   compose: ComposesResponseItem;
   rowIndex: number;
+  onSelect?: (id: string) => void;
+  isSelected?: boolean;
 };
 
-const AzureRow = ({ compose, rowIndex }: AzureRowPropTypes) => {
+const AzureRow = ({
+  compose,
+  rowIndex,
+  onSelect,
+  isSelected,
+}: AzureRowPropTypes) => {
   const details = <AzureDetails compose={compose} />;
   const instance = <AzureLaunchModal compose={compose} />;
   const status = <CloudStatus compose={compose} />;
@@ -25,6 +32,8 @@ const AzureRow = ({ compose, rowIndex }: AzureRowPropTypes) => {
       details={details}
       instance={instance}
       status={status}
+      {...(onSelect && { onSelect })}
+      {...(isSelected !== undefined && { isSelected })}
     />
   );
 };

--- a/src/Components/ImagesTable/components/Row/components/BlueprintTableRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/BlueprintTableRow.tsx
@@ -1,0 +1,145 @@
+import React, { useState } from 'react';
+
+import {
+  ClipboardCopy,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  Label,
+  Spinner,
+} from '@patternfly/react-core';
+import { RhUiResourcesEmptyIcon } from '@patternfly/react-icons';
+import {
+  ActionsColumn,
+  ExpandableRowContent,
+  Tbody,
+  Td,
+  Tr,
+} from '@patternfly/react-table';
+
+import { BlueprintItem } from '@/store/api/backend';
+import { selectSelectedBlueprintId } from '@/store/slices/blueprint';
+import {
+  timestampToDisplayString,
+  timestampToDisplayStringDetailed,
+} from '@/Utilities/time';
+
+import { useDeleteBPWithNotification as useDeleteBlueprintMutation } from '../../../../../Hooks';
+import { useAppSelector } from '../../../../../store/hooks';
+import Status from '../../Status/components/Status';
+
+type BlueprintTableRowProps = {
+  blueprint: BlueprintItem;
+  rowIndex: number;
+};
+
+const BlueprintTableRow = ({ blueprint, rowIndex }: BlueprintTableRowProps) => {
+  const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const { isLoading } = useDeleteBlueprintMutation({
+    fixedCacheKey: 'delete-blueprint',
+  });
+
+  const handleToggle = () => setIsExpanded(!isExpanded);
+
+  return (
+    <Tbody key={blueprint.id} isExpanded={isExpanded}>
+      <Tr
+        className='no-bottom-border'
+        isClickable
+        isRowSelected={blueprint.id === selectedBlueprintId}
+      >
+        <Td
+          expand={{
+            rowIndex: rowIndex,
+            isExpanded: isExpanded,
+            onToggle: handleToggle,
+          }}
+        />
+        <Td dataLabel='Name'>
+          {isLoading && blueprint.id === selectedBlueprintId && (
+            <Spinner size='md' />
+          )}
+          {blueprint.name}{' '}
+          <Label isCompact color='blue'>
+            Blueprint
+          </Label>
+        </Td>
+        <Td
+          dataLabel='Last updated'
+          title={
+            blueprint.last_modified_at
+              ? timestampToDisplayStringDetailed(blueprint.last_modified_at)
+              : undefined
+          }
+        >
+          {blueprint.last_modified_at
+            ? timestampToDisplayString(blueprint.last_modified_at)
+            : 'N/A'}
+        </Td>
+        <Td dataLabel='Operating system'>N/A</Td>
+        <Td dataLabel='Target environment'>N/A</Td>
+        <Td dataLabel='Status'>
+          <Status
+            icon={<RhUiResourcesEmptyIcon />}
+            text={
+              <span className='pf-v6-u-font-weight-bold'>No images built</span>
+            }
+          />
+        </Td>
+        <Td dataLabel='Instance'>N/A</Td>
+        <Td>
+          <ActionsColumn
+            items={[
+              {
+                title: 'Edit',
+                onClick: () => {},
+              },
+              {
+                title: 'Duplicate',
+                onClick: () => {},
+              },
+              {
+                title: 'Rebuild',
+                onClick: () => {},
+              },
+            ]}
+          />
+        </Td>
+      </Tr>
+      <Tr isExpanded={isExpanded}>
+        <Td colSpan={8}>
+          <ExpandableRowContent>
+            <div className='pf-v6-u-font-weight-bold pf-v6-u-pb-md'>
+              Blueprint Information
+            </div>
+            <DescriptionList isHorizontal isCompact className=' pf-v6-u-pl-xl'>
+              <DescriptionListGroup>
+                <DescriptionListTerm>UUID</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <ClipboardCopy
+                    hoverTip='Copy'
+                    clickTip='Copied'
+                    variant='inline-compact'
+                  >
+                    {blueprint.id}
+                  </ClipboardCopy>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Description</DescriptionListTerm>
+                <DescriptionListDescription>
+                  {blueprint.description || 'N/A'}
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </ExpandableRowContent>
+        </Td>
+      </Tr>
+    </Tbody>
+  );
+};
+
+export default BlueprintTableRow;

--- a/src/Components/ImagesTable/components/Row/components/BlueprintTableRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/BlueprintTableRow.tsx
@@ -7,7 +7,6 @@ import {
   DescriptionListGroup,
   DescriptionListTerm,
   Label,
-  Spinner,
 } from '@patternfly/react-core';
 import { RhUiResourcesEmptyIcon } from '@patternfly/react-icons';
 import {
@@ -19,14 +18,11 @@ import {
 } from '@patternfly/react-table';
 
 import { BlueprintItem } from '@/store/api/backend';
-import { selectSelectedBlueprintId } from '@/store/slices/blueprint';
 import {
   timestampToDisplayString,
   timestampToDisplayStringDetailed,
 } from '@/Utilities/time';
 
-import { useDeleteBPWithNotification as useDeleteBlueprintMutation } from '../../../../../Hooks';
-import { useAppSelector } from '../../../../../store/hooks';
 import Status from '../../Status/components/Status';
 
 type BlueprintTableRowProps = {
@@ -42,23 +38,14 @@ const BlueprintTableRow = ({
   onSelect,
   isSelected,
 }: BlueprintTableRowProps) => {
-  const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
   const [isExpanded, setIsExpanded] = useState(false);
-
-  const { isLoading } = useDeleteBlueprintMutation({
-    fixedCacheKey: 'delete-blueprint',
-  });
 
   const handleToggle = () => setIsExpanded(!isExpanded);
   const handleSelect = () => onSelect(blueprint.id);
 
   return (
     <Tbody key={blueprint.id} isExpanded={isExpanded}>
-      <Tr
-        className='no-bottom-border'
-        isClickable
-        isRowSelected={blueprint.id === selectedBlueprintId}
-      >
+      <Tr className='no-bottom-border' isClickable isRowSelected={isSelected}>
         <Td
           expand={{
             rowIndex: rowIndex,
@@ -74,9 +61,6 @@ const BlueprintTableRow = ({
           }}
         />
         <Td dataLabel='Name'>
-          {isLoading && blueprint.id === selectedBlueprintId && (
-            <Spinner size='md' />
-          )}
           {blueprint.name}{' '}
           <Label isCompact color='blue'>
             Blueprint

--- a/src/Components/ImagesTable/components/Row/components/BlueprintTableRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/BlueprintTableRow.tsx
@@ -32,9 +32,16 @@ import Status from '../../Status/components/Status';
 type BlueprintTableRowProps = {
   blueprint: BlueprintItem;
   rowIndex: number;
+  onSelect: (blueprintId: string) => void;
+  isSelected: boolean;
 };
 
-const BlueprintTableRow = ({ blueprint, rowIndex }: BlueprintTableRowProps) => {
+const BlueprintTableRow = ({
+  blueprint,
+  rowIndex,
+  onSelect,
+  isSelected,
+}: BlueprintTableRowProps) => {
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -43,6 +50,7 @@ const BlueprintTableRow = ({ blueprint, rowIndex }: BlueprintTableRowProps) => {
   });
 
   const handleToggle = () => setIsExpanded(!isExpanded);
+  const handleSelect = () => onSelect(blueprint.id);
 
   return (
     <Tbody key={blueprint.id} isExpanded={isExpanded}>
@@ -56,6 +64,13 @@ const BlueprintTableRow = ({ blueprint, rowIndex }: BlueprintTableRowProps) => {
             rowIndex: rowIndex,
             isExpanded: isExpanded,
             onToggle: handleToggle,
+          }}
+        />
+        <Td
+          select={{
+            rowIndex: rowIndex,
+            onSelect: handleSelect,
+            isSelected: isSelected,
           }}
         />
         <Td dataLabel='Name'>
@@ -110,7 +125,7 @@ const BlueprintTableRow = ({ blueprint, rowIndex }: BlueprintTableRowProps) => {
         </Td>
       </Tr>
       <Tr isExpanded={isExpanded}>
-        <Td colSpan={8}>
+        <Td colSpan={9}>
           <ExpandableRowContent>
             <div className='pf-v6-u-font-weight-bold pf-v6-u-pb-md'>
               Blueprint Information

--- a/src/Components/ImagesTable/components/Row/components/GcpRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/GcpRow.tsx
@@ -11,9 +11,16 @@ import { CloudStatus } from '../../Status';
 type GcpRowPropTypes = {
   compose: ComposesResponseItem;
   rowIndex: number;
+  onSelect?: (id: string) => void;
+  isSelected?: boolean;
 };
 
-const GcpRow = ({ compose, rowIndex }: GcpRowPropTypes) => {
+const GcpRow = ({
+  compose,
+  rowIndex,
+  onSelect,
+  isSelected,
+}: GcpRowPropTypes) => {
   const details = <GcpDetails compose={compose} />;
   const instance = <GcpLaunchModal compose={compose} />;
   const status = <CloudStatus compose={compose} />;
@@ -25,6 +32,8 @@ const GcpRow = ({ compose, rowIndex }: GcpRowPropTypes) => {
       details={details}
       status={status}
       instance={instance}
+      {...(onSelect && { onSelect })}
+      {...(isSelected !== undefined && { isSelected })}
     />
   );
 };

--- a/src/Components/ImagesTable/components/Row/components/ImagesTableRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/ImagesTableRow.tsx
@@ -21,9 +21,16 @@ import OciRow from './OciRow';
 type ImagesTableRowPropTypes = {
   compose: ComposesResponseItem;
   rowIndex: number;
+  onSelect?: (blueprintId: string) => void;
+  isSelected?: boolean;
 };
 
-const ImagesTableRow = ({ compose, rowIndex }: ImagesTableRowPropTypes) => {
+const ImagesTableRow = ({
+  compose,
+  rowIndex,
+  onSelect,
+  isSelected,
+}: ImagesTableRowPropTypes) => {
   const [pollingInterval, setPollingInterval] = useState(
     STATUS_POLLING_INTERVAL,
   );
@@ -95,19 +102,26 @@ const ImagesTableRow = ({ compose, rowIndex }: ImagesTableRowPropTypes) => {
 
   const type = compose.request.image_requests[0]?.upload_request?.type;
 
+  const rowProps = {
+    compose,
+    rowIndex,
+    ...(onSelect && { onSelect }),
+    ...(isSelected !== undefined && { isSelected }),
+  };
+
   switch (type as string) {
     case 'aws':
-      return <AwsRow compose={compose} rowIndex={rowIndex} />;
+      return <AwsRow {...rowProps} />;
     case 'gcp':
-      return <GcpRow compose={compose} rowIndex={rowIndex} />;
+      return <GcpRow {...rowProps} />;
     case 'azure':
-      return <AzureRow compose={compose} rowIndex={rowIndex} />;
+      return <AzureRow {...rowProps} />;
     case 'oci.objectstorage':
-      return <OciRow compose={compose} rowIndex={rowIndex} />;
+      return <OciRow {...rowProps} />;
     case 'aws.s3':
-      return <AwsS3Row compose={compose} rowIndex={rowIndex} />;
+      return <AwsS3Row {...rowProps} />;
     case 'local':
-      return <LocalRow compose={compose} rowIndex={rowIndex} />;
+      return <LocalRow {...rowProps} />;
   }
 };
 

--- a/src/Components/ImagesTable/components/Row/components/LocalRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/LocalRow.tsx
@@ -11,9 +11,16 @@ import { LocalStatus } from '../../Status';
 type LocalRowPropTypes = {
   compose: ComposesResponseItem;
   rowIndex: number;
+  onSelect?: (id: string) => void;
+  isSelected?: boolean;
 };
 
-const LocalRow = ({ compose, rowIndex }: LocalRowPropTypes) => {
+const LocalRow = ({
+  compose,
+  rowIndex,
+  onSelect,
+  isSelected,
+}: LocalRowPropTypes) => {
   const details = <LocalDetails compose={compose} />;
   const instance = <LocalInstance compose={compose} />;
   const status = <LocalStatus compose={compose} />;
@@ -24,6 +31,8 @@ const LocalRow = ({ compose, rowIndex }: LocalRowPropTypes) => {
       details={details}
       instance={instance}
       status={status}
+      {...(onSelect && { onSelect })}
+      {...(isSelected !== undefined && { isSelected })}
     />
   );
 };

--- a/src/Components/ImagesTable/components/Row/components/OciRow.tsx
+++ b/src/Components/ImagesTable/components/Row/components/OciRow.tsx
@@ -13,9 +13,16 @@ import { ExpiringStatus } from '../../Status';
 type OciRowPropTypes = {
   compose: ComposesResponseItem;
   rowIndex: number;
+  onSelect?: (id: string) => void;
+  isSelected?: boolean;
 };
 
-const OciRow = ({ compose, rowIndex }: OciRowPropTypes) => {
+const OciRow = ({
+  compose,
+  rowIndex,
+  onSelect,
+  isSelected,
+}: OciRowPropTypes) => {
   const daysToExpiration = Math.floor(
     computeHoursToExpiration(compose.created_at) / 24,
   );
@@ -38,6 +45,8 @@ const OciRow = ({ compose, rowIndex }: OciRowPropTypes) => {
       details={details}
       instance={instance}
       status={status}
+      {...(onSelect && { onSelect })}
+      {...(isSelected !== undefined && { isSelected })}
     />
   );
 };

--- a/src/Components/ImagesTable/components/Row/components/Row.tsx
+++ b/src/Components/ImagesTable/components/Row/components/Row.tsx
@@ -44,6 +44,8 @@ type RowPropTypes = {
   actions?: JSX.Element;
   instance: JSX.Element;
   details: JSX.Element;
+  onSelect?: (id: string) => void;
+  isSelected?: boolean;
 };
 
 const Row = ({
@@ -54,6 +56,8 @@ const Row = ({
   actions,
   details,
   instance,
+  onSelect,
+  isSelected,
 }: RowPropTypes) => {
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
@@ -88,6 +92,12 @@ const Row = ({
     }
   };
 
+  const handleSelect = () => {
+    if (onSelect) {
+      onSelect(compose.id);
+    }
+  };
+
   return (
     <Tbody key={compose.id} isExpanded={isExpanded}>
       <Tr className='no-bottom-border'>
@@ -98,8 +108,19 @@ const Row = ({
             onToggle: () => handleToggle(),
           }}
         />
+        {isImagesTableRevampEnabled && (
+          <Td
+            select={{
+              rowIndex: rowIndex,
+              onSelect: handleSelect,
+              isSelected: isSelected || false,
+            }}
+          />
+        )}
         <Td dataLabel='Image name'>
-          {compose.blueprint_id && !selectedBlueprintId ? (
+          {!isImagesTableRevampEnabled &&
+          compose.blueprint_id &&
+          !selectedBlueprintId ? (
             <Button
               component='a'
               variant='link'
@@ -171,7 +192,7 @@ const Row = ({
         </Td>
       </Tr>
       <Tr isExpanded={isExpanded}>
-        <Td colSpan={8}>
+        <Td colSpan={isImagesTableRevampEnabled ? 9 : 8}>
           <ExpandableRowContent>{details}</ExpandableRowContent>
         </Td>
       </Tr>

--- a/src/Components/ImagesTable/constants.ts
+++ b/src/Components/ImagesTable/constants.ts
@@ -1,0 +1,7 @@
+export const filterOptions = [
+  { value: 'name', label: 'Name' },
+  { value: 'latest', label: 'Last updated' },
+  { value: 'system', label: 'Operating system' },
+  { value: 'target', label: 'Target environment' },
+  { value: 'status', label: 'Status' },
+];

--- a/src/store/api/backend/onprem/composerApi/blueprints.ts
+++ b/src/store/api/backend/onprem/composerApi/blueprints.ts
@@ -86,7 +86,7 @@ export const blueprintEndpoints = (builder: OnPremBuilder) => ({
             ...parsed,
             id: filename as string,
             version: 1,
-            last_modified_at: Date.now().toString(),
+            last_modified_at: new Date().toISOString(),
           };
         }),
       );


### PR DESCRIPTION
This implements a `BlueprintTableRow` component to replace the previously used blueprint cards. A checkbox to select the active uuid was also added.

The table rows are now a mixture of blueprints with no composes and composes. 

There are two API setbacks:
- composes cannot be searched by name in the backend. Temporary client-side searching was implemented, but it applies only within the limit of 100 composes
- blueprints and composes are fetched only within the limit of 100 of each due to mixing of the paginations

<img width="1171" height="719" alt="image" src="https://github.com/user-attachments/assets/195ab0ea-11c2-4100-8501-a3087fed31e1" />
