### PR TITLE
Refactor image request mapping into composable store mappers (HMS-10944)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -175,6 +175,14 @@ module.exports = defineConfig([
         },
       ],
       'react-hooks/set-state-in-effect': 'warn', // TODO address issues and enable the rule
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "ImportSpecifier[imported.name='useAppStore']",
+          message:
+            'useAppStore exposes the raw store — only use it for store.getState() inside event handlers, never during render. Add an eslint-disable with justification if this usage is intentional.',
+        },
+      ],
     },
     settings: {
       react: {

--- a/src/Components/CreateImageWizard/components/ReviewWizardFooter.tsx
+++ b/src/Components/CreateImageWizard/components/ReviewWizardFooter.tsx
@@ -9,7 +9,6 @@ import {
   WizardFooterWrapper,
 } from '@patternfly/react-core';
 import { MenuToggleElement } from '@patternfly/react-core/dist/esm/components/MenuToggle/MenuToggle';
-import { useStore } from 'react-redux';
 
 import { selectSelectedBlueprintId } from '@/store/slices/blueprint';
 import { selectWizardModalMode } from '@/store/slices/wizardModal';
@@ -27,7 +26,6 @@ import {
   EditSaveAndBuildBtn,
   EditSaveButton,
 } from '../steps/Review/Footer/EditDropdown';
-import { mapRequestFromState } from '../utilities/requestMapper';
 import { useIsBlueprintValid } from '../utilities/useValidation';
 
 const ReviewWizardFooter = () => {
@@ -40,7 +38,6 @@ const ReviewWizardFooter = () => {
   const mode = useAppSelector(selectWizardModalMode);
   const blueprintId = useAppSelector(selectSelectedBlueprintId);
   const [isOpen, setIsOpen] = useState(false);
-  const store = useStore();
   const onToggleClick = () => {
     setIsOpen(!isOpen);
   };
@@ -53,10 +50,6 @@ const ReviewWizardFooter = () => {
       close();
     }
   }, [isUpdateSuccess, isCreateSuccess, resetCreate, resetUpdate, close]);
-
-  const getBlueprintPayload = () => {
-    return mapRequestFromState(store);
-  };
 
   const isEditMode = mode === 'edit';
 
@@ -84,7 +77,6 @@ const ReviewWizardFooter = () => {
                   ? [
                       <EditSaveButton
                         key='wizard-edit-save-btn'
-                        getBlueprintPayload={getBlueprintPayload}
                         setIsOpen={setIsOpen}
                         blueprintId={blueprintId || ''}
                         isDisabled={!isValid}
@@ -93,7 +85,6 @@ const ReviewWizardFooter = () => {
                   : [
                       <CreateSaveButton
                         key='wizard-create-save-btn'
-                        getBlueprintPayload={getBlueprintPayload}
                         setIsOpen={setIsOpen}
                         isDisabled={!isValid}
                       />,
@@ -105,14 +96,12 @@ const ReviewWizardFooter = () => {
         >
           {isEditMode ? (
             <EditSaveAndBuildBtn
-              getBlueprintPayload={getBlueprintPayload}
               blueprintId={blueprintId || ''}
               setIsOpen={setIsOpen}
               isDisabled={!isValid}
             />
           ) : (
             <CreateSaveAndBuildBtn
-              getBlueprintPayload={getBlueprintPayload}
               setIsOpen={setIsOpen}
               isDisabled={!isValid}
             />

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Aws/tests/AwsTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Aws/tests/AwsTarget.test.tsx
@@ -1,10 +1,9 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { screen, waitFor } from '@testing-library/react';
 
-import { mapRequestFromState } from '@/Components/CreateImageWizard/utilities/requestMapper';
 import { serviceMiddleware, serviceReducer } from '@/store';
-import { CreateBlueprintRequest, ImageRequest } from '@/store/api/backend';
-import { initialState } from '@/store/slices/wizard';
+import { ImageRequest } from '@/store/api/backend';
+import { initialState, mapStateToRequest } from '@/store/slices/wizard';
 import {
   clickWithWait,
   createUser,
@@ -231,7 +230,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
@@ -262,7 +261,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.image_requests[0].upload_request.type).toBe('aws');
     expect(request.image_requests[0].image_type).toBe('aws');
@@ -280,7 +279,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('share_with_accounts', ['111222333444']);
@@ -298,7 +297,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.image_requests[0].architecture).toBe('x86_64');
   });
@@ -315,7 +314,7 @@ describe('AWS CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.customizations.subscription).toBeUndefined();
   });

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Azure/tests/AzureTarget.test.tsx
@@ -1,10 +1,9 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { screen } from '@testing-library/react';
 
-import { mapRequestFromState } from '@/Components/CreateImageWizard/utilities/requestMapper';
 import { serviceMiddleware, serviceReducer } from '@/store';
-import { CreateBlueprintRequest, ImageRequest } from '@/store/api/backend';
-import { initialState } from '@/store/slices/wizard';
+import { ImageRequest } from '@/store/api/backend';
+import { initialState, mapStateToRequest } from '@/store/slices/wizard';
 import {
   clickWithWait,
   createUser,
@@ -358,7 +357,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
@@ -393,7 +392,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.image_requests).toHaveLength(1);
     expect(request.image_requests[0].image_type).toBe('azure');
@@ -421,7 +420,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.image_requests[0].upload_request.type).toBe('azure');
     expect(request.image_requests[0].image_type).toBe('azure');
@@ -440,7 +439,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('resource_group', '');
@@ -459,7 +458,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toEqual({
@@ -483,7 +482,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.image_requests[0].architecture).toBe('x86_64');
   });
@@ -501,7 +500,7 @@ describe('Azure CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.customizations.subscription).toBeUndefined();
   });

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/tests/GcpTarget.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/Gcp/tests/GcpTarget.test.tsx
@@ -1,10 +1,9 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { screen, waitFor } from '@testing-library/react';
 
-import { mapRequestFromState } from '@/Components/CreateImageWizard/utilities/requestMapper';
 import { serviceMiddleware, serviceReducer } from '@/store';
-import { CreateBlueprintRequest, ImageRequest } from '@/store/api/backend';
-import { initialState } from '@/store/slices/wizard';
+import { ImageRequest } from '@/store/api/backend';
+import { initialState, mapStateToRequest } from '@/store/slices/wizard';
 import {
   clickWithWait,
   createUser,
@@ -302,7 +301,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
@@ -332,7 +331,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('share_with_accounts', [
@@ -351,7 +350,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('share_with_accounts', [
@@ -370,7 +369,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     const options = request.image_requests[0].upload_request.options;
     expect(options).toHaveProperty('share_with_accounts', [
@@ -389,7 +388,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.image_requests[0].upload_request.type).toBe('gcp');
     expect(request.image_requests[0].image_type).toBe('gcp');
@@ -406,7 +405,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.image_requests[0].architecture).toBe('x86_64');
   });
@@ -422,7 +421,7 @@ describe('GCP CreateBlueprintRequest payload', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.customizations.subscription).toBeUndefined();
   });

--- a/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
@@ -1,8 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 
-import { mapRequestFromState } from '@/Components/CreateImageWizard/utilities/requestMapper';
-import { CreateBlueprintRequest } from '@/store/api/backend';
-import { initialState } from '@/store/slices/wizard';
+import { initialState, mapStateToRequest } from '@/store/slices/wizard';
 import { server } from '@/test/mocks/server';
 import {
   clickWithWait,
@@ -533,7 +531,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.customizations.custom_repositories).toHaveLength(1);
     expect(request.customizations.custom_repositories![0]).toEqual({
@@ -574,7 +572,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.customizations.payload_repositories).toHaveLength(1);
     expect(request.customizations.payload_repositories![0]).toEqual({
@@ -616,7 +614,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.customizations.custom_repositories![0].module_hotfixes).toBe(
       true,
@@ -636,7 +634,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.customizations.custom_repositories).toBeUndefined();
     expect(request.customizations.payload_repositories).toBeUndefined();
@@ -664,7 +662,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(
       request.customizations.custom_repositories![0].baseurl,
@@ -703,7 +701,7 @@ describe('Request Payload Generation', () => {
       },
     });
 
-    const request = mapRequestFromState(store) as CreateBlueprintRequest;
+    const request = mapStateToRequest(store.getState());
 
     expect(request.customizations.custom_repositories).toHaveLength(2);
     expect(request.customizations.payload_repositories).toHaveLength(2);

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -16,13 +16,19 @@ import {
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import {
-  ComposerCreateBlueprintRequest,
   CreateBlueprintRequest,
   CreateBlueprintResponse,
 } from '@/store/api/backend';
+import {
+  useAppDispatch,
+  useAppSelector,
+  // store.getState() in click handlers to build request body
+  // eslint-disable-next-line no-restricted-syntax
+  useAppStore,
+} from '@/store/hooks';
 import { setBlueprintId } from '@/store/slices/blueprint';
 import { selectIsOnPremise } from '@/store/slices/env';
-import { selectPackages } from '@/store/slices/wizard';
+import { mapStateToRequest, selectPackages } from '@/store/slices/wizard';
 
 import { AMPLITUDE_MODULE_NAME } from '../../../../../constants';
 import {
@@ -30,20 +36,14 @@ import {
   useCreateBPWithNotification as useCreateBlueprintMutation,
   useGetUser,
 } from '../../../../../Hooks';
-import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import { createAnalytics } from '../../../../../Utilities/analytics';
 
 type CreateDropdownProps = {
-  getBlueprintPayload: () =>
-    | CreateBlueprintRequest
-    | ComposerCreateBlueprintRequest
-    | undefined;
   setIsOpen: (isOpen: boolean) => void;
   isDisabled: boolean;
 };
 
 export const CreateSaveAndBuildBtn = ({
-  getBlueprintPayload,
   setIsOpen,
   isDisabled,
 }: CreateDropdownProps) => {
@@ -52,6 +52,7 @@ export const CreateSaveAndBuildBtn = ({
   const isOnPremise = useAppSelector(selectIsOnPremise);
 
   const packages = useAppSelector(selectPackages);
+  const store = useAppStore();
 
   const { trigger: buildBlueprint } = useComposeBlueprintMutation();
   const { trigger: createBlueprint } = useCreateBlueprintMutation({
@@ -59,10 +60,10 @@ export const CreateSaveAndBuildBtn = ({
   });
   const dispatch = useAppDispatch();
   const onSaveAndBuild = async () => {
-    const requestBody = await getBlueprintPayload();
+    const requestBody = mapStateToRequest(store.getState());
     setIsOpen(false);
 
-    if (!isOnPremise && requestBody) {
+    if (!isOnPremise) {
       const analyticsData = createAnalytics(
         requestBody as CreateBlueprintRequest,
         packages,
@@ -81,14 +82,12 @@ export const CreateSaveAndBuildBtn = ({
         ),
       });
     }
-    if (requestBody) {
-      const blueprint = (await createBlueprint({
-        createBlueprintRequest: requestBody as CreateBlueprintRequest,
-      })) as CreateBlueprintResponse;
+    const blueprint = (await createBlueprint({
+      createBlueprintRequest: requestBody as CreateBlueprintRequest,
+    })) as CreateBlueprintResponse;
 
-      buildBlueprint({ id: blueprint.id, body: {} });
-      dispatch(setBlueprintId(blueprint.id));
-    }
+    buildBlueprint({ id: blueprint.id, body: {} });
+    dispatch(setBlueprintId(blueprint.id));
   };
 
   return (
@@ -133,7 +132,6 @@ const SaveAndBuildImagesModal = ({
 
 export const CreateSaveButton = ({
   setIsOpen,
-  getBlueprintPayload,
   isDisabled,
 }: CreateDropdownProps) => {
   const { analytics, auth, isBeta } = useChrome();
@@ -141,6 +139,7 @@ export const CreateSaveButton = ({
   const isOnPremise = useAppSelector(selectIsOnPremise);
 
   const packages = useAppSelector(selectPackages);
+  const store = useAppStore();
 
   const { trigger: createBlueprint, isLoading } = useCreateBlueprintMutation({
     fixedCacheKey: 'createBlueprintKey',
@@ -165,10 +164,10 @@ export const CreateSaveButton = ({
   };
 
   const onSave = async () => {
-    const requestBody = await getBlueprintPayload();
+    const requestBody = mapStateToRequest(store.getState());
     setIsOpen(false);
 
-    if (!isOnPremise && requestBody) {
+    if (!isOnPremise) {
       const analyticsData = createAnalytics(
         requestBody as CreateBlueprintRequest,
         packages,
@@ -180,12 +179,10 @@ export const CreateSaveButton = ({
         account_id: userData?.identity.internal?.account_id || 'Not found',
       });
     }
-    if (requestBody) {
-      const blueprint = (await createBlueprint({
-        createBlueprintRequest: requestBody as CreateBlueprintRequest,
-      })) as CreateBlueprintResponse;
-      dispatch(setBlueprintId(blueprint.id));
-    }
+    const blueprint = (await createBlueprint({
+      createBlueprintRequest: requestBody as CreateBlueprintRequest,
+    })) as CreateBlueprintResponse;
+    dispatch(setBlueprintId(blueprint.id));
   };
 
   return (

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -10,12 +10,15 @@ import {
 } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
+import { CreateBlueprintRequest } from '@/store/api/backend';
 import {
-  ComposerCreateBlueprintRequest,
-  CreateBlueprintRequest,
-} from '@/store/api/backend';
+  useAppSelector,
+  // store.getState() in click handlers to build request body
+  // eslint-disable-next-line no-restricted-syntax
+  useAppStore,
+} from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-import { selectPackages } from '@/store/slices/wizard';
+import { mapStateToRequest, selectPackages } from '@/store/slices/wizard';
 
 import { AMPLITUDE_MODULE_NAME } from '../../../../../constants';
 import {
@@ -23,21 +26,15 @@ import {
   useGetUser,
   useUpdateBPWithNotification as useUpdateBlueprintMutation,
 } from '../../../../../Hooks';
-import { useAppSelector } from '../../../../../store/hooks';
 import { createAnalytics } from '../../../../../Utilities/analytics';
 
 type EditDropdownProps = {
-  getBlueprintPayload: () =>
-    | CreateBlueprintRequest
-    | ComposerCreateBlueprintRequest
-    | undefined;
   setIsOpen: (isOpen: boolean) => void;
   blueprintId: string;
   isDisabled: boolean;
 };
 
 export const EditSaveAndBuildBtn = ({
-  getBlueprintPayload,
   setIsOpen,
   blueprintId,
   isDisabled,
@@ -48,15 +45,16 @@ export const EditSaveAndBuildBtn = ({
 
   const { trigger: buildBlueprint } = useComposeBlueprintMutation();
   const packages = useAppSelector(selectPackages);
+  const store = useAppStore();
 
   const { trigger: updateBlueprint } = useUpdateBlueprintMutation({
     fixedCacheKey: 'updateBlueprintKey',
   });
 
   const onSaveAndBuild = async () => {
-    const requestBody = await getBlueprintPayload();
+    const requestBody = mapStateToRequest(store.getState());
 
-    if (!isOnPremise && requestBody) {
+    if (!isOnPremise) {
       const analyticsData = createAnalytics(
         requestBody as CreateBlueprintRequest,
         packages,
@@ -76,12 +74,10 @@ export const EditSaveAndBuildBtn = ({
       });
     }
     setIsOpen(false);
-    if (requestBody) {
-      await updateBlueprint({
-        id: blueprintId,
-        createBlueprintRequest: requestBody as CreateBlueprintRequest,
-      });
-    }
+    await updateBlueprint({
+      id: blueprintId,
+      createBlueprintRequest: requestBody as CreateBlueprintRequest,
+    });
     buildBlueprint({ id: blueprintId, body: {} });
   };
 
@@ -96,7 +92,6 @@ export const EditSaveAndBuildBtn = ({
 
 export const EditSaveButton = ({
   setIsOpen,
-  getBlueprintPayload,
   blueprintId,
   isDisabled,
 }: EditDropdownProps) => {
@@ -105,14 +100,15 @@ export const EditSaveButton = ({
   const isOnPremise = useAppSelector(selectIsOnPremise);
 
   const packages = useAppSelector(selectPackages);
+  const store = useAppStore();
 
   const { trigger: updateBlueprint, isLoading } = useUpdateBlueprintMutation({
     fixedCacheKey: 'updateBlueprintKey',
   });
   const onSave = async () => {
-    const requestBody = await getBlueprintPayload();
+    const requestBody = mapStateToRequest(store.getState());
 
-    if (!isOnPremise && requestBody) {
+    if (!isOnPremise) {
       const analyticsData = createAnalytics(
         requestBody as CreateBlueprintRequest,
         packages,
@@ -125,12 +121,10 @@ export const EditSaveButton = ({
       });
     }
     setIsOpen(false);
-    if (requestBody) {
-      updateBlueprint({
-        id: blueprintId,
-        createBlueprintRequest: requestBody as CreateBlueprintRequest,
-      });
-    }
+    updateBlueprint({
+      id: blueprintId,
+      createBlueprintRequest: requestBody as CreateBlueprintRequest,
+    });
   };
   return (
     <MenuToggleAction

--- a/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
@@ -9,7 +9,6 @@ import {
   WizardFooterWrapper,
 } from '@patternfly/react-core';
 import { MenuToggleElement } from '@patternfly/react-core/dist/esm/components/MenuToggle/MenuToggle';
-import { useStore } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { selectPathResolver } from '@/store/slices/env';
@@ -22,7 +21,6 @@ import {
   useUpdateBPWithNotification as useUpdateBlueprintMutation,
 } from '../../../../../Hooks';
 import { useAppSelector } from '../../../../../store/hooks';
-import { mapRequestFromState } from '../../../utilities/requestMapper';
 import { useIsBlueprintValid } from '../../../utilities/useValidation';
 
 const ReviewWizardFooter = () => {
@@ -36,7 +34,6 @@ const ReviewWizardFooter = () => {
   const resolvePath = useAppSelector(selectPathResolver);
   const { composeId } = useParams();
   const [isOpen, setIsOpen] = useState(false);
-  const store = useStore();
   const onToggleClick = () => {
     setIsOpen(!isOpen);
   };
@@ -50,10 +47,6 @@ const ReviewWizardFooter = () => {
       navigate(resolvePath(''));
     }
   }, [isUpdateSuccess, isCreateSuccess, resetCreate, resetUpdate, navigate]);
-
-  const getBlueprintPayload = () => {
-    return mapRequestFromState(store);
-  };
 
   return (
     <WizardFooterWrapper>
@@ -73,7 +66,6 @@ const ReviewWizardFooter = () => {
                   ? [
                       <EditSaveButton
                         key='wizard-edit-save-btn'
-                        getBlueprintPayload={getBlueprintPayload}
                         setIsOpen={setIsOpen}
                         blueprintId={composeId}
                         isDisabled={!isValid}
@@ -82,7 +74,6 @@ const ReviewWizardFooter = () => {
                   : [
                       <CreateSaveButton
                         key='wizard-create-save-btn'
-                        getBlueprintPayload={getBlueprintPayload}
                         setIsOpen={setIsOpen}
                         isDisabled={!isValid}
                       />,
@@ -94,14 +85,12 @@ const ReviewWizardFooter = () => {
         >
           {composeId ? (
             <EditSaveAndBuildBtn
-              getBlueprintPayload={getBlueprintPayload}
               setIsOpen={setIsOpen}
               blueprintId={composeId}
               isDisabled={!isValid}
             />
           ) : (
             <CreateSaveAndBuildBtn
-              getBlueprintPayload={getBlueprintPayload}
               setIsOpen={setIsOpen}
               isDisabled={!isValid}
             />

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -10,8 +10,6 @@ import {
   BtrfsVolume,
   ComposerAwsUploadRequestOptions,
   ComposerCreateBlueprintRequest,
-  ComposerImageRequest,
-  ComposerUploadTypes,
   CreateBlueprintRequest,
   CustomRepository,
   DistributionProfileItem,
@@ -21,18 +19,15 @@ import {
   FilesystemTyped,
   GcpUploadRequestOptions,
   ImageRequest,
-  ImageTypes,
   LogicalVolume,
   OpenScapCompliance,
   OpenScapProfile,
-  UploadTypes,
   VolumeGroup,
 } from '@/store/api/backend';
 import {
   ApiRepositoryImportResponseRead,
   ApiRepositoryResponseRead,
 } from '@/store/api/contentSources';
-import { selectIsOnPremise } from '@/store/slices/env';
 import {
   AwsShareMethod,
   ComplianceType,
@@ -44,31 +39,19 @@ import {
   isRhel,
   isSupportedImageType,
   mapCustomizations,
+  mapImageRequests,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
-  selectArchitecture,
-  selectAwsAccountId,
-  selectAwsRegion,
-  selectAzureHyperVGeneration,
-  selectAzureResourceGroup,
-  selectAzureSubscriptionId,
-  selectAzureTenantId,
   selectBlueprintDescription,
   selectBlueprintName,
   selectBootcDistributions,
   selectDistribution,
-  selectGcpAccountType,
-  selectGcpEmail,
   selectImageSource,
   selectImageTypes,
   selectIsImageMode,
   selectIsoPayloadReference,
   selectMetadata,
-  selectSnapshotDate,
-  selectTemplate,
-  selectTemplateName,
-  selectUseLatest,
   Units,
   WizardState,
 } from '@/store/slices/wizard';
@@ -81,7 +64,6 @@ import {
   RHEL_9,
   SATELLITE_PATH,
 } from '../../../constants';
-import { RootState } from '../../../store';
 
 /**
  * This function maps the wizard state to a valid CreateBlueprint request object
@@ -93,7 +75,6 @@ export const mapRequestFromState = (
   store: Store,
 ): CreateBlueprintRequest | ComposerCreateBlueprintRequest => {
   const state = store.getState();
-  const imageRequests = getImageRequests(state);
   const isImageMode = selectIsImageMode(state);
   const imageSource = selectImageSource(state);
 
@@ -134,7 +115,7 @@ export const mapRequestFromState = (
     description: selectBlueprintDescription(state),
     distribution: selectDistribution(state),
     bootc: bootcBody,
-    image_requests: imageRequests,
+    ...mapImageRequests(state),
     ...mapCustomizations(state),
   };
 };
@@ -743,30 +724,6 @@ const getFirstBootScript = (files?: File[]): string => {
   return firstBootFile?.data ? atob(firstBootFile.data) : '';
 };
 
-const getImageRequests = (
-  state: RootState,
-): ImageRequest[] | ComposerImageRequest[] => {
-  const imageTypes = selectImageTypes(state);
-  const snapshotDate = selectSnapshotDate(state);
-  const useLatest = selectUseLatest(state);
-  const template = selectTemplate(state);
-  const templateName = selectTemplateName(state);
-  return imageTypes.map((type) => ({
-    architecture: selectArchitecture(state),
-    image_type: type,
-    upload_request: {
-      type: uploadTypeByTargetEnv(type),
-      options: getImageOptions(type, state),
-    },
-    // Only include snapshot_date when using snapshot mode (not latest or template)
-    // Convert empty strings to undefined
-    snapshot_date:
-      !useLatest && !template && snapshotDate ? snapshotDate : undefined,
-    content_template: template || undefined,
-    content_template_name: templateName || undefined,
-  }));
-};
-
 const getRegistrationType = (
   request:
     | BlueprintResponse
@@ -795,88 +752,4 @@ const getSatelliteCommand = (files?: File[]): string => {
     (file) => file.path === SATELLITE_PATH,
   );
   return satelliteCommandFile?.data ? atob(satelliteCommandFile.data) : '';
-};
-
-const uploadTypeByTargetEnv = (
-  imageType: ImageTypes,
-): UploadTypes | ComposerUploadTypes => {
-  switch (imageType) {
-    case 'aws':
-      return 'aws';
-    case 'gcp':
-      return 'gcp';
-    case 'azure':
-      return 'azure';
-    case 'oci':
-      return 'oci.objectstorage';
-    case 'wsl':
-      return 'aws.s3';
-    case 'guest-image':
-      return 'aws.s3';
-    case 'image-installer':
-      return 'aws.s3';
-    case 'bootable-container-iso':
-      return 'aws.s3';
-    case 'network-installer':
-      return 'aws.s3';
-    case 'vsphere':
-      return 'aws.s3';
-    case 'vsphere-ova':
-      return 'aws.s3';
-    case 'ami':
-      return 'aws';
-    case 'pxe-tar-xz':
-      return 'aws.s3';
-    default: {
-      throw new Error(`image type: ${imageType} has no implementation yet`);
-    }
-  }
-};
-const getImageOptions = (
-  imageType: ImageTypes,
-  state: RootState,
-):
-  | AwsUploadRequestOptions
-  | AzureUploadRequestOptions
-  | GcpUploadRequestOptions
-  | ComposerAwsUploadRequestOptions => {
-  const isOnPremise = selectIsOnPremise(state);
-  switch (imageType) {
-    case 'aws':
-      if (!isOnPremise)
-        return { share_with_accounts: [selectAwsAccountId(state)] };
-
-      // TODO: we might want to update the image-builder-crc api
-      // to accept a region instead (with default us-east-1)
-      return {
-        share_with_accounts: [selectAwsAccountId(state)],
-        region: selectAwsRegion(state),
-      };
-    case 'azure':
-      return {
-        tenant_id: selectAzureTenantId(state),
-        subscription_id: selectAzureSubscriptionId(state),
-        resource_group: selectAzureResourceGroup(state) || '',
-        hyper_v_generation: selectAzureHyperVGeneration(state),
-      };
-    case 'gcp': {
-      const gcpEmail = selectGcpEmail(state);
-      let googleAccount: string = '';
-      switch (selectGcpAccountType(state)) {
-        case 'user':
-          googleAccount = `user:${gcpEmail}`;
-          break;
-        case 'serviceAccount':
-          googleAccount = `serviceAccount:${gcpEmail}`;
-          break;
-        case 'group':
-          googleAccount = `group:${gcpEmail}`;
-          break;
-        case 'domain':
-          googleAccount = `domain:${gcpEmail}`;
-      }
-      return { share_with_accounts: [googleAccount] };
-    }
-  }
-  return {};
 };

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -38,6 +38,7 @@ import {
   initialState,
   isRhel,
   isSupportedImageType,
+  mapBootcOptions,
   mapCustomizations,
   mapImageRequests,
   PackageRepository,
@@ -45,12 +46,7 @@ import {
   RegistrationType,
   selectBlueprintDescription,
   selectBlueprintName,
-  selectBootcDistributions,
   selectDistribution,
-  selectImageSource,
-  selectImageTypes,
-  selectIsImageMode,
-  selectIsoPayloadReference,
   selectMetadata,
   Units,
   WizardState,
@@ -75,46 +71,12 @@ export const mapRequestFromState = (
   store: Store,
 ): CreateBlueprintRequest | ComposerCreateBlueprintRequest => {
   const state = store.getState();
-  const isImageMode = selectIsImageMode(state);
-  const imageSource = selectImageSource(state);
-
-  let bootcReference: string | undefined;
-  const imageTypes = selectImageTypes(state);
-  if (isImageMode && imageSource) {
-    const bootcDistributions = selectBootcDistributions(state);
-    const selectedDistro = bootcDistributions.find(
-      (d) => d.reference === imageSource,
-    );
-    if (selectedDistro && imageTypes.length > 0) {
-      const match = bootcDistributions.find(
-        (d) => d.name === selectedDistro.name && d.type === imageTypes[0],
-      );
-      if (match) {
-        bootcReference = match.reference;
-      }
-    }
-    if (!bootcReference) {
-      bootcReference = imageSource;
-    }
-  }
-
-  const isoPayloadRef = selectIsoPayloadReference(state);
-  const bootcBody =
-    bootcReference !== undefined
-      ? {
-          reference: bootcReference,
-          ...(imageTypes[0] === 'bootable-container-iso' && isoPayloadRef
-            ? { iso_payload_reference: isoPayloadRef }
-            : {}),
-        }
-      : undefined;
-
   return {
     name: selectBlueprintName(state),
     metadata: selectMetadata(state),
     description: selectBlueprintDescription(state),
     distribution: selectDistribution(state),
-    bootc: bootcBody,
+    ...mapBootcOptions(state),
     ...mapImageRequests(state),
     ...mapCustomizations(state),
   };

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -1,4 +1,3 @@
-import { Store } from 'redux';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
@@ -38,7 +37,6 @@ import {
   initialState,
   isRhel,
   isSupportedImageType,
-  mapStateToRequest,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
@@ -54,18 +52,6 @@ import {
   RHEL_9,
   SATELLITE_PATH,
 } from '../../../constants';
-
-/**
- * This function maps the wizard state to a valid CreateBlueprint request object
- * @param {Store} store redux store
- *
- * @returns {CreateBlueprintRequest} blueprint creation request payload
- */
-export const mapRequestFromState = (
-  store: Store,
-): CreateBlueprintRequest | ComposerCreateBlueprintRequest => {
-  return mapStateToRequest(store.getState());
-};
 
 const convertFilesystemToPartition = (
   filesystem: Filesystem,

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -38,16 +38,10 @@ import {
   initialState,
   isRhel,
   isSupportedImageType,
-  mapBootcOptions,
-  mapCustomizations,
-  mapImageRequests,
+  mapStateToRequest,
   PackageRepository,
   parseSizeUnit,
   RegistrationType,
-  selectBlueprintDescription,
-  selectBlueprintName,
-  selectDistribution,
-  selectMetadata,
   Units,
   WizardState,
 } from '@/store/slices/wizard';
@@ -70,16 +64,7 @@ import {
 export const mapRequestFromState = (
   store: Store,
 ): CreateBlueprintRequest | ComposerCreateBlueprintRequest => {
-  const state = store.getState();
-  return {
-    name: selectBlueprintName(state),
-    metadata: selectMetadata(state),
-    description: selectBlueprintDescription(state),
-    distribution: selectDistribution(state),
-    ...mapBootcOptions(state),
-    ...mapImageRequests(state),
-    ...mapCustomizations(state),
-  };
+  return mapStateToRequest(store.getState());
 };
 
 const convertFilesystemToPartition = (

--- a/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
+++ b/src/Components/CreateImageWizard/utilities/tests/requestMapper.test.ts
@@ -8,13 +8,10 @@ import {
   Distributions,
   ImageRequest,
 } from '@/store/api/backend';
+import { mapStateToRequest } from '@/store/slices/wizard';
 import { createTestStore } from '@/test/testUtils';
 
-import {
-  mapBlueprintExportToState,
-  mapRequestFromState,
-  mapRequestToState,
-} from '../requestMapper';
+import { mapBlueprintExportToState, mapRequestToState } from '../requestMapper';
 
 const createMinimalBlueprintResponse = (
   overrides: Partial<BlueprintResponse> = {},
@@ -196,14 +193,14 @@ const toBlueprintResponse = (
 const stripUndefined = <T extends Record<string, unknown>>(obj: T): T =>
   JSON.parse(JSON.stringify(obj)) as T;
 
-describe('round-trip: mapRequestToState + mapRequestFromState', () => {
+describe('round-trip: mapRequestToState + mapStateToRequest', () => {
   it.each(Object.entries(editModeFixtures))(
     'round-trips correctly for %s blueprint',
     (_, expectedRequest) => {
       const response = toBlueprintResponse(expectedRequest);
       const wizardState = mapRequestToState(response);
       const store = createTestStore(wizardState);
-      const result = stripUndefined(mapRequestFromState(store));
+      const result = stripUndefined(mapStateToRequest(store.getState()));
       expect(result).toEqual(expectedRequest);
     },
   );

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,7 +1,17 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch, useSelector, useStore } from 'react-redux';
 
-import type { AppDispatch, RootState } from './index';
+import type {
+  AppDispatch,
+  onPremStore,
+  RootState,
+  serviceStore,
+} from './index';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();
+
+type AppStore = typeof onPremStore | typeof serviceStore;
+// Typed useStore for lazily reading state inside event handlers,
+// because we don't want to get the store state as the component renders
+export const useAppStore = useStore.withTypes<AppStore>();

--- a/src/store/slices/wizard/cloud/index.ts
+++ b/src/store/slices/wizard/cloud/index.ts
@@ -1,3 +1,4 @@
+export * from './mappers';
 export * from './selectors';
 export * from './slice';
 export { initialState as cloudProvidersState } from './state';

--- a/src/store/slices/wizard/cloud/mappers.ts
+++ b/src/store/slices/wizard/cloud/mappers.ts
@@ -1,0 +1,84 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import {
+  selectAwsAccountId,
+  selectAwsRegion,
+  selectAzureHyperVGeneration,
+  selectAzureResourceGroup,
+  selectAzureSubscriptionId,
+  selectAzureTenantId,
+  selectGcpAccountType,
+  selectGcpEmail,
+} from './selectors';
+
+import { selectIsOnPremise } from '../../env';
+
+export const mapAwsImageOptions = createSelector(
+  [selectIsOnPremise, selectAwsAccountId, selectAwsRegion],
+  (isOnPremise, accountId, region) => {
+    // Guard: skip cloud options when the user hasn't provided credentials.
+    // The old code sent { share_with_accounts: [''] } which is invalid.
+    if (!accountId) {
+      return {};
+    }
+
+    const share_with_accounts = [accountId];
+    if (!isOnPremise) return { share_with_accounts };
+
+    // TODO: we might want to update the image-builder-crc api
+    // to accept a region instead (with default us-east-1)
+    return {
+      share_with_accounts,
+      region,
+    };
+  },
+);
+
+export const mapAzureImageOptions = createSelector(
+  [
+    selectAzureTenantId,
+    selectAzureSubscriptionId,
+    selectAzureResourceGroup,
+    selectAzureHyperVGeneration,
+  ],
+  (tenantId, subscriptionId, resourceGroup, hyperVGen) => {
+    // Guard: skip cloud options when required credentials are missing.
+    if (!tenantId || !subscriptionId) {
+      return {};
+    }
+
+    return {
+      tenant_id: tenantId,
+      subscription_id: subscriptionId,
+      resource_group: resourceGroup || '',
+      hyper_v_generation: hyperVGen,
+    };
+  },
+);
+
+export const mapGcpImageOptions = createSelector(
+  [selectGcpEmail, selectGcpAccountType],
+  (gcpEmail, accountType) => {
+    // Guard: skip cloud options when required credentials are missing.
+    if (!gcpEmail || !accountType) {
+      return {};
+    }
+
+    return { share_with_accounts: [`${accountType}:${gcpEmail}`] };
+  },
+);
+
+export const mapAwsUploadRequest = createSelector(
+  [mapAwsImageOptions],
+  (options) => ({ upload_request: { type: 'aws' as const, options } }),
+);
+
+export const mapAzureUploadRequest = createSelector(
+  [mapAzureImageOptions],
+  (options) => ({ upload_request: { type: 'azure' as const, options } }),
+);
+
+export const mapGcpUploadRequest = createSelector(
+  [mapGcpImageOptions],
+  (options) => ({ upload_request: { type: 'gcp' as const, options } }),
+);

--- a/src/store/slices/wizard/content/mappers.ts
+++ b/src/store/slices/wizard/content/mappers.ts
@@ -9,6 +9,10 @@ import {
   selectPackages,
   selectPayloadRepositories,
   selectRecommendedRepositories,
+  selectSnapshotDate,
+  selectTemplate,
+  selectTemplateName,
+  selectUseLatest,
   selectVerifiedLocaleLangpacks,
 } from './selectors';
 import {
@@ -54,8 +58,8 @@ const mapCustomRepos = createSelector(
 
     const combined = [...cleaned];
 
-    for (const repo in recommendedRepositories) {
-      combined.push(convertSchemaToIBCustomRepo(recommendedRepositories[repo]));
+    for (const repo of recommendedRepositories) {
+      combined.push(convertSchemaToIBCustomRepo(repo));
     }
 
     if (combined.length === 0) {
@@ -71,10 +75,8 @@ const mapPayloadRepos = createSelector(
   (payloadRepositories, recommendedRepositories) => {
     const combined = [...payloadRepositories];
 
-    for (const repo in recommendedRepositories) {
-      combined.push(
-        convertSchemaToIBPayloadRepo(recommendedRepositories[repo]),
-      );
+    for (const repo of recommendedRepositories) {
+      combined.push(convertSchemaToIBPayloadRepo(repo));
     }
 
     if (combined.length === 0) {
@@ -92,5 +94,49 @@ export const mapContentCustomizations = createSelector(
     ...modules,
     ...customRepositories,
     ...payloadRepositories,
+  }),
+);
+
+const mapTemplate = createSelector([selectTemplate], (template) => {
+  if (!template) {
+    return undefined;
+  }
+
+  return {
+    content_template: template,
+  };
+});
+
+const mapTemplateName = createSelector([selectTemplateName], (name) => {
+  if (!name) {
+    return undefined;
+  }
+
+  return {
+    content_template_name: name,
+  };
+});
+
+const mapSnapshotDate = createSelector(
+  [selectUseLatest, selectTemplate, selectSnapshotDate],
+  (useLatest, template, snapshot) => {
+    // Only include snapshot_date when using snapshot mode (not latest or template)
+    // Convert empty strings to undefined
+    if (useLatest || template || !snapshot) {
+      return undefined;
+    }
+
+    return {
+      snapshot_date: snapshot,
+    };
+  },
+);
+
+export const mapContentImageRequest = createSelector(
+  [mapTemplate, mapTemplateName, mapSnapshotDate],
+  (template, name, snapshot) => ({
+    ...template,
+    ...name,
+    ...snapshot,
   }),
 );

--- a/src/store/slices/wizard/mappers.ts
+++ b/src/store/slices/wizard/mappers.ts
@@ -4,9 +4,21 @@
 // customizations object.
 import { createSelector } from '@reduxjs/toolkit';
 
+import {
+  mapAwsUploadRequest,
+  mapAzureUploadRequest,
+  mapGcpUploadRequest,
+} from './cloud';
 import { mapComplianceCustomizations } from './compliance';
-import { mapContentCustomizations } from './content';
+import { mapContentCustomizations, mapContentImageRequest } from './content';
 import { mapFilesystemCustomizations } from './filesystem';
+import {
+  OCI_UPLOAD_OPTIONS,
+  S3_UPLOAD_OPTIONS,
+  selectArchitecture,
+  selectImageTypes,
+  type SupportedImageTypes,
+} from './output';
 import {
   mapRegistrationCustomizations,
   mapSatelliteFiles,
@@ -49,4 +61,50 @@ export const mapCustomizations = createSelector(
       ...system,
     },
   }),
+);
+
+const mapUploadRequest = createSelector(
+  [mapAwsUploadRequest, mapAzureUploadRequest, mapGcpUploadRequest],
+  (awsUploadOptions, azureUploadOptions, gcpOptions) => {
+    return {
+      aws: awsUploadOptions,
+      ami: awsUploadOptions,
+      azure: azureUploadOptions,
+      vhd: azureUploadOptions,
+      gcp: gcpOptions,
+      oci: OCI_UPLOAD_OPTIONS,
+      wsl: S3_UPLOAD_OPTIONS,
+      'guest-image': S3_UPLOAD_OPTIONS,
+      'image-installer': S3_UPLOAD_OPTIONS,
+      'bootable-container-iso': S3_UPLOAD_OPTIONS,
+      'network-installer': S3_UPLOAD_OPTIONS,
+      vsphere: S3_UPLOAD_OPTIONS,
+      'vsphere-ova': S3_UPLOAD_OPTIONS,
+      'pxe-tar-xz': S3_UPLOAD_OPTIONS,
+    } satisfies Record<SupportedImageTypes, { upload_request: unknown }>;
+  },
+);
+
+export const mapImageRequests = createSelector(
+  [
+    selectImageTypes,
+    selectArchitecture,
+    mapContentImageRequest,
+    mapUploadRequest,
+  ],
+  (
+    imageTypes,
+    architecture,
+    contentStateToImageRequest,
+    uploadRequestOptions,
+  ) => {
+    return {
+      image_requests: imageTypes.map((imageType) => ({
+        architecture,
+        image_type: imageType,
+        ...uploadRequestOptions[imageType],
+        ...contentStateToImageRequest,
+      })),
+    };
+  },
 );

--- a/src/store/slices/wizard/mappers.ts
+++ b/src/store/slices/wizard/mappers.ts
@@ -4,6 +4,9 @@
 // customizations object.
 import { createSelector } from '@reduxjs/toolkit';
 
+import type { CreateBlueprintRequest } from '@/store/api/backend';
+import type { RootState } from '@/store/index';
+
 import {
   mapAwsUploadRequest,
   mapAzureUploadRequest,
@@ -11,11 +14,18 @@ import {
 } from './cloud';
 import { mapComplianceCustomizations } from './compliance';
 import { mapContentCustomizations, mapContentImageRequest } from './content';
+import {
+  selectBlueprintDescription,
+  selectBlueprintName,
+  selectMetadata,
+} from './details';
 import { mapFilesystemCustomizations } from './filesystem';
 import {
+  mapBootcOptions,
   OCI_UPLOAD_OPTIONS,
   S3_UPLOAD_OPTIONS,
   selectArchitecture,
+  selectDistribution,
   selectImageTypes,
   type SupportedImageTypes,
 } from './output';
@@ -108,3 +118,21 @@ export const mapImageRequests = createSelector(
     };
   },
 );
+
+// This function breaks the pattern of using `createSelector`. The reason
+// for this is that it is the top-level composer and it is the entry point
+// to the mapping functions. This function is called from event handlers
+// and never during render, so using an RTK derived selector for that doesn't
+// really make sense. Whereas the middle layer mappers are declarative and
+// composable in nature.
+export const mapStateToRequest = (
+  state: RootState,
+): CreateBlueprintRequest => ({
+  name: selectBlueprintName(state),
+  metadata: selectMetadata(state),
+  description: selectBlueprintDescription(state),
+  distribution: selectDistribution(state),
+  ...mapBootcOptions(state),
+  ...mapImageRequests(state),
+  ...mapCustomizations(state),
+});

--- a/src/store/slices/wizard/output/constants.ts
+++ b/src/store/slices/wizard/output/constants.ts
@@ -23,3 +23,17 @@ export const EDGE_TYPES = [
   'rhel-edge-commit',
   'rhel-edge-installer',
 ] as const;
+
+export const S3_UPLOAD_OPTIONS = {
+  upload_request: {
+    type: 'aws.s3' as const,
+    options: {},
+  },
+};
+
+export const OCI_UPLOAD_OPTIONS = {
+  upload_request: {
+    type: 'oci.objectstorage' as const,
+    options: {},
+  },
+};

--- a/src/store/slices/wizard/output/index.ts
+++ b/src/store/slices/wizard/output/index.ts
@@ -1,4 +1,5 @@
 export * from './constants';
+export * from './mappers';
 export * from './selectors';
 export * from './slice';
 export { initialState as outputState } from './state';

--- a/src/store/slices/wizard/output/mappers.ts
+++ b/src/store/slices/wizard/output/mappers.ts
@@ -1,0 +1,66 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+import {
+  selectBootcDistributions,
+  selectImageSource,
+  selectImageTypes,
+  selectIsoPayloadReference,
+} from './selectors';
+
+import { selectIsImageMode } from '../details';
+
+const mapBootcReference = createSelector(
+  [
+    selectIsImageMode,
+    selectImageTypes,
+    selectImageSource,
+    selectBootcDistributions,
+  ],
+  (isImageMode, imageTypes, imageSource, distributions) => {
+    if (isImageMode && imageSource) {
+      const selectedDistro = distributions.find(
+        (d) => d.reference === imageSource,
+      );
+
+      if (selectedDistro && imageTypes.length > 0) {
+        const match = distributions.find(
+          (d) => d.name === selectedDistro.name && d.type === imageTypes[0],
+        );
+        if (match) {
+          return match.reference;
+        }
+      }
+
+      return imageSource;
+    }
+
+    return undefined;
+  },
+);
+
+const mapPayloadReference = createSelector(
+  [selectImageTypes, selectIsoPayloadReference],
+  (imageTypes, isoPayloadRef) => {
+    if (imageTypes[0] !== 'bootable-container-iso' || !isoPayloadRef) {
+      return undefined;
+    }
+
+    return { iso_payload_reference: isoPayloadRef };
+  },
+);
+
+export const mapBootcOptions = createSelector(
+  [mapBootcReference, mapPayloadReference],
+  (bootcReference, payloadReference) => {
+    if (!bootcReference) {
+      return undefined;
+    }
+
+    return {
+      bootc: {
+        reference: bootcReference,
+        ...payloadReference,
+      },
+    };
+  },
+);


### PR DESCRIPTION
## Summary

Refactors the image request mapping logic from an imperative utility module into composable `createSelector` mappers colocated with their respective store slices, eliminating the indirection layer in `requestMapper.ts`.

## Changes

- Extract cloud upload options (AWS, Azure, GCP), bootc reference, and image request assembly into composable `createSelector` mappers in their respective wizard store slices
- Compose `mapStateToRequest` as a top-level pure function over the selector chain, replacing the imperative `mapRequestFromState` that took a raw `Store`
- Move store access into dropdown consumers via `useAppStore`, keeping evaluation lazy (on click) to avoid running selectors against incomplete wizard state during renders
- Add `satisfies Record<SupportedImageTypes, ...>` to the upload request lookup table so the compiler catches missing image types (the old `switch` had a `default: throw` guard; the new table now gets equivalent safety at compile time)
- Add `no-restricted-syntax` ESLint rule to gate `useAppStore` imports — requires an `eslint-disable` with justification at each call site
- Fix pre-existing `for...in` → `for...of` bug in `content/mappers.ts` where `recommendedRepositories` iterated string indices instead of repository objects


JIRA: [HMS-10944](https://issues.redhat.com/browse/HMS-10944)

[HMS-10944]: https://redhat.atlassian.net/browse/HMS-10944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ