### PR TITLE
Wizard: Review step revamp (HMS-10785)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -172,7 +172,7 @@ const CreateImageWizard = () => {
     detailsValidation.disabledNext ||
     registrationValidation.disabledNext ||
     snapshotValidation.disabledNext ||
-    (restrictions.users.required && usersHaveErrors);
+    (restrictions.users.isStandalone && usersHaveErrors);
 
   const advancedSettingsHasErrors =
     filesystemValidation.disabledNext ||
@@ -183,7 +183,7 @@ const CreateImageWizard = () => {
     servicesValidation.disabledNext ||
     firewallValidation.disabledNext ||
     firstBootValidation.disabledNext ||
-    (!(restrictions.users.shouldHide || restrictions.users.required) &&
+    (!(restrictions.users.shouldHide || restrictions.users.isStandalone) &&
       usersHaveErrors);
 
   useEffect(() => {
@@ -506,8 +506,10 @@ const CreateImageWizard = () => {
               !(
                 restrictions.openscap.shouldHide && restrictions.fips.shouldHide
               ) && <OscapStep key='oscap' />,
-              restrictions.users.required && <UserGroupsStep key='groups' />,
-              restrictions.users.required && <UsersStep key='users' />,
+              restrictions.users.isStandalone && (
+                <UserGroupsStep key='groups' />
+              ),
+              restrictions.users.isStandalone && <UsersStep key='users' />,
             ]
               .filter(Boolean)
               .flatMap((component, index, array) =>
@@ -567,7 +569,8 @@ const CreateImageWizard = () => {
             restrictions.kernel.shouldHide &&
             restrictions.services.shouldHide &&
             restrictions.firewall.shouldHide &&
-            (restrictions.users.shouldHide || restrictions.users.required) &&
+            (restrictions.users.shouldHide ||
+              restrictions.users.isStandalone) &&
             restrictions.firstBoot.shouldHide
           }
           footer={
@@ -609,10 +612,10 @@ const CreateImageWizard = () => {
                 <FirewallStep key='firewall' />
               ),
               !(
-                restrictions.users.shouldHide || restrictions.users.required
+                restrictions.users.shouldHide || restrictions.users.isStandalone
               ) && <UserGroupsStep key='groups' />,
               !(
-                restrictions.users.shouldHide || restrictions.users.required
+                restrictions.users.shouldHide || restrictions.users.isStandalone
               ) && <UsersStep key='users' />,
               !restrictions.firstBoot.shouldHide && (
                 <FirstBootStep key='firstboot' />

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Filesystem.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Filesystem.tsx
@@ -1,51 +1,171 @@
 import React from 'react';
 
-import { Label } from '@patternfly/react-core';
+import { Flex } from '@patternfly/react-core';
 
 import { useAppSelector } from '@/store/hooks';
 import {
+  selectDiskMinsize,
+  selectDiskUnit,
+  selectFilesystemPartitions,
   selectFscMode,
-  selectFSConfigurationsCount,
   selectImageMinSize,
+  selectPlainPartitions,
+  selectVolumeGroups,
 } from '@/store/slices';
 
-import { ReviewGroup } from '../../shared';
+import { FlexColumn, ReviewGroup, ReviewSection } from '../../shared';
 import { Hideable } from '../../types';
 
 export const Filesystem = ({ shouldHide }: Hideable) => {
-  const partitionType = useAppSelector(selectFscMode);
+  const mode = useAppSelector(selectFscMode);
   const minSize = useAppSelector(selectImageMinSize);
-  const configurations = useAppSelector(selectFSConfigurationsCount);
+  const diskMinsize = useAppSelector(selectDiskMinsize);
+  const diskUnit = useAppSelector(selectDiskUnit);
+  const plainPartitions = useAppSelector(selectPlainPartitions);
+  const volumeGroups = useAppSelector(selectVolumeGroups);
+  const basicPartitions = useAppSelector(selectFilesystemPartitions);
 
   if (shouldHide) {
     return null;
   }
 
+  const partitioningLabel =
+    mode === 'automatic'
+      ? 'Automatic partitioning'
+      : mode === 'advanced'
+        ? 'Advanced disk partitioning'
+        : 'Manual partitioning';
+
   return (
-    <>
+    <ReviewSection title='File system configurations'>
       <ReviewGroup
-        heading='Filesystem configurations'
-        className={partitionType !== 'basic' ? 'pf-v6-u-mb-md' : ''}
-        description={
-          <>
-            {configurations > 0 ? configurations : null}
-            <Label
-              className={configurations > 0 ? 'pf-v6-u-ml-md' : ''}
-              color='yellow'
-              isCompact
-            >
-              {partitionType === 'automatic' ? 'Automatic' : 'Manual'}
-            </Label>
-          </>
-        }
+        heading='Partitioning type'
+        description={partitioningLabel}
       />
-      {partitionType !== 'automatic' && minSize && (
+      {mode === 'basic' && minSize !== undefined && (
         <ReviewGroup
           heading='Image size (minimum)'
           description={minSize < 1 ? 'Less than 1GiB' : `${minSize} GiB`}
-          className='pf-v6-u-mb-md'
         />
       )}
-    </>
+      {mode === 'basic' && basicPartitions.length > 0 && (
+        <ReviewGroup
+          heading='Partitions'
+          description={
+            <Flex>
+              <FlexColumn
+                heading='Mount point'
+                labelKey='basic-partition-mount'
+                items={basicPartitions.map((p) => p.mountpoint)}
+              />
+              <FlexColumn
+                heading='Minimum'
+                labelKey='basic-partition-size'
+                items={basicPartitions.map((p) => p.min_size)}
+              />
+              <FlexColumn
+                heading='Unit'
+                labelKey='basic-partition-unit'
+                items={basicPartitions.map((p) => p.unit)}
+              />
+            </Flex>
+          }
+        />
+      )}
+      {mode === 'advanced' && diskMinsize && (
+        <ReviewGroup
+          heading='Minimum disk size'
+          description={`${diskMinsize} ${diskUnit}`}
+        />
+      )}
+      {mode === 'advanced' && plainPartitions.length > 0 && (
+        <ReviewGroup
+          heading='Partitions'
+          description={
+            <Flex>
+              <FlexColumn
+                heading='Mount point'
+                labelKey='adv-partition-mount'
+                items={plainPartitions.map((p) =>
+                  'mountpoint' in p ? (p.mountpoint ?? '--') : '--',
+                )}
+              />
+              <FlexColumn
+                heading='Type'
+                labelKey='adv-partition-type'
+                items={plainPartitions.map((p) =>
+                  'fs_type' in p ? p.fs_type : '--',
+                )}
+              />
+              <FlexColumn
+                heading='Minimum'
+                labelKey='adv-partition-size'
+                items={plainPartitions.map((p) => p.min_size ?? '--')}
+              />
+              <FlexColumn
+                heading='Unit'
+                labelKey='adv-partition-unit'
+                items={plainPartitions.map((p) => p.unit ?? '--')}
+              />
+            </Flex>
+          }
+        />
+      )}
+      {mode === 'advanced' &&
+        volumeGroups.map((vg, vgIndex) => (
+          <React.Fragment key={`vg-${vgIndex}`}>
+            {vg.name && (
+              <ReviewGroup
+                heading='Volume group manager'
+                description={vg.name}
+              />
+            )}
+            {(vg.min_size || vg.minsize) && (
+              <ReviewGroup
+                heading='Minimum group size'
+                description={`${vg.min_size || vg.minsize} ${vg.unit ?? 'GiB'}`}
+              />
+            )}
+            {vg.logical_volumes.length > 0 && (
+              <ReviewGroup
+                heading='Logical volumes'
+                description={
+                  <Flex>
+                    <FlexColumn
+                      heading='Name'
+                      labelKey={`lv-name-${vgIndex}`}
+                      items={vg.logical_volumes.map((lv) => lv.name ?? '--')}
+                    />
+                    <FlexColumn
+                      heading='Mount point'
+                      labelKey={`lv-mount-${vgIndex}`}
+                      items={vg.logical_volumes.map(
+                        (lv) => lv.mountpoint ?? '--',
+                      )}
+                    />
+                    <FlexColumn
+                      heading='Type'
+                      labelKey={`lv-type-${vgIndex}`}
+                      items={vg.logical_volumes.map((lv) => lv.fs_type)}
+                    />
+                    <FlexColumn
+                      heading='Minimum'
+                      labelKey={`lv-size-${vgIndex}`}
+                      items={vg.logical_volumes.map(
+                        (lv) => lv.min_size ?? '--',
+                      )}
+                    />
+                    <FlexColumn
+                      heading='Unit'
+                      labelKey={`lv-unit-${vgIndex}`}
+                      items={vg.logical_volumes.map((lv) => lv.unit ?? 'GiB')}
+                    />
+                  </Flex>
+                }
+              />
+            )}
+          </React.Fragment>
+        ))}
+    </ReviewSection>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Firewall.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Firewall.tsx
@@ -5,7 +5,7 @@ import { Flex } from '@patternfly/react-core';
 import { useAppSelector } from '@/store/hooks';
 import { selectFirewall, selectFirewallEnabled } from '@/store/slices';
 
-import { FlexColumn, ReviewGroup, StatusItem } from '../../shared';
+import { FlexColumn, ReviewGroup, ReviewSection } from '../../shared';
 import { Hideable } from '../../types';
 
 const padArray = (arr: string[], length: number): string[] => {
@@ -35,28 +35,29 @@ export const Firewall = ({ shouldHide }: Hideable) => {
   }
 
   return (
-    <>
+    <ReviewSection title='Firewall'>
       <ReviewGroup
-        heading='Firewall'
-        description={<StatusItem>Enabled</StatusItem>}
+        heading='Firewall designations'
+        description={
+          <Flex>
+            <FlexColumn
+              heading='Port'
+              items={ports}
+              labelKey='firewall-review-port'
+            />
+            <FlexColumn
+              heading='Enabled services'
+              items={enabled}
+              labelKey='firewall-review-enabled'
+            />
+            <FlexColumn
+              heading='Disabled services'
+              items={disabled}
+              labelKey='firewall-review-disabled'
+            />
+          </Flex>
+        }
       />
-      <Flex>
-        <FlexColumn
-          heading='Ports'
-          items={ports}
-          labelKey='firewall-review-port'
-        />
-        <FlexColumn
-          heading='Enabled services'
-          items={enabled}
-          labelKey='firewall-review-enabled'
-        />
-        <FlexColumn
-          heading='Disabled services'
-          items={disabled}
-          labelKey='firewall-review-disabled'
-        />
-      </Flex>
-    </>
+    </ReviewSection>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Firstboot.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Firstboot.tsx
@@ -1,24 +1,54 @@
-import React from 'react';
+import React, { useState } from 'react';
+
+import {
+  CodeBlock,
+  CodeBlockCode,
+  ExpandableSection,
+} from '@patternfly/react-core';
 
 import { useAppSelector } from '@/store/hooks';
 import { selectFirstBootScript } from '@/store/slices';
 
-import { ReviewGroup, StatusItem } from '../../shared';
+import { ReviewGroup, ReviewSection } from '../../shared';
 import { Hideable } from '../../types';
+
+const MAX_LINES = 8;
 
 export const Firstboot = ({ shouldHide }: Hideable) => {
   const script = useAppSelector(selectFirstBootScript);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   if (shouldHide || !script) {
     return null;
   }
 
+  const lines = script.split('\n');
+  const needsTruncation = lines.length > MAX_LINES;
+  const displayedScript = needsTruncation
+    ? lines.slice(0, MAX_LINES).join('\n')
+    : script;
+
   return (
-    <>
+    <ReviewSection title='First boot configuration'>
       <ReviewGroup
-        heading='First boot configuration'
-        description={<StatusItem>Configured</StatusItem>}
+        heading='Custom script'
+        description={
+          <CodeBlock>
+            <CodeBlockCode>{displayedScript}</CodeBlockCode>
+            {needsTruncation && (
+              <ExpandableSection
+                toggleText={isExpanded ? 'Show less' : 'Show more'}
+                isExpanded={isExpanded}
+                onToggle={(_event, expanded) => setIsExpanded(expanded)}
+              >
+                <CodeBlockCode>
+                  {lines.slice(MAX_LINES).join('\n')}
+                </CodeBlockCode>
+              </ExpandableSection>
+            )}
+          </CodeBlock>
+        }
       />
-    </>
+    </ReviewSection>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Hostname.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Hostname.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useAppSelector } from '@/store/hooks';
 import { selectHostname } from '@/store/slices';
 
-import { ReviewGroup } from '../../shared';
+import { ReviewGroup, ReviewSection } from '../../shared';
 import { Hideable } from '../../types';
 
 export const Hostname = ({ shouldHide }: Hideable) => {
@@ -14,10 +14,8 @@ export const Hostname = ({ shouldHide }: Hideable) => {
   }
 
   return (
-    <ReviewGroup
-      heading='Hostname'
-      description={hostname}
-      className='pf-v6-u-mb-md'
-    />
+    <ReviewSection title='Hostname'>
+      <ReviewGroup heading='Name' description={hostname} />
+    </ReviewSection>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Kernel.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Kernel.tsx
@@ -4,7 +4,7 @@ import { useAppSelector } from '@/store/hooks';
 import { selectKernel } from '@/store/slices';
 
 import { sortOpenscapItems } from '../../helpers';
-import { LabelMapper, ReviewGroup } from '../../shared';
+import { LabelMapper, ReviewGroup, ReviewSection } from '../../shared';
 import { Hideable } from '../../types';
 
 type KernelProps = Hideable & {
@@ -24,17 +24,13 @@ export const Kernel = ({ shouldHide, oscapKernelArgs = [] }: KernelProps) => {
   }
 
   return (
-    <>
+    <ReviewSection title='Kernel'>
       {name !== '' && (
-        <ReviewGroup
-          heading='Kernel package'
-          description={name}
-          className={append.length > 0 ? '' : 'pf-v6-u-mb-md'}
-        />
+        <ReviewGroup heading='Kernel package' description={name} />
       )}
       {args.length > 0 && (
         <ReviewGroup
-          heading='Args'
+          heading='Arguments'
           description={
             <LabelMapper
               id='kernel-append-review'
@@ -44,9 +40,8 @@ export const Kernel = ({ shouldHide, oscapKernelArgs = [] }: KernelProps) => {
               oscapItems={oscapKernelArgs}
             />
           }
-          className='pf-v6-u-mb-md'
         />
       )}
-    </>
+    </ReviewSection>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Locale.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Locale.tsx
@@ -5,7 +5,7 @@ import { Content } from '@patternfly/react-core';
 import { useAppSelector } from '@/store/hooks';
 import { selectKeyboard, selectLanguages } from '@/store/slices';
 
-import { ReviewGroup } from '../../shared';
+import { ReviewGroup, ReviewSection } from '../../shared';
 import { Hideable } from '../../types';
 
 export const Locale = ({ shouldHide }: Hideable) => {
@@ -17,25 +17,18 @@ export const Locale = ({ shouldHide }: Hideable) => {
   }
 
   return (
-    <>
+    <ReviewSection title='Locale'>
       {languages && languages.length > 0 && (
         <ReviewGroup
-          heading='Language'
+          heading={languages.length > 1 ? 'Languages' : 'Language'}
           description={languages.map((language, index) => (
             <Content component='p' key={`language-review-${index}`}>
               {language}
             </Content>
           ))}
-          className={keyboard ? '' : 'pf-v6-u-mb-md'}
         />
       )}
-      {keyboard && (
-        <ReviewGroup
-          heading='Keyboard'
-          description={keyboard}
-          className='pf-v6-u-mb-md'
-        />
-      )}
-    </>
+      {keyboard && <ReviewGroup heading='Keyboard' description={keyboard} />}
+    </ReviewSection>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Services.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Services.tsx
@@ -4,7 +4,7 @@ import { useAppSelector } from '@/store/hooks';
 import { selectServices } from '@/store/slices';
 
 import { sortOpenscapItems } from '../../helpers';
-import { LabelMapper, ReviewGroup } from '../../shared';
+import { LabelMapper, ReviewGroup, ReviewSection } from '../../shared';
 import { Hideable } from '../../types';
 
 type OscapServices = {
@@ -46,7 +46,7 @@ export const Services = ({
   }
 
   return (
-    <>
+    <ReviewSection title='Systemd services'>
       <ReviewGroup
         heading='Enabled systemd services'
         description={
@@ -82,8 +82,7 @@ export const Services = ({
             oscapItems={oscapServices.masked}
           />
         }
-        className='pf-v6-u-mb-md'
       />
-    </>
+    </ReviewSection>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Timezone.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Timezone.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useAppSelector } from '@/store/hooks';
 import { selectNtpServers, selectTimezone } from '@/store/slices';
 
-import { LabelMapper, ReviewGroup } from '../../shared';
+import { LabelMapper, ReviewGroup, ReviewSection } from '../../shared';
 import { Hideable } from '../../types';
 
 export const Timezone = ({ shouldHide }: Hideable) => {
@@ -15,12 +15,8 @@ export const Timezone = ({ shouldHide }: Hideable) => {
   }
 
   return (
-    <>
-      <ReviewGroup
-        heading='Timezone'
-        description={timezone}
-        className={ntpServers && ntpServers.length > 0 ? '' : 'pf-v6-u-mb-md'}
-      />
+    <ReviewSection title='Timezone'>
+      <ReviewGroup heading='Timezone' description={timezone} />
       {ntpServers && ntpServers.length > 0 && (
         <ReviewGroup
           heading='NTP servers'
@@ -31,9 +27,8 @@ export const Timezone = ({ shouldHide }: Hideable) => {
               items={ntpServers}
             />
           }
-          className='pf-v6-u-mb-md'
         />
       )}
-    </>
+    </ReviewSection>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/UserGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/UserGroups.tsx
@@ -8,7 +8,7 @@ import { selectNonEmptyUserGroups } from '@/store/slices/wizard';
 import { FlexColumn, ReviewGroup } from '../../shared';
 import { Hideable } from '../../types';
 
-export const UserGroups = ({ shouldHide }: Hideable) => {
+export const UserGroups = ({ shouldHide }: Partial<Hideable>) => {
   const userGroups = useAppSelector(selectNonEmptyUserGroups);
 
   if (shouldHide || userGroups.length === 0) {
@@ -16,20 +16,22 @@ export const UserGroups = ({ shouldHide }: Hideable) => {
   }
 
   return (
-    <>
-      <ReviewGroup heading='User groups' />
-      <Flex flexWrap={{ default: 'nowrap' }}>
-        <FlexColumn
-          heading='Name'
-          labelKey='user-group-name-review'
-          items={userGroups.map(({ name }) => name)}
-        />
-        <FlexColumn
-          heading='Group ID'
-          labelKey='user-group-gid-review'
-          items={userGroups.map(({ gid }) => gid ?? 'None')}
-        />
-      </Flex>
-    </>
+    <ReviewGroup
+      heading='User groups'
+      description={
+        <Flex>
+          <FlexColumn
+            heading='Name'
+            labelKey='user-group-name-review'
+            items={userGroups.map(({ name }) => name)}
+          />
+          <FlexColumn
+            heading='ID'
+            labelKey='user-group-gid-review'
+            items={userGroups.map(({ gid }) => gid ?? 'None')}
+          />
+        </Flex>
+      }
+    />
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Users.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/components/Users.tsx
@@ -8,7 +8,7 @@ import { selectNonEmptyUsers } from '@/store/slices/wizard';
 import { FlexColumn, ReviewGroup, StatusItem } from '../../shared';
 import { Hideable } from '../../types';
 
-export const Users = ({ shouldHide }: Hideable) => {
+export const Users = ({ shouldHide }: Partial<Hideable>) => {
   const users = useAppSelector(selectNonEmptyUsers);
 
   if (shouldHide || users.length === 0) {
@@ -16,56 +16,58 @@ export const Users = ({ shouldHide }: Hideable) => {
   }
 
   return (
-    <>
-      <ReviewGroup heading='Users' />
-      <Flex flexWrap={{ default: 'nowrap' }} style={{ overflowX: 'auto' }}>
-        <FlexColumn
-          heading='Username'
-          labelKey='user-name-review'
-          items={users.map(({ name }) => name)}
-        />
-        <FlexColumn
-          heading='Password'
-          labelKey='user-password-review'
-          items={users.map((_) => '*****')}
-        />
-        <FlexColumn
-          heading='SSH key'
-          labelKey='user-sshkey-review'
-          items={users.map(({ ssh_key }, index) => (
-            <Truncate
-              key={`inner-ssh-key-${index}`}
-              content={ssh_key}
-              position='end'
-              maxCharsDisplayed={15}
-            />
-          ))}
-        />
-        <FlexColumn
-          heading='Groups'
-          labelKey='user-groups-review'
-          items={users.map(({ groups }, index) => (
-            <Truncate
-              key={`inner-groups-key-${index}`}
-              content={groups.filter((group) => group.trim()).join(', ')}
-              position='end'
-              maxCharsDisplayed={15}
-            />
-          ))}
-        />
-        <FlexColumn
-          heading='Administrator'
-          labelKey='user-admin-review'
-          items={users.map(({ isAdministrator }, index) => (
-            <StatusItem
-              key={`inner-admin-key-${index}`}
-              variant={isAdministrator ? 'success' : 'danger'}
-            >
-              {isAdministrator ? 'Enabled' : 'Disabled'}
-            </StatusItem>
-          ))}
-        />
-      </Flex>
-    </>
+    <ReviewGroup
+      heading='Custom users'
+      description={
+        <Flex>
+          <FlexColumn
+            heading='Username'
+            labelKey='user-name-review'
+            items={users.map(({ name }) => name)}
+          />
+          <FlexColumn
+            heading='Password'
+            labelKey='user-password-review'
+            items={users.map((_) => '*****')}
+          />
+          <FlexColumn
+            heading='SSH Key'
+            labelKey='user-sshkey-review'
+            items={users.map(({ ssh_key }, index) => (
+              <Truncate
+                key={`inner-ssh-key-${index}`}
+                content={ssh_key}
+                position='end'
+                maxCharsDisplayed={15}
+              />
+            ))}
+          />
+          <FlexColumn
+            heading='Groups'
+            labelKey='user-groups-review'
+            items={users.map(({ groups }, index) => (
+              <Truncate
+                key={`inner-groups-key-${index}`}
+                content={groups.filter((group) => group.trim()).join(', ')}
+                position='end'
+                maxCharsDisplayed={15}
+              />
+            ))}
+          />
+          <FlexColumn
+            heading='Administrator'
+            labelKey='user-admin-review'
+            items={users.map(({ isAdministrator }, index) => (
+              <StatusItem
+                key={`inner-admin-key-${index}`}
+                variant={isAdministrator ? 'success' : 'danger'}
+              >
+                {isAdministrator ? 'Enabled' : 'Disabled'}
+              </StatusItem>
+            ))}
+          />
+        </Flex>
+      }
+    />
   );
 };

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 
 import { Card, CardBody } from '@patternfly/react-core';
 
+import { useAppSelector } from '@/store/hooks';
+import { selectHasUserGroups, selectHasUsers } from '@/store/slices/wizard';
+
 import {
   Filesystem,
   Firewall,
@@ -15,7 +18,7 @@ import {
 } from './components';
 import { UserGroups } from './components/UserGroups';
 
-import { ReviewCardHeader, ReviewList } from '../shared';
+import { ReviewCardHeader, ReviewSection } from '../shared';
 import { ReviewCardProps } from '../types';
 
 type OscapServices = {
@@ -34,6 +37,11 @@ const AdvancedSettingsOverview = ({
   oscapKernelArgs = [],
   oscapServices,
 }: AdvancedSettingsOverviewProps) => {
+  const usersHidden =
+    restrictions.users.shouldHide || restrictions.users.required;
+  const hasUsers = !usersHidden && useAppSelector(selectHasUsers);
+  const hasUserGroups = !usersHidden && useAppSelector(selectHasUserGroups);
+
   return (
     <Card>
       <ReviewCardHeader
@@ -41,32 +49,30 @@ const AdvancedSettingsOverview = ({
         stepId='advanced-settings-step'
       />
       <CardBody>
-        <ReviewList>
-          <Filesystem shouldHide={restrictions.filesystem.shouldHide} />
-          <Timezone shouldHide={restrictions.timezone.shouldHide} />
-          <Locale shouldHide={restrictions.locale.shouldHide} />
-          <Hostname shouldHide={restrictions.hostname.shouldHide} />
-          <Kernel
-            shouldHide={restrictions.kernel.shouldHide}
-            oscapKernelArgs={oscapKernelArgs}
-          />
-          <Services
-            shouldHide={restrictions.services.shouldHide}
-            oscapServices={oscapServices}
-          />
-          <Firewall shouldHide={restrictions.firewall.shouldHide} />
-          <Users
-            shouldHide={
-              restrictions.users.shouldHide || restrictions.users.required
-            }
-          />
-          <UserGroups
-            shouldHide={
-              restrictions.users.shouldHide || restrictions.users.required
-            }
-          />
-          <Firstboot shouldHide={restrictions.firstBoot.shouldHide} />
-        </ReviewList>
+        <Filesystem shouldHide={restrictions.filesystem.shouldHide} />
+        <Timezone shouldHide={restrictions.timezone.shouldHide} />
+        <Locale shouldHide={restrictions.locale.shouldHide} />
+        <Hostname shouldHide={restrictions.hostname.shouldHide} />
+        <Kernel
+          shouldHide={restrictions.kernel.shouldHide}
+          oscapKernelArgs={oscapKernelArgs}
+        />
+        <Services
+          shouldHide={restrictions.services.shouldHide}
+          oscapServices={oscapServices}
+        />
+        <Firewall shouldHide={restrictions.firewall.shouldHide} />
+        {hasUserGroups && (
+          <ReviewSection title='Groups'>
+            <UserGroups />
+          </ReviewSection>
+        )}
+        {hasUsers && (
+          <ReviewSection title='Users'>
+            <Users />
+          </ReviewSection>
+        )}
+        <Firstboot shouldHide={restrictions.firstBoot.shouldHide} />
       </CardBody>
     </Card>
   );

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
@@ -38,9 +38,9 @@ const AdvancedSettingsOverview = ({
   oscapServices,
 }: AdvancedSettingsOverviewProps) => {
   const usersHidden =
-    restrictions.users.shouldHide || restrictions.users.required;
-  const hasUsers = !usersHidden && useAppSelector(selectHasUsers);
-  const hasUserGroups = !usersHidden && useAppSelector(selectHasUserGroups);
+    restrictions.users.shouldHide || restrictions.users.isStandalone;
+  const hasUsers = useAppSelector(selectHasUsers);
+  const hasUserGroups = useAppSelector(selectHasUserGroups);
 
   return (
     <Card>
@@ -62,12 +62,12 @@ const AdvancedSettingsOverview = ({
           oscapServices={oscapServices}
         />
         <Firewall shouldHide={restrictions.firewall.shouldHide} />
-        {hasUserGroups && (
+        {!usersHidden && hasUserGroups && (
           <ReviewSection title='Groups'>
             <UserGroups />
           </ReviewSection>
         )}
-        {hasUsers && (
+        {!usersHidden && hasUsers && (
           <ReviewSection title='Users'>
             <Users />
           </ReviewSection>

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -1280,11 +1280,11 @@ echo 'Hello there, General Kenobi!'`;
       expect(screen.getByText('User groups')).toBeInTheDocument();
     });
 
-    test('does not render users section when users are required', () => {
+    test('does not render users section when users are standalone', () => {
       renderWithRedux(
         <AdvancedSettingsOverview
           restrictions={createDefaultRestrictions({
-            users: { required: true },
+            users: { isStandalone: true },
           })}
         />,
         {

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -34,7 +34,7 @@ describe('AdvancedSettingsOverview', () => {
 
   describe('Filesystem', () => {
     describe('Automatic mode', () => {
-      test('displays "Automatic" label', () => {
+      test('displays automatic partitioning label', () => {
         renderWithRedux(
           <AdvancedSettingsOverview
             restrictions={createDefaultRestrictions()}
@@ -58,10 +58,10 @@ describe('AdvancedSettingsOverview', () => {
           },
         );
 
-        expect(screen.getByText('Automatic')).toBeInTheDocument();
+        expect(screen.getByText('Automatic partitioning')).toBeInTheDocument();
       });
 
-      test('does not show partition count or min size', () => {
+      test('does not show partitions or min size', () => {
         renderWithRedux(
           <AdvancedSettingsOverview
             restrictions={createDefaultRestrictions()}
@@ -88,11 +88,12 @@ describe('AdvancedSettingsOverview', () => {
         expect(
           screen.queryByText('Image size (minimum)'),
         ).not.toBeInTheDocument();
+        expect(screen.queryByText('Partitions')).not.toBeInTheDocument();
       });
     });
 
     describe('Basic mode', () => {
-      test('displays "Manual" label', () => {
+      test('displays manual partitioning label', () => {
         renderWithRedux(
           <AdvancedSettingsOverview
             restrictions={createDefaultRestrictions()}
@@ -118,10 +119,10 @@ describe('AdvancedSettingsOverview', () => {
           },
         );
 
-        expect(screen.getByText('Manual')).toBeInTheDocument();
+        expect(screen.getByText('Manual partitioning')).toBeInTheDocument();
       });
 
-      test('shows partition count', () => {
+      test('shows partition mount points', () => {
         renderWithRedux(
           <AdvancedSettingsOverview
             restrictions={createDefaultRestrictions()}
@@ -147,7 +148,9 @@ describe('AdvancedSettingsOverview', () => {
           },
         );
 
-        expect(screen.getByText('2')).toBeInTheDocument();
+        expect(screen.getByText('Partitions')).toBeInTheDocument();
+        expect(screen.getByText('/')).toBeInTheDocument();
+        expect(screen.getByText('/home')).toBeInTheDocument();
       });
 
       test('shows min size in GiB', () => {
@@ -182,7 +185,7 @@ describe('AdvancedSettingsOverview', () => {
     });
 
     describe('Advanced mode', () => {
-      test('displays "Manual" label', () => {
+      test('displays advanced disk partitioning label', () => {
         renderWithRedux(
           <AdvancedSettingsOverview
             restrictions={createDefaultRestrictions()}
@@ -206,10 +209,41 @@ describe('AdvancedSettingsOverview', () => {
           },
         );
 
-        expect(screen.getByText('Manual')).toBeInTheDocument();
+        expect(
+          screen.getByText('Advanced disk partitioning'),
+        ).toBeInTheDocument();
       });
 
-      test('shows combined partition and logical volume count', () => {
+      test('shows plain partition details', () => {
+        renderWithRedux(
+          <AdvancedSettingsOverview
+            restrictions={createDefaultRestrictions()}
+          />,
+          {
+            output: {
+              ...initialState.output,
+              imageTypes: ['guest-image'],
+            },
+            filesystem: {
+              mode: 'advanced',
+              disk: {
+                minsize: '',
+                unit: 'GiB',
+                type: 'gpt',
+                partitions: advancedPartitions.singlePlain,
+              },
+              fileSystem: { partitions: [] },
+              partitioningMode: undefined,
+            },
+          },
+        );
+
+        expect(screen.getByText('Partitions')).toBeInTheDocument();
+        expect(screen.getByText('/boot')).toBeInTheDocument();
+        expect(screen.getByText('ext4')).toBeInTheDocument();
+      });
+
+      test('shows volume group and logical volumes', () => {
         renderWithRedux(
           <AdvancedSettingsOverview
             restrictions={createDefaultRestrictions()}
@@ -233,37 +267,11 @@ describe('AdvancedSettingsOverview', () => {
           },
         );
 
-        // 1 partition + 2 logical volumes = 3
-        expect(screen.getByText('3')).toBeInTheDocument();
-      });
-
-      test('shows min size in GiB', () => {
-        renderWithRedux(
-          <AdvancedSettingsOverview
-            restrictions={createDefaultRestrictions()}
-          />,
-          {
-            output: {
-              ...initialState.output,
-              imageTypes: ['guest-image'],
-            },
-            filesystem: {
-              mode: 'advanced',
-              disk: {
-                minsize: '',
-                unit: 'GiB',
-                type: 'gpt',
-                partitions: advancedPartitions.withLvm,
-              },
-              fileSystem: { partitions: [] },
-              partitioningMode: undefined,
-            },
-          },
-        );
-
-        expect(screen.getByText('Image size (minimum)')).toBeInTheDocument();
-        // 1 (boot) + 10 (root lv) + 5 (home lv) = 16 GiB
-        expect(screen.getByText('16 GiB')).toBeInTheDocument();
+        expect(screen.getByText('Volume group manager')).toBeInTheDocument();
+        expect(screen.getByText('vg0')).toBeInTheDocument();
+        expect(screen.getByText('Logical volumes')).toBeInTheDocument();
+        expect(screen.getByText('root')).toBeInTheDocument();
+        expect(screen.getByText('home')).toBeInTheDocument();
       });
     });
 
@@ -318,7 +326,7 @@ describe('AdvancedSettingsOverview', () => {
         },
       );
 
-      expect(screen.getByText('Timezone')).toBeInTheDocument();
+      expect(screen.getAllByText('Timezone')).toHaveLength(2);
       expect(screen.getByText('America/New_York')).toBeInTheDocument();
     });
 
@@ -340,7 +348,7 @@ describe('AdvancedSettingsOverview', () => {
         },
       );
 
-      expect(screen.getByText('Timezone')).toBeInTheDocument();
+      expect(screen.getAllByText('Timezone')).toHaveLength(2);
     });
 
     test('displays NTP servers when configured', () => {
@@ -413,6 +421,28 @@ describe('AdvancedSettingsOverview', () => {
       expect(screen.getByText('us')).toBeInTheDocument();
     });
 
+    test('displays singular Language heading for one language', () => {
+      renderWithRedux(
+        <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
+        {
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
+          system: {
+            ...initialState.system,
+            locale: {
+              languages: ['en_US.UTF-8'],
+              keyboard: '',
+            },
+          },
+        },
+      );
+
+      expect(screen.getByText('Language')).toBeInTheDocument();
+      expect(screen.queryByText('Languages')).not.toBeInTheDocument();
+    });
+
     test('displays multiple languages', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
@@ -431,6 +461,7 @@ describe('AdvancedSettingsOverview', () => {
         },
       );
 
+      expect(screen.getByText('Languages')).toBeInTheDocument();
       expect(screen.getByText('en_US.UTF-8')).toBeInTheDocument();
       expect(screen.getByText('es_ES.UTF-8')).toBeInTheDocument();
       expect(screen.getByText('fr_FR.UTF-8')).toBeInTheDocument();
@@ -455,6 +486,7 @@ describe('AdvancedSettingsOverview', () => {
       );
 
       expect(screen.queryByText('Language')).not.toBeInTheDocument();
+      expect(screen.queryByText('Languages')).not.toBeInTheDocument();
       expect(screen.getByText('Keyboard')).toBeInTheDocument();
       expect(screen.getByText('us')).toBeInTheDocument();
     });
@@ -501,6 +533,7 @@ describe('AdvancedSettingsOverview', () => {
       );
 
       expect(screen.queryByText('Language')).not.toBeInTheDocument();
+      expect(screen.queryByText('Languages')).not.toBeInTheDocument();
       expect(screen.queryByText('Keyboard')).not.toBeInTheDocument();
     });
   });
@@ -519,6 +552,7 @@ describe('AdvancedSettingsOverview', () => {
       );
 
       expect(screen.getByText('Hostname')).toBeInTheDocument();
+      expect(screen.getByText('Name')).toBeInTheDocument();
       expect(screen.getByText('my-server.example.com')).toBeInTheDocument();
     });
 
@@ -579,7 +613,7 @@ describe('AdvancedSettingsOverview', () => {
         },
       );
 
-      expect(screen.getByText('Args')).toBeInTheDocument();
+      expect(screen.getByText('Arguments')).toBeInTheDocument();
       expect(
         screen.getByRole('list', { name: 'Kernel arguments' }),
       ).toBeInTheDocument();
@@ -608,7 +642,7 @@ describe('AdvancedSettingsOverview', () => {
 
       expect(screen.getByText('Kernel package')).toBeInTheDocument();
       expect(screen.getByText('kernel-debug')).toBeInTheDocument();
-      expect(screen.getByText('Args')).toBeInTheDocument();
+      expect(screen.getByText('Arguments')).toBeInTheDocument();
       expect(screen.getByText('debug')).toBeInTheDocument();
       expect(screen.getByText('console=ttyS0')).toBeInTheDocument();
     });
@@ -632,7 +666,7 @@ describe('AdvancedSettingsOverview', () => {
       );
 
       expect(screen.queryByText('Kernel package')).not.toBeInTheDocument();
-      expect(screen.queryByText('Args')).not.toBeInTheDocument();
+      expect(screen.queryByText('Arguments')).not.toBeInTheDocument();
     });
 
     test('displays user-selected kernel args with blue labels', () => {
@@ -975,7 +1009,10 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getByText('Configured')).toBeInTheDocument();
+      expect(screen.getByText('Custom script')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Hello there, General Kenobi/),
+      ).toBeInTheDocument();
     });
   });
 
@@ -1047,7 +1084,7 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getByText('Users')).toBeInTheDocument();
+      expect(screen.getAllByText('Users').length).toBeGreaterThan(0);
       expect(screen.getByText('admin')).toBeInTheDocument();
       expect(screen.getAllByText('*****')).toHaveLength(1);
     });
@@ -1064,7 +1101,7 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getByText('Users')).toBeInTheDocument();
+      expect(screen.getAllByText('Users').length).toBeGreaterThan(0);
     });
 
     test('does not display user columns when no users configured', () => {
@@ -1081,7 +1118,7 @@ echo 'Hello there, General Kenobi!'`;
 
       expect(screen.queryByText('Username')).not.toBeInTheDocument();
       expect(screen.queryByText('Password')).not.toBeInTheDocument();
-      expect(screen.queryByText('SSH key')).not.toBeInTheDocument();
+      expect(screen.queryByText('SSH Key')).not.toBeInTheDocument();
       expect(screen.queryByText('Groups')).not.toBeInTheDocument();
       expect(screen.queryByText('Administrator')).not.toBeInTheDocument();
     });
@@ -1100,7 +1137,7 @@ echo 'Hello there, General Kenobi!'`;
 
       expect(screen.getByText('Username')).toBeInTheDocument();
       expect(screen.getByText('Password')).toBeInTheDocument();
-      expect(screen.getByText('SSH key')).toBeInTheDocument();
+      expect(screen.getByText('SSH Key')).toBeInTheDocument();
       expect(screen.getByText('Groups')).toBeInTheDocument();
       expect(screen.getByText('Administrator')).toBeInTheDocument();
     });
@@ -1171,7 +1208,7 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getByText('SSH key')).toBeInTheDocument();
+      expect(screen.getByText('SSH Key')).toBeInTheDocument();
       expect(screen.getByText('ssh-rsa AAAA')).toBeInTheDocument();
     });
 
@@ -1239,7 +1276,7 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getByText('Users')).toBeInTheDocument();
+      expect(screen.getAllByText('Users').length).toBeGreaterThan(0);
       expect(screen.getByText('User groups')).toBeInTheDocument();
     });
 
@@ -1315,10 +1352,10 @@ echo 'Hello there, General Kenobi!'`;
       );
 
       expect(screen.getByText('Firewall')).toBeInTheDocument();
-      expect(screen.getByText('Enabled')).toBeInTheDocument();
+      expect(screen.getByText('Firewall designations')).toBeInTheDocument();
     });
 
-    test('displays firewall as enabled when services are configured', () => {
+    test('displays firewall section when services are configured', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
@@ -1339,7 +1376,7 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getByText('Enabled')).toBeInTheDocument();
+      expect(screen.getByText('Firewall designations')).toBeInTheDocument();
     });
 
     test('displays ports column', () => {
@@ -1363,7 +1400,7 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getByText('Ports')).toBeInTheDocument();
+      expect(screen.getByText('Port')).toBeInTheDocument();
       expect(screen.getByText('22/tcp')).toBeInTheDocument();
       expect(screen.getByText('443/tcp')).toBeInTheDocument();
       expect(screen.getByText('8080/tcp')).toBeInTheDocument();
@@ -1469,7 +1506,7 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getByText('Ports')).toBeInTheDocument();
+      expect(screen.getByText('Port')).toBeInTheDocument();
       expect(screen.getByText('Enabled services')).toBeInTheDocument();
       expect(screen.getByText('Disabled services')).toBeInTheDocument();
 
@@ -1501,7 +1538,7 @@ echo 'Hello there, General Kenobi!'`;
       );
 
       expect(screen.queryByText('Firewall')).not.toBeInTheDocument();
-      expect(screen.queryByText('Ports')).not.toBeInTheDocument();
+      expect(screen.queryByText('Port')).not.toBeInTheDocument();
       expect(screen.queryByText('Enabled services')).not.toBeInTheDocument();
       expect(screen.queryByText('Disabled services')).not.toBeInTheDocument();
     });

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
@@ -71,8 +71,8 @@ const ImageOverview = ({ restrictions }: ReviewCardProps) => {
             description={arch}
           />
           <ReviewGroup heading='Target environments' />
-          <PrivateClouds environments={privateClouds} />
           <PublicClouds environments={publicClouds} />
+          <PrivateClouds environments={privateClouds} />
           <MiscFormats environments={miscFormats} />
           <Users
             shouldHide={

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
@@ -76,12 +76,12 @@ const ImageOverview = ({ restrictions }: ReviewCardProps) => {
           <MiscFormats environments={miscFormats} />
           <Users
             shouldHide={
-              restrictions.users.shouldHide || !restrictions.users.required
+              restrictions.users.shouldHide || !restrictions.users.isStandalone
             }
           />
           <UserGroups
             shouldHide={
-              restrictions.users.shouldHide || !restrictions.users.required
+              restrictions.users.shouldHide || !restrictions.users.isStandalone
             }
           />
         </ReviewList>

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -348,7 +348,7 @@ describe('ImageOverview', () => {
         },
       );
 
-      expect(screen.getByText('Users')).toBeInTheDocument();
+      expect(screen.getByText('Custom users')).toBeInTheDocument();
       expect(screen.getByText('admin')).toBeInTheDocument();
       expect(screen.getByText('User groups')).toBeInTheDocument();
       expect(screen.getByText('developers')).toBeInTheDocument();
@@ -370,7 +370,7 @@ describe('ImageOverview', () => {
         },
       );
 
-      expect(screen.queryByText('Users')).not.toBeInTheDocument();
+      expect(screen.queryByText('Custom users')).not.toBeInTheDocument();
       expect(screen.queryByText('User groups')).not.toBeInTheDocument();
     });
   });

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -328,11 +328,11 @@ describe('ImageOverview', () => {
   });
 
   describe('Users', () => {
-    test('renders users + groups section when users are required', () => {
+    test('renders users + groups section when users are standalone', () => {
       renderWithRedux(
         <ImageOverview
           restrictions={createDefaultRestrictions({
-            users: { required: true },
+            users: { isStandalone: true },
           })}
         />,
         {

--- a/src/Components/CreateImageWizard/steps/Review/components/shared/ReviewSection.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/shared/ReviewSection.tsx
@@ -1,0 +1,22 @@
+import React, { PropsWithChildren } from 'react';
+
+import { Divider, Title } from '@patternfly/react-core';
+
+import { ReviewList } from './ReviewList';
+
+export const ReviewSection = ({
+  title,
+  children,
+}: PropsWithChildren<{ title: string }>) => {
+  return (
+    <>
+      <Title headingLevel='h3' size='md' className='pf-v6-u-mb-sm'>
+        {title}
+      </Title>
+      <div className='pf-v6-u-pl-lg'>
+        <ReviewList>{children}</ReviewList>
+      </div>
+      <Divider className='pf-v6-u-my-md' />
+    </>
+  );
+};

--- a/src/Components/CreateImageWizard/steps/Review/components/shared/index.ts
+++ b/src/Components/CreateImageWizard/steps/Review/components/shared/index.ts
@@ -4,4 +4,5 @@ export { LabelMapper } from './LabelMapper';
 export { ReviewCardHeader } from './ReviewCardHeader';
 export { ReviewGroup } from './ReviewGroup';
 export { ReviewList } from './ReviewList';
+export { ReviewSection } from './ReviewSection';
 export { StatusItem } from './StatusItem';

--- a/src/Components/CreateImageWizard/steps/Review/components/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/tests/helpers.tsx
@@ -13,7 +13,7 @@ export const createDefaultRestrictions = (
   for (const key of ALL_CUSTOMIZATIONS) {
     restrictions[key] = {
       shouldHide: false,
-      required: false,
+      isStandalone: false,
       ...overrides[key],
     };
   }

--- a/src/store/api/distributions/hooks.tsx
+++ b/src/store/api/distributions/hooks.tsx
@@ -115,7 +115,8 @@ export const computeRestrictions = ({
 
     result[customization] = {
       shouldHide: !supportedOptions.has(customization),
-      required: ctx.isImageMode && ctx.isOnPremise && customization === 'users',
+      isStandalone:
+        ctx.isImageMode && ctx.isOnPremise && customization === 'users',
     };
   }
 

--- a/src/store/api/distributions/tests/hooks.test.tsx
+++ b/src/store/api/distributions/tests/hooks.test.tsx
@@ -31,7 +31,7 @@ describe('useCustomizationRestrictions hook logic', () => {
 
       for (const customization of getAllCustomizationTypes()) {
         expect(result[customization].shouldHide).toBe(false);
-        expect(result[customization].required).toBe(false);
+        expect(result[customization].isStandalone).toBe(false);
       }
     });
   });
@@ -57,30 +57,30 @@ describe('useCustomizationRestrictions hook logic', () => {
       }
     });
 
-    it('should not mark users as required in hosted image mode', () => {
+    it('should not mark users as standalone in hosted image mode', () => {
       const result = computeRestrictionStrategy({
         isImageMode: true,
         isOnPremise: false,
       });
 
       for (const customization of getAllCustomizationTypes()) {
-        expect(result[customization].required).toBe(false);
+        expect(result[customization].isStandalone).toBe(false);
       }
     });
 
-    it('should mark users as required in on-premise image mode', () => {
+    it('should mark users as standalone in on-premise image mode', () => {
       const result = computeRestrictionStrategy({
         isImageMode: true,
         isOnPremise: true,
       });
 
-      expect(result.users.required).toBe(true);
+      expect(result.users.isStandalone).toBe(true);
 
       const nonUserTypes = getAllCustomizationTypes().filter(
         (c) => c !== 'users',
       );
       for (const customization of nonUserTypes) {
-        expect(result[customization].required).toBe(false);
+        expect(result[customization].isStandalone).toBe(false);
       }
     });
   });
@@ -120,7 +120,7 @@ describe('useCustomizationRestrictions hook logic', () => {
       });
 
       expect(result.registration.shouldHide).toBe(true);
-      expect(result.registration.required).toBe(false);
+      expect(result.registration.isStandalone).toBe(false);
     });
 
     it('should not hide registration for RHEL distributions', () => {
@@ -162,8 +162,8 @@ describe('useCustomizationRestrictions hook logic', () => {
       expect(result.repositories.shouldHide).toBe(true);
       expect(result.firstBoot.shouldHide).toBe(true);
 
-      // Users should be required on-premise
-      expect(result.users.required).toBe(true);
+      // Users should be standalone on-premise
+      expect(result.users.isStandalone).toBe(true);
     });
   });
 
@@ -178,7 +178,7 @@ describe('useCustomizationRestrictions hook logic', () => {
       for (const customization of getAllCustomizationTypes()) {
         expect(result[customization]).toBeDefined();
         expect(result[customization]).toHaveProperty('shouldHide');
-        expect(result[customization]).toHaveProperty('required');
+        expect(result[customization]).toHaveProperty('isStandalone');
       }
     });
   });
@@ -277,7 +277,7 @@ describe('useCustomizationRestrictions hook logic', () => {
 
       for (const customization of getAllCustomizationTypes()) {
         expect(result[customization].shouldHide).toBe(false);
-        expect(result[customization].required).toBe(false);
+        expect(result[customization].isStandalone).toBe(false);
       }
     });
   });
@@ -287,11 +287,11 @@ describe('RestrictionStrategy type', () => {
   it('should have correct structure', () => {
     const strategy: RestrictionStrategy = {
       shouldHide: false,
-      required: false,
+      isStandalone: false,
     };
 
     expect(strategy).toHaveProperty('shouldHide');
-    expect(strategy).toHaveProperty('required');
+    expect(strategy).toHaveProperty('isStandalone');
   });
 });
 

--- a/src/store/api/distributions/types.ts
+++ b/src/store/api/distributions/types.ts
@@ -48,5 +48,5 @@ export type DistributionDetailsCustomizationApi = DistributionDetails;
 
 export type RestrictionStrategy = {
   shouldHide: boolean;
-  required: boolean;
+  isStandalone: boolean;
 };

--- a/src/store/slices/wizard/filesystem/selectors.ts
+++ b/src/store/slices/wizard/filesystem/selectors.ts
@@ -3,7 +3,7 @@ import { createSelector } from '@reduxjs/toolkit';
 import { UNIT_GIB } from '@/constants';
 import { RootState } from '@/store';
 
-import { Units } from './types';
+import { Units, VolumeGroupWithExtendedLV } from './types';
 import { getConversionFactor } from './utilities';
 
 export const selectFscMode = (state: RootState) => {
@@ -33,6 +33,17 @@ export const selectFilesystemPartitions = (state: RootState) => {
 export const selectPartitioningMode = (state: RootState) => {
   return state.wizard.filesystem.partitioningMode;
 };
+
+export const selectPlainPartitions = createSelector(
+  [selectDiskPartitions],
+  (partitions) => partitions.filter((p) => p.type !== 'lvm'),
+);
+
+export const selectVolumeGroups = createSelector(
+  [selectDiskPartitions],
+  (partitions) =>
+    partitions.filter((p) => p.type === 'lvm') as VolumeGroupWithExtendedLV[],
+);
 
 export const selectBasicPartitionCount = createSelector(
   [selectFilesystemPartitions],

--- a/src/store/slices/wizard/system/selectors.ts
+++ b/src/store/slices/wizard/system/selectors.ts
@@ -77,6 +77,16 @@ export const selectLocaleLangpackCandidates = createSelector(
   },
 );
 
+export const selectHasUsers = createSelector(
+  [selectNonEmptyUsers],
+  (users) => users.length > 0,
+);
+
+export const selectHasUserGroups = createSelector(
+  [selectNonEmptyUserGroups],
+  (groups) => groups.length > 0,
+);
+
 export const selectFirewallEnabled = createSelector(
   [selectFirewall],
   (firewall) => {


### PR DESCRIPTION
Edit the Review step according to mocks.

Renamed `required` to `isStandalone` in `RestrictionStrategy`. The field controls whether the Users customization gets its own wizard step instead of being nested under Advanced Settings. The old name suggested a data validation constraint, but it actually determines where the section is placed in the UI. 

<img width="1518" height="882" alt="review-revamp" src="https://github.com/user-attachments/assets/3cc9bf44-562c-4dfe-8d1c-8b2e4a362bc6" />
