### PR TITLE
Move target environment data transformations into RTK Query derived endpoints (HMS-10955)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 
 import {
   Alert,
@@ -9,12 +9,11 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 
-import { useTargetEnvironmentCategories } from '@/Hooks';
 import { rhsmApi } from '@/store/api';
 import {
-  BootcDistributionItem,
-  useGetArchitecturesQuery,
-  useGetDistributionsQuery,
+  type Distributions,
+  useGetArchitectureEnvironmentsQuery,
+  useGetDistributionEnvironmentsQuery,
 } from '@/store/api/backend';
 import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
@@ -35,7 +34,6 @@ import Gcp from './Gcp';
 import TargetEnvironmentOption from './TargetEnvironmentOption';
 
 const TEXT_WRAP_WIDTH = '54rem';
-const EMPTY_ENVIRONMENTS: string[] = [];
 
 const createLabelWithTooltip = (
   prefix: string,
@@ -69,50 +67,24 @@ const TargetEnvironment = () => {
     selectedImageTypes: environments,
   });
 
-  const {
-    isError: isArchError,
-    isFetching: isArchFetching,
-    environments: archEnvironments,
-  } = useGetArchitecturesQuery(
-    {
-      distribution,
-    },
-    {
-      skip: isImageMode,
-      selectFromResult: ({ data, isFetching, isError }) => ({
-        isError,
-        isFetching,
-        environments:
-          data?.find((elem) => elem.arch === arch)?.image_types ??
-          // this is defined as a const for referential stability
-          EMPTY_ENVIRONMENTS,
-      }),
-    },
+  const archResult = useGetArchitectureEnvironmentsQuery(
+    { distribution: distribution as Distributions, arch },
+    { skip: isImageMode },
   );
 
-  const {
-    data: bootcDistributionsRaw,
-    isError: isBootcError,
-    isFetching: isBootcFetching,
-  } = useGetDistributionsQuery(
-    { kind: 'bootc', arch, distro: distribution },
+  const distroResult = useGetDistributionEnvironmentsQuery(
+    { arch, distro: distribution },
     { skip: !isImageMode },
   );
 
-  const bootcDistributions = bootcDistributionsRaw as
-    | BootcDistributionItem[]
-    | undefined;
+  const { data, isFetching, isError } = isImageMode ? distroResult : archResult;
 
-  const isFetching = isArchFetching || isBootcFetching;
-  const isError = isArchError || isBootcError;
-
-  const supportedEnvironments = useMemo(() => {
-    if (!isImageMode) return archEnvironments;
-
-    return [
-      ...new Set(bootcDistributions?.map((d) => d.type) ?? EMPTY_ENVIRONMENTS),
-    ];
-  }, [isImageMode, bootcDistributions, archEnvironments]);
+  const {
+    publicClouds = [],
+    privateClouds = [],
+    miscFormats = [],
+    hasEnvironments = false,
+  } = data ?? {};
 
   const dispatch = useAppDispatch();
   const prefetchActivationKeys = rhsmApi.usePrefetch('listActivationKeys');
@@ -141,7 +113,7 @@ const TargetEnvironment = () => {
     if (!isImageMode || !environments.includes('bootable-container-iso')) {
       return;
     }
-    const entry = bootcDistributions?.find(
+    const entry = distroResult.data?.distributions.find(
       (d) => d.type === 'bootable-container-iso' && d.distro === distribution,
     );
     const refs = entry?.iso_payload_references;
@@ -155,7 +127,7 @@ const TargetEnvironment = () => {
   }, [
     isImageMode,
     environments,
-    bootcDistributions,
+    distroResult.data,
     distribution,
     isoPayloadReference,
     dispatch,
@@ -166,9 +138,6 @@ const TargetEnvironment = () => {
 
   const isOtherEnvironmentSelected =
     environments.length >= 1 && !environments.includes('network-installer');
-
-  const { privateClouds, publicClouds, miscFormats } =
-    useTargetEnvironmentCategories(supportedEnvironments);
 
   if (isFetching) {
     return (
@@ -193,7 +162,7 @@ const TargetEnvironment = () => {
     );
   }
 
-  if (supportedEnvironments.length === 0) {
+  if (!hasEnvironments) {
     return (
       <FormGroup
         isRequired={true}

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -25,7 +25,9 @@ import {
   selectDistribution,
   selectImageTypes,
   selectIsImageMode,
+  selectIsOnlyNetworkInstallerSelected,
   selectIsoPayloadReference,
+  selectIsOtherEnvironmentSelected,
 } from '@/store/slices/wizard';
 
 import Aws from './Aws';
@@ -62,6 +64,12 @@ const TargetEnvironment = () => {
   const environments = useAppSelector(selectImageTypes);
   const distribution = useAppSelector(selectDistribution);
   const isImageMode = useAppSelector(selectIsImageMode);
+  const isOnlyNetworkInstallerSelected = useAppSelector(
+    selectIsOnlyNetworkInstallerSelected,
+  );
+  const isOtherEnvironmentSelected = useAppSelector(
+    selectIsOtherEnvironmentSelected,
+  );
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: environments,
@@ -132,12 +140,6 @@ const TargetEnvironment = () => {
     isoPayloadReference,
     dispatch,
   ]);
-
-  const isOnlyNetworkInstallerSelected =
-    environments.length === 1 && environments.includes('network-installer');
-
-  const isOtherEnvironmentSelected =
-    environments.length >= 1 && !environments.includes('network-installer');
 
   if (isFetching) {
     return (

--- a/src/store/api/backend/derived.ts
+++ b/src/store/api/backend/derived.ts
@@ -1,0 +1,133 @@
+import type { EndpointBuilder } from '@reduxjs/toolkit/query/react';
+
+import {
+  isPrivateCloud,
+  isPublicCloud,
+  type MiscFormatType,
+  type PrivateCloudType,
+  type PublicCloudType,
+} from '@/store/slices/wizard';
+
+import type {
+  BootcDistributionItem,
+  DistributionItem,
+  Distributions,
+} from './hosted';
+import { imageBuilderApi } from './hosted/enhancedImageBuilderApi';
+import { composerApi } from './onprem/enhancedComposerApi';
+
+export type CategorizedEnvironments = {
+  publicClouds: PublicCloudType[];
+  privateClouds: PrivateCloudType[];
+  miscFormats: MiscFormatType[];
+  hasEnvironments: boolean;
+};
+
+export type ArchitectureEnvironmentsResult = CategorizedEnvironments;
+
+export type DistributionEnvironmentsResult = CategorizedEnvironments & {
+  distributions: BootcDistributionItem[];
+};
+
+const isBootcDistribution = (
+  item: DistributionItem | BootcDistributionItem,
+): item is BootcDistributionItem => 'distro' in item;
+
+export const categorizeEnvironments = (
+  environments: string[],
+): CategorizedEnvironments => ({
+  publicClouds: environments.filter((env): env is PublicCloudType =>
+    isPublicCloud(env),
+  ),
+  privateClouds: environments.filter((env): env is PrivateCloudType =>
+    isPrivateCloud(env),
+  ),
+  miscFormats: environments.filter(
+    (env): env is MiscFormatType => !isPublicCloud(env) && !isPrivateCloud(env),
+  ),
+  hasEnvironments: environments.length > 0,
+});
+
+// backendApi is a build-time conditional (composerApi | imageBuilderApi)
+// that resolves to exactly one API slice at runtime. TypeScript sees a
+// union type which makes injectEndpoints/queryFn inference unwieldy.
+// Since the runtime value is always a single concrete slice, the cast
+// on the builder parameter is safe.
+const backendApi = (
+  process.env.IS_ON_PREMISE ? composerApi : imageBuilderApi
+) as typeof composerApi;
+
+const derivedApi = backendApi.injectEndpoints({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  endpoints: (builder: EndpointBuilder<any, any, any>) => ({
+    getArchitectureEnvironments: builder.query<
+      ArchitectureEnvironmentsResult,
+      { distribution: Distributions; arch: string }
+    >({
+      queryFn: async ({ distribution, arch }, api) => {
+        const result = await api.dispatch(
+          backendApi.endpoints.getArchitectures.initiate(
+            { distribution },
+            // Skip the cache subscription since we only need the data;
+            // the derived endpoint manages its own cache entry.
+            { subscribe: false },
+          ),
+        );
+
+        if (result.error) {
+          return { error: result.error };
+        }
+
+        if (!result.data) {
+          return { error: { error: 'No architecture results returned' } };
+        }
+
+        const imageTypes =
+          result.data.find((a) => a.arch === arch)?.image_types ?? [];
+
+        return { data: categorizeEnvironments(imageTypes) };
+      },
+    }),
+
+    getDistributionEnvironments: builder.query<
+      DistributionEnvironmentsResult,
+      { arch: string; distro?: string }
+    >({
+      queryFn: async (queryArgs, api) => {
+        const result = await api.dispatch(
+          backendApi.endpoints.getDistributions.initiate(
+            { kind: 'bootc', ...queryArgs },
+            // Skip the cache subscription since we only need the data;
+            // the derived endpoint manages its own cache entry.
+            { subscribe: false },
+          ),
+        );
+
+        if (result.error) {
+          return { error: result.error };
+        }
+
+        if (!result.data) {
+          return {
+            error: { error: 'No distribution results returned' },
+          };
+        }
+
+        const distributions = result.data.filter(isBootcDistribution);
+        const imageTypes = [...new Set(distributions.map((d) => d.type))];
+
+        return {
+          data: {
+            ...categorizeEnvironments(imageTypes),
+            distributions,
+          },
+        };
+      },
+    }),
+  }),
+});
+
+export const {
+  useGetArchitectureEnvironmentsQuery,
+  useGetDistributionEnvironmentsQuery,
+} = derivedApi;

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -147,3 +147,12 @@ export type {
 } from './onprem';
 
 export { useSecuritySummary } from './hooks';
+
+export {
+  categorizeEnvironments,
+  useGetArchitectureEnvironmentsQuery,
+  useGetDistributionEnvironmentsQuery,
+  type ArchitectureEnvironmentsResult,
+  type CategorizedEnvironments,
+  type DistributionEnvironmentsResult,
+} from './derived';

--- a/src/store/api/backend/tests/derived.test.ts
+++ b/src/store/api/backend/tests/derived.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { categorizeEnvironments } from '../derived';
+
+describe('categorizeEnvironments', () => {
+  it('categorizes public clouds', () => {
+    const result = categorizeEnvironments(['aws', 'gcp', 'azure', 'oci']);
+
+    expect(result.publicClouds).toEqual(['aws', 'gcp', 'azure', 'oci']);
+    expect(result.privateClouds).toEqual([]);
+    expect(result.miscFormats).toEqual([]);
+    expect(result.hasEnvironments).toBe(true);
+  });
+
+  it('categorizes private clouds', () => {
+    const result = categorizeEnvironments(['vsphere', 'vsphere-ova']);
+
+    expect(result.publicClouds).toEqual([]);
+    expect(result.privateClouds).toEqual(['vsphere', 'vsphere-ova']);
+    expect(result.miscFormats).toEqual([]);
+    expect(result.hasEnvironments).toBe(true);
+  });
+
+  it('categorizes misc formats', () => {
+    const result = categorizeEnvironments([
+      'guest-image',
+      'image-installer',
+      'network-installer',
+    ]);
+
+    expect(result.publicClouds).toEqual([]);
+    expect(result.privateClouds).toEqual([]);
+    expect(result.miscFormats).toEqual([
+      'guest-image',
+      'image-installer',
+      'network-installer',
+    ]);
+    expect(result.hasEnvironments).toBe(true);
+  });
+
+  it('splits a mixed set into categories', () => {
+    const result = categorizeEnvironments([
+      'aws',
+      'vsphere',
+      'guest-image',
+      'gcp',
+      'vsphere-ova',
+      'image-installer',
+    ]);
+
+    expect(result.publicClouds).toEqual(['aws', 'gcp']);
+    expect(result.privateClouds).toEqual(['vsphere', 'vsphere-ova']);
+    expect(result.miscFormats).toEqual(['guest-image', 'image-installer']);
+    expect(result.hasEnvironments).toBe(true);
+  });
+
+  it('returns empty arrays for empty input', () => {
+    const result = categorizeEnvironments([]);
+
+    expect(result.publicClouds).toEqual([]);
+    expect(result.privateClouds).toEqual([]);
+    expect(result.miscFormats).toEqual([]);
+    expect(result.hasEnvironments).toBe(false);
+  });
+});

--- a/src/store/slices/wizard/output/selectors.ts
+++ b/src/store/slices/wizard/output/selectors.ts
@@ -1,3 +1,5 @@
+import { createSelector } from '@reduxjs/toolkit';
+
 import { RootState } from '@/store';
 
 export const selectImageSource = (state: RootState) => {
@@ -23,3 +25,15 @@ export const selectDistribution = (state: RootState) => {
 export const selectImageTypes = (state: RootState) => {
   return state.wizard.output.imageTypes;
 };
+
+export const selectIsOnlyNetworkInstallerSelected = createSelector(
+  selectImageTypes,
+  (imageTypes) =>
+    imageTypes.length === 1 && imageTypes.includes('network-installer'),
+);
+
+export const selectIsOtherEnvironmentSelected = createSelector(
+  selectImageTypes,
+  (imageTypes) =>
+    imageTypes.length >= 1 && !imageTypes.includes('network-installer'),
+);

--- a/src/store/slices/wizard/output/tests/output.test.ts
+++ b/src/store/slices/wizard/output/tests/output.test.ts
@@ -16,7 +16,9 @@ import {
   selectDistribution,
   selectImageSource,
   selectImageTypes,
+  selectIsOnlyNetworkInstallerSelected,
   selectIsoPayloadReference,
+  selectIsOtherEnvironmentSelected,
   wizardReducer,
   type WizardState,
 } from '@/store/slices/wizard';
@@ -302,6 +304,109 @@ describe('output selectors', () => {
       });
 
       expect(selectImageTypes(state)).toEqual(['aws', 'gcp']);
+    });
+  });
+
+  describe('selectIsOnlyNetworkInstallerSelected', () => {
+    it('should return true when only network-installer is selected', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: ['network-installer'],
+        },
+      });
+
+      expect(selectIsOnlyNetworkInstallerSelected(state)).toBe(true);
+    });
+
+    it('should return false when network-installer is combined with other types', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: ['network-installer', 'aws'],
+        },
+      });
+
+      expect(selectIsOnlyNetworkInstallerSelected(state)).toBe(false);
+    });
+
+    it('should return false when no image types are selected', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: [],
+        },
+      });
+
+      expect(selectIsOnlyNetworkInstallerSelected(state)).toBe(false);
+    });
+
+    it('should return false when a non-network-installer type is selected', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: ['aws'],
+        },
+      });
+
+      expect(selectIsOnlyNetworkInstallerSelected(state)).toBe(false);
+    });
+  });
+
+  describe('selectIsOtherEnvironmentSelected', () => {
+    it('should return true when a non-network-installer type is selected', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: ['aws'],
+        },
+      });
+
+      expect(selectIsOtherEnvironmentSelected(state)).toBe(true);
+    });
+
+    it('should return true when multiple non-network-installer types are selected', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: ['aws', 'gcp'],
+        },
+      });
+
+      expect(selectIsOtherEnvironmentSelected(state)).toBe(true);
+    });
+
+    it('should return false when only network-installer is selected', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: ['network-installer'],
+        },
+      });
+
+      expect(selectIsOtherEnvironmentSelected(state)).toBe(false);
+    });
+
+    it('should return false when network-installer is combined with other types', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: ['network-installer', 'aws'],
+        },
+      });
+
+      expect(selectIsOtherEnvironmentSelected(state)).toBe(false);
+    });
+
+    it('should return false when no image types are selected', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageTypes: [],
+        },
+      });
+
+      expect(selectIsOtherEnvironmentSelected(state)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Replace inline `selectFromResult` transformers and `useMemo` normalization in `TargetEnvironment` with derived RTK Query endpoints that delegate to the existing `getArchitectures` and `getDistributions` queries. This ensures both hosted and on-prem (cockpit) backends are handled correctly.

## Changes

- Add `getArchitectureEnvironments` and `getDistributionEnvironments` derived endpoints that dispatch to the existing backend queries via `api.dispatch` with `subscribe: false`, returning a common `CategorizedEnvironments` shape
- Simplify `TargetEnvironment` by consuming the derived hooks directly instead of transforming query results in-component
- Extract `isOnlyNetworkInstallerSelected` and `isOtherEnvironmentSelected` into memoized selectors in the output slice for reuse outside the component
