### PR TITLE
Sort cockpit composes by recency (HMS-10135)

### DIFF
--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -6,6 +6,7 @@ import { fsinfo } from 'cockpit/fsinfo';
 import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 
 import {
+  byCreatedAtDesc,
   getBlueprintsPath,
   readComposes,
   safeReadJsonFile,
@@ -103,6 +104,7 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
       for (const entry of entries) {
         composes = composes.concat(await readComposes(entry[0]));
       }
+      composes.sort(byCreatedAtDesc);
       return {
         meta: {
           count: composes.length,

--- a/src/store/api/backend/onprem/composerApi/helpers/byCreatedAtDesc.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/byCreatedAtDesc.ts
@@ -1,0 +1,6 @@
+import type { ComposesResponseItem } from '@/store/api/backend/hosted';
+
+export const byCreatedAtDesc = (
+  a: ComposesResponseItem,
+  b: ComposesResponseItem,
+) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime();

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -1,3 +1,4 @@
+export { byCreatedAtDesc } from './byCreatedAtDesc';
 export { parseJsonUnsafe } from './parseJson';
 export { lookupDatastreamDistro } from './dataStreamLookup';
 export { getBlueprintsPath } from './getBlueprintsPath';

--- a/src/store/api/backend/onprem/composerApi/helpers/readComposes.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/readComposes.ts
@@ -7,6 +7,7 @@ import type {
   ComposesResponseItem,
 } from '@/store/api/backend/hosted';
 
+import { byCreatedAtDesc } from './byCreatedAtDesc';
 import { getBlueprintsPath } from './getBlueprintsPath';
 import { safeReadJsonFile } from './safeReadJsonFile';
 
@@ -44,5 +45,7 @@ export const readComposes = async (
       },
     ];
   }
+  composes.sort(byCreatedAtDesc);
+
   return composes;
 };

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/readComposes.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/readComposes.test.ts
@@ -32,7 +32,7 @@ describe('readComposes', () => {
     vi.mocked(getBlueprintsPath).mockResolvedValue(blueprintsDir);
   });
 
-  it('returns all composes when all files are readable', async () => {
+  it('returns all composes sorted by most recent first', async () => {
     vi.mocked(fsinfo).mockResolvedValue({
       entries: {
         [`${bpID}.json`]: { mtime: 1000 },
@@ -49,20 +49,20 @@ describe('readComposes', () => {
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
-      id: 'compose-1',
-      request: mockRequest('rhel-9'),
-      created_at: new Date(2000 * 1000).toString(),
-      blueprint_id: bpID,
-    });
-    expect(result[1]).toEqual({
       id: 'compose-2',
       request: mockRequest('centos-9'),
       created_at: new Date(3000 * 1000).toString(),
       blueprint_id: bpID,
     });
+    expect(result[1]).toEqual({
+      id: 'compose-1',
+      request: mockRequest('rhel-9'),
+      created_at: new Date(2000 * 1000).toString(),
+      blueprint_id: bpID,
+    });
   });
 
-  it('skips unreadable files and returns the rest', async () => {
+  it('skips unreadable files and returns the rest sorted', async () => {
     vi.mocked(fsinfo).mockResolvedValue({
       entries: {
         [`${bpID}.json`]: { mtime: 1000 },
@@ -81,15 +81,15 @@ describe('readComposes', () => {
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
-      id: 'compose-1',
-      request: mockRequest('rhel-9'),
-      created_at: new Date(2000 * 1000).toString(),
-      blueprint_id: bpID,
-    });
-    expect(result[1]).toEqual({
       id: 'compose-3',
       request: mockRequest('centos-9'),
       created_at: new Date(4000 * 1000).toString(),
+      blueprint_id: bpID,
+    });
+    expect(result[1]).toEqual({
+      id: 'compose-1',
+      request: mockRequest('rhel-9'),
+      created_at: new Date(2000 * 1000).toString(),
       blueprint_id: bpID,
     });
   });


### PR DESCRIPTION
## Summary

The on-prem compose endpoints returned results in filesystem order, which is effectively arbitrary. This sorts composes by `created_at` descending so the most recent builds appear first, matching the hosted API behaviour.

Fixes #4059

## Changes

- Add a `byCreatedAtDesc` comparator for sorting `ComposesResponseItem` arrays
- Sort results in `readComposes` (per-blueprint) and `getComposes` (cross-blueprint) before returning
- Update existing tests to expect newest-first ordering
