### PR TITLE
coverage: Exclude auto-generated API files and declaration files (HMS-10974)

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -5,6 +5,12 @@
     "src/**/tests/**",
     "src/**/mocks/**",
     "**/*.scss",
-    "**/*.test.*"
+    "**/*.test.*",
+    "**/*.d.ts",
+    "**/imageBuilderApi.ts",
+    "**/complianceApi.ts",
+    "**/rhsmApi.ts",
+    "**/contentSourcesApi.ts",
+    "**/distributionDetailsApi.ts"
   ]
 }


### PR DESCRIPTION
The auto-generated RTK query API files and declaration files can be excluded from the coverage report.

JIRA: [HMS-10974](https://issues.redhat.com/browse/HMS-10974)

[HMS-10974]: https://redhat.atlassian.net/browse/HMS-10974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ