### PR TITLE
Wizard/Security: Hide selectors conditionally and add empty option (HMS-10983)

### DIFF
--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -218,7 +218,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await fillInImageOutput(frame);
     await frame.getByRole('textbox', { name: 'Blueprint name' }).fill('tmp');
     await frame.getByRole('button', { name: 'Base settings' }).click();
-    await frame.getByRole('button', { name: 'View details' }).nth(2).click();
+    await frame.getByRole('button', { name: 'View details' }).nth(1).click();
     await expect(
       frame.getByText('Red Hat Enterprise Linux 9 CIS'),
     ).toBeVisible();

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -205,6 +205,14 @@ const PolicySelector = ({ isDisabled = false }: PolicySelectorProps) => {
       ];
     }
 
+    if (policies.data.length === 0) {
+      return [
+        <SelectOption key='no-policies' value='no-policies' isDisabled>
+          No compliance policies found
+        </SelectOption>,
+      ];
+    }
+
     const res = [];
     for (const p of policies.data) {
       // there is a mismatch between API type and real data

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -196,14 +196,15 @@ const OscapContent = () => {
             </Content>
           )}
         </Content>
-        {registrationType.startsWith('register-now') && (
-          <Alert
-            title='Systems with a compliance policy or an OpenSCAP profile added will not be registered to Red Hat
+        {registrationType.startsWith('register-now') &&
+          complianceType !== 'none' && (
+            <Alert
+              title='Systems with a compliance policy or an OpenSCAP profile added will not be registered to Red Hat
               Lightspeed by default.'
-            variant='info'
-            isInline
-          />
-        )}
+              variant='info'
+              isInline
+            />
+          )}
         {!restrictions.openscap.shouldHide &&
           (isOnPremise && isLoadingOnPrem ? (
             <OscapOnPremSpinner />

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -229,46 +229,46 @@ const OscapContent = () => {
                       label='Use a custom compliance policy'
                       isChecked={complianceType === 'compliance'}
                       onChange={() => handleTypeChange('compliance')}
+                      body={
+                        complianceType === 'compliance' && (
+                          <Content className='pf-v6-u-pb-sm'>
+                            <Flex spaceItems={{ default: 'spaceItemsMd' }}>
+                              <FlexItem className='pf-v6-u-w-50'>
+                                <PolicySelector />
+                              </FlexItem>
+                              <FlexItem>
+                                <Popover
+                                  headerContent='Details'
+                                  bodyContent={<PolicyDetails />}
+                                  minWidth='30'
+                                >
+                                  <Button
+                                    variant='secondary'
+                                    icon={<InfoCircleIcon />}
+                                    iconPosition='left'
+                                    isDisabled={!policyID}
+                                  >
+                                    View details
+                                  </Button>
+                                </Popover>
+                              </FlexItem>
+                            </Flex>
+                            <FormHelperText>
+                              <HelperText>
+                                <HelperTextItem>
+                                  <ExternalLinkButton
+                                    url={COMPLIANCE_URL}
+                                    analyticsStepId='step-oscap'
+                                  >
+                                    Manage Red Hat Lightspeed compliance
+                                  </ExternalLinkButton>
+                                </HelperTextItem>
+                              </HelperText>
+                            </FormHelperText>
+                          </Content>
+                        )
+                      }
                     />
-                  </Content>
-                  <Content className='pf-v6-u-pl-lg pf-v6-u-pb-md'>
-                    <Flex spaceItems={{ default: 'spaceItemsMd' }}>
-                      <FlexItem className='pf-v6-u-w-50'>
-                        <PolicySelector
-                          isDisabled={complianceType !== 'compliance'}
-                        />
-                      </FlexItem>
-                      <FlexItem>
-                        <Popover
-                          headerContent='Details'
-                          bodyContent={<PolicyDetails />}
-                          minWidth='30'
-                        >
-                          <Button
-                            variant='secondary'
-                            icon={<InfoCircleIcon />}
-                            iconPosition='left'
-                            isDisabled={
-                              complianceType !== 'compliance' || !policyID
-                            }
-                          >
-                            View details
-                          </Button>
-                        </Popover>
-                      </FlexItem>
-                    </Flex>
-                    <FormHelperText>
-                      <HelperText>
-                        <HelperTextItem>
-                          <ExternalLinkButton
-                            url={COMPLIANCE_URL}
-                            analyticsStepId='step-oscap'
-                          >
-                            Manage Red Hat Lightspeed compliance
-                          </ExternalLinkButton>
-                        </HelperTextItem>
-                      </HelperText>
-                    </FormHelperText>
                   </Content>
                 </>
               )}
@@ -279,48 +279,51 @@ const OscapContent = () => {
                   label='Use a default OpenSCAP profile'
                   isChecked={complianceType === 'openscap'}
                   onChange={() => handleTypeChange('openscap')}
+                  body={
+                    complianceType === 'openscap' && (
+                      <Content className='pf-v6-u-pb-sm'>
+                        <Flex spaceItems={{ default: 'spaceItemsMd' }}>
+                          <FlexItem className='pf-v6-u-w-50'>
+                            <ProfileSelector
+                              profiles={profiles}
+                              isFetching={isFetching}
+                              isSuccess={isSuccess}
+                              refetch={refetch}
+                            />
+                          </FlexItem>
+                          <FlexItem>
+                            <Popover
+                              headerContent='Details'
+                              bodyContent={<OpenScapProfileDetails />}
+                              minWidth='30'
+                            >
+                              <Button
+                                variant='secondary'
+                                icon={<InfoCircleIcon />}
+                                iconPosition='left'
+                                isDisabled={!profileID}
+                              >
+                                View details
+                              </Button>
+                            </Popover>
+                          </FlexItem>
+                        </Flex>
+                        <FormHelperText>
+                          <HelperText>
+                            <HelperTextItem>
+                              <ExternalLinkButton
+                                url={OSCAP_URL}
+                                analyticsStepId='step-oscap'
+                              >
+                                Manage with OpenSCAP
+                              </ExternalLinkButton>
+                            </HelperTextItem>
+                          </HelperText>
+                        </FormHelperText>
+                      </Content>
+                    )
+                  }
                 />
-              </Content>
-              <Content className='pf-v6-u-pl-lg'>
-                <Flex spaceItems={{ default: 'spaceItemsMd' }}>
-                  <FlexItem className='pf-v6-u-w-50'>
-                    <ProfileSelector
-                      isDisabled={complianceType !== 'openscap'}
-                      profiles={profiles}
-                      isFetching={isFetching}
-                      isSuccess={isSuccess}
-                      refetch={refetch}
-                    />
-                  </FlexItem>
-                  <FlexItem>
-                    <Popover
-                      headerContent='Details'
-                      bodyContent={<OpenScapProfileDetails />}
-                      minWidth='30'
-                    >
-                      <Button
-                        variant='secondary'
-                        icon={<InfoCircleIcon />}
-                        iconPosition='left'
-                        isDisabled={complianceType !== 'openscap' || !profileID}
-                      >
-                        View details
-                      </Button>
-                    </Popover>
-                  </FlexItem>
-                </Flex>
-                <FormHelperText>
-                  <HelperText>
-                    <HelperTextItem>
-                      <ExternalLinkButton
-                        url={OSCAP_URL}
-                        analyticsStepId='step-oscap'
-                      >
-                        Manage with OpenSCAP
-                      </ExternalLinkButton>
-                    </HelperTextItem>
-                  </HelperText>
-                </FormHelperText>
               </Content>
             </FormGroup>
           ))}


### PR DESCRIPTION
This moves the OpenSCAP/compliance selectors to a body of the relevant radio and renders them conditionally based on whether the radio is selected. This is consistent with the behaviour of for example repeatable build and activation keys. The selectors also don't have to render as disabled when inactive.

This will also render a disabled option stating "No compliance policies found" when there are no policies created. This should be less confusing that an empty dropdown menu.

JIRA: [HMS-10983](https://issues.redhat.com/browse/HMS-10983)

[HMS-10983]: https://redhat.atlassian.net/browse/HMS-10983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="751" height="210" alt="image" src="https://github.com/user-attachments/assets/c156e0c2-58db-42ef-bba1-9600f8f364fc" />
