### PR TITLE
src: Replace deep imports with aliases (HMS-10985)

### DIFF
--- a/src/Components/CloudProviderConfig/AWSConfig.tsx
+++ b/src/Components/CloudProviderConfig/AWSConfig.tsx
@@ -13,6 +13,7 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 
 import { AWSWorkerConfig, WorkerConfigResponse } from '@/store/api/backend';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeAWSBucketName,
   changeAWSCredsPath,
@@ -23,7 +24,6 @@ import {
 
 import { isAwsBucketValid, isAwsCredsPathValid } from './validators';
 
-import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { ValidatedInput } from '../CreateImageWizard/ValidatedInput';
 
 type FormGroupProps<T> = {

--- a/src/Components/CloudProviderConfig/CloudProviderConfig.tsx
+++ b/src/Components/CloudProviderConfig/CloudProviderConfig.tsx
@@ -28,6 +28,7 @@ import {
   useGetWorkerConfigQuery,
   useUpdateWorkerConfigMutation,
 } from '@/store/api/backend';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeAWSBucketName,
   changeAWSCredsPath,
@@ -37,8 +38,6 @@ import {
 
 import { AWSConfig } from './AWSConfig';
 import { isAwsStepValid } from './validators';
-
-import { useAppDispatch, useAppSelector } from '../../store/hooks';
 
 const ConfigError = ({
   onClose,

--- a/src/Components/CreateImageWizard/steps/Details/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/index.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Content, FormGroup, Title } from '@patternfly/react-core';
 
+import { useDetailsValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
+import { ValidatedInputAndTextArea } from '@/Components/CreateImageWizard/ValidatedInput';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeBlueprintDescription,
@@ -10,9 +12,6 @@ import {
   selectBlueprintName,
   setIsCustomName,
 } from '@/store/slices/wizard';
-
-import { useDetailsValidation } from '../../utilities/useValidation';
-import { ValidatedInputAndTextArea } from '../../ValidatedInput';
 
 const DetailsStep = () => {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
@@ -2,11 +2,11 @@ import React, { useMemo, useState } from 'react';
 
 import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 
+import { useLocaleValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
+import SearchableSelect from '@/Components/sharedComponents/SearchableSelect';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { changeKeyboard, selectKeyboard } from '@/store/slices/wizard';
 
-import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
-import SearchableSelect from '../../../../sharedComponents/SearchableSelect';
-import { useLocaleValidation } from '../../../utilities/useValidation';
 import { keyboardsList } from '../data/keyboardsList';
 
 const KeyboardDropDown = () => {

--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -8,6 +8,9 @@ import {
 } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
+import { useLocaleValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
+import SearchableSelect from '@/Components/sharedComponents/SearchableSelect';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   addLanguage,
   removeLanguage,
@@ -15,9 +18,6 @@ import {
   selectLanguages,
 } from '@/store/slices/wizard';
 
-import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
-import SearchableSelect from '../../../../sharedComponents/SearchableSelect';
-import { useLocaleValidation } from '../../../utilities/useValidation';
 import { languagesList } from '../data/languagesList';
 
 const parseLanguageOption = (language: string) => {

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -19,6 +19,7 @@ import {
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
+import ExternalLinkButton from '@/Components/CreateImageWizard/utilities/ExternalLinkButton';
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import {
   AMPLITUDE_MODULE_NAME,
@@ -67,8 +68,6 @@ import PolicyDetails from './components/PolicyDetails';
 import PolicySelector from './components/PolicySelector';
 import OpenScapProfileDetails from './components/ProfileDetails';
 import ProfileSelector from './components/ProfileSelector';
-
-import ExternalLinkButton from '../../utilities/ExternalLinkButton';
 
 const OscapContent = () => {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -24,6 +24,7 @@ import {
 import { OptimizeIcon, SearchIcon, TimesIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
+import ManageRepositoriesButton from '@/Components/CreateImageWizard/steps/Repositories/components/ManageRepositoriesButton';
 import { excludeEUSReposFilter } from '@/Components/CreateImageWizard/steps/Repositories/repositoriesUtilities';
 import {
   AMPLITUDE_MODULE_NAME,
@@ -72,8 +73,6 @@ import { getEpelUrlForDistribution } from '@/Utilities/epel';
 import { releaseToVersion } from '@/Utilities/releaseToVersion';
 import { convertStringToDate } from '@/Utilities/time';
 import useDebounce from '@/Utilities/useDebounce';
-
-import ManageRepositoriesButton from '../../Repositories/components/ManageRepositoriesButton';
 
 type PackageSearchProps = {
   packageType: 'packages' | 'groups';

--- a/src/Components/CreateImageWizard/utilities/ExternalLinkButton.tsx
+++ b/src/Components/CreateImageWizard/utilities/ExternalLinkButton.tsx
@@ -4,11 +4,10 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
+import { AMPLITUDE_MODULE_NAME } from '@/constants';
+import { useGetUser } from '@/Hooks';
+import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-
-import { AMPLITUDE_MODULE_NAME } from '../../../constants';
-import { useGetUser } from '../../../Hooks';
-import { useAppSelector } from '../../../store/hooks';
 
 type ExternalLinkButtonProps = {
   url: string;

--- a/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
@@ -10,11 +10,10 @@ import {
   TextInputProps,
 } from '@patternfly/react-core';
 
+import { useAppSelector } from '@/store/hooks';
 import { selectImageTypes } from '@/store/slices/wizard';
 
 import { checkPasswordValidity } from './useValidation';
-
-import { useAppSelector } from '../../../store/hooks';
 
 type ValidatedPasswordInput = TextInputProps & {
   value: string;

--- a/src/Components/CreateImageWizard/utilities/checkRepositoriesAvailability.ts
+++ b/src/Components/CreateImageWizard/utilities/checkRepositoriesAvailability.ts
@@ -1,15 +1,14 @@
 import { useMemo } from 'react';
 
+import { ContentOrigin, PAGINATION_LIMIT } from '@/constants';
 import { useListRepositoriesQuery } from '@/store/api/contentSources';
+import { useAppSelector } from '@/store/hooks';
 import {
   selectArchitecture,
   selectCustomRepositories,
   selectDistribution,
 } from '@/store/slices/wizard';
-
-import { ContentOrigin, PAGINATION_LIMIT } from '../../../constants';
-import { useAppSelector } from '../../../store/hooks';
-import { releaseToVersion } from '../../../Utilities/releaseToVersion';
+import { releaseToVersion } from '@/Utilities/releaseToVersion';
 
 /**
  * This checks the list of the custom repositories against a list of repos freshly

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -4,10 +4,16 @@ import { CheckCircleIcon } from '@patternfly/react-icons';
 import { jwtDecode } from 'jwt-decode';
 
 import {
+  SYSTEM_GROUPS,
+  UNDEFINED_GROUPS_WARNING_KEY,
+  UNIQUE_VALIDATION_DELAY,
+} from '@/constants';
+import {
   BlueprintsResponse,
   useLazyGetBlueprintsQuery,
 } from '@/store/api/backend';
 import { useShowActivationKeyQuery } from '@/store/api/rhsm';
+import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
   DiskPartition,
@@ -57,12 +63,6 @@ import {
 
 import { getListOfDuplicates } from './getListOfDuplicates';
 
-import {
-  SYSTEM_GROUPS,
-  UNDEFINED_GROUPS_WARNING_KEY,
-  UNIQUE_VALIDATION_DELAY,
-} from '../../../constants';
-import { useAppSelector } from '../../../store/hooks';
 import { keyboardsList } from '../steps/Locale/data/keyboardsList';
 import { languagesList } from '../steps/Locale/data/languagesList';
 import { timezones } from '../steps/Timezone/timezonesList';

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -18,12 +18,13 @@ import {
 
 import './LandingPage.scss';
 
+import { useAppDispatch } from '@/store/hooks';
+import { setBlueprintId } from '@/store/slices/blueprint';
+import { openWizardModal } from '@/store/slices/wizardModal';
+import { useFlag } from '@/Utilities/useGetEnvironment';
+
 import ServiceUnavailableAlert from './ServiceUnavailableAlert';
 
-import { useAppDispatch } from '../../store/hooks';
-import { setBlueprintId } from '../../store/slices/blueprint';
-import { openWizardModal } from '../../store/slices/wizardModal';
-import { useFlag } from '../../Utilities/useGetEnvironment';
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
 import CreateImageWizard from '../CreateImageWizard/CreateImageWizard';
 import ImagesTable from '../ImagesTable';

--- a/src/Components/Launch/AWSLaunchModal.tsx
+++ b/src/Components/Launch/AWSLaunchModal.tsx
@@ -19,8 +19,7 @@ import {
   ComposesResponseItem,
   useGetComposeStatusQuery,
 } from '@/store/api/backend';
-
-import { isAwsUploadRequestOptions } from '../../store/typeGuards';
+import { isAwsUploadRequestOptions } from '@/store/typeGuards';
 
 type LaunchProps = {
   compose: ComposesResponseItem;

--- a/src/Components/Launch/AzureLaunchModal.tsx
+++ b/src/Components/Launch/AzureLaunchModal.tsx
@@ -19,8 +19,7 @@ import {
   ComposesResponseItem,
   useGetComposeStatusQuery,
 } from '@/store/api/backend';
-
-import { isAzureUploadStatus } from '../../store/typeGuards';
+import { isAzureUploadStatus } from '@/store/typeGuards';
 
 type LaunchProps = {
   compose: ComposesResponseItem;

--- a/src/Components/Launch/GcpLaunchModal.tsx
+++ b/src/Components/Launch/GcpLaunchModal.tsx
@@ -22,13 +22,13 @@ import {
   ComposesResponseItem,
   useGetComposeStatusQuery,
 } from '@/store/api/backend';
-
-import { generateDefaultName } from './useGenerateDefaultName';
-
 import {
   isGcpUploadRequestOptions,
   isGcpUploadStatus,
-} from '../../store/typeGuards';
+} from '@/store/typeGuards';
+
+import { generateDefaultName } from './useGenerateDefaultName';
+
 import { parseGcpSharedWith } from '../ImagesTable/components/ImageDetails/components/GcpDetails';
 
 type LaunchProps = { compose: ComposesResponseItem };

--- a/src/Components/Launch/OciLaunchModal.tsx
+++ b/src/Components/Launch/OciLaunchModal.tsx
@@ -22,10 +22,9 @@ import {
   ComposesResponseItem,
   useGetComposeStatusQuery,
 } from '@/store/api/backend';
+import { useAppSelector } from '@/store/hooks';
 import { selectPathResolver } from '@/store/slices/env';
-
-import { useAppSelector } from '../../store/hooks';
-import { isOciUploadStatus } from '../../store/typeGuards';
+import { isOciUploadStatus } from '@/store/typeGuards';
 
 type LaunchProps = {
   isExpired: boolean;

--- a/src/Components/sharedComponents/DocumentationButton.tsx
+++ b/src/Components/sharedComponents/DocumentationButton.tsx
@@ -4,11 +4,10 @@ import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
+import { AMPLITUDE_MODULE_NAME } from '@/constants';
+import { useGetDocumentationUrl, useGetUser } from '@/Hooks';
+import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-
-import { AMPLITUDE_MODULE_NAME } from '../../constants';
-import { useGetDocumentationUrl, useGetUser } from '../../Hooks';
-import { useAppSelector } from '../../store/hooks';
 
 const DocumentationButton = () => {
   const { analytics, auth } = useChrome();

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -10,15 +10,15 @@ import {
 
 import './ImageBuilderHeader.scss';
 
+import { OSBUILD_SERVICE_ARCHITECTURE_URL } from '@/constants';
+import { useGetDocumentationUrl } from '@/Hooks';
 import { useBackendPrefetch } from '@/store/api/backend';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import { selectDistribution } from '@/store/slices/wizard';
 import { openWizardModal } from '@/store/slices/wizardModal';
 import { useFlag } from '@/Utilities/useGetEnvironment';
 
-import { OSBUILD_SERVICE_ARCHITECTURE_URL } from '../../constants';
-import { useGetDocumentationUrl } from '../../Hooks';
-import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { ImportBlueprintModal } from '../Blueprints/ImportBlueprintModal';
 import { CloudProviderConfig } from '../CloudProviderConfig/CloudProviderConfig';
 

--- a/src/Hooks/MutationNotifications/useMutationWithNotification.tsx
+++ b/src/Hooks/MutationNotifications/useMutationWithNotification.tsx
@@ -5,9 +5,8 @@ import {
 } from '@reduxjs/toolkit/dist/query/react';
 
 import { errorMessage } from '@/store/api/backend';
+import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-
-import { useAppSelector } from '../../store/hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getErrorDescription = (err: any, isOnPremise: boolean) => {

--- a/src/Hooks/Utilities/useCockpitMachinesAvailable.tsx
+++ b/src/Hooks/Utilities/useCockpitMachinesAvailable.tsx
@@ -2,9 +2,8 @@ import { useEffect, useState } from 'react';
 
 import cockpit from 'cockpit';
 
+import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-
-import { useAppSelector } from '../../store/hooks';
 
 /**
  * Hook to check if cockpit-machines is installed and available.

--- a/src/Hooks/Utilities/useGetDocumentationUrl.tsx
+++ b/src/Hooks/Utilities/useGetDocumentationUrl.tsx
@@ -1,15 +1,14 @@
 import { useEffect, useState } from 'react';
 
-import { selectIsOnPremise } from '@/store/slices/env';
-
 import {
   IB_HOSTED_LIGHTSPEED_DOCUMENTATION_URL,
   IB_ON_PREMISE_OSBUILD_DOCUMENTATION_URL,
   IB_ON_PREMISE_RHEL10_DOCUMENTATION_URL,
   IB_ON_PREMISE_RHEL9_DOCUMENTATION_URL,
-} from '../../constants';
-import { useAppSelector } from '../../store/hooks';
-import { getHostDistro } from '../../Utilities/getHostInfo';
+} from '@/constants';
+import { useAppSelector } from '@/store/hooks';
+import { selectIsOnPremise } from '@/store/slices/env';
+import { getHostDistro } from '@/Utilities/getHostInfo';
 
 export const useGetDocumentationUrl = () => {
   const isOnPremise = useAppSelector(selectIsOnPremise);

--- a/src/Hooks/Utilities/useGetUser.tsx
+++ b/src/Hooks/Utilities/useGetUser.tsx
@@ -2,9 +2,8 @@ import { useEffect, useState } from 'react';
 
 import { ChromeUser } from '@redhat-cloud-services/types';
 
+import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-
-import { useAppSelector } from '../../store/hooks';
 
 export const useGetUser = (auth: { getUser(): Promise<void | ChromeUser> }) => {
   const [userData, setUserData] = useState<ChromeUser | void>(undefined);

--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -4,14 +4,14 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 
-import LandingPage from '../../../Components/LandingPage/LandingPage';
-import { IMAGE_BUILDER_API } from '../../../constants';
+import LandingPage from '@/Components/LandingPage/LandingPage';
+import { IMAGE_BUILDER_API } from '@/constants';
 import {
   emptyGetBlueprints,
   mockBlueprintIds,
-} from '../../fixtures/blueprints';
-import { server } from '../../mocks/server';
-import { renderCustomRoutesWithReduxRouter } from '../../renderUtils';
+} from '@/test/fixtures/blueprints';
+import { server } from '@/test/mocks/server';
+import { renderCustomRoutesWithReduxRouter } from '@/test/renderUtils';
 
 const selectBlueprintById = async (bpId: string) => {
   const user = userEvent.setup();

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -1,8 +1,8 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { mockComposes } from '../../fixtures/composes';
-import { renderCustomRoutesWithReduxRouter } from '../../renderUtils';
+import { mockComposes } from '@/test/fixtures/composes';
+import { renderCustomRoutesWithReduxRouter } from '@/test/renderUtils';
 
 describe('Images Table', () => {
   beforeEach(() => {

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -1,3 +1,4 @@
+import { RHEL_8, RHEL_9 } from '@/constants';
 import {
   CreateBlueprintResponse,
   Distributions,
@@ -5,8 +6,6 @@ import {
   GetBlueprintComposesApiResponse,
   GetBlueprintsApiResponse,
 } from '@/store/api/backend';
-
-import { RHEL_8, RHEL_9 } from '../../constants';
 
 export const mockBlueprintsCreation: CreateBlueprintResponse[] = [
   {

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -1,10 +1,9 @@
+import { RHEL_8, RHEL_9 } from '@/constants';
 import {
   ComposesResponse,
   ComposesResponseItem,
   ComposeStatus,
 } from '@/store/api/backend';
-
-import { RHEL_8, RHEL_9 } from '../../constants';
 
 // CreateImageWizard mocks
 export const mockComposesEmpty: ComposesResponse = {

--- a/src/test/fixtures/editMode.ts
+++ b/src/test/fixtures/editMode.ts
@@ -1,4 +1,17 @@
 import {
+  AARCH64,
+  CENTOS_9,
+  FIRST_BOOT_SERVICE,
+  FIRST_BOOT_SERVICE_DATA,
+  FIRSTBOOT_PATH,
+  FIRSTBOOT_SERVICE_PATH,
+  RHEL_8,
+  RHEL_9,
+  UNIT_GIB,
+  UNIT_MIB,
+  X86_64,
+} from '@/constants';
+import {
   BlueprintResponse,
   CreateBlueprintRequest,
   CustomRepository,
@@ -16,20 +29,6 @@ import {
   mockBlueprintNames,
   multipleTargetsBlueprintResponse,
 } from './blueprints';
-
-import {
-  AARCH64,
-  CENTOS_9,
-  FIRST_BOOT_SERVICE,
-  FIRST_BOOT_SERVICE_DATA,
-  FIRSTBOOT_PATH,
-  FIRSTBOOT_SERVICE_PATH,
-  RHEL_8,
-  RHEL_9,
-  UNIT_GIB,
-  UNIT_MIB,
-  X86_64,
-} from '../../constants';
 
 // Registration
 export const expectedSubscription = {

--- a/src/test/mocks/cockpit/cockpitFile.ts
+++ b/src/test/mocks/cockpit/cockpitFile.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
-import { mockComposes } from '../../fixtures/composes';
-import { getMockBlueprintResponse } from '../../fixtures/editMode';
+import { mockComposes } from '@/test/fixtures/composes';
+import { getMockBlueprintResponse } from '@/test/fixtures/editMode';
 
 const readBlueprint = (id: string): Promise<string> => {
   return new Promise((resolve) => {

--- a/src/test/mocks/cockpit/cockpitHTTP.ts
+++ b/src/test/mocks/cockpit/cockpitHTTP.ts
@@ -2,8 +2,7 @@
 import path from 'path';
 
 import type { Headers, Method, Params } from '@/store/api/shared';
-
-import { mockStatus } from '../../fixtures/composes';
+import { mockStatus } from '@/test/fixtures/composes';
 
 type requestOptions = {
   path: string;

--- a/src/test/mocks/cockpit/fsinfo.ts
+++ b/src/test/mocks/cockpit/fsinfo.ts
@@ -2,8 +2,8 @@
 
 import path from 'path';
 
-import { mockBlueprintIds } from '../../fixtures/blueprints';
-import { mockComposes } from '../../fixtures/composes';
+import { mockBlueprintIds } from '@/test/fixtures/blueprints';
+import { mockComposes } from '@/test/fixtures/composes';
 
 const bpDir = '/default/.local/state/cockpit-image-builder';
 

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
-import { CREATE_BLUEPRINT, IMAGE_BUILDER_API } from '../../constants';
+import { CREATE_BLUEPRINT, IMAGE_BUILDER_API } from '@/constants';
+
 import {
   mockBlueprintComposes,
   mockBlueprintComposesOutOfSync,


### PR DESCRIPTION
Some more deep imports replaces with aliases.

Tried to evade parts of codebase that are actively worked on to lessen chance of conflicts.

Doing smaller chunks feels slightly nicer than creating one big PR for all the imports.

JIRA: [HMS-10985](https://issues.redhat.com/browse/HMS-10985)

[HMS-10985]: https://redhat.atlassian.net/browse/HMS-10985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ