### PR TITLE
webpack: Remove unused eslint-disable comment for deprecated rule

### DIFF
--- a/webpack.dev-coverage.config.js
+++ b/webpack.dev-coverage.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
 const originalConfig = require(


### PR DESCRIPTION
The `@typescript-eslint/no-var-requires` rule was removed from the ESLint config, making the disable comment unnecessary. It was automatically cleaned up by npm run lint.