### PR TITLE
  Wizard: swap Users and Groups section order (HMS-10791)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -506,10 +506,10 @@ const CreateImageWizard = () => {
               !(
                 restrictions.openscap.shouldHide && restrictions.fips.shouldHide
               ) && <OscapStep key='oscap' />,
+              restrictions.users.isStandalone && <UsersStep key='users' />,
               restrictions.users.isStandalone && (
                 <UserGroupsStep key='groups' />
               ),
-              restrictions.users.isStandalone && <UsersStep key='users' />,
             ]
               .filter(Boolean)
               .flatMap((component, index, array) =>
@@ -613,10 +613,10 @@ const CreateImageWizard = () => {
               ),
               !(
                 restrictions.users.shouldHide || restrictions.users.isStandalone
-              ) && <UserGroupsStep key='groups' />,
+              ) && <UsersStep key='users' />,
               !(
                 restrictions.users.shouldHide || restrictions.users.isStandalone
-              ) && <UsersStep key='users' />,
+              ) && <UserGroupsStep key='groups' />,
               !restrictions.firstBoot.shouldHide && (
                 <FirstBootStep key='firstboot' />
               ),

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
@@ -62,14 +62,14 @@ const AdvancedSettingsOverview = ({
           oscapServices={oscapServices}
         />
         <Firewall shouldHide={restrictions.firewall.shouldHide} />
+        <ReviewSection title='Users' shouldHide={usersHidden || !hasUsers}>
+          <Users />
+        </ReviewSection>
         <ReviewSection
           title='Groups'
           shouldHide={usersHidden || !hasUserGroups}
         >
           <UserGroups />
-        </ReviewSection>
-        <ReviewSection title='Users' shouldHide={usersHidden || !hasUsers}>
-          <Users />
         </ReviewSection>
         <Firstboot shouldHide={restrictions.firstBoot.shouldHide} />
       </CardBody>


### PR DESCRIPTION
  Show Users before Groups since users are needed almost always
  while groups are rarely used.

JIRA: HMS-10791