### PR TITLE
Wizard: Review step line divider

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/components/shared/ReviewSection.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/shared/ReviewSection.tsx
@@ -16,7 +16,7 @@ export const ReviewSection = ({
       <div className='pf-v6-u-pl-lg'>
         <ReviewList>{children}</ReviewList>
       </div>
-      <Divider className='pf-v6-u-my-md' />
+      <Divider className='pf-v6-u-mt-lg pf-v6-u-mb-md' />
     </>
   );
 };


### PR DESCRIPTION
Adds lg margin on top of the line divider in the Review step for more breathing room and keeps md on the bottom as it was before.

@kingsleyzissou this is the Timezone section now:
<img width="990" height="686" alt="image" src="https://github.com/user-attachments/assets/b500c92f-797a-40c6-92b0-2a466ecb2e46" />
