### PR TITLE
ImageSourceSelect: split by build target with image ref sub menu for on-prem (HMS-11013)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -153,6 +153,7 @@ const ImageSourceSelect = () => {
           isDisabled
           style={
             {
+              minWidth: '20rem',
               maxWidth: '100%',
             } as React.CSSProperties
           }
@@ -169,6 +170,7 @@ const ImageSourceSelect = () => {
         isExpanded={isOpen}
         style={
           {
+            minWidth: '20rem',
             maxWidth: '100%',
           } as React.CSSProperties
         }

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect.tsx
@@ -227,7 +227,11 @@ const ImageSourceSelect = () => {
             <SelectList>
               {uniqueDistributions && uniqueDistributions.length > 0 ? (
                 uniqueDistributions.map((item) => (
-                  <SelectOption key={item.reference} value={item.reference}>
+                  <SelectOption
+                    key={item.reference}
+                    value={item.reference}
+                    description={isOnPremise ? item.reference : undefined}
+                  >
                     {item.name}
                   </SelectOption>
                 ))

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/Dropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/Dropdown.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import type { BootcDistributionItem } from '@/store/api/backend';
+import { useAppSelector } from '@/store/hooks';
+import { selectIsOnPremise } from '@/store/slices/env';
+import { selectArchitecture, selectImageSource } from '@/store/slices/wizard';
+
+import HostedImageSourceSelect from './Hosted';
+import OnPremImageSourceSelect from './OnPrem';
+
+export type ImageSourceDropdownProps = {
+  distributions: BootcDistributionItem[] | undefined;
+  selectedItem: BootcDistributionItem | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (event?: React.MouseEvent, selection?: string | number) => void;
+  onRefresh: () => void;
+};
+
+const ImageSourceDropdown = (props: ImageSourceDropdownProps) => {
+  const isOnPremise = useAppSelector(selectIsOnPremise);
+  const imageSource = useAppSelector(selectImageSource);
+  const arch = useAppSelector(selectArchitecture);
+
+  if (isOnPremise) {
+    const {
+      distributions,
+      selectedItem,
+      isLoading,
+      isError,
+      onSelect,
+      onRefresh,
+    } = props;
+    return (
+      <OnPremImageSourceSelect
+        distributions={distributions}
+        selectedItem={selectedItem}
+        isLoading={isLoading}
+        isError={isError}
+        onSelect={onSelect}
+        onRefresh={onRefresh}
+      />
+    );
+  }
+
+  return (
+    <HostedImageSourceSelect
+      {...props}
+      imageSource={imageSource}
+      arch={arch}
+      isError={props.isError}
+    />
+  );
+};
+
+export default ImageSourceDropdown;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/Hosted.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/Hosted.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+
+import {
+  FormGroup,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  Spinner,
+} from '@patternfly/react-core';
+
+import type { BootcDistributionItem } from '@/store/api/backend';
+
+import ImageSourceError from './ImageSourceError';
+
+type HostedImageSourceSelectProps = {
+  distributions: BootcDistributionItem[] | undefined;
+  selectedItem: BootcDistributionItem | undefined;
+  imageSource: string | undefined;
+  arch: string;
+  isLoading: boolean;
+  isError: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (event?: React.MouseEvent, selection?: string | number) => void;
+};
+
+const HostedImageSourceSelect = ({
+  distributions,
+  selectedItem,
+  imageSource,
+  arch,
+  isLoading,
+  isError,
+  isOpen,
+  onToggle,
+  onOpenChange,
+  onSelect,
+}: HostedImageSourceSelectProps) => {
+  // Filter out minor versions and deduplicate by name since the API
+  // returns one entry per target type but the dropdown should show one
+  // entry per base image.
+  const uniqueDistributions = distributions
+    ?.filter((d) => !d.name.includes('.'))
+    .reduce<BootcDistributionItem[]>((acc, item) => {
+      if (!acc.some((d) => d.name === item.name)) {
+        acc.push(item);
+      }
+      return acc;
+    }, []);
+
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => {
+    if (isLoading) {
+      return (
+        <MenuToggle
+          ref={toggleRef}
+          isDisabled
+          style={
+            {
+              minWidth: '20rem',
+              maxWidth: '100%',
+            } as React.CSSProperties
+          }
+        >
+          <Spinner size='sm' aria-hidden='true' /> Loading bootc images...
+        </MenuToggle>
+      );
+    }
+
+    return (
+      <MenuToggle
+        ref={toggleRef}
+        onClick={onToggle}
+        isExpanded={isOpen}
+        style={
+          {
+            minWidth: '20rem',
+            maxWidth: '100%',
+          } as React.CSSProperties
+        }
+      >
+        {selectedItem ? selectedItem.name : 'Select a bootc image'}
+      </MenuToggle>
+    );
+  };
+
+  return (
+    <FormGroup label='Image source' isRequired>
+      {isError && <ImageSourceError isOnPremise={false} />}
+      <Select
+        isOpen={isOpen}
+        selected={imageSource}
+        onSelect={onSelect}
+        onOpenChange={onOpenChange}
+        toggle={toggle}
+        shouldFocusToggleOnSelect
+      >
+        <SelectList>
+          {!uniqueDistributions?.length && (
+            <SelectOption isDisabled>
+              No bootc images available for {arch}
+            </SelectOption>
+          )}
+          {uniqueDistributions &&
+            uniqueDistributions.length > 0 &&
+            uniqueDistributions.map((item) => (
+              <SelectOption key={item.reference} value={item.reference}>
+                {item.name}
+              </SelectOption>
+            ))}
+        </SelectList>
+      </Select>
+    </FormGroup>
+  );
+};
+
+export default HostedImageSourceSelect;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/ImageSourceError.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/ImageSourceError.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { Alert } from '@patternfly/react-core';
+
+type ImageSourceErrorProps = {
+  isOnPremise: boolean;
+};
+
+const ImageSourceError = ({ isOnPremise }: ImageSourceErrorProps) => (
+  <Alert
+    title='Error loading bootc images'
+    variant='danger'
+    className='pf-v6-u-mb-md'
+  >
+    {isOnPremise
+      ? 'Unable to load available bootc images. Ensure podman is installed and accessible.'
+      : 'Unable to load available bootc images. Please try again later.'}
+  </Alert>
+);
+
+export default ImageSourceError;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem.css
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem.css
@@ -1,0 +1,15 @@
+.on-prem-image-item.pf-v6-c-menu__item {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--pf-t--global--spacer--sm);
+}
+
+.on-prem-image-item .pf-v6-c-menu__item-main {
+  width: auto;
+  flex: 1;
+  min-width: 0;
+}
+
+.on-prem-image-item .pf-v6-c-menu__item-description {
+  flex-shrink: 0;
+}

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem.tsx
@@ -1,0 +1,258 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  Alert,
+  Button,
+  ClipboardCopy,
+  Content,
+  ExpandableSection,
+  Flex,
+  FlexItem,
+  FormGroup,
+  Label,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+  Spinner,
+} from '@patternfly/react-core';
+import { SyncAltIcon } from '@patternfly/react-icons';
+
+import { RHEL_10_IMAGE_MODE_IMAGE, simpleTargetNames } from '@/constants';
+import type { BootcDistributionItem } from '@/store/api/backend';
+import { isImageType } from '@/store/slices/wizard';
+
+import { groupByName } from './groupByName';
+import ImageSourceError from './ImageSourceError';
+import './OnPrem.css';
+
+import RegistryAuthSection from '../RegistryAuthSection';
+
+type OnPremImageSourceSelectProps = {
+  distributions: BootcDistributionItem[] | undefined;
+  selectedItem: BootcDistributionItem | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  onSelect: (event?: React.MouseEvent, selection?: string | number) => void;
+  onRefresh: () => void;
+};
+
+const CopyInlineCompact = ({ text }: { text: string }) => (
+  <ClipboardCopy
+    copyAriaLabel='Copy podman pull command'
+    hoverTip='Copy'
+    clickTip='Copied'
+    variant='inline-compact'
+    isCode
+  >
+    {text}
+  </ClipboardCopy>
+);
+
+const InfoMessageContent = ({ source }: { source: string }) => (
+  <>
+    <Content component='p'>
+      Container images must be pulled using Podman with root privileges, as
+      rootless images are not accessible to image builder at build time.
+    </Content>
+    <Content component='p'>
+      To pull an image locally, ensure you are logged in to the registry and use
+      the following command to use the recommended image mode image:
+    </Content>
+    <CopyInlineCompact text={`sudo podman pull ${source}`} />
+  </>
+);
+
+const OnPremImageSourceSelect = ({
+  distributions,
+  selectedItem,
+  isLoading,
+  isError,
+  onSelect,
+  onRefresh,
+}: OnPremImageSourceSelectProps) => {
+  const grouped = useMemo(
+    () => (distributions ? groupByName(distributions) : []),
+    [distributions],
+  );
+
+  // Local group selection tracks the user's explicit choice.
+  // Falls back to the store's selected item name so the dropdown is
+  // pre-filled on mount after the parent auto-selects a default.
+  const [localGroupName, setLocalGroupName] = useState<string>();
+  const [isDistroOpen, setIsDistroOpen] = useState(false);
+  const [isImageOpen, setIsImageOpen] = useState(false);
+
+  const hasDistributions = (distributions?.length ?? 0) > 0;
+  const [isPullInfoExpanded, setIsPullInfoExpanded] = useState(false);
+  const hasAutoExpanded = useRef(false);
+
+  useEffect(() => {
+    if (hasAutoExpanded.current) return;
+    if (!isLoading && !isError) {
+      hasAutoExpanded.current = true;
+      setIsPullInfoExpanded(!hasDistributions);
+    }
+  }, [isLoading, isError, hasDistributions]);
+
+  const activeGroupName = localGroupName ?? selectedItem?.name;
+  const selectedGroup = grouped.find((g) => g.name === activeGroupName);
+
+  const onDistroSelect = (
+    _event?: React.MouseEvent,
+    selection?: string | number,
+  ) => {
+    const groupName = selection as string;
+    setLocalGroupName(groupName);
+    setIsDistroOpen(false);
+
+    const group = grouped.find((g) => g.name === groupName);
+    if (group?.items.length === 1) {
+      onSelect(undefined, group.items[0].reference);
+    }
+  };
+
+  const onImageSelect = (
+    _event?: React.MouseEvent,
+    selection?: string | number,
+  ) => {
+    onSelect(undefined, selection);
+    setIsImageOpen(false);
+  };
+
+  const toggleStyle = {
+    minWidth: '20rem',
+    maxWidth: '100%',
+  } as React.CSSProperties;
+
+  const distroToggle = (toggleRef: React.Ref<MenuToggleElement>) => {
+    if (isLoading) {
+      return (
+        <MenuToggle ref={toggleRef} isDisabled style={toggleStyle}>
+          <Spinner size='sm' aria-hidden='true' /> Loading bootc images...
+        </MenuToggle>
+      );
+    }
+
+    return (
+      <MenuToggle
+        ref={toggleRef}
+        onClick={() => setIsDistroOpen((prev) => !prev)}
+        isExpanded={isDistroOpen}
+        style={toggleStyle}
+      >
+        {activeGroupName ?? 'Select a distribution'}
+      </MenuToggle>
+    );
+  };
+
+  const imageToggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsImageOpen((prev) => !prev)}
+      isExpanded={isImageOpen}
+      isDisabled={!selectedGroup}
+      style={toggleStyle}
+    >
+      {selectedItem && selectedItem.name === activeGroupName
+        ? selectedItem.reference
+        : 'Select an image'}
+    </MenuToggle>
+  );
+
+  return (
+    <>
+      <FormGroup label='Release' isRequired>
+        <Select
+          isOpen={isDistroOpen}
+          selected={activeGroupName}
+          onSelect={onDistroSelect}
+          onOpenChange={setIsDistroOpen}
+          toggle={distroToggle}
+          shouldFocusToggleOnSelect
+        >
+          <SelectList>
+            {grouped.length === 0 && (
+              <SelectOption isDisabled>No bootc images available</SelectOption>
+            )}
+            {grouped.map((group) => (
+              <SelectOption key={group.name} value={group.name}>
+                {group.name}
+              </SelectOption>
+            ))}
+          </SelectList>
+        </Select>
+      </FormGroup>
+      <FormGroup label='Image source' isRequired>
+        <RegistryAuthSection />
+        {isError && <ImageSourceError isOnPremise />}
+        {!isLoading && !isError && (
+          <ExpandableSection
+            toggleText={
+              isPullInfoExpanded
+                ? 'Hide information about pulling images'
+                : 'Show information about pulling images'
+            }
+            onToggle={(_event, expanded) => setIsPullInfoExpanded(expanded)}
+            isExpanded={isPullInfoExpanded}
+            className='pf-v6-u-pb-sm'
+          >
+            <Alert
+              title={
+                hasDistributions ? 'Note on pulling images' : 'No images found'
+              }
+              variant={hasDistributions ? 'info' : 'warning'}
+              className='pf-v6-u-mb-md'
+            >
+              <InfoMessageContent source={RHEL_10_IMAGE_MODE_IMAGE} />
+            </Alert>
+          </ExpandableSection>
+        )}
+        <Flex>
+          <FlexItem>
+            <Select
+              isOpen={isImageOpen}
+              selected={selectedItem?.reference}
+              onSelect={onImageSelect}
+              onOpenChange={setIsImageOpen}
+              toggle={imageToggle}
+              shouldFocusToggleOnSelect
+            >
+              <SelectList>
+                {selectedGroup?.items.map((item) => (
+                  <SelectOption
+                    key={item.reference}
+                    value={item.reference}
+                    className='on-prem-image-item'
+                    description={
+                      <Label color='blue' isCompact>
+                        {isImageType(item.type)
+                          ? simpleTargetNames[item.type]
+                          : item.type}
+                      </Label>
+                    }
+                  >
+                    {item.reference}
+                  </SelectOption>
+                ))}
+              </SelectList>
+            </Select>
+          </FlexItem>
+          <FlexItem>
+            <Button
+              variant='plain'
+              icon={<SyncAltIcon />}
+              onClick={onRefresh}
+              isDisabled={isLoading}
+              isInline
+              aria-label='Refresh image sources'
+            />
+          </FlexItem>
+        </Flex>
+      </FormGroup>
+    </>
+  );
+};
+
+export default OnPremImageSourceSelect;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/groupByName.ts
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/groupByName.ts
@@ -1,0 +1,21 @@
+import type { BootcDistributionItem } from '@/store/api/backend';
+
+export type GroupedDistribution = {
+  name: string;
+  items: BootcDistributionItem[];
+};
+
+export const groupByName = (
+  distributions: BootcDistributionItem[],
+): GroupedDistribution[] => {
+  const groups = new Map<string, BootcDistributionItem[]>();
+  for (const item of distributions) {
+    const existing = groups.get(item.name);
+    if (existing) {
+      existing.push(item);
+    } else {
+      groups.set(item.name, [item]);
+    }
+  }
+  return Array.from(groups, ([name, items]) => ({ name, items }));
+};

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/index.tsx
@@ -1,24 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import {
-  Alert,
-  Button,
-  ClipboardCopy,
-  Content,
-  ExpandableSection,
-  Flex,
-  FlexItem,
-  FormGroup,
-  MenuToggle,
-  MenuToggleElement,
-  Select,
-  SelectList,
-  SelectOption,
-  Spinner,
-} from '@patternfly/react-core';
-import { SyncAltIcon } from '@patternfly/react-icons';
-
-import { RHEL_10_IMAGE_MODE_IMAGE } from '@/constants';
 import {
   BootcDistributionItem,
   useGetDistributionsQuery,
@@ -30,39 +11,13 @@ import {
   changeBootcDistributions,
   changeDistribution,
   changeImageSource,
+  changeImageTypes,
   selectArchitecture,
   selectImageSource,
+  type SupportedImageTypes,
 } from '@/store/slices/wizard';
 
-import RegistryAuthSection from '../RegistryAuthSection';
-
-const CopyInlineCompact = ({ text }: { text: string }) => (
-  <ClipboardCopy
-    copyAriaLabel='Copy podman pull command'
-    hoverTip='Copy'
-    clickTip='Copied'
-    variant='inline-compact'
-    isCode
-  >
-    {text}
-  </ClipboardCopy>
-);
-
-const InfoMessageContent = ({ source }: { source: string }) => {
-  return (
-    <>
-      <Content component='p'>
-        Container images must be pulled using Podman with root privileges, as
-        rootless images are not accessible to image builder at build time.
-      </Content>
-      <Content component='p'>
-        To pull an image locally, ensure you are logged in to the registry and
-        use the following command to use the recommended image mode image:
-      </Content>
-      <CopyInlineCompact text={`sudo podman pull ${source}`} />
-    </>
-  );
-};
+import ImageSourceDropdown from './Dropdown';
 
 const ImageSourceSelect = () => {
   const dispatch = useAppDispatch();
@@ -70,9 +25,6 @@ const ImageSourceSelect = () => {
   const arch = useAppSelector(selectArchitecture);
   const imageSource = useAppSelector(selectImageSource);
   const [isOpen, setIsOpen] = useState(false);
-
-  const [isPullInfoExpanded, setIsPullInfoExpanded] = useState(false);
-  const hasAutoExpanded = useRef(false);
 
   const {
     data: distributions,
@@ -84,16 +36,6 @@ const ImageSourceSelect = () => {
   const bootcDistributions = distributions as
     | BootcDistributionItem[]
     | undefined;
-
-  const hasDistributions = (bootcDistributions?.length ?? 0) > 0;
-
-  useEffect(() => {
-    if (hasAutoExpanded.current) return;
-    if (isOnPremise && !isLoading && !isError) {
-      hasAutoExpanded.current = true;
-      setIsPullInfoExpanded(!hasDistributions);
-    }
-  }, [isOnPremise, isLoading, isError, hasDistributions]);
 
   useEffect(() => {
     if (bootcDistributions) {
@@ -117,21 +59,6 @@ const ImageSourceSelect = () => {
     dispatch(changeDistribution(defaultItem.distro as Distributions));
   }, [bootcDistributions, dispatch, imageSource]);
 
-  // On-prem: show all distributions as-is (including minor versions).
-  // Hosted: filter out minor versions (e.g. rhel-10.1) and deduplicate
-  // by name since the API returns one entry per target type but the
-  // dropdown should show one entry per base image.
-  const uniqueDistributions = isOnPremise
-    ? bootcDistributions
-    : bootcDistributions
-        ?.filter((d) => !d.name.includes('.'))
-        .reduce<BootcDistributionItem[]>((acc, item) => {
-          if (!acc.some((d) => d.name === item.name)) {
-            acc.push(item);
-          }
-          return acc;
-        }, []);
-
   const selectedItem = bootcDistributions?.find(
     (d) => d.reference === imageSource,
   );
@@ -141,124 +68,25 @@ const ImageSourceSelect = () => {
     const selected = bootcDistributions?.find((d) => d.reference === selection);
     if (selected) {
       dispatch(changeDistribution(selected.distro as Distributions));
+      if (isOnPremise) {
+        dispatch(changeImageTypes([selected.type as SupportedImageTypes]));
+      }
     }
     setIsOpen(false);
   };
 
-  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => {
-    if (isLoading) {
-      return (
-        <MenuToggle
-          ref={toggleRef}
-          isDisabled
-          style={
-            {
-              minWidth: '20rem',
-              maxWidth: '100%',
-            } as React.CSSProperties
-          }
-        >
-          <Spinner size='sm' aria-hidden='true' /> Loading bootc images...
-        </MenuToggle>
-      );
-    }
-
-    return (
-      <MenuToggle
-        ref={toggleRef}
-        onClick={() => setIsOpen(!isOpen)}
-        isExpanded={isOpen}
-        style={
-          {
-            minWidth: '20rem',
-            maxWidth: '100%',
-          } as React.CSSProperties
-        }
-      >
-        {selectedItem ? selectedItem.name : 'Select a bootc image'}
-      </MenuToggle>
-    );
-  };
-
   return (
-    <FormGroup label='Image source' isRequired>
-      {isOnPremise && <RegistryAuthSection />}
-      {isError && (
-        <Alert
-          title='Error loading bootc images'
-          variant='danger'
-          className='pf-v6-u-mb-md'
-        >
-          {isOnPremise
-            ? 'Unable to load available bootc images. Ensure podman is installed and accessible.'
-            : 'Unable to load available bootc images. Please try again later.'}
-        </Alert>
-      )}
-      {isOnPremise && !isLoading && !isError && (
-        <ExpandableSection
-          toggleText={
-            isPullInfoExpanded
-              ? 'Hide information about pulling images'
-              : 'Show information about pulling images'
-          }
-          onToggle={(_event, expanded) => setIsPullInfoExpanded(expanded)}
-          isExpanded={isPullInfoExpanded}
-          className='pf-v6-u-pb-sm'
-        >
-          <Alert
-            title={
-              hasDistributions ? 'Note on pulling images' : 'No images found'
-            }
-            variant={hasDistributions ? 'info' : 'warning'}
-            className='pf-v6-u-mb-md'
-          >
-            <InfoMessageContent source={RHEL_10_IMAGE_MODE_IMAGE} />
-          </Alert>
-        </ExpandableSection>
-      )}
-      <Flex>
-        <FlexItem>
-          <Select
-            isOpen={isOpen}
-            selected={imageSource}
-            onSelect={onSelect}
-            onOpenChange={(open) => setIsOpen(open)}
-            toggle={toggle}
-            shouldFocusToggleOnSelect
-          >
-            <SelectList>
-              {uniqueDistributions && uniqueDistributions.length > 0 ? (
-                uniqueDistributions.map((item) => (
-                  <SelectOption
-                    key={item.reference}
-                    value={item.reference}
-                    description={isOnPremise ? item.reference : undefined}
-                  >
-                    {item.name}
-                  </SelectOption>
-                ))
-              ) : (
-                <SelectOption isDisabled>
-                  No bootc images available for {arch}
-                </SelectOption>
-              )}
-            </SelectList>
-          </Select>
-        </FlexItem>
-        {isOnPremise && (
-          <FlexItem>
-            <Button
-              variant='plain'
-              icon={<SyncAltIcon />}
-              onClick={() => refetch()}
-              isDisabled={isLoading}
-              isInline
-              aria-label='Refresh image sources'
-            />
-          </FlexItem>
-        )}
-      </Flex>
-    </FormGroup>
+    <ImageSourceDropdown
+      distributions={bootcDistributions}
+      selectedItem={selectedItem}
+      isLoading={isLoading}
+      isError={isError}
+      isOpen={isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
+      onOpenChange={(open) => setIsOpen(open)}
+      onSelect={onSelect}
+      onRefresh={() => refetch()}
+    />
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/index.tsx
@@ -34,7 +34,7 @@ import {
   selectImageSource,
 } from '@/store/slices/wizard';
 
-import RegistryAuthSection from './RegistryAuthSection';
+import RegistryAuthSection from '../RegistryAuthSection';
 
 const CopyInlineCompact = ({ text }: { text: string }) => (
   <ClipboardCopy

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -27,6 +27,7 @@ import {
   selectArchitecture,
   selectDistribution,
   selectForceShowErrors,
+  selectImageSourceFilter,
   selectImageTypes,
   selectIsImageMode,
   selectIsOnlyNetworkInstallerSelected,
@@ -85,8 +86,10 @@ const TargetEnvironment = () => {
     { skip: isImageMode },
   );
 
+  const imageSourceFilter = useAppSelector(selectImageSourceFilter);
+
   const distroResult = useGetDistributionEnvironmentsQuery(
-    { arch, distro: distribution },
+    { arch, distro: distribution, ...imageSourceFilter },
     { skip: !isImageMode },
   );
 
@@ -288,87 +291,89 @@ const TargetEnvironment = () => {
         </FormGroup>
       )}
 
-      <FormGroup
-        label={
-          privateClouds.length > 0 || publicClouds.length > 0
-            ? 'Miscellaneous formats'
-            : undefined
-        }
-        className='pf-v6-u-mt-md'
-        role='group'
-        aria-label='Miscellaneous formats'
-        fieldId='misc-formats-group'
-      >
-        {miscFormats.includes('guest-image') && (
-          <TargetEnvironmentOption
-            environment='guest-image'
-            label={createLabelWithTooltip(
-              'Virtualization',
-              'Guest image (.qcow2)',
-              'A deployment-ready virtual disk format used by Openshift Virtualization and libvirt. It allows for efficient storage usage by only writing the changes made to the disk image rather than the entire image, ensuring the file only consumes physical storage as data is written.',
-            )}
-            ariaLabel='Virtualization guest image'
-            isDisabled={isOnlyNetworkInstallerSelected}
-          />
-        )}
-        {miscFormats.includes('image-installer') && (
-          <TargetEnvironmentOption
-            environment='image-installer'
-            label={createLabelWithTooltip(
-              'Bare metal',
-              'Installer (.iso)',
-              'This is a standard bootable image used to install RHEL directly onto physical hardware or "bare metal" servers. It contains the necessary installer and kernel to initialize a system from scratch, ensuring the OS is configured correctly for your specific hardware environment.',
-            )}
-            ariaLabel='Bare metal installer'
-            isDisabled={isOnlyNetworkInstallerSelected}
-          />
-        )}
-        {miscFormats.includes('bootable-container-iso') && isImageMode && (
-          <TargetEnvironmentOption
-            environment='bootable-container-iso'
-            label='Container installer (.iso)'
-            ariaLabel='Container installer'
-          />
-        )}
-        {miscFormats.includes('network-installer') && (
-          <TargetEnvironmentOption
-            environment='network-installer'
-            label={createLabelWithTooltip(
-              'Network',
-              'Installer (.iso)',
-              isOtherEnvironmentSelected
-                ? 'Network installer cannot be combined with other image types'
-                : 'This is a lightweight image that differs from a standard "full" ISO by requiring an active network connection to pull the latest software directly from package repositories, as no OS packages are stored locally on the image.',
-            )}
-            ariaLabel='Network installer'
-            isDisabled={isOtherEnvironmentSelected}
-          />
-        )}
-        {miscFormats.includes('pxe-tar-xz') && (
-          <TargetEnvironmentOption
-            environment='pxe-tar-xz'
-            label={createLabelWithTooltip(
-              'Network',
-              'PXE boot (.tar.xz)',
-              'A PXE boot image is a compressed archive containing the kernel, initramfs, and root filesystem needed to boot a system over the network using the Preboot Execution Environment (PXE) protocol.',
-            )}
-            ariaLabel='PXE boot image'
-            isDisabled={isOnlyNetworkInstallerSelected}
-          />
-        )}
-        {miscFormats.includes('wsl') && (
-          <TargetEnvironmentOption
-            environment='wsl'
-            label={createLabelWithTooltip(
-              'WSL',
-              'Windows Subsystem for Linux (.wsl)',
-              "RHEL on Microsoft's Windows Subsystem for Linux (WSL) can be used for development and learning use cases. WSL is supported by Red Hat under the Validated Software Pattern and Third Party Component Support Policy, which does not include production use cases.",
-            )}
-            ariaLabel='Windows Subsystem for Linux'
-            isDisabled={isOnlyNetworkInstallerSelected}
-          />
-        )}
-      </FormGroup>
+      {miscFormats.length > 0 && (
+        <FormGroup
+          label={
+            privateClouds.length > 0 || publicClouds.length > 0
+              ? 'Miscellaneous formats'
+              : undefined
+          }
+          className='pf-v6-u-mt-md'
+          role='group'
+          aria-label='Miscellaneous formats'
+          fieldId='misc-formats-group'
+        >
+          {miscFormats.includes('guest-image') && (
+            <TargetEnvironmentOption
+              environment='guest-image'
+              label={createLabelWithTooltip(
+                'Virtualization',
+                'Guest image (.qcow2)',
+                'A deployment-ready virtual disk format used by Openshift Virtualization and libvirt. It allows for efficient storage usage by only writing the changes made to the disk image rather than the entire image, ensuring the file only consumes physical storage as data is written.',
+              )}
+              ariaLabel='Virtualization guest image'
+              isDisabled={isOnlyNetworkInstallerSelected}
+            />
+          )}
+          {miscFormats.includes('image-installer') && (
+            <TargetEnvironmentOption
+              environment='image-installer'
+              label={createLabelWithTooltip(
+                'Bare metal',
+                'Installer (.iso)',
+                'This is a standard bootable image used to install RHEL directly onto physical hardware or "bare metal" servers. It contains the necessary installer and kernel to initialize a system from scratch, ensuring the OS is configured correctly for your specific hardware environment.',
+              )}
+              ariaLabel='Bare metal installer'
+              isDisabled={isOnlyNetworkInstallerSelected}
+            />
+          )}
+          {miscFormats.includes('bootable-container-iso') && isImageMode && (
+            <TargetEnvironmentOption
+              environment='bootable-container-iso'
+              label='Container installer (.iso)'
+              ariaLabel='Container installer'
+            />
+          )}
+          {miscFormats.includes('network-installer') && (
+            <TargetEnvironmentOption
+              environment='network-installer'
+              label={createLabelWithTooltip(
+                'Network',
+                'Installer (.iso)',
+                isOtherEnvironmentSelected
+                  ? 'Network installer cannot be combined with other image types'
+                  : 'This is a lightweight image that differs from a standard "full" ISO by requiring an active network connection to pull the latest software directly from package repositories, as no OS packages are stored locally on the image.',
+              )}
+              ariaLabel='Network installer'
+              isDisabled={isOtherEnvironmentSelected}
+            />
+          )}
+          {miscFormats.includes('pxe-tar-xz') && (
+            <TargetEnvironmentOption
+              environment='pxe-tar-xz'
+              label={createLabelWithTooltip(
+                'Network',
+                'PXE boot (.tar.xz)',
+                'A PXE boot image is a compressed archive containing the kernel, initramfs, and root filesystem needed to boot a system over the network using the Preboot Execution Environment (PXE) protocol.',
+              )}
+              ariaLabel='PXE boot image'
+              isDisabled={isOnlyNetworkInstallerSelected}
+            />
+          )}
+          {miscFormats.includes('wsl') && (
+            <TargetEnvironmentOption
+              environment='wsl'
+              label={createLabelWithTooltip(
+                'WSL',
+                'Windows Subsystem for Linux (.wsl)',
+                "RHEL on Microsoft's Windows Subsystem for Linux (WSL) can be used for development and learning use cases. WSL is supported by Red Hat under the Validated Software Pattern and Third Party Component Support Policy, which does not include production use cases.",
+              )}
+              ariaLabel='Windows Subsystem for Linux'
+              isDisabled={isOnlyNetworkInstallerSelected}
+            />
+          )}
+        </FormGroup>
+      )}
 
       {isOnlyNetworkInstallerSelected && (
         <Alert

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -74,7 +74,9 @@ describe('ImageSourceSelect', () => {
       renderImageSourceSelect();
 
       expect(await screen.findByText('Image source')).toBeInTheDocument();
-      expect(screen.getByText('*')).toBeInTheDocument();
+      // On-prem renders two required FormGroups (Release + Image source)
+      const requiredMarkers = screen.getAllByText('*');
+      expect(requiredMarkers.length).toBeGreaterThanOrEqual(1);
     });
 
     test('auto-selects the first rhel-10 distribution', async () => {

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/groupByName.test.ts
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/groupByName.test.ts
@@ -1,0 +1,100 @@
+import type { BootcDistributionItem } from '@/store/api/backend';
+
+import { groupByName } from '../components/ImageSourceSelect/groupByName';
+
+const makeItem = (
+  name: string,
+  reference: string,
+  type = 'guest-image',
+): BootcDistributionItem => ({
+  distro: 'rhel-10',
+  name,
+  type,
+  arch: 'x86_64',
+  reference,
+});
+
+describe('groupByName', () => {
+  test('returns empty array for empty input', () => {
+    expect(groupByName([])).toEqual([]);
+  });
+
+  test('creates one group per unique name', () => {
+    const items = [makeItem('RHEL 10', 'ref-a'), makeItem('RHEL 9', 'ref-b')];
+
+    const result = groupByName(items);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      name: 'RHEL 10',
+      items: [items[0]],
+    });
+    expect(result[1]).toEqual({
+      name: 'RHEL 9',
+      items: [items[1]],
+    });
+  });
+
+  test('groups items with the same name together', () => {
+    const items = [
+      makeItem('RHEL 10', 'ref-kvm', 'guest-image'),
+      makeItem('RHEL 10', 'ref-aws', 'aws'),
+      makeItem('RHEL 9', 'ref-9'),
+    ];
+
+    const result = groupByName(items);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('RHEL 10');
+    expect(result[0].items).toHaveLength(2);
+    expect(result[0].items[0].reference).toBe('ref-kvm');
+    expect(result[0].items[1].reference).toBe('ref-aws');
+    expect(result[1].name).toBe('RHEL 9');
+    expect(result[1].items).toHaveLength(1);
+  });
+
+  test('preserves insertion order of groups', () => {
+    const items = [
+      makeItem('Fedora 44', 'ref-f'),
+      makeItem('RHEL 10', 'ref-r'),
+      makeItem('CentOS 10', 'ref-c'),
+    ];
+
+    const result = groupByName(items);
+
+    expect(result.map((g) => g.name)).toEqual([
+      'Fedora 44',
+      'RHEL 10',
+      'CentOS 10',
+    ]);
+  });
+
+  test('preserves item order within each group', () => {
+    const items = [
+      makeItem('RHEL 10', 'ref-first', 'guest-image'),
+      makeItem('RHEL 10', 'ref-second', 'aws'),
+      makeItem('RHEL 10', 'ref-third', 'vsphere'),
+    ];
+
+    const result = groupByName(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].items.map((i) => i.reference)).toEqual([
+      'ref-first',
+      'ref-second',
+      'ref-third',
+    ]);
+  });
+
+  test('handles single item input', () => {
+    const items = [makeItem('RHEL 10', 'ref-only')];
+
+    const result = groupByName(items);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      name: 'RHEL 10',
+      items: [items[0]],
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/helpers.tsx
@@ -156,8 +156,9 @@ export const renderImageSourceSelect = (
 
 // ImageSourceSelect interaction helpers
 export const openImageSourceSelect = async (user: UserEventInstance) => {
+  // On-prem uses "Select a distribution"; hosted uses "Select a bootc image"
   const toggle = await screen.findByRole('button', {
-    name: /select a bootc image/i,
+    name: /select a (bootc image|distribution)/i,
   });
   await clickWithWait(user, toggle);
 };

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/mocks/fixtures.ts
@@ -131,14 +131,14 @@ export const mockBootcDistributionsMultipleTypes: BootcDistributionItem[] = [
     name: 'Red Hat Enterprise Linux (RHEL) 10',
     type: 'guest-image',
     arch: 'x86_64',
-    reference: 'registry.redhat.io/rhel10/rhel-bootc:rhel-10',
+    reference: 'registry.redhat.io/rhel10/rhel-bootc-kvm:10.3',
   },
   {
     distro: 'rhel-10',
     name: 'Red Hat Enterprise Linux (RHEL) 10',
     type: 'aws',
     arch: 'x86_64',
-    reference: 'registry.redhat.io/rhel10/rhel-bootc:rhel-10',
+    reference: 'registry.redhat.io/rhel10/rhel-bootc-aws:10.3',
   },
 ];
 

--- a/src/store/api/backend/derived.ts
+++ b/src/store/api/backend/derived.ts
@@ -91,9 +91,9 @@ const derivedApi = backendApi.injectEndpoints({
 
     getDistributionEnvironments: builder.query<
       DistributionEnvironmentsResult,
-      { arch: string; distro?: string }
+      { arch: string; distro?: string; imageSource?: string }
     >({
-      queryFn: async (queryArgs, api) => {
+      queryFn: async ({ imageSource, ...queryArgs }, api) => {
         const result = await api.dispatch(
           backendApi.endpoints.getDistributions.initiate(
             { kind: 'bootc', ...queryArgs },
@@ -114,7 +114,18 @@ const derivedApi = backendApi.injectEndpoints({
         }
 
         const distributions = result.data.filter(isBootcDistribution);
-        const imageTypes = [...new Set(distributions.map((d) => d.type))];
+
+        // When an exact image reference is provided, narrow the
+        // available target types to only those matching that image.
+        // This is used on-prem where each container image supports
+        // a single output type via its image-builder.image.type label.
+        const selectedType = imageSource
+          ? distributions.find((d) => d.reference === imageSource)?.type
+          : undefined;
+
+        const imageTypes = selectedType
+          ? [selectedType]
+          : [...new Set(distributions.map((d) => d.type))];
 
         return {
           data: {

--- a/src/store/api/backend/onprem/composerApi/architecture.ts
+++ b/src/store/api/backend/onprem/composerApi/architecture.ts
@@ -1,6 +1,7 @@
 import { type OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 
 import {
+  byDistroDescending,
   filterBootcImages,
   getCloudConfigs,
   listPodmanImages,
@@ -48,7 +49,8 @@ export const architectureEndpoints = (builder: OnPremBuilder) => ({
           Architecture: normalizeArch(img.Architecture ?? arch),
         }))
         .filter(filterBootcImages)
-        .map(toBootcDistro);
+        .map(toBootcDistro)
+        .sort(byDistroDescending);
     }),
   }),
   getArchitectures: builder.query<

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -4,6 +4,7 @@ export { lookupDatastreamDistro } from './dataStreamLookup';
 export { getBlueprintsPath } from './getBlueprintsPath';
 export { getCloudConfigs } from './getCloudConfigs';
 export {
+  byDistroDescending,
   inferDistro,
   filterBootcImages,
   listPodmanImages,

--- a/src/store/api/backend/onprem/composerApi/helpers/podman/filters.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podman/filters.ts
@@ -6,6 +6,17 @@ import {
 
 import { inferDistro } from './inferDistro';
 
+// The backend (osbuild-composer) uses different names for some image
+// types than the frontend. Normalize at the boundary so downstream
+// code only deals with frontend types.
+const backendToFrontendType: Record<string, string> = {
+  qcow2: 'guest-image',
+  ami: 'aws',
+};
+
+const normalizeImageType = (type: string): string =>
+  backendToFrontendType[type] ?? type;
+
 export const filterBootcImages = (
   image: PodmanImageInfo,
 ): image is ValidatedPodmanImage => {
@@ -36,11 +47,14 @@ export const toBootcDistro = (
 ): BootcDistributionItem => {
   const { distro, name } = inferDistro(image);
 
+  const rawType = image.Labels['image-builder.image.type'];
+  const imageType = rawType ? normalizeImageType(rawType) : 'guest-image';
+
   return {
     arch: image.Architecture,
     distro,
     reference: image.RepoTags[0],
-    name,
-    type: 'guest-image',
+    name: name,
+    type: imageType,
   };
 };

--- a/src/store/api/backend/onprem/composerApi/helpers/podman/filters.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podman/filters.ts
@@ -1,4 +1,4 @@
-import { BootcDistributionItem } from '@/store/api/backend';
+import type { BootcDistributionItem } from '@/store/api/backend';
 import {
   PodmanImageInfo,
   ValidatedPodmanImage,
@@ -16,6 +16,26 @@ const backendToFrontendType: Record<string, string> = {
 
 const normalizeImageType = (type: string): string =>
   backendToFrontendType[type] ?? type;
+
+// Extract numeric version from a distro string like "rhel-10" or
+// "rhel-10.3". Returns NaN for non-RHEL distros so they sort after RHEL.
+const rhelVersion = (distro: string): number => {
+  const match = distro.match(/^rhel-(\d+(?:\.\d+)?)/);
+  return match ? parseFloat(match[1]) : NaN;
+};
+
+// Sort comparator: RHEL descending by version, then non-RHEL alphabetical.
+export const byDistroDescending = (
+  a: BootcDistributionItem,
+  b: BootcDistributionItem,
+): number => {
+  const aVer = rhelVersion(a.distro);
+  const bVer = rhelVersion(b.distro);
+  if (!isNaN(aVer) && !isNaN(bVer)) return bVer - aVer;
+  if (!isNaN(aVer)) return -1;
+  if (!isNaN(bVer)) return 1;
+  return a.name.localeCompare(b.name);
+};
 
 export const filterBootcImages = (
   image: PodmanImageInfo,

--- a/src/store/api/backend/onprem/composerApi/helpers/podman/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podman/index.ts
@@ -1,4 +1,8 @@
-export { filterBootcImages, toBootcDistro } from './filters';
+export {
+  byDistroDescending,
+  filterBootcImages,
+  toBootcDistro,
+} from './filters';
 export { normalizeArch } from './normalizeArch';
 export { listPodmanImages } from './images';
 export { podmanInspect } from './inspect';

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/byDistroDescending.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/byDistroDescending.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BootcDistributionItem } from '@/store/api/backend';
+
+import { byDistroDescending } from '../podman';
+
+const makeItem = (distro: string, name: string): BootcDistributionItem => ({
+  distro,
+  name,
+  type: 'guest-image',
+  arch: 'x86_64',
+  reference: `localhost/${distro}:latest`,
+});
+
+describe('byDistroDescending', () => {
+  it('sorts RHEL versions descending', () => {
+    const items = [
+      makeItem('rhel-9', 'RHEL 9'),
+      makeItem('rhel-10.3', 'RHEL 10.3'),
+      makeItem('rhel-10', 'RHEL 10'),
+      makeItem('rhel-10.1', 'RHEL 10.1'),
+    ];
+
+    const sorted = [...items].sort(byDistroDescending);
+
+    expect(sorted.map((i) => i.distro)).toEqual([
+      'rhel-10.3',
+      'rhel-10.1',
+      'rhel-10',
+      'rhel-9',
+    ]);
+  });
+
+  it('places RHEL before non-RHEL', () => {
+    const items = [
+      makeItem('fedora-42', 'Fedora 42'),
+      makeItem('rhel-9', 'RHEL 9'),
+      makeItem('centos-10', 'CentOS Stream 10'),
+    ];
+
+    const sorted = [...items].sort(byDistroDescending);
+
+    expect(sorted.map((i) => i.distro)).toEqual([
+      'rhel-9',
+      'centos-10',
+      'fedora-42',
+    ]);
+  });
+
+  it('sorts non-RHEL items alphabetically by name', () => {
+    const items = [
+      makeItem('fedora-42', 'Fedora 42'),
+      makeItem('centos-10', 'CentOS Stream 10'),
+      makeItem('unknown', 'Alpine'),
+    ];
+
+    const sorted = [...items].sort(byDistroDescending);
+
+    expect(sorted.map((i) => i.name)).toEqual([
+      'Alpine',
+      'CentOS Stream 10',
+      'Fedora 42',
+    ]);
+  });
+});

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/toBootcDistro.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/toBootcDistro.test.ts
@@ -55,10 +55,34 @@ describe('toBootcDistro', () => {
     expect(result.arch).toBe('arm64');
   });
 
-  it('always sets type to guest-image', () => {
+  it('defaults to guest-image when no image-builder.image.type label', () => {
     const result = toBootcDistro(makeImage());
 
     expect(result.type).toBe('guest-image');
+  });
+
+  it('normalizes qcow2 to guest-image', () => {
+    const result = toBootcDistro(
+      makeImage({ 'image-builder.image.type': 'qcow2' }),
+    );
+
+    expect(result.type).toBe('guest-image');
+  });
+
+  it('normalizes ami to aws', () => {
+    const result = toBootcDistro(
+      makeImage({ 'image-builder.image.type': 'ami' }),
+    );
+
+    expect(result.type).toBe('aws');
+  });
+
+  it('passes through unrecognized image types as-is', () => {
+    const result = toBootcDistro(
+      makeImage({ 'image-builder.image.type': 'vsphere' }),
+    );
+
+    expect(result.type).toBe('vsphere');
   });
 
   it('produces fedora distro for a Fedora image', () => {

--- a/src/store/slices/wizard/output/selectors.ts
+++ b/src/store/slices/wizard/output/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from '@reduxjs/toolkit';
 
 import { RootState } from '@/store';
+import { selectIsOnPremise } from '@/store/slices/env';
 
 export const selectImageSource = (state: RootState) => {
   return state.wizard.output.imageSource;
@@ -36,4 +37,14 @@ export const selectIsOtherEnvironmentSelected = createSelector(
   selectImageTypes,
   (imageTypes) =>
     imageTypes.length >= 1 && !imageTypes.includes('network-installer'),
+);
+
+export const selectImageSourceFilter = createSelector(
+  selectIsOnPremise,
+  selectImageSource,
+  (
+    isOnPremise,
+    imageSource,
+  ): { imageSource: string } | Record<string, never> =>
+    isOnPremise && imageSource ? { imageSource } : {},
 );

--- a/src/store/slices/wizard/output/tests/output.test.ts
+++ b/src/store/slices/wizard/output/tests/output.test.ts
@@ -15,6 +15,7 @@ import {
   selectBootcDistributions,
   selectDistribution,
   selectImageSource,
+  selectImageSourceFilter,
   selectImageTypes,
   selectIsOnlyNetworkInstallerSelected,
   selectIsoPayloadReference,
@@ -23,7 +24,7 @@ import {
   type WizardState,
 } from '@/store/slices/wizard';
 
-import { createMockState } from '../../tests/mockWizardState';
+import { createMockState, mockRootState } from '../../tests/mockWizardState';
 
 describe('output reducers', () => {
   describe('changeImageSource', () => {
@@ -407,6 +408,46 @@ describe('output selectors', () => {
       });
 
       expect(selectIsOtherEnvironmentSelected(state)).toBe(false);
+    });
+  });
+
+  describe('selectImageSourceFilter', () => {
+    it('should return imageSource when on-premise with imageSource set', () => {
+      const state = {
+        ...mockRootState,
+        env: { isOnPremise: true },
+        wizard: {
+          ...mockRootState.wizard,
+          output: {
+            ...initialState.output,
+            imageSource: 'registry.redhat.io/rhel10/rhel-bootc:10.0',
+          },
+        },
+      };
+
+      expect(selectImageSourceFilter(state)).toEqual({
+        imageSource: 'registry.redhat.io/rhel10/rhel-bootc:10.0',
+      });
+    });
+
+    it('should return empty object when on-premise with no imageSource', () => {
+      const state = {
+        ...mockRootState,
+        env: { isOnPremise: true },
+      };
+
+      expect(selectImageSourceFilter(state)).toEqual({});
+    });
+
+    it('should return empty object when hosted, even with imageSource set', () => {
+      const state = createMockState({
+        output: {
+          ...initialState.output,
+          imageSource: 'registry.redhat.io/rhel10/rhel-bootc:10.0',
+        },
+      });
+
+      expect(selectImageSourceFilter(state)).toEqual({});
     });
   });
 });


### PR DESCRIPTION
## Summary

Rework the ImageSourceSelect component to properly handle on-prem bootc-derived images, which have different selection semantics (flyout menus, per-image output types) than the hosted variant.

## Changes

- Split `ImageSourceSelect` into separate Hosted, OnPrem, and Dropdown components to eliminate conditional rendering logic and make each variant self-contained
- Filter available target environments based on the selected on-prem image's `image-builder.image.type` label, so users only see output types their image actually supports
- Normalize backend image type names (e.g. `qcow2` → `guest-image`, `ami` → `aws`) at the podman boundary so downstream code uses consistent frontend types
- Sort on-prem distributions by RHEL version descending and show the full image reference as a sublabel to disambiguate images that share the same inferred name
- Rewrite skipped ImageSourceSelect tests for the flyout menu interaction pattern and add unit tests for `groupByName` and the new store selectors
