### PR TITLE
store/onprem: add .cache to .state migration

### DIFF
--- a/src/store/api/backend/onprem/composerApi/helpers/getBlueprintsPath.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/getBlueprintsPath.ts
@@ -13,6 +13,14 @@ export const getBlueprintsPath = async (): Promise<string> => {
   }
   const blueprintsDir = path.join(stateDir, BLUEPRINTS_DIR);
 
+  // Backwards compatibility, drop after 10.4?
+  await cockpit.script(`
+if [ ! -e "${blueprintsDir}" ] && [ -d "${user.home}/.cache/cockpit-image-builder" ] ; then
+  mkdir -p "${stateDir}"
+  cp -a "${user.home}/.cache/cockpit-image-builder" "${stateDir}/"
+fi
+`);
+
   // make sure the directory exists
   await cockpit.spawn(['mkdir', '-p', blueprintsDir], {});
   return blueprintsDir;


### PR DESCRIPTION
This was backported to 10.2. For certainty, let's keep it around for a bit longer, in case users upgrade from 10.0 or 10.1 straight to a future minor version.