### PR TITLE
test: Add co-located unit tests for Registration (HMS-11002)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/tests/ActivationKeysList.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/ActivationKeysList.test.tsx
@@ -1,0 +1,182 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { initialState } from '@/store/slices/wizard';
+import { server } from '@/test/mocks/server';
+import { clickWithWait, createUser } from '@/test/testUtils';
+
+import { renderRegistrationStep } from './helpers';
+import {
+  createDefaultFetchHandler,
+  createFetchHandler,
+  fetchMock,
+  mockEmptyActivationKeys,
+} from './mocks';
+
+fetchMock.enableMocks();
+
+// Disable global MSW server for this file - we use fetch mocks instead
+beforeAll(() => {
+  server.close();
+});
+
+// Restore global MSW server so other tests don't break
+afterAll(() => {
+  server.listen();
+});
+
+beforeEach(() => {
+  fetchMock.mockResponse(createDefaultFetchHandler);
+});
+
+afterEach(() => {
+  fetchMock.resetMocks();
+});
+
+describe('Activation Keys List', () => {
+  describe('Rendering', () => {
+    test('displays activation key select', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now-rhc',
+        },
+      });
+
+      expect(
+        await screen.findByPlaceholderText(/select activation key/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Activation Key Selection', () => {
+    test('displays list of activation keys when opened', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now-rhc',
+        },
+      });
+      const user = createUser();
+
+      const selectToggle = await screen.findByPlaceholderText(
+        /select activation key/i,
+      );
+      await clickWithWait(user, selectToggle);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('option', { name: /activation-key-1/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', { name: /activation-key-2/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', { name: /test-key-alpha/i }),
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('selects an activation key', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now-rhc',
+        },
+      });
+      const user = createUser();
+
+      const selectToggle = await screen.findByPlaceholderText(
+        /select activation key/i,
+      );
+      await clickWithWait(user, selectToggle);
+
+      const option = await screen.findByRole('option', {
+        name: /activation-key-1/i,
+      });
+      await clickWithWait(user, option);
+
+      await waitFor(() => {
+        expect(selectToggle).toHaveValue('activation-key-1');
+      });
+    });
+
+    test('shows view details button for activation keys', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now-rhc',
+        },
+      });
+
+      expect(
+        await screen.findByRole('button', { name: /view details/i }),
+      ).toBeInTheDocument();
+    });
+
+    test('toggles activation key details visibility', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now-rhc',
+        },
+      });
+      const user = createUser();
+
+      const viewDetailsButton = await screen.findByRole('button', {
+        name: /view details/i,
+      });
+
+      expect(screen.queryByText(/Name/i)).not.toBeInTheDocument();
+
+      await clickWithWait(user, viewDetailsButton);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Name/i)).toBeInTheDocument();
+      });
+
+      await clickWithWait(user, viewDetailsButton);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/Name/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Empty State', () => {
+    test('handles empty activation keys list', async () => {
+      fetchMock.mockResponse(
+        createFetchHandler({ activationKeys: mockEmptyActivationKeys }),
+      );
+
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now-rhc',
+        },
+      });
+
+      const selectToggle = await screen.findByPlaceholderText(
+        /select activation key/i,
+      );
+
+      expect(selectToggle).toBeInTheDocument();
+    });
+  });
+
+  describe('Error Handling', () => {
+    test('shows error alert when activation keys fail to load', async () => {
+      fetchMock.mockReject(new Error('Failed to fetch activation keys'));
+
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now-rhc',
+        },
+      });
+
+      expect(
+        await screen.findByText(/activation keys unavailable/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/Registration/tests/Registration.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/Registration.test.tsx
@@ -1,0 +1,309 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { initialState } from '@/store/slices/wizard';
+import { clearWithWait, clickWithWait, createUser } from '@/test/testUtils';
+
+import {
+  enterActivationKey,
+  enterOrgId,
+  renderRegistrationStep,
+  selectAutomaticRegistration,
+  selectRegisterLater,
+  selectSatelliteRegistration,
+  toggleInsights,
+  toggleRhc,
+} from './helpers';
+
+describe('Registration Component', () => {
+  describe('Rendering', () => {
+    test('displays step title and description', async () => {
+      renderRegistrationStep();
+
+      expect(
+        await screen.findByRole('heading', { name: /register/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /configure registration settings for systems that will use this image/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('displays registration method options', async () => {
+      renderRegistrationStep();
+
+      expect(
+        await screen.findByRole('radio', {
+          name: /automatically register to red hat/i,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', { name: /register later/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', {
+          name: /register for a satellite or capsule server/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    test('defaults to automatic registration with insights and rhc enabled', async () => {
+      renderRegistrationStep();
+
+      const autoRegisterRadio = await screen.findByRole('radio', {
+        name: /automatically register to red hat/i,
+      });
+      expect(autoRegisterRadio).toBeChecked();
+
+      const insightsSwitch = screen.getByRole('switch', {
+        name: /enable predictive analytics/i,
+      });
+      const rhcSwitch = screen.getByRole('switch', {
+        name: /enable remote remediations/i,
+      });
+
+      await waitFor(() => {
+        expect(insightsSwitch).toBeChecked();
+        expect(rhcSwitch).toBeChecked();
+      });
+    });
+  });
+
+  describe('Registration Mode Selection', () => {
+    test('switches to register later mode', async () => {
+      renderRegistrationStep();
+      const user = createUser();
+
+      await selectRegisterLater(user);
+
+      const registerLaterRadio = screen.getByRole('radio', {
+        name: /register later/i,
+      });
+      expect(registerLaterRadio).toBeChecked();
+
+      expect(
+        screen.queryByRole('switch', {
+          name: /enable predictive analytics/i,
+        }),
+      ).not.toBeChecked();
+    });
+
+    test('switches to satellite registration mode', async () => {
+      renderRegistrationStep();
+      const user = createUser();
+
+      await selectSatelliteRegistration(user);
+
+      const satelliteRadio = screen.getByRole('radio', {
+        name: /register for a satellite or capsule server/i,
+      });
+      expect(satelliteRadio).toBeChecked();
+
+      expect(
+        await screen.findByRole('textbox', { name: /registration command/i }),
+      ).toBeInTheDocument();
+    });
+
+    test('can switch back to automatic registration', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-later',
+        },
+      });
+      const user = createUser();
+
+      await selectAutomaticRegistration(user);
+
+      const autoRegisterRadio = screen.getByRole('radio', {
+        name: /automatically register to red hat/i,
+      });
+      expect(autoRegisterRadio).toBeChecked();
+
+      expect(
+        await screen.findByRole('switch', {
+          name: /enable predictive analytics/i,
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Insights and RHC Toggles', () => {
+    test('toggling insights off also disables rhc', async () => {
+      renderRegistrationStep();
+      const user = createUser();
+
+      const insightsSwitch = await screen.findByRole('switch', {
+        name: /enable predictive analytics/i,
+      });
+      const rhcSwitch = screen.getByRole('switch', {
+        name: /enable remote remediations/i,
+      });
+
+      await waitFor(() => expect(insightsSwitch).toBeChecked());
+      await waitFor(() => expect(rhcSwitch).toBeChecked());
+
+      await toggleInsights(user);
+
+      await waitFor(() => {
+        expect(insightsSwitch).not.toBeChecked();
+        expect(rhcSwitch).not.toBeChecked();
+      });
+    });
+
+    test('toggling rhc on enables insights', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now',
+        },
+      });
+      const user = createUser();
+
+      const insightsSwitch = await screen.findByRole('switch', {
+        name: /enable predictive analytics/i,
+      });
+      const rhcSwitch = screen.getByRole('switch', {
+        name: /enable remote remediations/i,
+      });
+
+      await waitFor(() => {
+        expect(insightsSwitch).not.toBeChecked();
+        expect(rhcSwitch).not.toBeChecked();
+      });
+
+      await toggleRhc(user);
+
+      await waitFor(() => {
+        expect(insightsSwitch).toBeChecked();
+        expect(rhcSwitch).toBeChecked();
+      });
+    });
+
+    test('toggling rhc off keeps insights enabled', async () => {
+      renderRegistrationStep();
+      const user = createUser();
+
+      const insightsSwitch = await screen.findByRole('switch', {
+        name: /enable predictive analytics/i,
+      });
+      const rhcSwitch = screen.getByRole('switch', {
+        name: /enable remote remediations/i,
+      });
+
+      await waitFor(() => {
+        expect(insightsSwitch).toBeChecked();
+        expect(rhcSwitch).toBeChecked();
+      });
+
+      await toggleRhc(user);
+
+      await waitFor(() => {
+        expect(insightsSwitch).toBeChecked();
+        expect(rhcSwitch).not.toBeChecked();
+      });
+    });
+
+    test('can enable insights independently', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-now',
+        },
+      });
+      const user = createUser();
+
+      const insightsSwitch = await screen.findByRole('switch', {
+        name: /enable predictive analytics/i,
+      });
+      const rhcSwitch = screen.getByRole('switch', {
+        name: /enable remote remediations/i,
+      });
+
+      await waitFor(() => {
+        expect(insightsSwitch).not.toBeChecked();
+        expect(rhcSwitch).not.toBeChecked();
+      });
+
+      await toggleInsights(user);
+
+      await waitFor(() => {
+        expect(insightsSwitch).toBeChecked();
+        expect(rhcSwitch).not.toBeChecked();
+      });
+    });
+  });
+
+  describe('On-Premise Manual Activation Key', () => {
+    test('displays activation key and org id inputs for on-premise', async () => {
+      renderRegistrationStep(
+        {},
+        { preloadedState: { env: { isOnPremise: true } } },
+      );
+
+      expect(
+        await screen.findByRole('textbox', { name: /activation key/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('textbox', { name: /organization id/i }),
+      ).toBeInTheDocument();
+    });
+
+    test('validates activation key is not empty', async () => {
+      renderRegistrationStep(
+        {},
+        { preloadedState: { env: { isOnPremise: true } } },
+      );
+      const user = createUser();
+
+      const activationKeyInput = await screen.findByRole('textbox', {
+        name: /activation key/i,
+      });
+
+      await clearWithWait(user, activationKeyInput);
+      await clickWithWait(user, document.body);
+
+      expect(
+        await screen.findByText(/the activation key cannot be empty/i),
+      ).toBeInTheDocument();
+    });
+
+    test('validates organization id is numeric', async () => {
+      renderRegistrationStep(
+        {
+          registration: {
+            ...initialState.registration,
+            orgId: 'abc123',
+          },
+        },
+        { preloadedState: { env: { isOnPremise: true } } },
+      );
+      const user = createUser();
+
+      await enterOrgId(user, 'abcdefghijkl');
+      await clickWithWait(user, document.body);
+
+      expect(
+        await screen.findByText(/please enter a valid organization id/i),
+      ).toBeInTheDocument();
+    });
+
+    test('accepts valid activation key and org id', async () => {
+      renderRegistrationStep(
+        {},
+        { preloadedState: { env: { isOnPremise: true } } },
+      );
+      const user = createUser();
+
+      await enterActivationKey(user, 'test-activation-key');
+      await enterOrgId(user, '12345');
+
+      expect(
+        screen.queryByText(/the activation key cannot be empty/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/please enter a valid organization id/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/Registration/tests/SatelliteRegistration.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/SatelliteRegistration.test.tsx
@@ -1,0 +1,215 @@
+import { screen, waitFor } from '@testing-library/react';
+
+import { initialState } from '@/store/slices/wizard';
+import { clearWithWait, clickWithWait, createUser } from '@/test/testUtils';
+
+import {
+  enterSatelliteCommand,
+  renderRegistrationStep,
+  selectSatelliteRegistration,
+} from './helpers';
+import {
+  INVALID_SATELLITE_COMMAND,
+  SATELLITE_COMMAND_EXPIRED_TOKEN,
+  SATELLITE_COMMAND_NO_EXPIRATION,
+  VALID_CERTIFICATE,
+  VALID_SATELLITE_COMMAND,
+} from './mocks';
+
+describe('Satellite Registration', () => {
+  describe('Rendering', () => {
+    test('displays satellite registration fields when selected', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+        },
+      });
+
+      expect(
+        await screen.findByRole('textbox', { name: /registration command/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /upload/i }),
+      ).toBeInTheDocument();
+    });
+
+    test('hides satellite fields for other registration modes', async () => {
+      renderRegistrationStep();
+
+      expect(
+        screen.queryByRole('textbox', { name: /registration command/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Command Validation', () => {
+    test('shows error for invalid command', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+        },
+      });
+      const user = createUser();
+
+      await enterSatelliteCommand(user, INVALID_SATELLITE_COMMAND);
+      await clickWithWait(user, document.body);
+
+      expect(
+        await screen.findByText(/invalid or missing token/i),
+      ).toBeInTheDocument();
+    });
+
+    test('shows warning for expired token', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+        },
+      });
+      const user = createUser();
+
+      await enterSatelliteCommand(user, SATELLITE_COMMAND_EXPIRED_TOKEN);
+
+      expect(
+        await screen.findByText(
+          /the token is already expired or will expire by next day/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    test('accepts valid command with no expiration', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+        },
+      });
+      const user = createUser();
+
+      await enterSatelliteCommand(user, SATELLITE_COMMAND_NO_EXPIRATION);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/invalid or missing token/i),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(
+            /the token is already expired or will expire by next day/i,
+          ),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    test('accepts valid command with standard token', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+        },
+      });
+      const user = createUser();
+
+      await enterSatelliteCommand(user, VALID_SATELLITE_COMMAND);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/invalid or missing token/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    test('clears error when valid command is entered after invalid', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+        },
+      });
+      const user = createUser();
+
+      const commandInput = await screen.findByRole('textbox', {
+        name: /registration command/i,
+      });
+
+      await enterSatelliteCommand(user, INVALID_SATELLITE_COMMAND);
+      await clickWithWait(user, document.body);
+
+      expect(
+        await screen.findByText(/invalid or missing token/i),
+      ).toBeInTheDocument();
+
+      await clearWithWait(user, commandInput);
+      await enterSatelliteCommand(user, VALID_SATELLITE_COMMAND);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(/invalid or missing token/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Certificate Upload', () => {
+    test('displays certificate upload field', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+        },
+      });
+
+      expect(
+        await screen.findByRole('button', { name: /upload/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/upload a certificate file/i),
+      ).toBeInTheDocument();
+    });
+
+    test('shows success message when certificate is uploaded', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+          satelliteRegistration: {
+            ...initialState.registration.satelliteRegistration,
+            caCert: VALID_CERTIFICATE,
+          },
+        },
+      });
+
+      expect(
+        await screen.findByText(/certificate was uploaded/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('textbox', { name: /read only filename/i }),
+      ).toHaveValue('CA detected');
+    });
+  });
+
+  describe('Mode Switching', () => {
+    test('persists satellite command when switching modes', async () => {
+      renderRegistrationStep({
+        registration: {
+          ...initialState.registration,
+          type: 'register-satellite',
+          satelliteRegistration: {
+            ...initialState.registration.satelliteRegistration,
+            command: VALID_SATELLITE_COMMAND,
+          },
+        },
+      });
+      const user = createUser();
+
+      await selectSatelliteRegistration(user);
+
+      const commandInput = await screen.findByRole('textbox', {
+        name: /registration command/i,
+      });
+
+      expect(commandInput).toHaveValue(VALID_SATELLITE_COMMAND);
+    });
+  });
+});

--- a/src/Components/CreateImageWizard/steps/Registration/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/helpers.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+
+import { screen } from '@testing-library/react';
+
+import {
+  clickWithWait,
+  renderWithRedux,
+  type RenderWithReduxOptions,
+  typeWithWait,
+  type UserEventInstance,
+  type WizardStateOverrides,
+} from '@/test/testUtils';
+
+import RegistrationStep from '../index';
+
+export const renderRegistrationStep = (
+  wizardStateOverrides: WizardStateOverrides = {},
+  options: RenderWithReduxOptions = {},
+) => {
+  return renderWithRedux(<RegistrationStep />, wizardStateOverrides, options);
+};
+
+export const selectAutomaticRegistration = async (user: UserEventInstance) => {
+  const radio = await screen.findByRole('radio', {
+    name: /automatically register to red hat/i,
+  });
+  await clickWithWait(user, radio);
+};
+
+export const selectRegisterLater = async (user: UserEventInstance) => {
+  const radio = await screen.findByRole('radio', {
+    name: /register later/i,
+  });
+  await clickWithWait(user, radio);
+};
+
+export const selectSatelliteRegistration = async (user: UserEventInstance) => {
+  const radio = await screen.findByRole('radio', {
+    name: /register for a satellite or capsule server/i,
+  });
+  await clickWithWait(user, radio);
+};
+
+export const toggleInsights = async (user: UserEventInstance) => {
+  const toggle = await screen.findByRole('switch', {
+    name: /enable predictive analytics/i,
+  });
+  await clickWithWait(user, toggle);
+};
+
+export const toggleRhc = async (user: UserEventInstance) => {
+  const toggle = await screen.findByRole('switch', {
+    name: /enable remote remediations/i,
+  });
+  await clickWithWait(user, toggle);
+};
+
+export const enterActivationKey = async (
+  user: UserEventInstance,
+  key: string,
+) => {
+  const input = await screen.findByRole('textbox', {
+    name: /activation key/i,
+  });
+  await typeWithWait(user, input, key);
+};
+
+export const enterOrgId = async (user: UserEventInstance, orgId: string) => {
+  const input = await screen.findByRole('textbox', {
+    name: /organization id/i,
+  });
+  await typeWithWait(user, input, orgId);
+};
+
+export const enterSatelliteCommand = async (
+  user: UserEventInstance,
+  command: string,
+) => {
+  const input = await screen.findByRole('textbox', {
+    name: /registration command/i,
+  });
+  await typeWithWait(user, input, command);
+};

--- a/src/Components/CreateImageWizard/steps/Registration/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/mocks/fixtures.ts
@@ -1,3 +1,32 @@
+import type { ListActivationKeysApiResponse } from '@/store/api/rhsm';
+
+export const mockActivationKeys: ListActivationKeysApiResponse = {
+  body: [
+    {
+      name: 'activation-key-1',
+      role: undefined,
+      serviceLevel: 'Self-Support',
+      usage: 'Production',
+    },
+    {
+      name: 'activation-key-2',
+      role: undefined,
+      serviceLevel: undefined,
+      usage: 'Development',
+    },
+    {
+      name: 'test-key-alpha',
+      role: undefined,
+      serviceLevel: 'Self-Support',
+      usage: 'Production',
+    },
+  ],
+};
+
+export const mockEmptyActivationKeys: ListActivationKeysApiResponse = {
+  body: [],
+};
+
 export const VALID_SATELLITE_COMMAND = `
 set -o pipefail && curl -sS 'https://ec2-107-23-89.compute-1.amazonaws.com/register?activation_keys=ak&location_id=2&organization_id=1&update_packages=false'
 // -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJleHAiOjQxMDI0NDQ4MDB9.CQ6hOQJLJDfD_P5gaEIEseY5iMRLhnk7iC5ZJ4Rzno0 | bash`;

--- a/src/Components/CreateImageWizard/steps/Registration/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/mocks/fixtures.ts
@@ -1,0 +1,35 @@
+export const VALID_SATELLITE_COMMAND = `
+set -o pipefail && curl -sS 'https://ec2-107-23-89.compute-1.amazonaws.com/register?activation_keys=ak&location_id=2&organization_id=1&update_packages=false'
+// -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJleHAiOjQxMDI0NDQ4MDB9.CQ6hOQJLJDfD_P5gaEIEseY5iMRLhnk7iC5ZJ4Rzno0 | bash`;
+
+export const SATELLITE_COMMAND_EXPIRED_TOKEN = `
+set -o pipefail && curl -sS 'https://ec2-107-23-89.compute-1.amazonaws.com/register?activation_keys=ak&location_id=2&organization_id=1&update_packages=false'
+// -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo1LCJpYXQiOjE3MjM4Mzc3MjIsImp0aSI6IjBhNTU3MDM3ZDIyNzUyMDYwM2M3MWIzZDI4NGYwZjQ1NmFjYjE5NzEyNmFmNTk5NzU0NWJmODcwZDczM2RhY2YiLCJleHAiOjE3MjM4NTIxMjIsInNjb3BlIjoicmVnaXN0cmF0aW9uI2dsb2JhbCByZWdpc3RyYXRpb24jaG9zdCJ9.HsSnZEqq--MIJfP3_awn6SflEruoEm77iSWh0Pi6EW4'
+//  | bash`;
+
+export const SATELLITE_COMMAND_NO_EXPIRATION = `
+set -o pipefail && curl -sS 'https://ec2-107-23-89.compute-1.amazonaws.com/register?activation_keys=ak&location_id=2&organization_id=1&update_packages=false'
+// -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c' | bash`;
+
+export const INVALID_SATELLITE_COMMAND = 'invalid-command';
+
+export const VALID_CERTIFICATE = `-----BEGIN CERTIFICATE-----
+MIIDUDCCAjigAwIBAgIUIE7ftn9J9krO6TRJg8M3plAZGgEwDQYJKoZIhvcNAQEL
+BQAwYjELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcM
+DVNhbiBGcmFuY2lzY28xETAPBgNVBAoMCFRlc3QgT3JnMRMwEQYDVQQDDAp0ZXN0
+LmxvY2FsMB4XDTI1MDIwNTEzMzk0N1oXDTI2MDIwNTEzMzk0N1owYjELMAkGA1UE
+BhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExFjAUBgNVBAcMDVNhbiBGcmFuY2lz
+Y28xETAPBgNVBAoMCFRlc3QgT3JnMRMwEQYDVQQDDAp0ZXN0LmxvY2FsMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAy8JdVoIaWh0PO1dL7xuGUNBUx6hZ
+PBYSnWpPS7lNL3Y/KHNNZhStm0ISFYcB4C/mlJN+9kMcl3CXoktZHfrkencRwhlv
+9aua70fZmmjgHDn3Stm25pqrhehUzoKZPlai9eXGJfY1q52ZMjNa0dxJjt6IST8U
+oAwwXrBr14dUjuMM0ZhLeLtiTAh1Eb8CnXMmVmkhoMBbMODE3Lkqr72K8kseu8Qx
+6Iq96ggkwiAQr3+h2GOkqtEl6BQEbjG1CVlVMCTU3B3yJ/uDUYvqK3897PdgWkUQ
+2L3dZPTWv+p8+UjaC4zVYGnM7NpJisMZPXsbA9KiqaF+bUvLLjP9budPXwIDAQAB
+MA0GCSqGSIb3DQEBCwUAA4IBAQCz2uByr3Tf34zSeYhy1z6MLJR4ijcfuWhxuE7D
+M5fB4I0Ua3K6+ptZDvlWuikF+5InnoU3HSfrXVPCJ1my4jsgk+c4YKPW0yVRrr6m
+hS2CKZyngICWnGCIYrlXlKeNJe4j23WF7IRhsykvkpt69Vw1x99UIJBcobOx+Kw/
+zB92/XFIBwOZArUmGDaiL5MnqhmFWfc6mtIELxIRKCj9LQG9y7L1JoVyqug3thgZ
+CdoLGtbHXri9BSR+8ogXu4JWp0YwMHTul6AEb2kcSZHTrYj6lUkXJMsw+E5jV37G
+jZKGigLMSUp2z4jT+aX+HblYHrvTbrKct23EMeJeANQzF08e
+-----END CERTIFICATE-----`;

--- a/src/Components/CreateImageWizard/steps/Registration/tests/mocks/handlers.ts
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/mocks/handlers.ts
@@ -1,0 +1,36 @@
+import type { ListActivationKeysApiResponse } from '@/store/api/rhsm';
+import {
+  composeHandlers,
+  type FetchHandler,
+  fetchMock,
+  type FetchRequest,
+} from '@/test/testUtils';
+
+import { mockActivationKeys } from './fixtures';
+
+export { fetchMock };
+
+type RhsmHandlerOptions = {
+  activationKeys?: ListActivationKeysApiResponse;
+};
+
+export const createRhsmHandler = (
+  options: RhsmHandlerOptions = {},
+): FetchHandler => {
+  const { activationKeys = mockActivationKeys } = options;
+
+  return ({ url, method }: FetchRequest) => {
+    if (url.includes('/activation_keys') && method === 'GET') {
+      return JSON.stringify(activationKeys);
+    }
+    return null;
+  };
+};
+
+export const createFetchHandler = (
+  options: RhsmHandlerOptions = {},
+): FetchHandler => {
+  return composeHandlers(createRhsmHandler(options));
+};
+
+export const createDefaultFetchHandler = createFetchHandler();

--- a/src/Components/CreateImageWizard/steps/Registration/tests/mocks/index.ts
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './fixtures';

--- a/src/Components/CreateImageWizard/steps/Registration/tests/mocks/index.ts
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/mocks/index.ts
@@ -1,1 +1,6 @@
+export {
+  createDefaultFetchHandler,
+  createFetchHandler,
+  fetchMock,
+} from './handlers';
 export * from './fixtures';


### PR DESCRIPTION
Registration step was revamped when the plan was to move all testing to playwright and deprecate vitest.

Since that changed, unit tests for the steps have been missing. This add them.

JIRA: [HMS-11002](https://issues.redhat.com/browse/HMS-11002)

[HMS-11002]: https://redhat.atlassian.net/browse/HMS-11002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ