### PR TITLE
Wizard/Review: Make "Target environments" heading bigger (HMS-10792)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { Card, CardBody } from '@patternfly/react-core';
+import { Card, CardBody, Title } from '@patternfly/react-core';
 
 import { ON_PREM_RELEASES, RELEASES } from '@/constants';
 import { useTargetEnvironmentCategories } from '@/Hooks';
@@ -70,7 +70,9 @@ const ImageOverview = ({ restrictions }: ReviewCardProps) => {
             heading='Architecture'
             description={arch}
           />
-          <ReviewGroup heading='Target environments' />
+          <Title headingLevel='h3' size='md'>
+            Target environments
+          </Title>
           <PublicClouds environments={publicClouds} />
           <PrivateClouds environments={privateClouds} />
           <MiscFormats environments={miscFormats} />


### PR DESCRIPTION
Make the heading bigger for cleaner visual hierarchy between "Target environment" and subcategories (private cloud, misc formats).

Before:
<img width="653" height="320" alt="image" src="https://github.com/user-attachments/assets/391a7ebb-87e1-4c8a-8557-083393e20c2e" />

After:
<img width="653" height="320" alt="image" src="https://github.com/user-attachments/assets/ac73d206-522a-457e-8f97-a3609290b864" />
