### PR TITLE
Wizard: stop blocking Next while activation key  is loading (HMS-10658)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
@@ -23,6 +23,7 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 import { v4 as uuidv4 } from 'uuid';
 
 import ExternalLinkButton from '@/Components/CreateImageWizard/utilities/ExternalLinkButton';
+import { useRegistrationValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import { ACTIVATION_KEYS_URL, CDN_PROD_URL, CDN_STAGE_URL } from '@/constants';
 import {
   useCreateActivationKeysMutation,
@@ -37,6 +38,7 @@ import {
   selectActivationKey,
   selectRegistrationType,
 } from '@/store/slices/wizard';
+import { selectForceShowErrors } from '@/store/slices/wizard/validation/selectors';
 import { getErrorMessage } from '@/Utilities/getErrorMessage';
 import sortfn from '@/Utilities/sortfn';
 import { useGetEnvironment } from '@/Utilities/useGetEnvironment';
@@ -51,6 +53,8 @@ const ActivationKeysList = ({ onErrorChange }: RegistrationProps) => {
 
   const activationKey = useAppSelector(selectActivationKey);
   const registrationType = useAppSelector(selectRegistrationType);
+  const forceShowErrors = useAppSelector(selectForceShowErrors);
+  const stepValidation = useRegistrationValidation();
 
   const defaultActivationKeyName = uuidv4();
 
@@ -312,16 +316,22 @@ const ActivationKeysList = ({ onErrorChange }: RegistrationProps) => {
         </Flex>
         <FormHelperText>
           <HelperText>
-            <HelperTextItem>
-              Image Builder provides and defaults to a no-cost activation key if
-              none exist.{' '}
-              <ExternalLinkButton
-                url={ACTIVATION_KEYS_URL}
-                analyticsStepId='step-registration'
-              >
-                Manage activation keys
-              </ExternalLinkButton>
-            </HelperTextItem>
+            {forceShowErrors && stepValidation.errors.activationKey ? (
+              <HelperTextItem variant='error'>
+                {stepValidation.errors.activationKey}
+              </HelperTextItem>
+            ) : (
+              <HelperTextItem>
+                Image Builder provides and defaults to a no-cost activation key
+                if none exist.{' '}
+                <ExternalLinkButton
+                  url={ACTIVATION_KEYS_URL}
+                  analyticsStepId='step-registration'
+                >
+                  Manage activation keys
+                </ExternalLinkButton>
+              </HelperTextItem>
+            )}
           </HelperText>
         </FormHelperText>
       </FormGroup>

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -181,13 +181,12 @@ export function useRegistrationValidation(): StepValidation {
   const caCertificate = useAppSelector(selectSatelliteCaCertificate);
   const [currentTimeSeconds] = useState(() => Date.now() / 1000);
 
-  const { isFetching: isFetchingKeyInfo, isError: isErrorKeyInfo } =
-    useShowActivationKeyQuery(
-      { name: activationKey! },
-      {
-        skip: !activationKey || isOnPremise,
-      },
-    );
+  const { isError: isErrorKeyInfo } = useShowActivationKeyQuery(
+    { name: activationKey! },
+    {
+      skip: !activationKey || isOnPremise,
+    },
+  );
 
   if (registrationType === 'register-later') {
     return { errors: {}, disabledNext: false };
@@ -217,7 +216,7 @@ export function useRegistrationValidation(): StepValidation {
 
   if (registrationType !== 'register-satellite' && !activationKey) {
     return {
-      errors: { activationKey: 'No activation key selected' },
+      errors: { activationKey: 'Missing activation key' },
       disabledNext: true,
     };
   }
@@ -225,7 +224,7 @@ export function useRegistrationValidation(): StepValidation {
   if (
     registrationType !== 'register-satellite' &&
     activationKey &&
-    (isFetchingKeyInfo || isErrorKeyInfo) &&
+    isErrorKeyInfo &&
     !isOnPremise
   ) {
     return {


### PR DESCRIPTION
 When the activation key query is in flight, the Next button was
  blocked until the query resolved. This fix removes isFetching from
  the validation condition so navigation is not blocked while the
  query loads.

  If no activation key is selected, clicking Next now scrolls to
  the Registration section and shows a "Missing activation key"
  error inline.

JIRA: (HMS-10658)


