### PR TITLE
LandingPage: Control the New in Image Builder alert via unleash (HMS-11006)

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -23,6 +23,7 @@ import { setBlueprintId } from '@/store/slices/blueprint';
 import { openWizardModal } from '@/store/slices/wizardModal';
 import { useFlag } from '@/Utilities/useGetEnvironment';
 
+import { NewAlert } from './NewAlert';
 import ServiceUnavailableAlert from './ServiceUnavailableAlert';
 
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
@@ -32,14 +33,12 @@ import NewImagesTable from '../ImagesTable/NewImagesTable';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
 export const LandingPage = () => {
-  // New feature alert
-  // const [showAlert, setShowAlert] = useState(true);
-  // const isOnPremise = useAppSelector(selectIsOnPremise);
-
   const dispatch = useAppDispatch();
+
   const location = useLocation();
   const { composeId } = useParams();
   const [searchParams] = useSearchParams();
+
   const serviceUnavailable = useFlag('image-builder.service-unavailable');
   const isImagesTableRevampEnabled = useFlag(
     'image-builder.images-table-revamp.enabled',
@@ -63,8 +62,7 @@ export const LandingPage = () => {
     <>
       <PageSection hasBodyWrapper={false}>
         {serviceUnavailable && <ServiceUnavailableAlert />}
-        {/* New feature alert */}
-        {/*!isOnPremise && showAlert && <NewAlert setShowAlert={setShowAlert} />*/}
+        <NewAlert />
         {!isImagesTableRevampEnabled ? (
           <Sidebar hasBorder className='pf-v6-u-background-color-100'>
             <SidebarPanel

--- a/src/Components/LandingPage/NewAlert.tsx
+++ b/src/Components/LandingPage/NewAlert.tsx
@@ -8,57 +8,61 @@ import {
   Flex,
   FlexItem,
 } from '@patternfly/react-core';
+import { useVariant } from '@unleash/proxy-client-react';
 
-// Import for optional quickstarts functionality
-// import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+export const NewAlert = () => {
+  const variant = useVariant('image-builder.new-feature');
+  let payload;
+  try {
+    payload = variant.payload ? JSON.parse(variant.payload.value) : undefined;
+  } catch {
+    payload = undefined;
+  }
 
-type NewAlertPropTypes = {
-  setShowAlert: React.Dispatch<React.SetStateAction<boolean>>;
-};
+  const title = payload?.title || '';
+  const body = payload?.body || '';
+  const localStorageKey = payload?.localStorageKey || '';
 
-export const NewAlert = ({ setShowAlert }: NewAlertPropTypes) => {
-  const isAlertDismissed = window.localStorage.getItem(
-    'imageBuilder.newFeatureNewCustomizationsAlertDismissed', // TODO: update when new feature
-  );
+  const isAlertDismissed = localStorageKey
+    ? window.localStorage.getItem(localStorageKey)
+    : false;
+
   const [displayAlert, setDisplayAlert] = useState(!isAlertDismissed);
+  const [isTemporarilyHidden, setIsTemporarilyHidden] = useState(false);
 
   const dismissAlert = () => {
     setDisplayAlert(false);
-    window.localStorage.setItem(
-      'imageBuilder.newFeatureNewCustomizationsAlertDismissed', // TODO: update when new feature
-      'true',
-    );
+    if (localStorageKey) {
+      window.localStorage.setItem(localStorageKey, 'true');
+    }
   };
 
-  // Optional quickstarts functionality
-  // const { quickStarts } = useChrome();
-  // const activateQuickstart = (qs: string) => () =>
-  //   quickStarts.activateQuickstart(qs);
-
-  if (displayAlert) {
-    return (
-      <Alert
-        data-testid='new-in-image-builder-banner'
-        isExpandable
-        style={{ margin: '0 0 16px 0' }}
-        title='New in image builder: ...' // TODO: update when new feature
-        actionClose={
-          <Flex>
-            <FlexItem>
-              <AlertActionLink onClick={dismissAlert}>
-                Don&apos;t show me this again
-              </AlertActionLink>
-            </FlexItem>
-            <FlexItem>
-              <AlertActionCloseButton onClose={() => setShowAlert(false)} />
-            </FlexItem>
-          </Flex>
-        }
-      >
-        <Content>{/* New feature alert content */}</Content>
-      </Alert>
-    );
-  } else {
-    return;
+  if (!variant.enabled || !displayAlert || isTemporarilyHidden || !title) {
+    return null;
   }
+
+  return (
+    <Alert
+      data-testid='new-in-image-builder-banner'
+      isExpandable
+      style={{ margin: '0 0 16px 0' }}
+      title={title}
+      actionClose={
+        <Flex>
+          <FlexItem>
+            <AlertActionLink onClick={dismissAlert}>
+              Don&apos;t show me this again
+            </AlertActionLink>
+          </FlexItem>
+          <FlexItem>
+            <AlertActionCloseButton
+              onClose={() => setIsTemporarilyHidden(true)}
+            />
+          </FlexItem>
+        </Flex>
+      }
+    >
+      <Content>{body}</Content>
+    </Alert>
+  );
 };

--- a/src/Components/LandingPage/tests/LandingPage.test.tsx
+++ b/src/Components/LandingPage/tests/LandingPage.test.tsx
@@ -41,10 +41,8 @@ describe('Landing Page', () => {
     );
   });
 
-  test('does not show New in image builder banner when on-premises', async () => {
-    renderLandingPage({
-      preloadedState: { env: { isOnPremise: true } },
-    });
+  test('does not show New in image builder banner when flag is disabled', async () => {
+    renderLandingPage();
 
     await screen.findByRole('heading', { name: 'Image builder' });
     expect(

--- a/src/Components/LandingPage/tests/NewAlert.test.tsx
+++ b/src/Components/LandingPage/tests/NewAlert.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { useVariant } from '@unleash/proxy-client-react';
+
+import { createUser } from '@/test/testUtils';
+import { clickWithWait } from '@/test/testUtils/userEvents';
+
+import { NewAlert } from '../NewAlert';
+
+type PayloadData = {
+  title?: string;
+  body?: string;
+  localStorageKey?: string;
+};
+
+const mockVariant = (payloadData?: PayloadData) => {
+  vi.mocked(useVariant).mockReturnValue({
+    name: 'image-builder.new-feature',
+    enabled: true,
+    payload: payloadData
+      ? {
+          type: 'json',
+          value: JSON.stringify(payloadData),
+        }
+      : {
+          type: 'json',
+          value: JSON.stringify(''),
+        },
+  });
+};
+
+describe('New Alert', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('does not render when no payload is provided', () => {
+    mockVariant();
+
+    render(<NewAlert />);
+
+    expect(
+      screen.queryByTestId('new-in-image-builder-banner'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders with title and body from payload', () => {
+    mockVariant({
+      title: 'New feature available',
+      body: 'Try out the new customizations',
+      localStorageKey: 'imageBuilder.newFeature',
+    });
+
+    render(<NewAlert />);
+
+    expect(screen.getByText('New feature available')).toBeInTheDocument();
+  });
+
+  test('permanently dismisses alert via "Do not show me this again"', async () => {
+    const user = createUser();
+    mockVariant({
+      title: 'New feature available',
+      body: 'Try out the new customizations',
+      localStorageKey: 'imageBuilder.newFeature',
+    });
+
+    render(<NewAlert />);
+
+    await clickWithWait(user, screen.getByText("Don't show me this again"));
+
+    expect(
+      screen.queryByTestId('new-in-image-builder-banner'),
+    ).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('imageBuilder.newFeature')).toBe('true');
+  });
+
+  test('temporarily dismisses alert via close button', async () => {
+    const user = createUser();
+    mockVariant({
+      title: 'New feature available',
+      body: 'Try out the new customizations',
+      localStorageKey: 'imageBuilder.newFeature',
+    });
+
+    render(<NewAlert />);
+
+    await clickWithWait(user, screen.getByRole('button', { name: /close/i }));
+
+    expect(
+      screen.queryByTestId('new-in-image-builder-banner'),
+    ).not.toBeInTheDocument();
+    expect(window.localStorage.getItem('imageBuilder.newFeature')).toBeNull();
+  });
+
+  test('does not render when previously dismissed via localStorage', () => {
+    window.localStorage.setItem('imageBuilder.newFeature', 'true');
+
+    mockVariant({
+      title: 'New feature available',
+      body: 'Try out the new customizations',
+      localStorageKey: 'imageBuilder.newFeature',
+    });
+
+    render(<NewAlert />);
+
+    expect(
+      screen.queryByTestId('new-in-image-builder-banner'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not write to localStorage when dismissing without localStorageKey', async () => {
+    const user = createUser();
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+    mockVariant({
+      title: 'New feature available',
+      body: 'Try out the new customizations',
+    });
+
+    render(<NewAlert />);
+
+    expect(screen.getByText('New feature available')).toBeInTheDocument();
+
+    await clickWithWait(user, screen.getByText("Don't show me this again"));
+
+    expect(
+      screen.queryByTestId('new-in-image-builder-banner'),
+    ).not.toBeInTheDocument();
+    expect(setItemSpy).not.toHaveBeenCalled();
+    setItemSpy.mockRestore();
+  });
+
+  test('does not render when payload is malformed JSON', () => {
+    vi.mocked(useVariant).mockReturnValue({
+      name: 'image-builder.new-feature',
+      enabled: true,
+      payload: {
+        type: 'json',
+        value: 'not valid json{{{',
+      },
+    });
+
+    render(<NewAlert />);
+
+    expect(
+      screen.queryByTestId('new-in-image-builder-banner'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows body text when alert is expanded', async () => {
+    const user = createUser();
+    mockVariant({
+      title: 'New feature available',
+      body: 'Try out the new customizations',
+      localStorageKey: 'imageBuilder.newFeature',
+    });
+
+    render(<NewAlert />);
+
+    await clickWithWait(
+      user,
+      screen.getByRole('button', { name: /custom alert details/i }),
+    );
+
+    expect(
+      screen.getByText('Try out the new customizations'),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This connects the "New in Image Builder" info alert to an unleash operational flag 'image-builder.new-feature', meaning it can be enabled and disabled via unleash. It's content and the localStorage item for a permanent alert dismissal are read from the flag variant, meaning no release is needed to render and update wording in the alert.

JIRA: [HMS-11006](https://issues.redhat.com/browse/HMS-11006)

[HMS-11006]: https://redhat.atlassian.net/browse/HMS-11006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ