### PR TITLE
Wizard/Registration: Swap 'Register later' and 'Register with Satellite' (HMS-11023)

### DIFF
--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -392,6 +392,11 @@ registrationModes.forEach(
                 name: 'Automatically register to Red Hat',
               }),
             ).toBeChecked();
+            if (isHosted()) {
+              await expect(
+                frame.getByPlaceholder('Select activation key'),
+              ).not.toHaveValue('');
+            }
           } else if (name === 'register-later') {
             await expect(
               frame.getByRole('radio', { name: 'Register later' }),

--- a/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
@@ -90,18 +90,6 @@ const Registration = ({ onErrorChange }: RegistrationProps) => {
       </Content>
       <Content className='pf-v6-u-pb-sm'>
         <Radio
-          label='Register later'
-          isChecked={registrationType === 'register-later'}
-          onChange={() => {
-            dispatch(changeRegistrationType('register-later'));
-            onErrorChange(false);
-          }}
-          id='register-later'
-          name='registration-type'
-        />
-      </Content>
-      <Content className='pf-v6-u-pb-sm'>
-        <Radio
           label='Register for a Satellite or Capsule server'
           isChecked={registrationType === 'register-satellite'}
           onChange={() => {
@@ -115,6 +103,18 @@ const Registration = ({ onErrorChange }: RegistrationProps) => {
               <SatelliteRegistration />
             )
           }
+        />
+      </Content>
+      <Content className='pf-v6-u-pb-sm'>
+        <Radio
+          label='Register later'
+          isChecked={registrationType === 'register-later'}
+          onChange={() => {
+            dispatch(changeRegistrationType('register-later'));
+            onErrorChange(false);
+          }}
+          id='register-later'
+          name='registration-type'
         />
       </Content>
     </FormGroup>


### PR DESCRIPTION
This swaps the order of the options as per recent UX sync. The 'Register later' is now at the bottom of the registration radios list.

JIRA: [HMS-11023](https://issues.redhat.com/browse/HMS-11023)

[HMS-11023]: https://redhat.atlassian.net/browse/HMS-11023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ