### PR TITLE
Replace async host detection with Redux store sync

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -249,6 +249,7 @@ module.exports = defineConfig([
       ],
       '@typescript-eslint/await-thenable': 'error',
       '@typescript-eslint/no-floating-promises': 'error',
+      'no-restricted-imports': 'off',
     },
   },
 

--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -4,7 +4,8 @@ import * as path from 'path';
 import { expect } from '@playwright/test';
 import { v4 as uuidv4 } from 'uuid';
 
-import { isRhel } from '../../src/store/slices/wizard';
+import { isRhel } from '@/store/slices/wizard/output/typeguards';
+
 import { test } from '../fixtures/customizations';
 import {
   getHostDistroKey,

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 import { expect, FrameLocator, type Page, test } from '@playwright/test';
 
-import { isRhel } from '@/store/slices/wizard';
+import { isRhel } from '@/store/slices/wizard/output/typeguards';
 
 import { callApi } from './apiHelpers';
 import { closePopupsIfExist, getHostDistroKey, isHosted } from './helpers';

--- a/src/AppCockpit.tsx
+++ b/src/AppCockpit.tsx
@@ -14,12 +14,17 @@ import './AppCockpit.scss';
 import { NotReady, RequireAdmin } from './Components/Cockpit';
 import { Router } from './Router';
 import { onPremStore as store } from './store';
+import { useGetHostInfoQuery } from './store/api/backend';
 import { useGetComposerSocketStatus } from './Utilities/useComposerStatus';
 import { useIsCockpitAdmin } from './Utilities/useIsCockpitAdmin';
 
 const Application = () => {
   const { enabled, started } = useGetComposerSocketStatus();
   const isAdmin = useIsCockpitAdmin();
+
+  // this runs the initial call for getting the host
+  // arch and distro on app init
+  useGetHostInfoQuery();
 
   if (!started || !enabled) {
     return <NotReady enabled={enabled} />;

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -39,6 +39,7 @@ import {
   loadWizardState,
   mapToCustomRepositories,
   parseStateFromRequest,
+  selectDistribution,
   WizardState,
 } from '@/store/slices/wizard';
 import { openWizardModal } from '@/store/slices/wizardModal';
@@ -66,6 +67,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
   };
   const dispatch = useAppDispatch();
   const isOnPremise = useAppSelector(selectIsOnPremise);
+  const distribution = useAppSelector(selectDistribution);
   const [fileContent, setFileContent] = React.useState('');
   const [importedBlueprint, setImportedBlueprint] =
     React.useState<WizardState>();
@@ -195,8 +197,9 @@ export const ImportBlueprintModal: React.FunctionComponent<
           const isJson = filename.endsWith('.json');
           if (isToml) {
             const tomlBlueprint = TOML.parse(fileContent);
-            const blueprintFromFile = await mapOnPremToHosted(
+            const blueprintFromFile = mapOnPremToHosted(
               tomlBlueprint as BlueprintItem,
+              distribution,
             );
             const importBlueprintState =
               parseStateFromRequest(blueprintFromFile);
@@ -253,8 +256,10 @@ export const ImportBlueprintModal: React.FunctionComponent<
               setIsOnPremBlueprint(false);
               setImportedBlueprint(importBlueprintState);
             } catch (_error) {
-              const blueprintFromFileMapped =
-                await mapOnPremToHosted(blueprintFromFile);
+              const blueprintFromFileMapped = mapOnPremToHosted(
+                blueprintFromFile,
+                distribution,
+              );
               const importBlueprintState = parseStateFromRequest(
                 blueprintFromFileMapped,
               );

--- a/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
+++ b/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
@@ -9,7 +9,6 @@ import {
   Fdo,
   File,
   FirewallCustomization,
-  getHostDistro,
   Ignition,
   Installer,
   Kernel,
@@ -18,6 +17,7 @@ import {
   Services,
   Timezone,
 } from '@/store/api/backend';
+import { getHostDistro } from '@/store/api/backend/onprem/composerApi/helpers';
 
 import { RHEL_10 } from '../../../constants';
 

--- a/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
+++ b/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
@@ -17,9 +17,6 @@ import {
   Services,
   Timezone,
 } from '@/store/api/backend';
-import { getHostDistro } from '@/store/api/backend/onprem/composerApi/helpers';
-
-import { RHEL_10 } from '../../../constants';
 
 export type BlueprintOnPrem = {
   name: string;
@@ -105,9 +102,10 @@ export type SshKeyOnPrem = {
   key: string;
 };
 
-export const mapOnPremToHosted = async (
+export const mapOnPremToHosted = (
   blueprint: BlueprintOnPrem,
-): Promise<BlueprintExportResponse> => {
+  distro: Distributions,
+): BlueprintExportResponse => {
   const users = blueprint.customizations?.user?.map((u) => ({
     name: u.name,
     ssh_key: u.key,
@@ -126,9 +124,6 @@ export const mapOnPremToHosted = async (
     blueprint.customizations?.groups !== undefined
       ? blueprint.customizations.groups.map((p) => `@${p.name}`)
       : undefined;
-  const distro = process.env.IS_ON_PREMISE
-    ? await getHostDistro()
-    : blueprint.distro || RHEL_10;
   return {
     name: blueprint.name,
     description: blueprint.description || '',

--- a/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
+++ b/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
@@ -9,6 +9,7 @@ import {
   Fdo,
   File,
   FirewallCustomization,
+  getHostDistro,
   Ignition,
   Installer,
   Kernel,
@@ -19,7 +20,6 @@ import {
 } from '@/store/api/backend';
 
 import { RHEL_10 } from '../../../constants';
-import { getHostDistro } from '../../../Utilities/getHostInfo';
 
 export type BlueprintOnPrem = {
   name: string;

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -19,7 +19,11 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useGetUser } from '@/Hooks';
-import { useGetBlueprintQuery } from '@/store/api/backend';
+import {
+  getHostArch,
+  getHostDistro,
+  useGetBlueprintQuery,
+} from '@/store/api/backend';
 import { useCustomizationRestrictions } from '@/store/api/distributions/hooks';
 import {
   selectSelectedBlueprintId,
@@ -66,7 +70,6 @@ import {
   RHEL_9,
 } from '../../constants';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import { getHostArch, getHostDistro } from '../../Utilities/getHostInfo';
 import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
 import DetailsStep from '../CreateImageWizard/steps/Details';
 import FileSystemStep from '../CreateImageWizard/steps/FileSystem';

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -19,11 +19,7 @@ import { useAddNotification } from '@redhat-cloud-services/frontend-components-n
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useGetUser } from '@/Hooks';
-import {
-  getHostArch,
-  getHostDistro,
-  useGetBlueprintQuery,
-} from '@/store/api/backend';
+import { useGetBlueprintQuery } from '@/store/api/backend';
 import { useCustomizationRestrictions } from '@/store/api/distributions/hooks';
 import {
   selectSelectedBlueprintId,
@@ -126,7 +122,6 @@ const CreateImageWizard = () => {
   const { userData } = useGetUser(auth);
   const hasTrackedInitialStepRef = useRef(false);
   const hasTrackedWizardOpenedRef = useRef(false);
-  const isHostDistroDetected = useRef(!isOnPremise);
 
   const {
     data: blueprintDetails,
@@ -242,36 +237,6 @@ const CreateImageWizard = () => {
   }, [mode, showWizardModal]);
 
   useEffect(() => {
-    if (
-      (mode !== 'create' && mode !== 'import') ||
-      !isOnPremise ||
-      !showWizardModal
-    ) {
-      return;
-    }
-
-    const initializeHostDistro = async () => {
-      const distro = await getHostDistro();
-      dispatch(changeDistribution(distro));
-      isHostDistroDetected.current = true;
-    };
-
-    const initializeHostArch = async () => {
-      const arch = await getHostArch();
-      dispatch(changeArchitecture(arch));
-    };
-
-    if (!searchParams.get('release')) {
-      initializeHostDistro();
-    }
-    if (!searchParams.get('arch')) {
-      initializeHostArch();
-    }
-    // This useEffect hook should run *only* when the modal opens in import/create mode
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, showWizardModal]);
-
-  useEffect(() => {
     if (mode === 'edit' && isError) {
       dispatch(closeWizardModal());
       dispatch(setBlueprintId(undefined));
@@ -320,7 +285,7 @@ const CreateImageWizard = () => {
         ? DEFAULT_TIMEZONE
         : 'America/New_York';
 
-    if (!timezone && isHostDistroDetected.current) {
+    if (!timezone) {
       dispatch(changeTimezone(defaultTimezone));
     }
   }, [

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 
 import {
   Content,
@@ -8,8 +8,7 @@ import {
 } from '@patternfly/react-core';
 import { BuildIcon, RepositoryIcon } from '@patternfly/react-icons';
 
-import { RHEL_10, RHEL_10_IMAGE_MODE_IMAGE, X86_64 } from '@/constants';
-import { Distributions, getHostDistro } from '@/store/api/backend';
+import { RHEL_10_IMAGE_MODE_IMAGE, X86_64 } from '@/constants';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
@@ -29,23 +28,8 @@ const BlueprintMode = () => {
   const isImageMode = useAppSelector(selectIsImageMode);
   const distribution = useAppSelector(selectDistribution);
   const architecture = useAppSelector(selectArchitecture);
-  const [defaultDistro, setDefaultDistro] = useState<Distributions>(RHEL_10);
-  const previousDistro = useRef<Distributions>(RHEL_10);
+  const previousDistro = useRef(distribution);
   const previousArch = useRef(architecture);
-
-  useEffect(() => {
-    if (!isOnPremise) return;
-    const fetchDefaultDistro = async () => {
-      try {
-        const distro = await getHostDistro();
-        setDefaultDistro(distro as Distributions);
-      } catch {
-        // defaultDistro remains RHEL_10
-      }
-    };
-
-    fetchDefaultDistro();
-  }, [isOnPremise]);
 
   return (
     <FormGroup label='Image type' isRequired>
@@ -57,11 +41,7 @@ const BlueprintMode = () => {
           isSelected={!isImageMode}
           onChange={() => {
             dispatch(changeBlueprintMode('package'));
-            dispatch(
-              changeDistribution(
-                isOnPremise ? defaultDistro : previousDistro.current,
-              ),
-            );
+            dispatch(changeDistribution(previousDistro.current));
             // Image source is only relevant in image mode
             dispatch(changeImageSource(undefined));
             if (!isOnPremise) {

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/BlueprintMode.tsx
@@ -9,7 +9,7 @@ import {
 import { BuildIcon, RepositoryIcon } from '@patternfly/react-icons';
 
 import { RHEL_10, RHEL_10_IMAGE_MODE_IMAGE, X86_64 } from '@/constants';
-import { Distributions } from '@/store/api/backend';
+import { Distributions, getHostDistro } from '@/store/api/backend';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
@@ -22,7 +22,6 @@ import {
   selectDistribution,
   selectIsImageMode,
 } from '@/store/slices/wizard';
-import { getHostDistro } from '@/Utilities/getHostInfo';
 
 const BlueprintMode = () => {
   const dispatch = useAppDispatch();

--- a/src/Components/CreateImageWizard/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/tests/helpers.tsx
@@ -7,6 +7,7 @@ import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 import TOML from 'smol-toml';
 
 import { mapOnPremToHosted } from '@/Components/Blueprints/helpers/onPremToHostedBlueprintMapper';
+import { RHEL_10 } from '@/constants';
 import { RootState, serviceMiddleware, serviceReducer } from '@/store';
 import { BlueprintItem } from '@/store/api/backend';
 import { parseStateFromRequest } from '@/store/slices/wizard';
@@ -125,8 +126,9 @@ export const renderImportMode = async (
   blueprintToml: string,
 ): Promise<{ store: EnhancedStore<RootState> }> => {
   const tomlBlueprint = TOML.parse(blueprintToml);
-  const blueprintFromFile = await mapOnPremToHosted(
+  const blueprintFromFile = mapOnPremToHosted(
     tomlBlueprint as BlueprintItem,
+    RHEL_10,
   );
   const importBlueprintState = parseStateFromRequest(blueprintFromFile);
 

--- a/src/Hooks/Utilities/useGetDocumentationUrl.tsx
+++ b/src/Hooks/Utilities/useGetDocumentationUrl.tsx
@@ -6,9 +6,9 @@ import {
   IB_ON_PREMISE_RHEL10_DOCUMENTATION_URL,
   IB_ON_PREMISE_RHEL9_DOCUMENTATION_URL,
 } from '@/constants';
+import { getHostDistro } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-import { getHostDistro } from '@/Utilities/getHostInfo';
 
 export const useGetDocumentationUrl = () => {
   const isOnPremise = useAppSelector(selectIsOnPremise);

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -106,6 +106,7 @@ export {
   getHostDistro,
   toComposerComposeRequest,
   useExportBlueprintCockpitQuery,
+  useGetHostInfoQuery,
   useGetRegistryAuthStatusQuery,
   useGetWorkerConfigQuery,
   useLazyExportBlueprintCockpitQuery,

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -102,6 +102,8 @@ export {
   useRecommendPackageMutation,
 } from './hosted';
 export {
+  getHostArch,
+  getHostDistro,
   toComposerComposeRequest,
   useExportBlueprintCockpitQuery,
   useGetRegistryAuthStatusQuery,

--- a/src/store/api/backend/onprem/composerApi/helpers/hostInfo.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/hostInfo.ts
@@ -1,10 +1,12 @@
 import cockpit from 'cockpit';
 import { read_os_release } from 'os-release';
 
-import { AARCH64, FEDORA_ELN, X86_64 } from '../constants';
-import { Distributions } from '../store/api/backend/hosted';
+import { AARCH64, FEDORA_ELN, X86_64 } from '@/constants';
+import type { Distributions } from '@/store/api/backend/hosted';
 
-type Architecture = 'x86_64' | 'aarch64';
+type Architecture = typeof X86_64 | typeof AARCH64;
+
+const SUPPORTED_ARCHITECTURES: Architecture[] = [X86_64, AARCH64];
 
 // Module-level cache for promises - ensures only one request is made
 // even if multiple callers invoke concurrently
@@ -44,7 +46,7 @@ export const getHostArch = async (): Promise<Architecture> => {
           superuser: 'try',
         });
         const arch = (hostArch as string).trim() as Architecture;
-        if (![X86_64, AARCH64].includes(arch)) {
+        if (!SUPPORTED_ARCHITECTURES.includes(arch)) {
           throw new Error(`Unsupported architecture: ${arch}`);
         }
         return arch;

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -3,6 +3,7 @@ export { parseJsonUnsafe } from './parseJson';
 export { lookupDatastreamDistro } from './dataStreamLookup';
 export { getBlueprintsPath } from './getBlueprintsPath';
 export { getCloudConfigs } from './getCloudConfigs';
+export { getHostArch, getHostDistro } from './hostInfo';
 export {
   byDistroDescending,
   inferDistro,

--- a/src/store/api/backend/onprem/composerApi/host.ts
+++ b/src/store/api/backend/onprem/composerApi/host.ts
@@ -1,0 +1,26 @@
+import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
+
+import { getHostArch, getHostDistro } from './helpers';
+
+import type { Distributions, ImageRequest } from '../../hosted';
+
+type HostInfo = {
+  arch: ImageRequest['architecture'];
+  distro: Distributions;
+};
+
+export const hostEndpoints = (builder: OnPremBuilder) => ({
+  getHostInfo: builder.query<HostInfo, void>({
+    queryFn: onPremQueryHandler(async () => {
+      const [distro, arch] = await Promise.all([
+        getHostDistro(),
+        getHostArch(),
+      ]);
+
+      return {
+        distro,
+        arch,
+      };
+    }),
+  }),
+});

--- a/src/store/api/backend/onprem/composerApi/index.ts
+++ b/src/store/api/backend/onprem/composerApi/index.ts
@@ -1,6 +1,7 @@
 import { architectureEndpoints } from './architecture';
 import { blueprintEndpoints } from './blueprints';
 import { composeEndpoints } from './composes';
+import { hostEndpoints } from './host';
 import { oscapEndpoints } from './oscap';
 import { registryEndpoints } from './registry';
 import { workerEndpoints } from './worker';
@@ -13,6 +14,7 @@ export const composerApi = emptyComposerApi.injectEndpoints({
       ...architectureEndpoints(builder),
       ...blueprintEndpoints(builder),
       ...composeEndpoints(builder),
+      ...hostEndpoints(builder),
       ...oscapEndpoints(builder),
       ...registryEndpoints(builder),
       ...workerEndpoints(builder),
@@ -46,6 +48,7 @@ export const {
   useGetWorkerConfigQuery,
   useRegistryLoginMutation,
   useUpdateWorkerConfigMutation,
+  useGetHostInfoQuery,
 } = composerApi;
 
 // re-export this for testing

--- a/src/store/api/backend/onprem/composerApi/index.ts
+++ b/src/store/api/backend/onprem/composerApi/index.ts
@@ -49,4 +49,8 @@ export const {
 } = composerApi;
 
 // re-export this for testing
-export { toComposerComposeRequest } from './helpers';
+export {
+  getHostArch,
+  getHostDistro,
+  toComposerComposeRequest,
+} from './helpers';

--- a/src/store/api/backend/onprem/composerApi/oscap.ts
+++ b/src/store/api/backend/onprem/composerApi/oscap.ts
@@ -66,7 +66,10 @@ export const oscapEndpoints = (builder: OnPremBuilder) => ({
         )) as string;
 
         const parsed = TOML.parse(result);
-        const blueprint = await mapOnPremToHosted(parsed as BlueprintItem);
+        const blueprint = mapOnPremToHosted(
+          parsed as BlueprintItem,
+          distribution,
+        );
 
         result = (await cockpit.spawn(
           [

--- a/src/store/api/backend/onprem/index.ts
+++ b/src/store/api/backend/onprem/index.ts
@@ -24,6 +24,7 @@ export {
   useRegistryLoginMutation,
   useUpdateBlueprintMutation,
   useUpdateWorkerConfigMutation,
+  useGetHostInfoQuery,
 } from './composerApi';
 
 export type * from './types';

--- a/src/store/api/backend/onprem/index.ts
+++ b/src/store/api/backend/onprem/index.ts
@@ -1,5 +1,7 @@
 export { composerApi } from './enhancedComposerApi';
 export {
+  getHostArch,
+  getHostDistro,
   toComposerComposeRequest,
   useComposeBlueprintMutation,
   useCreateBlueprintMutation,

--- a/src/store/api/backend/onprem/matchers.ts
+++ b/src/store/api/backend/onprem/matchers.ts
@@ -1,0 +1,5 @@
+import { composerApi } from './enhancedComposerApi';
+
+export const matchGetHostInfoFulfilled = process.env.IS_ON_PREMISE
+  ? composerApi.endpoints.getHostInfo.matchFulfilled
+  : () => false;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -83,15 +83,13 @@ export const serviceStore = configureStore({
   middleware: serviceMiddleware,
 });
 
-// we don't need to export these for now, they are just helpers
-// for some of the functions in this file
-type onPremState = ReturnType<typeof onPremStore.getState>;
+export type OnPremState = ReturnType<typeof onPremStore.getState>;
 type serviceState = ReturnType<typeof serviceStore.getState>;
 
 export const store = process.env.IS_ON_PREMISE ? onPremStore : serviceStore;
 
 // Infer the `RootState` and `AppDispatch` types from the store itself
-export type RootState = onPremState | serviceState;
+export type RootState = OnPremState | serviceState;
 // Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
 export type AppDispatch =
   | typeof onPremStore.dispatch

--- a/src/store/middleware/listeners.ts
+++ b/src/store/middleware/listeners.ts
@@ -2,10 +2,18 @@ import { createListenerMiddleware } from '@reduxjs/toolkit';
 
 import { WizardStartListening } from './types';
 
-import { changeArchitecture, changeDistribution } from '../slices/wizard';
+import {
+  changeArchitecture,
+  changeDistribution,
+  initializeWizard,
+} from '../slices/wizard';
 // export from slices/wizard/listeners rather than slices/wizard
 // this is needed to avoid circular dependencies
-import { filterImageTypes, registerLater } from '../slices/wizard/listeners';
+import {
+  applyHostInfo,
+  filterImageTypes,
+  registerLater,
+} from '../slices/wizard/listeners';
 
 export const listenerMiddleware = createListenerMiddleware();
 
@@ -25,4 +33,9 @@ startListening({
 startListening({
   actionCreator: changeDistribution,
   effect: registerLater,
+});
+
+startListening({
+  actionCreator: initializeWizard,
+  effect: applyHostInfo,
 });

--- a/src/store/slices/wizard/listeners.ts
+++ b/src/store/slices/wizard/listeners.ts
@@ -1,8 +1,14 @@
-import { backendApi } from '@/store/api/backend';
+import { backendApi, composerApi } from '@/store/api/backend';
+import type { OnPremState, RootState } from '@/store/index';
 import type { WizardListenerEffect } from '@/store/middleware/types';
+
+const isOnPremState = (state: RootState): state is OnPremState =>
+  'onPremApi' in state;
 
 import { selectIsImageMode } from './details';
 import {
+  changeArchitecture,
+  changeDistribution,
   changeImageTypes,
   isRhel,
   selectArchitecture,
@@ -41,6 +47,24 @@ export const filterImageTypes: WizardListenerEffect = (
   listenerApi.dispatch(
     changeImageTypes(imageTypes.filter((t) => allowed?.includes(t))),
   );
+};
+
+// On-premise, re-apply the host's arch and distro after the wizard
+// resets to defaults. The reducer sets initialState first, then this
+// listener reads the cached getHostInfo result and dispatches the
+// correct values.
+export const applyHostInfo: WizardListenerEffect = (_action, listenerApi) => {
+  if (!process.env.IS_ON_PREMISE) return;
+
+  const state = listenerApi.getState();
+  if (!isOnPremState(state)) return;
+
+  const hostInfo = composerApi.endpoints.getHostInfo.select()(state);
+
+  if (hostInfo.data) {
+    listenerApi.dispatch(changeArchitecture(hostInfo.data.arch));
+    listenerApi.dispatch(changeDistribution(hostInfo.data.distro));
+  }
 };
 
 // This was previously a mutation inside the changeDistribution reducer.

--- a/src/store/slices/wizard/output/slice.ts
+++ b/src/store/slices/wizard/output/slice.ts
@@ -5,6 +5,8 @@ import {
   Distributions,
   ImageRequest,
 } from '@/store/api/backend';
+// import from the specific module to avoid a circular dependency
+import { matchGetHostInfoFulfilled } from '@/store/api/backend/onprem/matchers';
 
 import { initialState } from './state';
 import { ImageSource, SupportedImageTypes } from './types';
@@ -75,7 +77,15 @@ export const outputSlice = createSlice({
         (_state, action) =>
           (action.payload as Partial<typeof action.payload>).output ??
           initialState,
-      );
+      )
+      .addMatcher(matchGetHostInfoFulfilled, (state, action) => {
+        // On-premise the UI locks arch and distro selectors to the host
+        // values (ArchSelect filters options, ReleaseSelect uses
+        // ON_PREM_RELEASES), so there is no risk of overwriting a
+        // user-chosen value here.
+        state.architecture = action.payload.arch;
+        state.distribution = action.payload.distro;
+      });
   },
 });
 

--- a/src/store/slices/wizard/tests/hostInfoSync.test.ts
+++ b/src/store/slices/wizard/tests/hostInfoSync.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RootState } from '@/store';
+import {
+  changeArchitecture,
+  changeDistribution,
+  initializeWizard,
+} from '@/store/slices/wizard';
+
+import { createListenerApi, mockRootState } from './mockWizardState';
+
+import { applyHostInfo } from '../listeners';
+
+const ORIGINAL_ENV = process.env;
+
+// Constructs an action matching composerApi.endpoints.getHostInfo.matchFulfilled.
+// RTK Query fulfilled actions use:
+//   type: `${reducerPath}/executeQuery/fulfilled`
+//   meta.arg.endpointName: endpoint name
+const createHostInfoFulfilledAction = (payload: {
+  arch: string;
+  distro: string;
+}) => ({
+  type: 'onPremApi/executeQuery/fulfilled' as const,
+  payload,
+  meta: {
+    arg: {
+      endpointName: 'getHostInfo' as const,
+      type: 'query' as const,
+      queryCacheKey: 'getHostInfo(undefined)',
+      originalArgs: undefined,
+    },
+    requestId: 'test-request-id',
+    requestStatus: 'fulfilled' as const,
+  },
+});
+
+// Minimal RTK Query cache state for the onPremApi slice.
+// When hostInfo is provided, seeds the getHostInfo cache entry.
+const createOnPremApiCache = (hostInfo?: { arch: string; distro: string }) => ({
+  queries: hostInfo
+    ? {
+        'getHostInfo(undefined)': {
+          status: 'fulfilled',
+          data: hostInfo,
+          endpointName: 'getHostInfo',
+          requestId: 'test',
+          startedTimeStamp: 0,
+          fulfilledTimeStamp: 0,
+        },
+      }
+    : {},
+  mutations: {},
+  provided: {},
+  subscriptions: {},
+  config: {
+    online: true,
+    focused: true,
+    middlewareRegistered: true,
+    refetchOnMountOrArgChange: false,
+    refetchOnReconnect: false,
+    refetchOnFocus: false,
+    keepUnusedDataFor: 60,
+    reducerPath: 'onPremApi' as const,
+    invalidationBehavior: 'delayed',
+  },
+});
+
+describe('host info store sync', () => {
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+    vi.resetModules();
+  });
+
+  describe('matchFulfilled handler (reducer)', () => {
+    it('sets architecture and distribution when getHostInfo fulfills on-premise', async () => {
+      process.env = { ...ORIGINAL_ENV, IS_ON_PREMISE: 'true' };
+      vi.resetModules();
+
+      const { wizardReducer, initialState } =
+        await import('@/store/slices/wizard');
+
+      const action = createHostInfoFulfilledAction({
+        arch: 'aarch64',
+        distro: 'rhel-9',
+      });
+
+      const result = wizardReducer(initialState, action);
+
+      expect(result.output.architecture).toBe('aarch64');
+      expect(result.output.distribution).toBe('rhel-9');
+    });
+
+    it('does not update state when not on-premise', async () => {
+      delete process.env.IS_ON_PREMISE;
+      vi.resetModules();
+
+      const { wizardReducer, initialState } =
+        await import('@/store/slices/wizard');
+
+      const action = createHostInfoFulfilledAction({
+        arch: 'aarch64',
+        distro: 'rhel-9',
+      });
+
+      const result = wizardReducer(initialState, action);
+
+      expect(result.output.architecture).toBe(initialState.output.architecture);
+      expect(result.output.distribution).toBe(initialState.output.distribution);
+    });
+  });
+
+  describe('applyHostInfo listener', () => {
+    it('dispatches changeArchitecture and changeDistribution from cached host info', () => {
+      process.env = { ...ORIGINAL_ENV, IS_ON_PREMISE: 'true' };
+
+      const state = {
+        ...mockRootState,
+        onPremApi: createOnPremApiCache({
+          arch: 'aarch64',
+          distro: 'rhel-9',
+        }),
+      } as unknown as RootState;
+
+      const listenerApi = createListenerApi(state);
+
+      applyHostInfo(initializeWizard(), listenerApi);
+
+      expect(listenerApi.dispatch).toHaveBeenCalledWith(
+        changeArchitecture('aarch64'),
+      );
+      expect(listenerApi.dispatch).toHaveBeenCalledWith(
+        changeDistribution('rhel-9'),
+      );
+    });
+
+    it('does not dispatch when cache has no data', () => {
+      process.env = { ...ORIGINAL_ENV, IS_ON_PREMISE: 'true' };
+
+      const state = {
+        ...mockRootState,
+        onPremApi: createOnPremApiCache(),
+      } as unknown as RootState;
+
+      const listenerApi = createListenerApi(state);
+
+      applyHostInfo(initializeWizard(), listenerApi);
+
+      expect(listenerApi.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('does not dispatch when not on-premise', () => {
+      delete process.env.IS_ON_PREMISE;
+
+      const state = {
+        ...mockRootState,
+        onPremApi: createOnPremApiCache({
+          arch: 'aarch64',
+          distro: 'rhel-9',
+        }),
+      } as unknown as RootState;
+
+      const listenerApi = createListenerApi(state);
+
+      applyHostInfo(initializeWizard(), listenerApi);
+
+      expect(listenerApi.dispatch).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Replace async host detection patterns (`useEffect` + `getHostArch`/`getHostDistro`) with idiomatic Redux store sync so that the wizard slice always has the correct host architecture and distribution on-premise.

## Changes

- Add a `getHostInfo` RTK Query endpoint that calls both host detection helpers concurrently, triggered on app init in `AppCockpit`
- Sync host info into the wizard slice via a `matchFulfilled` handler (initial query) and an `initializeWizard` listener (subsequent wizard resets)
- Remove async `useEffect`-based host detection from `CreateImageWizard` and `BlueprintMode`
- Make `mapOnPremToHosted` a pure function by accepting `distro` as a parameter instead of calling `getHostDistro()` internally
- Add unit tests for the `matchFulfilled` handler and `applyHostInfo` listener
