### PR TITLE
Wizard/FSC: Lock partitions required by OSCAP (HMS-10790)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/components/MinimumSize.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/MinimumSize.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Tooltip } from '@patternfly/react-core';
+
 import { useFilesystemValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import { ValidatedInputAndTextArea } from '@/Components/CreateImageWizard/ValidatedInput';
 import { useAppDispatch } from '@/store/hooks';
@@ -18,13 +20,20 @@ type MinimumSizePropTypes = {
     | LogicalVolumeWithBase
     | VolumeGroupWithExtendedLV;
   customization: PartitioningCustomization;
+  isOscapRequired?: boolean;
+  oscapMinSizeLabel?: string;
 };
 
-const MinimumSize = ({ partition, customization }: MinimumSizePropTypes) => {
+const MinimumSize = ({
+  partition,
+  customization,
+  isOscapRequired,
+  oscapMinSizeLabel,
+}: MinimumSizePropTypes) => {
   const dispatch = useAppDispatch();
   const stepValidation = useFilesystemValidation();
 
-  return (
+  const sizeInput = (
     <ValidatedInputAndTextArea
       ariaLabel='minimum partition size'
       value={partition.min_size || ''}
@@ -58,6 +67,18 @@ const MinimumSize = ({ partition, customization }: MinimumSizePropTypes) => {
       }}
     />
   );
+
+  if (isOscapRequired && oscapMinSizeLabel) {
+    return (
+      <Tooltip
+        content={`Minimum ${oscapMinSizeLabel} required by the selected OpenSCAP profile`}
+      >
+        <div>{sizeInput}</div>
+      </Tooltip>
+    );
+  }
+
+  return sizeInput;
 };
 
 export default MinimumSize;

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Mountpoint.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Mountpoint.tsx
@@ -20,9 +20,14 @@ type MountpointProps = {
     | PlainPartitionWithBase
     | LogicalVolumeWithBase;
   customization: PartitioningCustomization;
+  isOscapRequired?: boolean;
 };
 
-const Mountpoint = ({ partition, customization }: MountpointProps) => {
+const Mountpoint = ({
+  partition,
+  customization,
+  isOscapRequired,
+}: MountpointProps) => {
   const dispatch = useAppDispatch();
   const stepValidation = useFilesystemValidation();
   const filesystemPartitions = useAppSelector(selectFilesystemPartitions);
@@ -32,14 +37,21 @@ const Mountpoint = ({ partition, customization }: MountpointProps) => {
     partition.mountpoint === '/' &&
     filesystemPartitions.filter((p) => p.mountpoint === '/').length === 1;
 
+  const isDisabled =
+    isOscapRequired ||
+    ('fs_type' in partition && partition.fs_type === 'swap') ||
+    hasOneRoot;
+
+  const tooltipContent = isOscapRequired
+    ? 'Required by the selected OpenSCAP profile'
+    : 'Root partition is required';
+
   const mountpointInput = (
     <ValidatedInputAndTextArea
       ariaLabel='Mount point input'
       placeholder='Define mount point'
       value={partition.mountpoint || ''}
-      isDisabled={
-        ('fs_type' in partition && partition.fs_type === 'swap') || hasOneRoot
-      }
+      isDisabled={isDisabled}
       onChange={(event, mountpoint) => {
         dispatch(
           changePartitionMountpoint({
@@ -54,8 +66,8 @@ const Mountpoint = ({ partition, customization }: MountpointProps) => {
     />
   );
 
-  return hasOneRoot ? (
-    <Tooltip content='Root partition is required'>
+  return isOscapRequired || hasOneRoot ? (
+    <Tooltip content={tooltipContent}>
       <div>{mountpointInput}</div>
     </Tooltip>
   ) : (

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 
-import { Button, TextInput } from '@patternfly/react-core';
-import { MinusCircleIcon } from '@patternfly/react-icons';
+import { Button, TextInput, Tooltip } from '@patternfly/react-core';
+import { LockIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
 
-import { useAppDispatch } from '@/store/hooks';
-import { FilesystemPartition, removePartition } from '@/store/slices/wizard';
+import { useGetOscapCustomizationsQuery } from '@/store/api/backend';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import {
+  FilesystemPartition,
+  parseSizeUnit,
+  removePartition,
+  selectComplianceProfileID,
+  selectDistribution,
+} from '@/store/slices/wizard';
 
 import MinimumSize from './MinimumSize';
 import Mountpoint from './Mountpoint';
@@ -20,16 +27,53 @@ type RowPropTypes = {
 
 const Row = ({ partition, isRemovingDisabled }: RowPropTypes) => {
   const dispatch = useAppDispatch();
+  const release = useAppSelector(selectDistribution);
+  const complianceProfileID = useAppSelector(selectComplianceProfileID);
+
+  const { data: oscapProfileInfo } = useGetOscapCustomizationsQuery(
+    {
+      distribution: release,
+      // @ts-expect-error skipped when undefined
+      profile: complianceProfileID,
+    },
+    {
+      skip: !complianceProfileID,
+    },
+  );
+
+  const oscapPartition = oscapProfileInfo?.filesystem?.find(
+    (fs) => fs.mountpoint === partition.mountpoint,
+  );
+  const isOscapRequired = !!oscapPartition;
+
+  const oscapMinSizeLabel = oscapPartition
+    ? parseSizeUnit(String(oscapPartition.min_size)).join(' ')
+    : '';
+
   const handleRemovePartition = (id: string) => {
     dispatch(removePartition(id));
   };
 
   const customization = 'fileSystem';
 
+  const removeButton = (
+    <Button
+      isDisabled={isOscapRequired || isRemovingDisabled}
+      variant='plain'
+      icon={isOscapRequired ? <LockIcon /> : <MinusCircleIcon />}
+      onClick={() => handleRemovePartition(partition.id)}
+      aria-label='Remove partition'
+    />
+  );
+
   return (
     <Tr id={partition.id}>
       <Td width={40}>
-        <Mountpoint partition={partition} customization={customization} />
+        <Mountpoint
+          partition={partition}
+          customization={customization}
+          isOscapRequired={isOscapRequired}
+        />
       </Td>
       <Td width={20}>
         <TextInput
@@ -40,19 +84,28 @@ const Row = ({ partition, isRemovingDisabled }: RowPropTypes) => {
         />
       </Td>
       <Td width={20}>
-        <MinimumSize partition={partition} customization={customization} />
+        <MinimumSize
+          partition={partition}
+          customization={customization}
+          isOscapRequired={isOscapRequired}
+          oscapMinSizeLabel={oscapMinSizeLabel}
+        />
       </Td>
       <Td width={20}>
-        <SizeUnit partition={partition} customization={customization} />
+        <SizeUnit
+          partition={partition}
+          customization={customization}
+          isOscapRequired={isOscapRequired}
+        />
       </Td>
       <Td isActionCell>
-        <Button
-          variant='plain'
-          icon={<MinusCircleIcon />}
-          onClick={() => handleRemovePartition(partition.id)}
-          isDisabled={isRemovingDisabled}
-          aria-label='Remove partition'
-        />
+        {isOscapRequired ? (
+          <Tooltip content='Required by the selected OpenSCAP profile'>
+            <span>{removeButton}</span>
+          </Tooltip>
+        ) : (
+          removeButton
+        )}
       </Td>
     </Tr>
   );

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/SizeUnit.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/SizeUnit.tsx
@@ -27,9 +27,14 @@ type SizeUnitPropTypes = {
     | LogicalVolumeWithBase
     | VolumeGroupWithExtendedLV;
   customization: PartitioningCustomization;
+  isOscapRequired?: boolean;
 };
 
-const SizeUnit = ({ partition, customization }: SizeUnitPropTypes) => {
+const SizeUnit = ({
+  partition,
+  customization,
+  isOscapRequired,
+}: SizeUnitPropTypes) => {
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
 
@@ -66,6 +71,7 @@ const SizeUnit = ({ partition, customization }: SizeUnitPropTypes) => {
       onClick={onToggleClick}
       isExpanded={isOpen}
       isFullWidth
+      isDisabled={!!isOscapRequired}
     >
       {partition.unit}
     </MenuToggle>

--- a/src/Components/CreateImageWizard/steps/FileSystem/tests/FileSystem.test.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/tests/FileSystem.test.tsx
@@ -1,6 +1,8 @@
-import { screen, within } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 
+import { RHEL_9 } from '@/constants';
 import { initialState } from '@/store/slices/wizard';
+import { server } from '@/test/mocks/server';
 import {
   clearWithWait,
   clickWithWait,
@@ -9,6 +11,31 @@ import {
 } from '@/test/testUtils';
 
 import { renderFileSystemStep } from './helpers';
+import {
+  createDefaultFetchHandler,
+  fetchMock,
+  mockOscapProfile,
+} from './mocks';
+
+fetchMock.enableMocks();
+
+// Disable global MSW server for this file - we use fetch mocks instead
+beforeAll(() => {
+  server.close();
+});
+
+// Restore global MSW server so other tests don't break
+afterAll(() => {
+  server.listen();
+});
+
+beforeEach(() => {
+  fetchMock.mockResponse(createDefaultFetchHandler);
+});
+
+afterEach(() => {
+  fetchMock.resetMocks();
+});
 
 describe('FileSystem Component', () => {
   describe('Rendering', () => {
@@ -687,6 +714,190 @@ describe('FileSystem Component', () => {
       expect(
         await screen.findByRole('button', { name: /add partition/i }),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('OpenSCAP required partitions', () => {
+    const renderWithOscapPartitions = () => {
+      return renderFileSystemStep({
+        output: {
+          ...initialState.output,
+          distribution: RHEL_9,
+        },
+        compliance: {
+          type: 'openscap',
+          profileID: mockOscapProfile,
+          policyID: undefined,
+          policyTitle: undefined,
+          fips: { enabled: false },
+        },
+        filesystem: {
+          mode: 'basic',
+          disk: { minsize: '', unit: 'GiB', partitions: [], type: undefined },
+          fileSystem: {
+            partitions: [
+              {
+                id: '1',
+                mountpoint: '/',
+                min_size: '10',
+                unit: 'GiB',
+              },
+              {
+                id: '2',
+                mountpoint: '/home',
+                min_size: '1',
+                unit: 'GiB',
+              },
+              {
+                id: '3',
+                mountpoint: '/var',
+                min_size: '5',
+                unit: 'GiB',
+              },
+              {
+                id: '4',
+                mountpoint: '/tmp',
+                min_size: '2',
+                unit: 'GiB',
+              },
+            ],
+          },
+          partitioningMode: undefined,
+        },
+      });
+    };
+
+    test('OSCAP-required partition has disabled mountpoint input', async () => {
+      renderWithOscapPartitions();
+
+      const table = await screen.findByRole('grid', {
+        name: /file system table/i,
+      });
+      const rows = within(table).getAllByRole('row');
+      const requiredRow = rows[2]; // /home
+      await waitFor(() =>
+        expect(
+          within(requiredRow).getByRole('textbox', {
+            name: /mount point input/i,
+          }),
+        ).toBeDisabled(),
+      );
+    });
+
+    test('OSCAP-required partition has disabled remove button', async () => {
+      renderWithOscapPartitions();
+
+      const table = await screen.findByRole('grid', {
+        name: /file system table/i,
+      });
+      const rows = within(table).getAllByRole('row');
+      const requiredRow = rows[3]; // /var
+      await waitFor(() =>
+        expect(
+          within(requiredRow).getByRole('button', {
+            name: /remove partition/i,
+          }),
+        ).toBeDisabled(),
+      );
+    });
+
+    test('OSCAP-required partition has disabled size unit dropdown', async () => {
+      renderWithOscapPartitions();
+
+      const table = await screen.findByRole('grid', {
+        name: /file system table/i,
+      });
+      const rows = within(table).getAllByRole('row');
+      const requiredRow = rows[2]; // /home
+      await waitFor(() =>
+        expect(
+          within(requiredRow).getByRole('button', { name: 'GiB' }),
+        ).toBeDisabled(),
+      );
+    });
+
+    test('non-required partition controls remain enabled', async () => {
+      renderWithOscapPartitions();
+
+      const table = await screen.findByRole('grid', {
+        name: /file system table/i,
+      });
+      const rows = within(table).getAllByRole('row');
+
+      // Check that a required row is locked
+      const requiredRow = rows[2]; // /home — OSCAP-required
+      await waitFor(() =>
+        expect(
+          within(requiredRow).getByRole('textbox', {
+            name: /mount point input/i,
+          }),
+        ).toBeDisabled(),
+      );
+
+      // Verify the non-required row remains enabled
+      const userRow = rows[4]; // /tmp — not in OSCAP profile
+      expect(
+        within(userRow).getByRole('textbox', { name: /mount point input/i }),
+      ).toBeEnabled();
+      expect(
+        within(userRow).getByRole('button', { name: /remove partition/i }),
+      ).toBeEnabled();
+      expect(
+        within(userRow).getByRole('button', { name: 'GiB' }),
+      ).toBeEnabled();
+    });
+
+    test('shows validation error when size is below OSCAP minimum', async () => {
+      const user = createUser();
+      renderWithOscapPartitions();
+
+      const table = await screen.findByRole('grid', {
+        name: /file system table/i,
+      });
+      const rows = within(table).getAllByRole('row');
+      const varRow = rows[3]; // /var
+
+      await waitFor(() =>
+        expect(
+          within(varRow).getByRole('textbox', {
+            name: /mount point input/i,
+          }),
+        ).toBeDisabled(),
+      );
+
+      const sizeInput = within(varRow).getByRole('textbox', {
+        name: /minimum partition size/i,
+      });
+
+      await clickWithWait(user, sizeInput);
+      await clearWithWait(user, sizeInput);
+      await typeWithWait(user, sizeInput, '1');
+
+      expect(
+        await screen.findByText(/required by OpenSCAP profile/i),
+      ).toBeInTheDocument();
+    });
+
+    test('no validation error when size meets OSCAP minimum', async () => {
+      renderWithOscapPartitions();
+
+      const table = await screen.findByRole('grid', {
+        name: /file system table/i,
+      });
+      const rows = within(table).getAllByRole('row');
+      const varRow = rows[3]; // /var
+
+      await waitFor(() =>
+        expect(
+          within(varRow).getByRole('textbox', {
+            name: /mount point input/i,
+          }),
+        ).toBeDisabled(),
+      );
+
+      expect(
+        screen.queryByText(/required by OpenSCAP profile/i),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/FileSystem/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/steps/FileSystem/tests/mocks/fixtures.ts
@@ -1,0 +1,19 @@
+import type { GetOscapCustomizationsApiResponse } from '@/store/api/backend';
+
+export const mockOscapProfile =
+  'xccdf_org.ssgproject.content_profile_cis_workstation_l1';
+
+export const mockOscapCustomizations: GetOscapCustomizationsApiResponse = {
+  openscap: {
+    profile_id: mockOscapProfile,
+    profile_name:
+      'CIS Red Hat Enterprise Linux 9 Benchmark for Level 1 - Workstation',
+    profile_description: 'Mock OpenSCAP profile for testing',
+  },
+  packages: ['aide'],
+  filesystem: [
+    { mountpoint: '/', min_size: 10737418240 },
+    { mountpoint: '/home', min_size: 1073741824 },
+    { mountpoint: '/var', min_size: 5368709120 },
+  ],
+};

--- a/src/Components/CreateImageWizard/steps/FileSystem/tests/mocks/handlers.ts
+++ b/src/Components/CreateImageWizard/steps/FileSystem/tests/mocks/handlers.ts
@@ -1,0 +1,29 @@
+import type { GetOscapCustomizationsApiResponse } from '@/store/api/backend';
+import {
+  composeHandlers,
+  createOscapHandler,
+  type FetchHandler,
+  fetchMock,
+} from '@/test/testUtils';
+
+import { mockOscapCustomizations } from './fixtures';
+
+export { fetchMock };
+
+type FetchHandlerOverrides = {
+  customizations?: GetOscapCustomizationsApiResponse;
+};
+
+export const createFetchHandler = (
+  overrides: FetchHandlerOverrides = {},
+): FetchHandler => {
+  const handlers = [
+    createOscapHandler({
+      customizations: overrides.customizations ?? mockOscapCustomizations,
+    }),
+  ];
+
+  return composeHandlers(...handlers);
+};
+
+export const createDefaultFetchHandler = createFetchHandler();

--- a/src/Components/CreateImageWizard/steps/FileSystem/tests/mocks/index.ts
+++ b/src/Components/CreateImageWizard/steps/FileSystem/tests/mocks/index.ts
@@ -1,0 +1,6 @@
+export {
+  createDefaultFetchHandler,
+  createFetchHandler,
+  fetchMock,
+} from './handlers';
+export * from './fixtures';

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -10,16 +10,19 @@ import {
 } from '@/constants';
 import {
   BlueprintsResponse,
+  useGetOscapCustomizationsQuery,
   useLazyGetBlueprintsQuery,
 } from '@/store/api/backend';
 import { useShowActivationKeyQuery } from '@/store/api/rhsm';
 import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
+  convertToBytes,
   DiskPartition,
   FilesystemPartition,
   MAX_REGULAR_GID,
   MIN_REGULAR_GID,
+  parseSizeUnit,
   selectAapCallbackUrl,
   selectAapHostConfigKey,
   selectAapTlsCertificateAuthority,
@@ -33,8 +36,10 @@ import {
   selectBlueprintId,
   selectBlueprintMode,
   selectBlueprintName,
+  selectComplianceProfileID,
   selectDiskMinsize,
   selectDiskPartitions,
+  selectDistribution,
   selectFilesystemPartitions,
   selectFirewall,
   selectFirstBootScript,
@@ -418,7 +423,20 @@ export function useFilesystemValidation(): StepValidation {
   const diskPartitions = useAppSelector(selectDiskPartitions);
   const diskMinsize = useAppSelector(selectDiskMinsize);
   const blueprintMode = useAppSelector(selectBlueprintMode);
+  const release = useAppSelector(selectDistribution);
+  const complianceProfileID = useAppSelector(selectComplianceProfileID);
   let disabledNext = false;
+
+  const { data: oscapProfileInfo } = useGetOscapCustomizationsQuery(
+    {
+      distribution: release,
+      // @ts-expect-error skipped when undefined
+      profile: complianceProfileID,
+    },
+    {
+      skip: !complianceProfileID,
+    },
+  );
 
   const errors: { [key: string]: string } = {};
   if (fscMode === 'automatic') {
@@ -455,6 +473,26 @@ export function useFilesystemValidation(): StepValidation {
     ) {
       disabledNext = true;
     }
+
+    if ('mountpoint' in partition && partition.mountpoint) {
+      const oscapPartition = oscapProfileInfo?.filesystem?.find(
+        (fs) => fs.mountpoint === partition.mountpoint,
+      );
+      if (oscapPartition) {
+        const currentBytes = convertToBytes(
+          partition.min_size || '0',
+          partition.unit || 'GiB',
+        );
+        const requiredBytes = oscapPartition.min_size;
+        if (currentBytes < requiredBytes) {
+          const [size, unit] = parseSizeUnit(String(requiredBytes));
+          errors[`min-size-${partition.id}`] =
+            `Minimum size of ${size} ${unit} required by OpenSCAP profile`;
+          disabledNext = true;
+        }
+      }
+    }
+
     if (fscMode === 'advanced') {
       if (validatePartitionName(partition, errors, nameDuplicates)) {
         disabledNext = true;


### PR DESCRIPTION
This marks partitions included in OpenSCAP profile customizations as required. The mountpoint can't be changed, the partition can't be removed and the minimum size must be at least the required minimum size for the OpenSCAP required mountpoint.