### PR TITLE
Add Fedora ELN host distro support

### DIFF
--- a/playwright/helpers/helpers.ts
+++ b/playwright/helpers/helpers.ts
@@ -9,6 +9,8 @@ import {
   type Page,
 } from '@playwright/test';
 
+import { FEDORA_ELN, ON_PREM_RELEASES } from '@/constants';
+
 export const disablePreview = async (page: Page) => {
   const toggleSwitch = page.locator('#preview-toggle');
 
@@ -50,17 +52,6 @@ export const closePopupsIfExist = async (page: Page) => {
   }
 };
 
-// copied over from constants
-const ON_PREM_RELEASES = new Map([
-  ['centos-10', 'CentOS Stream 10'],
-  ['fedora-41', 'Fedora Linux 41'],
-  ['fedora-42', 'Fedora Linux 42'],
-  ['fedora-43', 'Fedora Linux 43'],
-  ['fedora-44', 'Fedora Linux 44'],
-  ['fedora-45', 'Fedora Linux 45'],
-  ['rhel-10', 'Red Hat Enterprise Linux (RHEL) 10'],
-]);
-
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const getHostDistroKey = (): string => {
   const osRelData = readFileSync('/etc/os-release');
@@ -75,7 +66,9 @@ export const getHostDistroKey = (): string => {
     (osRel as any)[lineData[0]] = lineData[1].replace(/"/g, '');
   }
 
-  const key = `${(osRel as any)['ID']}-${(osRel as any)['VERSION_ID'].split('.')[0]}`;
+  const id = (osRel as any)['ID'];
+  const versionId = (osRel as any)['VERSION_ID'];
+  const key = id === 'eln' ? FEDORA_ELN : `${id}-${versionId.split('.')[0]}`;
   if (!ON_PREM_RELEASES.has(key)) {
     /* eslint-disable no-console */
     console.error('getHostDistroKey failed, os-release config:', osRel);

--- a/src/Utilities/getHostInfo.ts
+++ b/src/Utilities/getHostInfo.ts
@@ -1,7 +1,7 @@
 import cockpit from 'cockpit';
 import { read_os_release } from 'os-release';
 
-import { AARCH64, X86_64 } from '../constants';
+import { AARCH64, FEDORA_ELN, X86_64 } from '../constants';
 import { Distributions } from '../store/api/backend/hosted';
 
 type Architecture = 'x86_64' | 'aarch64';
@@ -16,11 +16,16 @@ export const getHostDistro = async (): Promise<Distributions> => {
     cachedHostDistro = (async () => {
       try {
         const osRel = await read_os_release();
-        let distro = `${osRel.ID}-${osRel.VERSION_ID}`;
+        // ELN is a rolling release with no meaningful version;
+        // its os-release has ID=eln, so map it to 'fedora-eln'
+        let distro =
+          osRel.ID === 'eln' ? FEDORA_ELN : `${osRel.ID}-${osRel.VERSION_ID}`;
+
         // use major releases, and rely on composer's distro aliasing (rhel)
         if (distro.indexOf('.') !== -1) {
           distro = distro.split('.')[0];
         }
+
         return distro as Distributions;
       } catch (err) {
         cachedHostDistro = null;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -63,6 +63,7 @@ export const FEDORA_42 = 'fedora-42';
 export const FEDORA_43 = 'fedora-43';
 export const FEDORA_44 = 'fedora-44';
 export const FEDORA_45 = 'fedora-45';
+export const FEDORA_ELN = 'fedora-eln';
 export const X86_64 = 'x86_64';
 export const AARCH64 = 'aarch64';
 
@@ -127,6 +128,7 @@ export const ON_PREM_RELEASES = new Map([
   [FEDORA_43, 'Fedora Linux 43'],
   [FEDORA_44, 'Fedora Linux 44'],
   [FEDORA_45, 'Fedora Linux 45'],
+  [FEDORA_ELN, 'Fedora Linux ELN'],
   [RHEL_9, 'Red Hat Enterprise Linux (RHEL) 9'],
   [RHEL_10, 'Red Hat Enterprise Linux (RHEL) 10'],
 ]);


### PR DESCRIPTION
## Summary

Adds Fedora ELN as a supported host distribution for cockpit-image-builder. Downstream ELN tests were failing because the distro was unrecognized.

## Changes

- Add `fedora-eln` constant and `ON_PREM_RELEASES` entry in `src/constants.ts`
- Map ELN's `ID=eln` os-release field to the `fedora-eln` distro key in both `getHostDistro()` and the Playwright `getHostDistroKey()` helper
- Replace the duplicated `ON_PREM_RELEASES` map in the Playwright helpers with an import from `src/constants`
