### PR TITLE
Wizard/FSC: Ensure min size and unit always on the same row (HMS-11026)

### DIFF
--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -58,7 +58,7 @@ test('Import a blueprint with invalid customization', async ({
     ).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     const closeRootButton = frame
-      .locator('td:nth-child(5) > .pf-v6-c-button')
+      .getByRole('button', { name: 'Remove partition' })
       .first();
     await expect(closeRootButton).toBeEnabled();
     await closeRootButton.click();

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/DiskRow.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/DiskRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button } from '@patternfly/react-core';
+import { Button, Split, SplitItem } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
 
@@ -48,11 +48,15 @@ const DiskRow = ({ partition }: DiskRowPropTypes) => {
       <Td width={10}>
         <PartitionType partition={partition} customization={customization} />
       </Td>
-      <Td width={15}>
-        <MinimumSize partition={partition} customization={customization} />
-      </Td>
-      <Td width={15}>
-        <SizeUnit partition={partition} customization={customization} />
+      <Td width={30}>
+        <Split hasGutter>
+          <SplitItem isFilled>
+            <MinimumSize partition={partition} customization={customization} />
+          </SplitItem>
+          <SplitItem>
+            <SizeUnit partition={partition} customization={customization} />
+          </SplitItem>
+        </Split>
       </Td>
       <Td isActionCell>
         <Button

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
@@ -43,7 +43,6 @@ const FileSystemTable = ({ partitions, mode }: FileSystemTableTypes) => {
           <Th>Mount point</Th>
           <Th>Type</Th>
           <Th>Minimum size</Th>
-          <Th aria-label='Unit'>Unit</Th>
           <Th aria-label='Remove mount point' />
         </Tr>
       </Thead>

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 
-import { Button, TextInput, Tooltip } from '@patternfly/react-core';
+import {
+  Button,
+  Split,
+  SplitItem,
+  TextInput,
+  Tooltip,
+} from '@patternfly/react-core';
 import { LockIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
 
@@ -60,7 +66,7 @@ const Row = ({ partition, isRemovingDisabled }: RowPropTypes) => {
     <Button
       isDisabled={isOscapRequired || isRemovingDisabled}
       variant='plain'
-      icon={isOscapRequired ? <LockIcon /> : <MinusCircleIcon />}
+      icon={isRemovingDisabled ? <LockIcon /> : <MinusCircleIcon />}
       onClick={() => handleRemovePartition(partition.id)}
       aria-label='Remove partition'
     />
@@ -83,20 +89,24 @@ const Row = ({ partition, isRemovingDisabled }: RowPropTypes) => {
           isDisabled
         />
       </Td>
-      <Td width={20}>
-        <MinimumSize
-          partition={partition}
-          customization={customization}
-          isOscapRequired={isOscapRequired}
-          oscapMinSizeLabel={oscapMinSizeLabel}
-        />
-      </Td>
-      <Td width={20}>
-        <SizeUnit
-          partition={partition}
-          customization={customization}
-          isOscapRequired={isOscapRequired}
-        />
+      <Td width={40}>
+        <Split hasGutter>
+          <SplitItem isFilled>
+            <MinimumSize
+              partition={partition}
+              customization={customization}
+              isOscapRequired={isOscapRequired}
+              oscapMinSizeLabel={oscapMinSizeLabel}
+            />
+          </SplitItem>
+          <SplitItem>
+            <SizeUnit
+              partition={partition}
+              customization={customization}
+              isOscapRequired={isOscapRequired}
+            />
+          </SplitItem>
+        </Split>
       </Td>
       <Td isActionCell>
         {isOscapRequired ? (


### PR DESCRIPTION
This ensures that even in very narrow window view the minimum size of partition and its unit will always be on the same row as they're linked to each other.

Before:
<img width="519" height="279" alt="image" src="https://github.com/user-attachments/assets/1ec65d8b-a05f-4fa3-b132-40765445e192" />

After:
<img width="524" height="263" alt="image" src="https://github.com/user-attachments/assets/dfa73c6a-e813-4dcf-a91d-239fb3afaf4b" />


JIRA: [HMS-11026](https://issues.redhat.com/browse/HMS-11026)

[HMS-11026]: https://redhat.atlassian.net/browse/HMS-11026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ