### PR TITLE
Wizard/FSC: Deduplicate `useGetOscapCustomizationsQuery` request (HMS-10790)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
@@ -2,7 +2,15 @@ import React, { useMemo } from 'react';
 
 import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 
-import { DiskPartition, FilesystemPartition } from '@/store/slices/wizard';
+import { useGetOscapCustomizationsQuery } from '@/store/api/backend';
+import { useAppSelector } from '@/store/hooks';
+import {
+  DiskPartition,
+  FilesystemPartition,
+  parseSizeUnit,
+  selectComplianceProfileID,
+  selectDistribution,
+} from '@/store/slices/wizard';
 
 import DiskRow from './DiskRow';
 import Row from './Row';
@@ -18,6 +26,32 @@ type FileSystemTableTypes =
     };
 
 const FileSystemTable = ({ partitions, mode }: FileSystemTableTypes) => {
+  const release = useAppSelector(selectDistribution);
+  const complianceProfileID = useAppSelector(selectComplianceProfileID);
+
+  const { data: oscapProfileInfo } = useGetOscapCustomizationsQuery(
+    {
+      distribution: release,
+      // @ts-expect-error skipped when undefined
+      profile: complianceProfileID,
+    },
+    {
+      skip: !complianceProfileID,
+    },
+  );
+
+  const getOscapPartitionInfo = (mountpoint: string) => {
+    const oscapPartition = oscapProfileInfo?.filesystem?.find(
+      (fs) => fs.mountpoint === mountpoint,
+    );
+    return {
+      isOscapRequired: !!oscapPartition,
+      oscapMinSizeLabel: oscapPartition
+        ? parseSizeUnit(String(oscapPartition.min_size)).join(' ')
+        : '',
+    };
+  };
+
   const isFilesystemPartition = (
     p: FilesystemPartition | DiskPartition,
   ): p is FilesystemPartition => !('type' in p);
@@ -57,6 +91,7 @@ const FileSystemTable = ({ partitions, mode }: FileSystemTableTypes) => {
                 isRemovingDisabled={
                   rootPartitionsCount === 1 && partition.mountpoint === '/'
                 }
+                {...getOscapPartitionInfo(partition.mountpoint)}
               />
             ))
           : partitions.map((partition) => (

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
@@ -4,15 +4,8 @@ import { Button, TextInput, Tooltip } from '@patternfly/react-core';
 import { LockIcon, MinusCircleIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
 
-import { useGetOscapCustomizationsQuery } from '@/store/api/backend';
-import { useAppDispatch, useAppSelector } from '@/store/hooks';
-import {
-  FilesystemPartition,
-  parseSizeUnit,
-  removePartition,
-  selectComplianceProfileID,
-  selectDistribution,
-} from '@/store/slices/wizard';
+import { useAppDispatch } from '@/store/hooks';
+import { FilesystemPartition, removePartition } from '@/store/slices/wizard';
 
 import MinimumSize from './MinimumSize';
 import Mountpoint from './Mountpoint';
@@ -23,32 +16,17 @@ export const FileSystemContext = React.createContext<boolean>(true);
 type RowPropTypes = {
   partition: FilesystemPartition;
   isRemovingDisabled: boolean;
+  isOscapRequired: boolean;
+  oscapMinSizeLabel: string;
 };
 
-const Row = ({ partition, isRemovingDisabled }: RowPropTypes) => {
+const Row = ({
+  partition,
+  isRemovingDisabled,
+  isOscapRequired,
+  oscapMinSizeLabel,
+}: RowPropTypes) => {
   const dispatch = useAppDispatch();
-  const release = useAppSelector(selectDistribution);
-  const complianceProfileID = useAppSelector(selectComplianceProfileID);
-
-  const { data: oscapProfileInfo } = useGetOscapCustomizationsQuery(
-    {
-      distribution: release,
-      // @ts-expect-error skipped when undefined
-      profile: complianceProfileID,
-    },
-    {
-      skip: !complianceProfileID,
-    },
-  );
-
-  const oscapPartition = oscapProfileInfo?.filesystem?.find(
-    (fs) => fs.mountpoint === partition.mountpoint,
-  );
-  const isOscapRequired = !!oscapPartition;
-
-  const oscapMinSizeLabel = oscapPartition
-    ? parseSizeUnit(String(oscapPartition.min_size)).join(' ')
-    : '';
 
   const handleRemovePartition = (id: string) => {
     dispatch(removePartition(id));


### PR DESCRIPTION
The request would be called for every row. RTK query would have deduplicated the requests, but this is cleaner approach, with one subscription instead of N.