### PR TITLE
Wizard/FSC: Update icon and tooltip of disabled partitions (HMS-11027)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
@@ -44,7 +44,13 @@ const Row = ({
     <Button
       isDisabled={isOscapRequired || isRemovingDisabled}
       variant='plain'
-      icon={isRemovingDisabled ? <LockIcon /> : <MinusCircleIcon />}
+      icon={
+        isOscapRequired || isRemovingDisabled ? (
+          <LockIcon />
+        ) : (
+          <MinusCircleIcon />
+        )
+      }
       onClick={() => handleRemovePartition(partition.id)}
       aria-label='Remove partition'
     />
@@ -87,8 +93,14 @@ const Row = ({
         </Split>
       </Td>
       <Td isActionCell>
-        {isOscapRequired ? (
-          <Tooltip content='Required by the selected OpenSCAP profile'>
+        {isOscapRequired || isRemovingDisabled ? (
+          <Tooltip
+            content={
+              isOscapRequired
+                ? 'Required by the selected OpenSCAP profile'
+                : 'Root partition is required'
+            }
+          >
             <span>{removeButton}</span>
           </Tooltip>
         ) : (


### PR DESCRIPTION
This renders lock icon when the removing of the partition is disabled and adds a tooltip on hover to the required root partition.

JIRA: [HMS-11027](https://issues.redhat.com/browse/HMS-11027)

[HMS-11027]: https://redhat.atlassian.net/browse/HMS-11027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ