### PR TITLE
Wizard: PackageTable width fix (HMS-10794)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
@@ -278,7 +278,7 @@ const PackagesTable = ({
   ]);
 
   return (
-    <Table data-testid='packages-table'>
+    <Table data-testid='packages-table' style={{ tableLayout: 'fixed' }}>
       <Thead>
         <Tr>
           <Th width={10} aria-label='Expanded' />


### PR DESCRIPTION
Fix the jumping width of the Packages table.
<img width="1600" height="888" alt="package-width" src="https://github.com/user-attachments/assets/dd6ca1a2-a47b-4abe-97ce-a025d74a1aba" />
