### PR TITLE
Wizard/Snapshots: Validate on progressing (HMS-10760)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Snapshot/components/Snapshot.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/components/Snapshot.tsx
@@ -11,13 +11,17 @@ import {
   Radio,
 } from '@patternfly/react-core';
 
-import { isSnapshotDateValid } from '@/Components/CreateImageWizard/validators';
+import {
+  isSnapshotDateValid,
+  isSnapshotValid,
+} from '@/Components/CreateImageWizard/validators';
 import { TEMPLATES_URL } from '@/constants';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeSnapshotDate,
   changeTemplate,
   changeUseLatest,
+  selectForceShowErrors,
   selectSnapshotDate,
   selectTemplate,
   selectUseLatest,
@@ -29,6 +33,10 @@ import Templates from './Templates';
 const Snapshot = () => {
   const dispatch = useAppDispatch();
   const snapshotDate = useAppSelector(selectSnapshotDate);
+  const forceShowErrors = useAppSelector(selectForceShowErrors);
+
+  const showDateError =
+    (forceShowErrors || !!snapshotDate) && !isSnapshotValid(snapshotDate);
 
   const useLatest = useAppSelector(selectUseLatest);
   const templateUuid = useAppSelector(selectTemplate);
@@ -88,8 +96,9 @@ const Snapshot = () => {
                     id='snapshot-date-picker'
                     name='pick-snapshot-date'
                     value={snapshotDate ? snapshotDate.split('T')[0] : ''}
-                    required
-                    requiredDateOptions={{ isRequired: true }}
+                    inputProps={{
+                      validated: showDateError ? 'error' : 'default',
+                    }}
                     placeholder='YYYY-MM-DD'
                     validators={[
                       (date: Date) => {
@@ -122,6 +131,15 @@ const Snapshot = () => {
                     Clear date
                   </Button>
                 </Flex>
+                {forceShowErrors && !snapshotDate && (
+                  <FormHelperText>
+                    <HelperText>
+                      <HelperTextItem variant='error'>
+                        Date cannot be blank
+                      </HelperTextItem>
+                    </HelperText>
+                  </FormHelperText>
+                )}
               </FormGroup>
               <FormHelperText>
                 <HelperText>

--- a/src/Components/CreateImageWizard/steps/Snapshot/tests/RepeatableBuild.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/tests/RepeatableBuild.test.tsx
@@ -134,8 +134,8 @@ describe('Repeatable Build Component', () => {
 
       await clickClearDate(user);
       expect(
-        await screen.findByText('Date cannot be blank'),
-      ).toBeInTheDocument();
+        screen.queryByText('Date cannot be blank'),
+      ).not.toBeInTheDocument();
       await checkDatePickerValue('');
 
       await clickTodaysDate(user);


### PR DESCRIPTION
`requiredDateOptions` were immediately rendering a missing date error on clicking the "Clear date" button. This replaces it with a custom validation that gets triggered when trying to progress in the Wizard (Next/Review).

This way the user can clear the input without being immediatelly screamed at by the validator.