### PR TITLE
Wizard: fix adding LabelInput values (HMS-10877)

### DIFF
--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 
 import {
+  Button,
+  Flex,
+  FlexItem,
   HelperText,
   HelperTextItem,
   Label,
@@ -9,6 +12,7 @@ import {
   TextInputGroupMain,
   Truncate,
 } from '@patternfly/react-core/dist/esm';
+import { PlusCircleIcon } from '@patternfly/react-icons';
 import { UnknownAction } from 'redux';
 
 import { StepValidation } from './utilities/useValidation';
@@ -33,6 +37,8 @@ type LabelInputProps = {
   truncateLength?: number;
   isCompact?: boolean;
   chipCollapseThreshold?: number;
+  hideAddLabel?: boolean;
+  helperText?: string;
 };
 
 const LabelInput = ({
@@ -49,6 +55,8 @@ const LabelInput = ({
   truncateLength = DEFAULT_TRUNCATE_LENGTH,
   isCompact = false,
   chipCollapseThreshold = DEFAULT_CHIP_COLLAPSE_THRESHOLD,
+  hideAddLabel = false,
+  helperText,
 }: LabelInputProps) => {
   const dispatch = useAppDispatch();
 
@@ -70,12 +78,17 @@ const LabelInput = ({
   };
 
   const addItem = (value: string) => {
-    if (list?.includes(value) || requiredList?.includes(value)) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    if (list?.includes(trimmed) || requiredList?.includes(trimmed)) {
       setOnStepInputErrorText(`${item} already exists.`);
       return;
     }
 
-    if (!validator(value)) {
+    if (!validator(trimmed)) {
       switch (fieldName) {
         case 'ports':
           setOnStepInputErrorText(
@@ -121,7 +134,7 @@ const LabelInput = ({
       return;
     }
 
-    dispatch(addAction(value));
+    dispatch(addAction(trimmed));
     setInputValue('');
     setOnStepInputErrorText('');
   };
@@ -146,64 +159,78 @@ const LabelInput = ({
   const totalItems = (requiredList?.length ?? 0) + (list?.length ?? 0);
 
   return (
-    <>
-      <TextInputGroup>
-        <TextInputGroupMain
-          aria-label={ariaLabel}
-          placeholder={placeholder}
-          onChange={onTextInputChange}
-          value={inputValue}
-          onKeyDown={(e) => handleKeyDown(e, inputValue)}
-        >
-          {totalItems > 0 && (
-            <LabelGroup
-              isCompact={isCompact}
-              numLabels={chipCollapseThreshold}
-              expandedText='Show less'
-              collapsedText={
-                totalItems > chipCollapseThreshold
-                  ? `${totalItems - chipCollapseThreshold} more`
-                  : undefined
-              }
-              className='pf-v6-u-mr-sm'
-            >
-              {requiredList?.map((labelItem) => (
-                <Label key={labelItem}>{labelItem}</Label>
-              ))}
-              {list?.map((labelItem) => (
-                <Label
-                  key={labelItem}
-                  color='blue'
-                  isCompact={isCompact}
-                  onClose={(e) => handleRemoveItem(e, labelItem)}
-                  closeBtnAriaLabel={`Remove ${labelItem}`}
-                >
-                  <Truncate
-                    content={labelItem}
-                    maxCharsDisplayed={truncateLength}
-                  />
-                </Label>
-              ))}
-            </LabelGroup>
+    <Flex flexWrap={{ default: 'nowrap' }}>
+      <FlexItem grow={{ default: 'grow' }}>
+        <TextInputGroup>
+          <TextInputGroupMain
+            aria-label={ariaLabel}
+            placeholder={placeholder}
+            onChange={onTextInputChange}
+            value={inputValue}
+            onKeyDown={(e) => handleKeyDown(e, inputValue)}
+          >
+            {totalItems > 0 && (
+              <LabelGroup
+                isCompact={isCompact}
+                numLabels={chipCollapseThreshold}
+                expandedText='Show less'
+                collapsedText={
+                  totalItems > chipCollapseThreshold
+                    ? `${totalItems - chipCollapseThreshold} more`
+                    : undefined
+                }
+                className='pf-v6-u-mr-sm'
+              >
+                {requiredList?.map((labelItem) => (
+                  <Label key={labelItem}>{labelItem}</Label>
+                ))}
+                {list?.map((labelItem) => (
+                  <Label
+                    key={labelItem}
+                    color='blue'
+                    isCompact={isCompact}
+                    onClose={(e) => handleRemoveItem(e, labelItem)}
+                    closeBtnAriaLabel={`Remove ${labelItem}`}
+                  >
+                    <Truncate
+                      content={labelItem}
+                      maxCharsDisplayed={truncateLength}
+                    />
+                  </Label>
+                ))}
+              </LabelGroup>
+            )}
+          </TextInputGroupMain>
+        </TextInputGroup>
+        <HelperText>
+          {errors.length > 0
+            ? errors.map((error, index) => (
+                <HelperTextItem key={index} variant={'error'}>
+                  {error}
+                </HelperTextItem>
+              ))
+            : !warning && (
+                <HelperTextItem>
+                  {helperText && `${helperText} `}
+                  Press Enter or click {hideAddLabel ? 'the add icon' : 'Add'}.
+                </HelperTextItem>
+              )}
+          {warning && (
+            <HelperTextItem variant={'warning'}>{warning}</HelperTextItem>
           )}
-        </TextInputGroupMain>
-      </TextInputGroup>
-
-      {errors.length > 0 && (
-        <HelperText>
-          {errors.map((error, index) => (
-            <HelperTextItem key={index} variant={'error'}>
-              {error}
-            </HelperTextItem>
-          ))}
         </HelperText>
-      )}
-      {warning && (
-        <HelperText>
-          <HelperTextItem variant={'warning'}>{warning}</HelperTextItem>
-        </HelperText>
-      )}
-    </>
+      </FlexItem>
+      <FlexItem alignSelf={{ default: 'alignSelfFlexStart' }}>
+        <Button
+          variant='control'
+          aria-label={ariaLabel}
+          icon={<PlusCircleIcon />}
+          onClick={() => addItem(inputValue)}
+        >
+          {!hideAddLabel && 'Add'}
+        </Button>
+      </FlexItem>
+    </Flex>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Firewall/components/PortsInput.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/components/PortsInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 
 import LabelInput from '@/Components/CreateImageWizard/LabelInput';
 import { useFirewallValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
@@ -25,10 +25,8 @@ const PortsInput = () => {
         removeAction={removePort}
         stepValidation={stepValidation}
         fieldName='ports'
+        helperText='Examples: 8080:tcp, 443:udp.'
       />
-      <HelperText className='pf-v6-u-pt-sm'>
-        <HelperTextItem>Examples: 8080:tcp, 443:udp</HelperTextItem>
-      </HelperText>
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Firewall/components/Services.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/components/Services.tsx
@@ -24,7 +24,7 @@ const Services = () => {
     <>
       <FormGroup label='Enabled services'>
         <LabelInput
-          ariaLabel='Add enabled service'
+          ariaLabel='Add enabled firewall service'
           placeholder='Enter firewalld service'
           validator={isServiceValid}
           list={enabledServices}
@@ -37,7 +37,7 @@ const Services = () => {
       </FormGroup>
       <FormGroup label='Disabled services'>
         <LabelInput
-          ariaLabel='Add disabled service'
+          ariaLabel='Add disabled firewall service'
           placeholder='Enter firewalld service'
           validator={isServiceValid}
           list={disabledServices}

--- a/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 
 import LabelInput from '@/Components/CreateImageWizard/LabelInput';
 import { useKernelValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
@@ -51,13 +51,8 @@ const KernelArguments = () => {
         removeAction={removeKernelArg}
         stepValidation={stepValidation}
         fieldName='kernelAppend'
+        helperText='Enter additional kernel boot parameters. Examples: nomodeset or console=ttyS0.'
       />
-      <HelperText className='pf-v6-u-pt-sm'>
-        <HelperTextItem>
-          Enter additional kernel boot parameters. Examples: nomodeset or
-          console=ttyS0.
-        </HelperTextItem>
-      </HelperText>
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Kernel/tests/Kernel.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/tests/Kernel.test.tsx
@@ -107,7 +107,7 @@ describe('Kernel Component', () => {
       await selectKernelOption(user, 'kernel');
 
       expect(
-        await screen.findByRole('button', { name: /kernel/i }),
+        await screen.findByRole('button', { name: 'kernel' }),
       ).toBeInTheDocument();
 
       await clearKernelName(user);

--- a/src/Components/CreateImageWizard/steps/Kernel/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/tests/helpers.tsx
@@ -27,7 +27,7 @@ export const openKernelNameDropdown = async (user: UserEventInstance) => {
 
 export const clearKernelName = async (user: UserEventInstance) => {
   const toggle = await screen.findByRole('button', {
-    name: /kernel/i,
+    name: 'kernel',
   });
   await clickWithWait(user, toggle);
   await selectKernelOption(user, 'Default');

--- a/src/Components/CreateImageWizard/steps/Services/components/ServicesInputs.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/components/ServicesInputs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 
 import LabelInput from '@/Components/CreateImageWizard/LabelInput';
 import { useServicesValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
@@ -56,7 +56,7 @@ const ServicesInput = () => {
     <>
       <FormGroup isRequired={false} label='Enabled services'>
         <LabelInput
-          ariaLabel='Add enabled service'
+          ariaLabel='Add enabled systemd service'
           placeholder='Add enabled service'
           validator={isServiceValid}
           list={enabledServices.filter(
@@ -69,17 +69,12 @@ const ServicesInput = () => {
           stepValidation={stepValidation}
           fieldName='enabledSystemdServices'
           chipCollapseThreshold={8}
+          helperText='These services are currently active and set to start automatically at boot.'
         />
-        <HelperText className='pf-v6-u-pt-sm'>
-          <HelperTextItem>
-            These services are currently active and set to start automatically
-            at boot.
-          </HelperTextItem>
-        </HelperText>
       </FormGroup>
       <FormGroup isRequired={false} label='Disabled services'>
         <LabelInput
-          ariaLabel='Add disabled service'
+          ariaLabel='Add disabled systemd service'
           placeholder='Add disabled service'
           validator={isServiceValid}
           list={disabledServices.filter(
@@ -93,17 +88,12 @@ const ServicesInput = () => {
           stepValidation={stepValidation}
           fieldName='disabledSystemdServices'
           chipCollapseThreshold={8}
+          helperText='These services are installed but will not start automatically at boot.'
         />
-        <HelperText className='pf-v6-u-pt-sm'>
-          <HelperTextItem>
-            These services are installed but will not start automatically at
-            boot.
-          </HelperTextItem>
-        </HelperText>
       </FormGroup>
       <FormGroup isRequired={false} label='Masked services'>
         <LabelInput
-          ariaLabel='Add masked service'
+          ariaLabel='Add masked systemd service'
           placeholder='Add masked service'
           validator={isServiceValid}
           list={maskedServices.filter(
@@ -116,13 +106,8 @@ const ServicesInput = () => {
           stepValidation={stepValidation}
           fieldName='maskedSystemdServices'
           chipCollapseThreshold={8}
+          helperText='These services are completely blocked from being started manually or automatically.'
         />
-        <HelperText className='pf-v6-u-pt-sm'>
-          <HelperTextItem>
-            These services are completely blocked from being started manually or
-            automatically.
-          </HelperTextItem>
-        </HelperText>
       </FormGroup>
     </>
   );

--- a/src/Components/CreateImageWizard/steps/Timezone/components/NtpServersInput.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/components/NtpServersInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 
 import LabelInput from '@/Components/CreateImageWizard/LabelInput';
 import { useTimezoneValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
@@ -29,13 +29,8 @@ const NtpServersInput = () => {
         removeAction={removeNtpServer}
         stepValidation={stepValidation}
         fieldName='ntpServers'
+        helperText='Specify NTP servers by hostname or IP address. Examples: server.example.com, 172.16.254.1.'
       />
-      <HelperText className='pf-v6-u-pt-sm'>
-        <HelperTextItem>
-          Specify NTP servers by hostname or IP address. Examples:
-          server.example.com, 172.16.254.1
-        </HelperTextItem>
-      </HelperText>
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Users/components/UserRow.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserRow.tsx
@@ -149,6 +149,7 @@ const UserRow = ({ user, index, userCount }: UserRowProps) => {
             fieldName='groups'
             truncateLength={12}
             isCompact
+            hideAddLabel
           />
         </Td>
         <Td>

--- a/src/Components/CreateImageWizard/tests/LabelInput.test.tsx
+++ b/src/Components/CreateImageWizard/tests/LabelInput.test.tsx
@@ -1,0 +1,152 @@
+import React, { type ComponentProps } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import {
+  clickWithWait,
+  createUser,
+  keyboardWithWait,
+  typeWithWait,
+} from '@/test/testUtils';
+
+import LabelInput from '../LabelInput';
+import type { StepValidation } from '../utilities/useValidation';
+
+const { dispatchMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn(),
+}));
+
+vi.mock('@/store/hooks', () => ({
+  useAppDispatch: () => dispatchMock,
+}));
+
+const stepValidation: StepValidation = {
+  errors: {},
+  disabledNext: false,
+};
+
+const renderLabelInput = (
+  props: Partial<ComponentProps<typeof LabelInput>> = {},
+) => {
+  const defaultProps: ComponentProps<typeof LabelInput> = {
+    ariaLabel: 'Add group',
+    placeholder: 'Add label',
+    validator: (value) => /^[a-z-]+$/.test(value),
+    list: [],
+    item: 'Item',
+    addAction: (value) => ({ type: 'test/add', payload: value }),
+    removeAction: (value) => ({ type: 'test/remove', payload: value }),
+    stepValidation,
+    fieldName: 'groups',
+  };
+
+  return render(<LabelInput {...defaultProps} {...props} />);
+};
+
+describe('LabelInput', () => {
+  beforeEach(() => {
+    dispatchMock.mockClear();
+  });
+
+  test('does not dispatch for empty input via Add button or Enter', async () => {
+    renderLabelInput();
+    const user = createUser();
+
+    const input = screen.getByPlaceholderText('Add label');
+    const addButton = screen.getByRole('button', { name: 'Add group' });
+
+    await clickWithWait(user, addButton);
+    await clickWithWait(user, input);
+    await keyboardWithWait(user, '{Enter}');
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  test('dispatches add action when clicking Add with a valid value', async () => {
+    renderLabelInput();
+    const user = createUser();
+
+    const input = screen.getByPlaceholderText('Add label');
+    await typeWithWait(user, input, 'admins');
+    await clickWithWait(
+      user,
+      screen.getByRole('button', { name: 'Add group' }),
+    );
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: 'test/add',
+      payload: 'admins',
+    });
+    expect(input).toHaveValue('');
+  });
+
+  test('dispatches add action when pressing Enter with a valid value', async () => {
+    renderLabelInput();
+    const user = createUser();
+
+    const input = screen.getByPlaceholderText('Add label');
+    await typeWithWait(user, input, 'wheel{Enter}');
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: 'test/add',
+      payload: 'wheel',
+    });
+    expect(input).toHaveValue('');
+  });
+
+  test('shows duplicate error when an item already exists', async () => {
+    renderLabelInput({ list: ['admins'] });
+    const user = createUser();
+
+    await typeWithWait(
+      user,
+      screen.getByPlaceholderText('Add label'),
+      'admins',
+    );
+    await clickWithWait(
+      user,
+      screen.getByRole('button', { name: 'Add group' }),
+    );
+
+    expect(screen.getByText('Item already exists.')).toBeInTheDocument();
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  test('shows field-specific validation error for invalid input', async () => {
+    renderLabelInput({
+      validator: () => false,
+      fieldName: 'groups',
+    });
+    const user = createUser();
+
+    await typeWithWait(
+      user,
+      screen.getByPlaceholderText('Add label'),
+      'invalid value',
+    );
+    await clickWithWait(
+      user,
+      screen.getByRole('button', { name: 'Add group' }),
+    );
+
+    expect(
+      screen.getByText('Expected format: <group-name>. Example: admin'),
+    ).toBeInTheDocument();
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  test('dispatches remove action when removing a chip', async () => {
+    renderLabelInput({ list: ['admins'] });
+    const user = createUser();
+
+    await clickWithWait(
+      user,
+      screen.getByRole('button', { name: 'Remove admins' }),
+    );
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: 'test/remove',
+      payload: 'admins',
+    });
+  });
+});


### PR DESCRIPTION
Adds the "Press Enter or Add icon" text for the user under the LabellInput fields, and adds the Add button back to keep some clickable option.

<img width="1183" height="172" alt="image" src="https://github.com/user-attachments/assets/edcb6aaf-75cd-4d48-a48b-927df4da2349" />
<img width="1192" height="205" alt="image" src="https://github.com/user-attachments/assets/4a0e48e0-e199-446d-aa66-14c97616e136" />
<img width="1180" height="501" alt="image" src="https://github.com/user-attachments/assets/b53f9e51-a398-4ac9-bc46-891b2c8f590b" />
<img width="1180" height="528" alt="image" src="https://github.com/user-attachments/assets/30c192ca-a705-4e0b-9924-84348034a1fc" />
<img width="273" height="226" alt="image" src="https://github.com/user-attachments/assets/e8689c36-81e5-4069-bb2e-1737a281e774" />
<img width="255" height="146" alt="image" src="https://github.com/user-attachments/assets/bad6bcbf-abb0-4aef-a423-dcaa30c48908" />
