### PR TITLE
src/api: switch to image-builder for composes and their statuses

### DIFF
--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -3,7 +3,10 @@ import path from 'path';
 import cockpit from 'cockpit';
 import { fsinfo } from 'cockpit/fsinfo';
 
+import { getHostDistro } from '@/Utilities/getHostInfo';
+import { mapHostedToOnPrem } from '@/Components/Blueprints/helpers/onPremToHostedBlueprintMapper';
 import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   byCreatedAtDesc,
@@ -11,6 +14,10 @@ import {
   readComposes,
   safeReadJsonFile,
   toComposerComposeRequest,
+  imageStatusFromBuildlog,
+  progressFromFile,
+  uploadStatusFromFile,
+  imageStatusFallback,
 } from './helpers';
 
 import {
@@ -29,6 +36,13 @@ import {
 import { assertComposeResponse, assertComposeStatus } from '../typeguards';
 import { type ComposerCreateBlueprintRequest } from '../types';
 
+const imagetype = (it: string) => {
+  if (it === "guest-image") {
+    return "qcow2"
+  }
+  return it
+}
+
 export const composeEndpoints = (builder: OnPremBuilder) => ({
   composeBlueprint: builder.mutation<
     ComposeBlueprintApiResponse,
@@ -45,6 +59,11 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
 
         const blueprint = parsed as ComposerCreateBlueprintRequest;
         const composes: ComposeResponse[] = [];
+        const dataDir = path.join("/var/lib/cockpit-image-builder");
+        await cockpit.spawn(['mkdir', '-p', dataDir], {
+          superuser: "require",
+        });
+
         for (const ir of blueprint.image_requests) {
           if (ir.upload_request.type === 'aws.s3') {
             // this differs to crc because the on-prem backend
@@ -54,35 +73,43 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
             ir.upload_request.type = 'local';
           }
 
-          // this request gets saved to the local storage and needs to
-          // match the hosted format
+          const bp_onprem = mapHostedToOnPrem(blueprint as CreateBlueprintRequest)
+          await cockpit.file("/tmp/bp.json").replace(JSON.stringify(bp_onprem));
+          const hostDistro = await getHostDistro();
+          const user = await cockpit.user();
+          const id = uuidv4();
+          await cockpit.spawn([
+            "systemd-run",
+            "--setenv",
+            "HOME=" + user.home,
+            "--unit",
+            "cockpit-image-builder-" + id,
+            "--service-type=oneshot",
+            "--no-block",
+            "--collect",
+            "--",
+            "image-builder",
+            "build",
+            imagetype(ir.image_type),
+            "--distro",
+            blueprint.distro || hostDistro,
+            "--blueprint",
+            "/tmp/bp.json",
+            "--with-buildlog",
+            "--with-manifest",
+            "--with-upload-result",
+            "--progress", "file",
+            "--format", "json",
+            "--output-dir",
+            path.join(dataDir, id),
+          ], {
+            superuser: "require",
+          });
+
           const crcComposeRequest = {
             ...blueprint,
             image_requests: [ir],
           };
-
-          const result = await baseQuery({
-            url: '/compose',
-            method: 'POST',
-            body: JSON.stringify(
-              // since this is the request that gets sent to the cloudapi
-              // backend, we need to modify it slightly
-              toComposerComposeRequest(
-                blueprint,
-                crcComposeRequest.distribution,
-                [ir],
-              ),
-            ),
-            headers: {
-              'content-type': 'application/json',
-            },
-          });
-
-          if (result.error) {
-            throw result.error;
-          }
-
-          const { id } = assertComposeResponse(result.data);
           await cockpit
             .file(path.join(blueprintsDir, filename, id))
             .replace(JSON.stringify(crcComposeRequest));
@@ -140,22 +167,13 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
     GetComposeStatusApiArg
   >({
     queryFn: onPremQueryHandler(async ({ queryArgs, baseQuery }) => {
-      const result = await baseQuery({
-        url: `/composes/${queryArgs.composeId}`,
-        method: 'GET',
-      });
-
-      if (result.error) {
-        throw result.error;
-      }
-
-      const data = assertComposeStatus(result.data);
       const blueprintsDir = await getBlueprintsPath();
-      const info = await fsinfo(blueprintsDir, ['entries'], {
+      const bpinfo = await fsinfo(blueprintsDir, ['entries'], {
         superuser: 'try',
       });
+      const entries = Object.entries(bpinfo.entries || {});
+      const dataDir = path.join("/var/lib/cockpit-image-builder");
 
-      const entries = Object.entries(info.entries || {});
       for (const bpEntry of entries) {
         const request = await safeReadJsonFile<ComposeRequest>(
           path.join(blueprintsDir, bpEntry[0], queryArgs.composeId),
@@ -163,12 +181,70 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
         if (!request) {
           continue;
         }
-        return {
-          image_status: data.image_status,
+        const status = {
+          image_status: {
+            status: "pending",
+          },
           request,
         };
-      }
 
+        const units = await cockpit.spawn(["systemctl", "list-units", "--output", "json", `cockpit-image-builder-${queryArgs.composeId}.service`], {
+          superuser: "require",
+        })
+        // cockpit-image-builder units are started with `--collect`, so if it exists, it is active.
+        const unitActive = JSON.parse(units).length > 0;
+        if (unitActive) {
+          status.image_status.status = "building";
+        }
+
+        const composeDir = path.join(dataDir, queryArgs.composeId);
+        let info;
+        try {
+          info = await fsinfo(composeDir, ['entries', 'type'], {
+            superuser: 'try',
+          });
+        } catch (e) {
+          // Checks if the compose was created using osbuild-composer if the unit does not exist,
+          // otherwise the unit is active but hasn't created the output directory yet.
+          if (!unitActive) {
+            status.image_status = await imageStatusFallback(queryArgs.composeId);
+          }
+          return status;
+        }
+
+        const buildlogEntry = Object.keys(info.entries).find(entry => entry.endsWith('buildlog'));
+        const progressEntry = Object.keys(info.entries).find(entry => entry.endsWith('progress'));
+        const upresEntry = Object.keys(info.entries).find(entry => entry.endsWith('upload-result'));
+
+        // imageStatusFromBuildlog will return a failure if the buildlog
+        // is empty, so only call it if the unit is no longer active.
+        if (buildlogEntry !== undefined && !unitActive) {
+          status.image_status = await imageStatusFromBuildlog(path.join(composeDir, buildlogEntry));
+          if (status.image_status.status === "failure") {
+            return status
+          }
+        }
+
+        if (progressEntry !== undefined) {
+          const progress = await progressFromFile(path.join(composeDir, progressEntry));
+          status.image_status.progress = {
+            done: progress.done,
+            total: progress.total,
+          };
+          if (progress.subprogress) {
+            status.image_status.progress.subprogress = {
+              done: progress.done,
+              total: progress.total,
+            };
+          }
+        }
+
+        if (upresEntry !== undefined) {
+          status.image_status.upload_status = await uploadStatusFromFile(path.join(composeDir, upresEntry));
+        }
+
+        return status;
+      }
       throw new Error('Compose not found');
     }),
   }),

--- a/src/store/api/backend/onprem/composerApi/helpers/imageStatusFallback.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/imageStatusFallback.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+import { fsinfo } from 'cockpit/fsinfo';
+
+import { ImageStatus } from '../../hosted';
+
+
+export const imageStatusFallback = async (
+  composeID: string
+): Promise<ImageStatus> => {
+  const dataDir = path.join("/var/lib/osbuild-composer/artifacts", composeID);
+
+  let info;
+  try {
+    info = await fsinfo(dataDir, ['entries'], {
+      superuser: 'try',
+    });
+  } catch {
+    return {
+      status: "failure",
+      error: {
+        reason: "missing artifact directory",
+      },
+    };
+  }
+
+  if (Object.keys(info.entries).length > 0) {
+    return {
+      status: "success",
+      upload_status: {
+        status: "success",
+        type: "local",
+        options: {
+          artifact_path: path.join(dataDir, Object.keys(info.entries)[0]),
+        },
+      },
+    };
+  }
+  return {
+    status: "failure",
+    error: {
+      reason: "missing artifact in fallback directory",
+    },
+  };
+};

--- a/src/store/api/backend/onprem/composerApi/helpers/imageStatusFromBuildlog.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/imageStatusFromBuildlog.ts
@@ -1,0 +1,47 @@
+import { ImageStatus } from '../../../hosted';
+
+import { safeReadJsonFile } from './safeReadJsonFile';
+
+
+type ValidationError = {
+  message: string;
+  path: string[];
+};
+
+type OSBuildResult = {
+  success: boolean;
+  error: object | undefined;
+  errors: ValidationError[] | undefined;
+};
+
+export const imageStatusFromBuildlog = async (
+  buildlog: string
+): Promise<ImageStatus> => {
+  const result = await safeReadJsonFile<OSBuildResult>(buildlog);
+
+  // imageStatusFromBuildlog is only called if the systemd unit running
+  // image-builder is no longer active.
+  if (result === null) {
+    return {
+      status: "failure",
+      reason: "image-builder process not running and no result was found",
+    };
+  }
+
+  if (result.success) {
+    return {
+      status: "success",
+    };
+  }
+
+  // osbuild failures are always id: 10
+  return {
+    status: "failure",
+    error: {
+      id: 10,
+      reason: "osbuild failed",
+      details: result.error || result.errors,
+    }
+  }
+};
+

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -14,3 +14,7 @@ export {
 export { readComposes } from './readComposes';
 export { safeReadJsonFile } from './safeReadJsonFile';
 export { toComposerComposeRequest } from './toComposerComposeRequest';
+export { imageStatusFromBuildlog } from './imageStatusFromBuildlog';
+export { progressFromFile } from './progressFromFile';
+export { uploadStatusFromFile } from './uploadStatusFromFile';
+export { imageStatusFallback } from './imageStatusFallback';

--- a/src/store/api/backend/onprem/composerApi/helpers/progressFromFile.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/progressFromFile.ts
@@ -1,0 +1,15 @@
+import { safeReadJsonFile } from './safeReadJsonFile';
+
+type SubProgress = {
+  message?: string | undefined;
+  done: number;
+  total: number;
+};
+type Progress = SubProgress & {
+  subprogress?: SubProgress | undefined;
+};
+export const progressFromFile = async (
+  file: string
+): Promise<Progress> => {
+  return await safeReadJsonFile<Progress>(file);
+};

--- a/src/store/api/backend/onprem/composerApi/helpers/safeReadJsonFile.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/safeReadJsonFile.ts
@@ -4,7 +4,7 @@ export const safeReadJsonFile = async <T>(
   filePath: string,
 ): Promise<T | null> => {
   try {
-    const content = await cockpit.file(filePath).read();
+    const content = await cockpit.file(filePath, { superuser: "try" }).read();
     return JSON.parse(content) as T;
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/store/api/backend/onprem/composerApi/helpers/uploadStatusFromFile.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/uploadStatusFromFile.ts
@@ -1,0 +1,36 @@
+import type { UploadStatus } from '../../../hosted';
+
+import { safeReadJsonFile } from './safeReadJsonFile';
+
+type UploadResult = {
+  provider: string,
+  image_id: string,
+};
+
+export const uploadStatusFromFile = async (
+  file: string
+): Promise<UploadStatus> => {
+  const uploadResult = await safeReadJsonFile<UploadResult>(file);
+  const failureState = {
+      status: "failure",
+      type: "local",
+      options: {}
+    }
+
+  if (uploadResult === null) {
+    return failureState;
+  }
+
+  switch (uploadResult.provider) {
+    case 'LocalPath':
+      return {
+        status: "success",
+        type: "local",
+        options: {
+          artifact_path: uploadResult.image_id,
+        },
+      };
+    default:
+      return failureState;
+  }
+};


### PR DESCRIPTION
`systemd-run` is used to start composes, the cache directory is the default used by image-builder. The output directories are located in `/var/lib/cockpit-image-builder/`, with each build having its own uuid.

The status constructed in the following way:
1. start from pending;

2. if the unit is still active, set to building;

3. if the unit is not active and the image-builder output directory does not exist, try to find any artifacts in the osbuild-composer output directory;
3a. mark as succes if something is found, failed if not;

4. if the unit is not active and a buildlog containing an osbuild v2 result is present, try to parse the osbuild result; 4a. if osbuild succeeded, set to success and continue, 4b. if osbuild failed or if the buildlog does not contain a valid osbuild v2 result, return a failed status;

5. add progress information if it is available;'

6. add the upload result if it is available and return.