### PR TITLE
devDeps: Manually bump prettier from 3.8.4 to 3.9.5 (HMS-11048)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "packageurl-js": "2.0.1",
         "path-browserify": "1.0.1",
         "postcss-scss": "4.0.9",
-        "prettier": "3.8.4",
+        "prettier": "3.9.5",
         "react-chartjs-2": "5.3.1",
         "sass": "1.100.0",
         "sass-loader": "17.0.0",
@@ -17749,9 +17749,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "packageurl-js": "2.0.1",
     "path-browserify": "1.0.1",
     "postcss-scss": "4.0.9",
-    "prettier": "3.8.4",
+    "prettier": "3.9.5",
     "react-chartjs-2": "5.3.1",
     "sass": "1.100.0",
     "sass-loader": "17.0.0",

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/MinimumSize.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/MinimumSize.tsx
@@ -16,9 +16,7 @@ import {
 
 type MinimumSizePropTypes = {
   partition:
-    | FilesystemPartition
-    | LogicalVolumeWithBase
-    | VolumeGroupWithExtendedLV;
+    FilesystemPartition | LogicalVolumeWithBase | VolumeGroupWithExtendedLV;
   customization: PartitioningCustomization;
   isOscapRequired?: boolean;
   oscapMinSizeLabel?: string;

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Mountpoint.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Mountpoint.tsx
@@ -16,9 +16,7 @@ import {
 
 type MountpointProps = {
   partition:
-    | FilesystemPartition
-    | PlainPartitionWithBase
-    | LogicalVolumeWithBase;
+    FilesystemPartition | PlainPartitionWithBase | LogicalVolumeWithBase;
   customization: PartitioningCustomization;
   isOscapRequired?: boolean;
 };

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/SizeUnit.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/SizeUnit.tsx
@@ -23,9 +23,7 @@ const units = ['GiB', 'MiB'];
 
 type SizeUnitPropTypes = {
   partition:
-    | FilesystemPartition
-    | LogicalVolumeWithBase
-    | VolumeGroupWithExtendedLV;
+    FilesystemPartition | LogicalVolumeWithBase | VolumeGroupWithExtendedLV;
   customization: PartitioningCustomization;
   isOscapRequired?: boolean;
 };

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
@@ -33,8 +33,7 @@ import MinimumSize from './MinimumSize';
 import SizeUnit from './SizeUnit';
 
 type VolumeGroupType =
-  | Extract<DiskPartition, VolumeGroup & DiskPartitionBase>
-  | undefined;
+  Extract<DiskPartition, VolumeGroup & DiskPartitionBase> | undefined;
 
 type VolumeGroupsType = {
   volumeGroups: VolumeGroupType[];

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/index.tsx
@@ -34,8 +34,7 @@ const ImageSourceSelect = () => {
   } = useGetDistributionsQuery({ kind: 'bootc', arch });
 
   const bootcDistributions = distributions as
-    | BootcDistributionItem[]
-    | undefined;
+    BootcDistributionItem[] | undefined;
 
   useEffect(() => {
     if (bootcDistributions) {

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -99,11 +99,7 @@ import {
 } from '../validators';
 
 type HelperTextVariant =
-  | 'default'
-  | 'indeterminate'
-  | 'warning'
-  | 'success'
-  | 'error';
+  'default' | 'indeterminate' | 'warning' | 'success' | 'error';
 
 export type StepValidation = {
   errors: {

--- a/src/Components/ImagesTable/components/Row/components/Row.tsx
+++ b/src/Components/ImagesTable/components/Row/components/Row.tsx
@@ -79,8 +79,7 @@ const Row = ({
   });
 
   const options = data?.image_status.upload_status?.options as unknown as
-    | LocalUploadStatus
-    | undefined;
+    LocalUploadStatus | undefined;
 
   const handleClick = ({
     blueprintId,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -332,12 +332,12 @@ export const SATELLITE_SERVICE = 'register-satellite';
 
 // For use when calling content API (now required)
 export enum ContentOrigin {
-  'REDHAT' = 'red_hat',
-  'EXTERNAL' = 'external', // custom only
-  'UPLOAD' = 'upload', // custom upload repo
-  'COMMUNITY' = 'community', // shared epel repos
-  'CUSTOM' = 'external,upload',
-  'ALL' = 'red_hat,external,upload',
+  REDHAT = 'red_hat',
+  EXTERNAL = 'external', // custom only
+  UPLOAD = 'upload', // custom upload repo
+  COMMUNITY = 'community', // shared epel repos
+  CUSTOM = 'external,upload',
+  ALL = 'red_hat,external,upload',
 }
 
 export const AMPLITUDE_MODULE_NAME = 'imageBuilder';

--- a/src/store/api/backend/hosted/imageBuilderApi.ts
+++ b/src/store/api/backend/hosted/imageBuilderApi.ts
@@ -387,8 +387,7 @@ export type BootcDistributionItem = {
   iso_payload_references?: string[] | undefined;
 };
 export type DistributionsResponse = (
-  | DistributionItem
-  | BootcDistributionItem
+  DistributionItem | BootcDistributionItem
 )[];
 export type DistributionKind = 'bootc';
 export type PartitionType = 'gpt' | 'dos';
@@ -647,11 +646,7 @@ export type ImageTypes =
   | 'rhel-edge-installer'
   | 'vhd';
 export type UploadTypes =
-  | 'aws'
-  | 'gcp'
-  | 'azure'
-  | 'aws.s3'
-  | 'oci.objectstorage';
+  'aws' | 'gcp' | 'azure' | 'aws.s3' | 'oci.objectstorage';
 export type AwsUploadRequestOptions = {
   share_with_accounts?: string[] | undefined;
   share_with_sources?: string[] | undefined;

--- a/src/store/api/backend/onprem/types/generated.ts
+++ b/src/store/api/backend/onprem/types/generated.ts
@@ -36,12 +36,7 @@ export type ObjectReference = {
 };
 export type ComposeStatusValue = 'success' | 'failure' | 'pending';
 export type ImageStatusValue =
-  | 'success'
-  | 'failure'
-  | 'pending'
-  | 'building'
-  | 'uploading'
-  | 'registering';
+  'success' | 'failure' | 'pending' | 'building' | 'uploading' | 'registering';
 export type SubProgress = {
   /** Amount of completed steps in the build. */
   done: number;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -94,5 +94,4 @@ export const store = process.env.IS_ON_PREMISE ? onPremStore : serviceStore;
 export type RootState = onPremState | serviceState;
 // Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
 export type AppDispatch =
-  | typeof onPremStore.dispatch
-  | typeof serviceStore.dispatch;
+  typeof onPremStore.dispatch | typeof serviceStore.dispatch;


### PR DESCRIPTION
This bumps prettier from 3.8.4 to 3.9.5 and runs `npm run format` after the update.

JIRA: [HMS-11048](https://issues.redhat.com/browse/HMS-11048)

[HMS-11048]: https://redhat.atlassian.net/browse/HMS-11048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ