### PR TITLE
CI: Bump checkout to v7 and enable `allow-unsafe-pr-checkout` (HMS-11049)

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -23,10 +23,11 @@ jobs:
           sudo apt install -y jq
 
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - uses: octokit/request-action@v2.x
         id: fetch_pulls


### PR DESCRIPTION
This bumps the checkout action to version 7 and enables `allow-unsafe-pr-checkout` to opt in for checkout of fork PRs.

JIRA: [HMS-11049](https://issues.redhat.com/browse/HMS-11049)

[HMS-11049]: https://redhat.atlassian.net/browse/HMS-11049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ