### PR TITLE
playwright: Improve flakey behaviour (HMS-11052)

### DIFF
--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -409,10 +409,15 @@ registrationModes.forEach(
             ).toBeChecked();
           }
 
+          // security needs to finish loading, before trying to progress
+          await expect(frame.getByRole('progressbar')).toBeHidden();
+
           await frame.getByRole('button', { name: 'Review image' }).click();
-          await frame
-            .getByRole('button', { name: 'Save changes to blueprint' })
-            .click();
+          const saveButton = frame.getByRole('button', {
+            name: 'Save changes to blueprint',
+          });
+          await expect(saveButton).toBeEnabled();
+          await saveButton.click();
         });
 
         let exportedBP = '';


### PR DESCRIPTION
With the changes to the footer button behaviour in Wizard I believe there was introduced a race condition where the Wizard no longer blocks progress through the wizard when the security step is still loading.

Since playwright tests can be too fast for their own good, they get to the "Create/Save" button before the profiles are there, making the button disabled but still being furiously clicked on by the tests. This adds a simple check to wait for the security loading state to disappear and for the "Save" button to be enabled, which should hopefully help with the flakiness.

JIRA: [HMS-11052](https://issues.redhat.com/browse/HMS-11052)

[HMS-11052]: https://redhat.atlassian.net/browse/HMS-11052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ