### PR TITLE
Wizard: add banner with a new announce

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -25,6 +25,7 @@ import { useFlag } from '@/Utilities/useGetEnvironment';
 
 import { NewAlert } from './NewAlert';
 import ServiceUnavailableAlert from './ServiceUnavailableAlert';
+import SingleTargetAlert from './SingleTargetAlert';
 
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
 import CreateImageWizard from '../CreateImageWizard/CreateImageWizard';
@@ -40,6 +41,9 @@ export const LandingPage = () => {
   const [searchParams] = useSearchParams();
 
   const serviceUnavailable = useFlag('image-builder.service-unavailable');
+  const singleTargetMigration = useFlag(
+    'image-builder.single-target-migration',
+  );
   const isImagesTableRevampEnabled = useFlag(
     'image-builder.images-table-revamp.enabled',
   );
@@ -62,6 +66,7 @@ export const LandingPage = () => {
     <>
       <PageSection hasBodyWrapper={false}>
         {serviceUnavailable && <ServiceUnavailableAlert />}
+        {singleTargetMigration && <SingleTargetAlert />}
         <NewAlert />
         {!isImagesTableRevampEnabled ? (
           <Sidebar hasBorder className='pf-v6-u-background-color-100'>

--- a/src/Components/LandingPage/SingleTargetAlert.tsx
+++ b/src/Components/LandingPage/SingleTargetAlert.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertActionLink,
+  Content,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import { useVariant } from '@unleash/proxy-client-react';
+
+const SingleTargetAlert = () => {
+  const variant = useVariant('image-builder.single-target-migration');
+  let payload;
+  try {
+    payload = variant.payload ? JSON.parse(variant.payload.value) : undefined;
+  } catch {
+    payload = undefined;
+  }
+
+  const title = payload?.title || '';
+  const body = payload?.body || '';
+
+  const localStorageKey = 'imageBuilder.singleTargetMigration.dismissed';
+  const isAlertDismissed = window.localStorage.getItem(localStorageKey);
+
+  const [displayAlert, setDisplayAlert] = useState(!isAlertDismissed);
+  const [isTemporarilyHidden, setIsTemporarilyHidden] = useState(false);
+
+  const dismissAlert = () => {
+    setDisplayAlert(false);
+    window.localStorage.setItem(localStorageKey, 'true');
+  };
+
+  if (!variant.enabled || !displayAlert || isTemporarilyHidden || !title) {
+    return null;
+  }
+
+  return (
+    <Alert
+      data-testid='single-target-migration-banner'
+      isExpandable
+      variant='warning'
+      style={{ margin: '0 0 16px 0' }}
+      title={title}
+      actionClose={
+        <Flex>
+          <FlexItem>
+            <AlertActionLink onClick={dismissAlert}>
+              Don&apos;t show me this again
+            </AlertActionLink>
+          </FlexItem>
+          <FlexItem>
+            <AlertActionCloseButton
+              onClose={() => setIsTemporarilyHidden(true)}
+            />
+          </FlexItem>
+        </Flex>
+      }
+    >
+      <Content>{body}</Content>
+    </Alert>
+  );
+};
+
+export default SingleTargetAlert;

--- a/src/Components/LandingPage/tests/SingleTargetAlert.test.tsx
+++ b/src/Components/LandingPage/tests/SingleTargetAlert.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { useVariant } from '@unleash/proxy-client-react';
+
+import { createUser } from '@/test/testUtils';
+import { clickWithWait } from '@/test/testUtils/userEvents';
+
+import SingleTargetAlert from '../SingleTargetAlert';
+
+type PayloadData = {
+  title?: string;
+  body?: string;
+};
+
+const mockVariant = (payloadData?: PayloadData) => {
+  vi.mocked(useVariant).mockReturnValue({
+    name: 'image-builder.single-target-migration',
+    enabled: true,
+    payload: payloadData
+      ? {
+          type: 'json',
+          value: JSON.stringify(payloadData),
+        }
+      : {
+          type: 'json',
+          value: JSON.stringify(''),
+        },
+  });
+};
+
+const STORAGE_KEY = 'imageBuilder.singleTargetMigration.dismissed';
+
+describe('Single Target Alert', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('does not render when no payload is provided', () => {
+    mockVariant();
+
+    render(<SingleTargetAlert />);
+
+    expect(
+      screen.queryByTestId('single-target-migration-banner'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('renders with title and body from payload', async () => {
+    const user = createUser();
+    mockVariant({
+      title: 'Single target images coming soon',
+      body: 'Image Builder will transition to single-target images.',
+    });
+
+    render(<SingleTargetAlert />);
+
+    expect(
+      screen.getByText('Single target images coming soon'),
+    ).toBeInTheDocument();
+
+    await clickWithWait(
+      user,
+      screen.getByRole('button', { name: /warning alert details/i }),
+    );
+
+    expect(
+      screen.getByText(
+        'Image Builder will transition to single-target images.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  test('renders as a warning alert', () => {
+    mockVariant({
+      title: 'Single target images coming soon',
+      body: 'Details about the change.',
+    });
+
+    render(<SingleTargetAlert />);
+
+    const heading = screen.getByRole('heading', {
+      name: /Warning alert:/i,
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  test('permanently dismisses alert via "Do not show me this again"', async () => {
+    const user = createUser();
+    mockVariant({
+      title: 'Single target images coming soon',
+      body: 'Details about the change.',
+    });
+
+    render(<SingleTargetAlert />);
+
+    await clickWithWait(user, screen.getByText("Don't show me this again"));
+
+    expect(
+      screen.queryByTestId('single-target-migration-banner'),
+    ).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  test('temporarily dismisses alert via close button', async () => {
+    const user = createUser();
+    mockVariant({
+      title: 'Single target images coming soon',
+      body: 'Details about the change.',
+    });
+
+    render(<SingleTargetAlert />);
+
+    await clickWithWait(user, screen.getByRole('button', { name: /close/i }));
+
+    expect(
+      screen.queryByTestId('single-target-migration-banner'),
+    ).not.toBeInTheDocument();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  test('does not render when previously dismissed via localStorage', () => {
+    window.localStorage.setItem(STORAGE_KEY, 'true');
+
+    mockVariant({
+      title: 'Single target images coming soon',
+      body: 'Details about the change.',
+    });
+
+    render(<SingleTargetAlert />);
+
+    expect(
+      screen.queryByTestId('single-target-migration-banner'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not render when payload is malformed JSON', () => {
+    vi.mocked(useVariant).mockReturnValue({
+      name: 'image-builder.single-target-migration',
+      enabled: true,
+      payload: {
+        type: 'json',
+        value: 'not valid json{{{',
+      },
+    });
+
+    render(<SingleTargetAlert />);
+
+    expect(
+      screen.queryByTestId('single-target-migration-banner'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -40,6 +40,7 @@ export const useFlagWithEphemDefault = (
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
     case 'image-builder.images-table-revamp.enabled':
+    case 'image-builder.single-target-migration':
     default:
       return false;
   }


### PR DESCRIPTION
Adds banner with the single target migration announcement.
@regexowl I went for a new banner in case we want to use the "new feature" one in the meantime 