### PR TITLE
Refactor RegistryAuth and optimize login cache update

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/RegistryAuth.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/RegistryAuth.tsx
@@ -3,12 +3,27 @@ import React, { useState } from 'react';
 import {
   Button,
   Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  CardTitle,
   Content,
+  ContentVariants,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
   EmptyStateFooter,
+  Flex,
+  FlexItem,
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  TextInput,
 } from '@patternfly/react-core';
+
+import { useRegistryLoginMutation } from '@/store/api/backend';
+import { OnPremError } from '@/store/api/shared';
 
 const EmptyCard = ({ openForm }: { openForm: (arg0: boolean) => void }) => {
   return (
@@ -30,6 +45,143 @@ const EmptyCard = ({ openForm }: { openForm: (arg0: boolean) => void }) => {
   );
 };
 
+const LoginCard = ({ closeForm }: { closeForm: (arg0: boolean) => void }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [hasSubmitted, setHasSubmitted] = useState(false);
+  const [registryLogin, loginMutation] = useRegistryLoginMutation();
+
+  const usernameError = hasSubmitted && !username ? 'Username is required' : '';
+  const passwordError = hasSubmitted && !password ? 'Password is required' : '';
+  const loginError = (loginMutation.error as OnPremError | undefined) ?? null;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (!loginMutation.isLoading) {
+        handleLogin();
+      }
+    }
+  };
+
+  const handleLogin = async () => {
+    loginMutation.reset();
+    setHasSubmitted(true);
+    if (!username || !password) {
+      return;
+    }
+    const result = await registryLogin({ username, password });
+    if (!('error' in result)) {
+      resetForm();
+    }
+  };
+
+  const resetForm = () => {
+    closeForm(false);
+    setUsername('');
+    setPassword('');
+    setHasSubmitted(false);
+    loginMutation.reset();
+  };
+
+  return (
+    <Card variant='secondary' className='pf-v6-u-mt-md'>
+      <CardHeader>
+        <CardTitle>Log in to registry.redhat.io</CardTitle>
+      </CardHeader>
+      <CardBody>
+        <Content component={ContentVariants.p}>
+          Enter your credentials to load available registry images.
+        </Content>
+        <FormGroup label='Username' isRequired fieldId='registry-username'>
+          <TextInput
+            isRequired
+            type='text'
+            id='registry-username'
+            value={username}
+            validated={usernameError || loginError ? 'error' : 'default'}
+            onChange={(_event, value) => setUsername(value)}
+            onKeyDown={handleKeyDown}
+            autoComplete='username'
+            aria-describedby={
+              usernameError ? 'registry-username-error' : undefined
+            }
+          />
+          {usernameError && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant='error' id='registry-username-error'>
+                  {usernameError}
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
+        </FormGroup>
+        <FormGroup
+          label='Password'
+          isRequired
+          fieldId='registry-password'
+          className='pf-v6-u-mt-md'
+        >
+          <TextInput
+            isRequired
+            type='password'
+            id='registry-password'
+            value={password}
+            validated={passwordError || loginError ? 'error' : 'default'}
+            onChange={(_event, value) => setPassword(value)}
+            onKeyDown={handleKeyDown}
+            autoComplete='current-password'
+            aria-describedby={
+              passwordError || loginError
+                ? 'registry-password-error'
+                : undefined
+            }
+          />
+          {(passwordError || loginError) && (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem variant='error' id='registry-password-error'>
+                  {passwordError || loginError?.message}
+                </HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
+        </FormGroup>
+      </CardBody>
+      <CardFooter>
+        <Flex gap={{ default: 'gapSm' }}>
+          <FlexItem>
+            <Button
+              variant='primary'
+              onClick={handleLogin}
+              isDisabled={loginMutation.isLoading}
+              isLoading={loginMutation.isLoading}
+            >
+              Log in
+            </Button>
+          </FlexItem>
+          <FlexItem>
+            <Button
+              variant='link'
+              style={
+                // this is needed since the card background is `secondary`
+                {
+                  '--pf-v6-c-button--m-link--hover--BackgroundColor':
+                    'transparent',
+                } as React.CSSProperties
+              }
+              onClick={resetForm}
+            >
+              Cancel
+            </Button>
+          </FlexItem>
+        </Flex>
+      </CardFooter>
+    </Card>
+  );
+};
+
 const RegistryAuth = () => {
   const [isFormVisible, setIsFormVisible] = useState(false);
 
@@ -37,8 +189,7 @@ const RegistryAuth = () => {
     return <EmptyCard openForm={setIsFormVisible} />;
   }
 
-  // we'll add the login form back in the next commit
-  return null;
+  return <LoginCard closeForm={setIsFormVisible} />;
 };
 
 export default RegistryAuth;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/RegistryAuth.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/RegistryAuth.tsx
@@ -2,338 +2,43 @@ import React, { useState } from 'react';
 
 import {
   Button,
+  Card,
   Content,
-  Flex,
-  FlexItem,
-  FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
-  Label,
-  Spinner,
-  TextInput,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
 } from '@patternfly/react-core';
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
 
-import {
-  useGetRegistryAuthStatusQuery,
-  useRegistryLoginMutation,
-} from '@/store/api/backend';
-import type { RegistryAuthStatus } from '@/store/api/backend/onprem';
-import type { OnPremError } from '@/store/api/shared/types';
-
-const isOnPremError = (e: unknown): e is OnPremError =>
-  typeof e === 'object' &&
-  e !== null &&
-  'message' in e &&
-  typeof (e as { message: unknown }).message === 'string';
-
-type AuthState =
-  | RegistryAuthStatus
-  | { status: 'checking' }
-  | { status: 'network-error'; error: string };
-
-const deriveAuthState = (
-  isLoading: boolean,
-  isError: boolean,
-  error: unknown,
-  data: RegistryAuthStatus | undefined,
-): AuthState => {
-  if (isLoading) {
-    return { status: 'checking' };
-  }
-  if (isError) {
-    return {
-      status: 'network-error',
-      error: isOnPremError(error) ? error.message : 'Unable to reach registry',
-    };
-  }
-  return data ?? { status: 'checking' };
+const EmptyCard = ({ openForm }: { openForm: (arg0: boolean) => void }) => {
+  return (
+    <Card variant='secondary' className='pf-v6-u-mt-md pf-v6-u-py-md'>
+      <EmptyState titleText='Login to select an image' headingLevel='h4'>
+        <EmptyStateBody>
+          <Content>Registry images come from registry.redhat.io.</Content>
+          <Content>
+            Sign in to browse available images for this release.
+          </Content>
+        </EmptyStateBody>
+        <EmptyStateFooter>
+          <EmptyStateActions>
+            <Button onClick={() => openForm(true)}>Login</Button>
+          </EmptyStateActions>
+        </EmptyStateFooter>
+      </EmptyState>
+    </Card>
+  );
 };
 
 const RegistryAuth = () => {
   const [isFormVisible, setIsFormVisible] = useState(false);
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [hasSubmitted, setHasSubmitted] = useState(false);
 
-  const {
-    data: registryAuth,
-    isLoading,
-    isError,
-    error: authQueryError,
-  } = useGetRegistryAuthStatusQuery(undefined, {
-    refetchOnMountOrArgChange: true,
-  });
-
-  const [
-    registryLogin,
-    {
-      isLoading: isLoginLoading,
-      error: loginMutationError,
-      reset: resetMutation,
-    },
-  ] = useRegistryLoginMutation();
-
-  const authState = deriveAuthState(
-    isLoading,
-    isError,
-    authQueryError,
-    registryAuth,
-  );
-
-  const loginError = loginMutationError
-    ? isOnPremError(loginMutationError)
-      ? loginMutationError.message
-      : 'Login failed'
-    : null;
-
-  const usernameError = hasSubmitted && !username ? 'Username is required' : '';
-  const passwordError = hasSubmitted && !password ? 'Password is required' : '';
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      if (!isLoginLoading) {
-        handleLogin();
-      }
-    }
-  };
-
-  const handleLogin = async () => {
-    resetMutation();
-    setHasSubmitted(true);
-    if (!username || !password) {
-      return;
-    }
-    try {
-      await registryLogin({ username, password }).unwrap();
-      resetForm();
-    } catch {
-      // Form stays open on error
-    }
-  };
-
-  const resetForm = () => {
-    setIsFormVisible(false);
-    setUsername('');
-    setPassword('');
-    setHasSubmitted(false);
-    resetMutation();
-  };
-
-  const showLoginAction =
-    authState.status === 'not-logged-in' || authState.status === 'auth-failed';
-
-  return (
-    <div className='pf-v6-u-mt-md'>
-      <StatusDisplay
-        authState={authState}
-        showLoginAction={showLoginAction && !isFormVisible}
-        onLoginClick={() => setIsFormVisible(true)}
-      />
-      {isFormVisible && (
-        <>
-          <Flex
-            alignItems={{ default: 'alignItemsFlexStart' }}
-            gap={{ default: 'gapSm' }}
-            className='pf-v6-u-mt-sm'
-          >
-            <FlexItem>
-              <FormGroup
-                label='Username'
-                isRequired
-                fieldId='registry-username'
-              >
-                <TextInput
-                  isRequired
-                  type='text'
-                  id='registry-username'
-                  value={username}
-                  validated={usernameError ? 'error' : 'default'}
-                  onChange={(_event, value) => setUsername(value)}
-                  onKeyDown={handleKeyDown}
-                  autoComplete='username'
-                  aria-describedby={
-                    usernameError ? 'registry-username-error' : undefined
-                  }
-                />
-                {usernameError && (
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem
-                        variant='error'
-                        id='registry-username-error'
-                      >
-                        {usernameError}
-                      </HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                )}
-              </FormGroup>
-            </FlexItem>
-            <FlexItem>
-              <FormGroup
-                label='Password'
-                isRequired
-                fieldId='registry-password'
-              >
-                <TextInput
-                  isRequired
-                  type='password'
-                  id='registry-password'
-                  value={password}
-                  validated={passwordError || loginError ? 'error' : 'default'}
-                  onChange={(_event, value) => setPassword(value)}
-                  onKeyDown={handleKeyDown}
-                  autoComplete='current-password'
-                  aria-describedby={
-                    passwordError || loginError
-                      ? 'registry-password-error'
-                      : undefined
-                  }
-                />
-                {(passwordError || loginError) && (
-                  <FormHelperText>
-                    <HelperText>
-                      <HelperTextItem
-                        variant='error'
-                        id='registry-password-error'
-                      >
-                        {passwordError || loginError}
-                      </HelperTextItem>
-                    </HelperText>
-                  </FormHelperText>
-                )}
-              </FormGroup>
-            </FlexItem>
-          </Flex>
-          <Flex gap={{ default: 'gapSm' }} className='pf-v6-u-mt-sm'>
-            <FlexItem>
-              <Button
-                variant='primary'
-                onClick={handleLogin}
-                isDisabled={isLoginLoading}
-                isLoading={isLoginLoading}
-              >
-                Log in
-              </Button>
-            </FlexItem>
-            <FlexItem>
-              <Button variant='link' onClick={resetForm}>
-                Cancel
-              </Button>
-            </FlexItem>
-          </Flex>
-        </>
-      )}
-    </div>
-  );
-};
-
-type StatusDisplayProps = {
-  authState: AuthState;
-  showLoginAction: boolean;
-  onLoginClick: () => void;
-};
-
-const StatusDisplay = ({
-  authState,
-  showLoginAction,
-  onLoginClick,
-}: StatusDisplayProps) => {
-  switch (authState.status) {
-    case 'checking':
-      return (
-        <Flex
-          alignItems={{ default: 'alignItemsCenter' }}
-          gap={{ default: 'gapSm' }}
-        >
-          <FlexItem>
-            <Spinner size='sm' aria-label='Checking registry authentication' />
-          </FlexItem>
-          <FlexItem>
-            <Content>Checking registry authentication...</Content>
-          </FlexItem>
-        </Flex>
-      );
-    case 'authenticated':
-      return (
-        <Label
-          color='green'
-          variant='outline'
-          icon={
-            <CheckCircleIcon color='var(--pf-t--global--icon--color--status--success--default)' />
-          }
-        >
-          Logged in to registry.redhat.io as {authState.username}
-        </Label>
-      );
-    case 'not-logged-in':
-      return (
-        <Flex
-          alignItems={{ default: 'alignItemsCenter' }}
-          gap={{ default: 'gapSm' }}
-        >
-          <FlexItem>
-            <Label
-              color='orange'
-              variant='outline'
-              icon={
-                <ExclamationTriangleIcon color='var(--pf-t--global--icon--color--status--warning--default)' />
-              }
-            >
-              Not logged in to registry.redhat.io
-            </Label>
-          </FlexItem>
-          {showLoginAction && (
-            <FlexItem>
-              <Button variant='link' onClick={onLoginClick} isInline>
-                Log in
-              </Button>
-            </FlexItem>
-          )}
-        </Flex>
-      );
-    case 'auth-failed':
-      return (
-        <Flex
-          alignItems={{ default: 'alignItemsCenter' }}
-          gap={{ default: 'gapSm' }}
-        >
-          <FlexItem>
-            <Label
-              color='orange'
-              variant='outline'
-              icon={
-                <ExclamationTriangleIcon color='var(--pf-t--global--icon--color--status--warning--default)' />
-              }
-            >
-              Authentication failed for {authState.username} — credentials may
-              be expired
-            </Label>
-          </FlexItem>
-          {showLoginAction && (
-            <FlexItem>
-              <Button variant='link' onClick={onLoginClick} isInline>
-                Log in
-              </Button>
-            </FlexItem>
-          )}
-        </Flex>
-      );
-    case 'network-error':
-      return (
-        <Content>Unable to reach registry.redhat.io: {authState.error}</Content>
-      );
-    default: {
-      const _exhaustive: never = authState;
-      return _exhaustive;
-    }
+  if (!isFormVisible) {
+    return <EmptyCard openForm={setIsFormVisible} />;
   }
+
+  // we'll add the login form back in the next commit
+  return null;
 };
 
 export default RegistryAuth;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/RegistryAuth.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/RegistryAuth.tsx
@@ -19,10 +19,15 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
+  Spinner,
   TextInput,
 } from '@patternfly/react-core';
 
-import { useRegistryLoginMutation } from '@/store/api/backend';
+import {
+  useGetRegistryAuthStatusQuery,
+  useRegistryLoginMutation,
+  useRegistryLogoutMutation,
+} from '@/store/api/backend';
 import { OnPremError } from '@/store/api/shared';
 
 const EmptyCard = ({ openForm }: { openForm: (arg0: boolean) => void }) => {
@@ -182,8 +187,42 @@ const LoginCard = ({ closeForm }: { closeForm: (arg0: boolean) => void }) => {
   );
 };
 
+const RegistryStatus = ({ username }: { username: string }) => {
+  const [logout] = useRegistryLogoutMutation();
+
+  return (
+    <Flex gap={{ default: 'gapSm' }}>
+      <FlexItem>
+        <Content className='pf-v6-u-mt-md pf-v6-u-text-color-subtle'>
+          Connected to registry.redhat.io &middot; {username}
+        </Content>
+      </FlexItem>
+      <FlexItem>
+        <Button variant='link' onClick={() => logout()}>
+          Log out
+        </Button>
+      </FlexItem>
+    </Flex>
+  );
+};
+
 const RegistryAuth = () => {
   const [isFormVisible, setIsFormVisible] = useState(false);
+
+  const { data, isLoading } = useGetRegistryAuthStatusQuery();
+
+  if (isLoading) {
+    return (
+      <div className='pf-v6-u-mt-md'>
+        <Spinner size='sm' aria-label='Checking registry authentication' />
+        <Content>Checking registry authentication...</Content>
+      </div>
+    );
+  }
+
+  if (data && data.status === 'authenticated') {
+    return <RegistryStatus username={data.username} />;
+  }
 
   if (!isFormVisible) {
     return <EmptyCard openForm={setIsFormVisible} />;

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -110,6 +110,7 @@ export {
   useGetWorkerConfigQuery,
   useLazyExportBlueprintCockpitQuery,
   useRegistryLoginMutation,
+  useRegistryLogoutMutation,
   useUpdateWorkerConfigMutation,
 } from './onprem';
 

--- a/src/store/api/backend/onprem/composerApi/index.ts
+++ b/src/store/api/backend/onprem/composerApi/index.ts
@@ -45,6 +45,7 @@ export const {
   useGetRegistryAuthStatusQuery,
   useGetWorkerConfigQuery,
   useRegistryLoginMutation,
+  useRegistryLogoutMutation,
   useUpdateWorkerConfigMutation,
 } = composerApi;
 

--- a/src/store/api/backend/onprem/composerApi/registry.ts
+++ b/src/store/api/backend/onprem/composerApi/registry.ts
@@ -30,4 +30,11 @@ export const registryEndpoints = (builder: OnPremBuilder) => ({
       },
     ),
   }),
+  registryLogout: builder.mutation<void, void>({
+    queryFn: onPremQueryHandler(async () => {
+      await cockpit.spawn(['podman', 'logout', 'registry.redhat.io'], {
+        superuser: 'require',
+      });
+    }),
+  }),
 });

--- a/src/store/api/backend/onprem/enhancedComposerApi.ts
+++ b/src/store/api/backend/onprem/enhancedComposerApi.ts
@@ -68,6 +68,9 @@ const enhancedApi = composerApi.enhanceEndpoints({
         }
       },
     },
+    registryLogout: {
+      invalidatesTags: [{ type: 'RegistryAuth' }],
+    },
     updateWorkerConfig: {
       invalidatesTags: [{ type: 'WorkerConfig' }],
     },

--- a/src/store/api/backend/onprem/enhancedComposerApi.ts
+++ b/src/store/api/backend/onprem/enhancedComposerApi.ts
@@ -49,7 +49,24 @@ const enhancedApi = composerApi.enhanceEndpoints({
       providesTags: [{ type: 'WorkerConfig' }],
     },
     registryLogin: {
-      invalidatesTags: [{ type: 'RegistryAuth' }],
+      // Write the login result directly into the auth status cache.
+      // The mutation already returns RegistryAuthStatus so there is
+      // no need to invalidate and re-run checkRegistryAuth (which
+      // spawns two podman commands).
+      onQueryStarted: async (_, { dispatch, queryFulfilled }) => {
+        try {
+          const { data } = await queryFulfilled;
+          dispatch(
+            composerApi.util.updateQueryData(
+              'getRegistryAuthStatus',
+              undefined,
+              () => data,
+            ),
+          );
+        } catch {
+          // mutation failed — no cache update needed
+        }
+      },
     },
     updateWorkerConfig: {
       invalidatesTags: [{ type: 'WorkerConfig' }],

--- a/src/store/api/backend/onprem/index.ts
+++ b/src/store/api/backend/onprem/index.ts
@@ -22,6 +22,7 @@ export {
   useLazyGetBlueprintsQuery,
   useLazyGetOscapCustomizationsQuery,
   useRegistryLoginMutation,
+  useRegistryLogoutMutation,
   useUpdateBlueprintMutation,
   useUpdateWorkerConfigMutation,
 } from './composerApi';


### PR DESCRIPTION
## Summary

Refactor the `RegistryAuth` component from a monolithic state machine into focused sub-components (`EmptyCard`, `LoginCard`, `RegistryStatus`), and optimize the login flow by writing directly to the RTK Query cache on successful login — avoiding a redundant round-trip of two `podman` spawns.

## Changes

- Decompose `RegistryAuth` into `EmptyCard`, `LoginCard`, and `RegistryStatus` sub-components for readability and testability
- Write login result directly into the `getRegistryAuthStatus` cache via `onQueryStarted`, skipping the re-fetch that would spawn `podman login --get-login` and `podman search`
- Add `registryLogout` endpoint with tag-based cache invalidation
- Remove the `deriveAuthState` / `StatusDisplay` state machine in favor of simpler conditional rendering
- Delete empty `RegistryAuthSection.tsx`
