### PR TITLE
Wizard: add "single target migration" banner on-prem (HMS-11066)

### DIFF
--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -204,7 +204,7 @@ registrationModes.forEach(
               await viewDetailsBtn.click();
               await expect(viewDetailsBtn).toBeVisible();
               await expect(frame.getByText('activation-key-')).toBeVisible();
-              await frame.getByLabel('Close').click();
+              await frame.getByLabel('Close', { exact: true }).click();
             }
 
             // Test enabling/disabling predictive analytics

--- a/src/Components/LandingPage/SingleTargetAlert.tsx
+++ b/src/Components/LandingPage/SingleTargetAlert.tsx
@@ -8,20 +8,13 @@ import {
   Flex,
   FlexItem,
 } from '@patternfly/react-core';
-import { useVariant } from '@unleash/proxy-client-react';
+
+const TITLE =
+  'Blueprints are transitioning to single image target environments.';
+const BODY =
+  'Existing multi-target blueprints will be migrated to single-target configurations.';
 
 const SingleTargetAlert = () => {
-  const variant = useVariant('image-builder.single-target-migration');
-  let payload;
-  try {
-    payload = variant.payload ? JSON.parse(variant.payload.value) : undefined;
-  } catch {
-    payload = undefined;
-  }
-
-  const title = payload?.title || '';
-  const body = payload?.body || '';
-
   const localStorageKey = 'imageBuilder.singleTargetMigration.dismissed';
   const isAlertDismissed = window.localStorage.getItem(localStorageKey);
 
@@ -33,7 +26,7 @@ const SingleTargetAlert = () => {
     window.localStorage.setItem(localStorageKey, 'true');
   };
 
-  if (!variant.enabled || !displayAlert || isTemporarilyHidden || !title) {
+  if (!displayAlert || isTemporarilyHidden) {
     return null;
   }
 
@@ -43,7 +36,7 @@ const SingleTargetAlert = () => {
       isExpandable
       variant='warning'
       style={{ margin: '0 0 16px 0' }}
-      title={title}
+      title={TITLE}
       actionClose={
         <Flex>
           <FlexItem>
@@ -59,7 +52,16 @@ const SingleTargetAlert = () => {
         </Flex>
       }
     >
-      <Content>{body}</Content>
+      <Content>
+        {BODY}{' '}
+        <a
+          href='https://access.redhat.com/articles/7145853'
+          target='_blank'
+          rel='noopener noreferrer'
+        >
+          Learn more about this upcoming change
+        </a>
+      </Content>
     </Alert>
   );
 };

--- a/src/Components/LandingPage/tests/SingleTargetAlert.test.tsx
+++ b/src/Components/LandingPage/tests/SingleTargetAlert.test.tsx
@@ -1,33 +1,11 @@
 import React from 'react';
 
 import { render, screen } from '@testing-library/react';
-import { useVariant } from '@unleash/proxy-client-react';
 
 import { createUser } from '@/test/testUtils';
 import { clickWithWait } from '@/test/testUtils/userEvents';
 
 import SingleTargetAlert from '../SingleTargetAlert';
-
-type PayloadData = {
-  title?: string;
-  body?: string;
-};
-
-const mockVariant = (payloadData?: PayloadData) => {
-  vi.mocked(useVariant).mockReturnValue({
-    name: 'image-builder.single-target-migration',
-    enabled: true,
-    payload: payloadData
-      ? {
-          type: 'json',
-          value: JSON.stringify(payloadData),
-        }
-      : {
-          type: 'json',
-          value: JSON.stringify(''),
-        },
-  });
-};
 
 const STORAGE_KEY = 'imageBuilder.singleTargetMigration.dismissed';
 
@@ -36,31 +14,15 @@ describe('Single Target Alert', () => {
     window.localStorage.clear();
   });
 
-  afterEach(() => {
-    vi.clearAllMocks();
-  });
-
-  test('does not render when no payload is provided', () => {
-    mockVariant();
-
-    render(<SingleTargetAlert />);
-
-    expect(
-      screen.queryByTestId('single-target-migration-banner'),
-    ).not.toBeInTheDocument();
-  });
-
-  test('renders with title and body from payload', async () => {
+  test('renders with title and body', async () => {
     const user = createUser();
-    mockVariant({
-      title: 'Single target images coming soon',
-      body: 'Image Builder will transition to single-target images.',
-    });
 
     render(<SingleTargetAlert />);
 
     expect(
-      screen.getByText('Single target images coming soon'),
+      screen.getByText(
+        'Blueprints are transitioning to single image target environments.',
+      ),
     ).toBeInTheDocument();
 
     await clickWithWait(
@@ -70,17 +32,12 @@ describe('Single Target Alert', () => {
 
     expect(
       screen.getByText(
-        'Image Builder will transition to single-target images.',
+        /Existing multi-target blueprints will be migrated to single-target configurations/,
       ),
     ).toBeInTheDocument();
   });
 
   test('renders as a warning alert', () => {
-    mockVariant({
-      title: 'Single target images coming soon',
-      body: 'Details about the change.',
-    });
-
     render(<SingleTargetAlert />);
 
     const heading = screen.getByRole('heading', {
@@ -91,10 +48,6 @@ describe('Single Target Alert', () => {
 
   test('permanently dismisses alert via "Do not show me this again"', async () => {
     const user = createUser();
-    mockVariant({
-      title: 'Single target images coming soon',
-      body: 'Details about the change.',
-    });
 
     render(<SingleTargetAlert />);
 
@@ -108,10 +61,6 @@ describe('Single Target Alert', () => {
 
   test('temporarily dismisses alert via close button', async () => {
     const user = createUser();
-    mockVariant({
-      title: 'Single target images coming soon',
-      body: 'Details about the change.',
-    });
 
     render(<SingleTargetAlert />);
 
@@ -125,28 +74,6 @@ describe('Single Target Alert', () => {
 
   test('does not render when previously dismissed via localStorage', () => {
     window.localStorage.setItem(STORAGE_KEY, 'true');
-
-    mockVariant({
-      title: 'Single target images coming soon',
-      body: 'Details about the change.',
-    });
-
-    render(<SingleTargetAlert />);
-
-    expect(
-      screen.queryByTestId('single-target-migration-banner'),
-    ).not.toBeInTheDocument();
-  });
-
-  test('does not render when payload is malformed JSON', () => {
-    vi.mocked(useVariant).mockReturnValue({
-      name: 'image-builder.single-target-migration',
-      enabled: true,
-      payload: {
-        type: 'json',
-        value: 'not valid json{{{',
-      },
-    });
 
     render(<SingleTargetAlert />);
 

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -39,8 +39,9 @@ export const useFlagWithEphemDefault = (
 
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
-    case 'image-builder.images-table-revamp.enabled':
     case 'image-builder.single-target-migration':
+      return true;
+    case 'image-builder.images-table-revamp.enabled':
     default:
       return false;
   }


### PR DESCRIPTION
Adds the banner to on-prem to match hosted service. Since the content of the banner has to be hardcoded for on-prem, I've removed the variant and changeable content from unleash and kept it simple. It will be deleted afterwards anyways.

<img width="1492" height="158" alt="image" src="https://github.com/user-attachments/assets/76d8b734-622e-4e26-91ba-7b078bf0191a" />

