### PR TITLE
Wizard/AAP: Improve validation (HMS-10759)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -90,6 +90,7 @@ import TimezoneStep from '../CreateImageWizard/steps/Timezone';
 import UserGroupsStep from '../CreateImageWizard/steps/UserGroups';
 import UsersStep from '../CreateImageWizard/steps/Users';
 import {
+  useAAPValidation,
   useAwsValidation,
   useAzureValidation,
   useDetailsValidation,
@@ -143,6 +144,7 @@ const CreateImageWizard = () => {
   const targetEnvironments = useAppSelector(selectImageTypes);
 
   // Validation hooks
+  const aapValidation = useAAPValidation();
   const awsValidation = useAwsValidation();
   const gcpValidation = useGcpValidation();
   const azureValidation = useAzureValidation();
@@ -176,6 +178,7 @@ const CreateImageWizard = () => {
     azureValidation.disabledNext ||
     detailsValidation.disabledNext ||
     registrationValidation.disabledNext ||
+    aapValidation.disabledNext ||
     snapshotValidation.disabledNext ||
     imagePullValidation.disabledNext ||
     (restrictions.users.isStandalone && usersHaveErrors);

--- a/src/Components/CreateImageWizard/steps/Registration/components/AAP/tests/AAP.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/AAP/tests/AAP.test.tsx
@@ -100,6 +100,20 @@ describe('AAP Component', () => {
       ).not.toBeInTheDocument();
     });
 
+    test('typing a partial URL does not show certificate errors', async () => {
+      renderAAPStep();
+      const user = createUser();
+
+      await enterCallbackUrl(user, 'htt');
+
+      expect(
+        screen.queryByText(/HTTP URL requires a custom TLS certificate/i),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/HTTPS URL requires either/i),
+      ).not.toBeInTheDocument();
+    });
+
     test('certificate input reappears when insecure checkbox is unchecked', async () => {
       renderAAPStep();
       const user = createUser();

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -122,6 +122,7 @@ export type UsersStepValidation = {
 };
 
 export function useIsBlueprintValid(): boolean {
+  const aap = useAAPValidation();
   const registration = useRegistrationValidation();
   const filesystem = useFilesystemValidation();
   const snapshot = useSnapshotValidation();
@@ -139,6 +140,7 @@ export function useIsBlueprintValid(): boolean {
   const gcpTarget = useGcpValidation();
   const awsTarget = useAwsValidation();
   return (
+    !aap.disabledNext &&
     !registration.disabledNext &&
     !filesystem.disabledNext &&
     !snapshot.disabledNext &&

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -323,7 +323,7 @@ export function useAAPValidation(): StepValidation {
     }
   }
 
-  if (callbackUrl && callbackUrl.trim() !== '') {
+  if (callbackUrl && callbackUrl.trim() !== '' && isValidUrl(callbackUrl)) {
     const isHttpsUrl = callbackUrl.toLowerCase().startsWith('https://');
 
     // If URL is HTTP, require TLS certificate


### PR DESCRIPTION
This improves AAP validation in a few places:
- URL and CA fields trigger validation independently
- AAP validation errors block Wizard from progressing via Next
- AAP validation errors block the Create/Save blueprint button