### PR TITLE
Wizard: Hide caret for repo and pkg search inputs (HMS-10761)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -12,7 +12,6 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
-  MenuToggle,
   MenuToggleElement,
   Select,
   SelectList,
@@ -851,10 +850,6 @@ const PackageSearch = ({
     }
   };
 
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
   const onClearButtonClick = () => {
     setSearchTerm('');
     setIsOpen(false);
@@ -985,13 +980,13 @@ const PackageSearch = ({
     setIsOpen(false);
   };
 
+  // MenuToggle with variant='typeahead' always renders a caret button that
+  // cannot be hidden via props. Using a div with the same PF classes gives
+  // identical styling without the caret.
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      variant='typeahead'
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      isFullWidth
+    <div
+      ref={toggleRef as React.Ref<HTMLDivElement>}
+      className={`pf-v6-c-menu-toggle pf-m-typeahead pf-m-full-width${isOpen ? ' pf-m-expanded' : ''}`}
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain
@@ -1014,7 +1009,7 @@ const PackageSearch = ({
           />
         </TextInputGroupUtilities>
       </TextInputGroup>
-    </MenuToggle>
+    </div>
   );
 
   return (

--- a/src/Components/CreateImageWizard/steps/Repositories/components/RepositorySearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/RepositorySearch.tsx
@@ -2,7 +2,6 @@ import React, { useMemo, useState } from 'react';
 
 import {
   Button,
-  MenuToggle,
   MenuToggleElement,
   Select,
   SelectList,
@@ -118,10 +117,6 @@ const RepositorySearch = ({
     setIsOpen(true);
   };
 
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
   const onClearButtonClick = () => {
     setInputValue('');
     setFilterValue('');
@@ -139,13 +134,13 @@ const RepositorySearch = ({
     return null;
   };
 
+  // MenuToggle with variant='typeahead' always renders a caret button that
+  // cannot be hidden via props. Using a div with the same PF classes gives
+  // identical styling without the caret.
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
-    <MenuToggle
-      ref={toggleRef}
-      variant='typeahead'
-      onClick={onToggleClick}
-      isExpanded={isOpen}
-      isFullWidth
+    <div
+      ref={toggleRef as React.Ref<HTMLDivElement>}
+      className={`pf-v6-c-menu-toggle pf-m-typeahead pf-m-full-width${isOpen ? ' pf-m-expanded' : ''}`}
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain
@@ -167,7 +162,7 @@ const RepositorySearch = ({
           />
         </TextInputGroupUtilities>
       </TextInputGroup>
-    </MenuToggle>
+    </div>
   );
 
   return (

--- a/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/tests/Repositories.test.tsx
@@ -46,9 +46,6 @@ describe('Repositories Component', () => {
         screen.getByRole('button', { name: /clear search/i }),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole('button', { name: /menu toggle/i }),
-      ).toBeInTheDocument();
-      expect(
         screen.getByRole('button', { name: /refresh repositories/i }),
       ).toBeInTheDocument();
     });
@@ -90,11 +87,11 @@ describe('Repositories Component', () => {
       renderRepositoriesStep();
       const user = createUser();
 
-      // Open dropdown by clicking toggle
-      const toggle = await screen.findByRole('button', {
-        name: /menu toggle/i,
+      // Open dropdown by clicking the search input
+      const searchInput = await screen.findByRole('textbox', {
+        name: /filter repositories/i,
       });
-      await clickWithWait(user, toggle);
+      await clickWithWait(user, searchInput);
 
       // Should show repositories without typing
       expect(
@@ -113,10 +110,10 @@ describe('Repositories Component', () => {
       const user = createUser();
 
       // Open dropdown - should show "No repositories available"
-      const toggle = await screen.findByRole('button', {
-        name: /menu toggle/i,
+      const searchInput = await screen.findByRole('textbox', {
+        name: /filter repositories/i,
       });
-      await clickWithWait(user, toggle);
+      await clickWithWait(user, searchInput);
 
       expect(
         await screen.findByRole('option', {
@@ -125,9 +122,6 @@ describe('Repositories Component', () => {
       ).toBeInTheDocument();
 
       // Type to search - should show "No repositories found for..."
-      const searchInput = await screen.findByRole('textbox', {
-        name: /filter repositories/i,
-      });
       await typeWithWait(user, searchInput, 'nonexistent');
 
       expect(
@@ -156,17 +150,14 @@ describe('Repositories Component', () => {
       const user = createUser();
 
       // Open dropdown without search
-      const toggle = await screen.findByRole('button', {
-        name: /menu toggle/i,
+      const searchInput = await screen.findByRole('textbox', {
+        name: /filter repositories/i,
       });
-      await clickWithWait(user, toggle);
+      await clickWithWait(user, searchInput);
 
       await screen.findByRole('option', { name: /no repositories available/i });
 
       // Type to search - should use limit=50
-      const searchInput = await screen.findByRole('textbox', {
-        name: /filter repositories/i,
-      });
       await typeWithWait(user, searchInput, 'test');
 
       await screen.findByRole('option', {
@@ -718,9 +709,6 @@ describe('Request Payload Generation', () => {
       });
       await typeWithWait(user, searchInput, 'test-repo{Enter}');
 
-      expect(
-        screen.getByRole('button', { name: /menu toggle/i }),
-      ).toBeInTheDocument();
       expect(searchInput).toBeInTheDocument();
       expect(searchInput).toHaveValue('test-repo');
     });


### PR DESCRIPTION
This replaces previously used `MenuToggle` with a plain `<div>` with PF's typeahead classes for `PackageSearch` and `RepositorySearch` components.

PF6's `MenuToggle` with variant='typeahead' always renders a caret that can't be hidden/disabled. `<div>` with styling is hacky, but it's the only way to remove the dropdown caret, but still be able to pass the ref and make the component look the same.