### PR TITLE
Wizard: let logged-out users browse and build official images

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
@@ -58,8 +58,13 @@ const OfficialImageSource = () => {
     { skip: !selectedRef },
   );
 
-  const [pullImage, { isLoading: isPulling, isError: isPullError }] =
-    usePullImageMutation();
+  // The mutation state is scoped to the reference it was started with,
+  // so switching to another image doesn't show its busy/error state.
+  const [pullImage, pullState] = usePullImageMutation();
+  const isPulling =
+    pullState.isLoading && pullState.originalArgs?.reference === selectedRef;
+  const isPullError =
+    pullState.isError && pullState.originalArgs?.reference === selectedRef;
 
   const showSelectionError = forceShowErrors && !hasOfficialSelection;
   const showPullValidation = hasOfficialSelection && imageExists === false;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
@@ -53,9 +53,11 @@ const OfficialImageSource = () => {
     return KNOWN_IMAGES.map((known) => ({ ...known, arch }));
   }, [isAuthenticated, arch]);
 
+  // Local images can be removed outside the wizard (e.g. podman rmi),
+  // so bypass the cache and re-check whenever this section mounts.
   const { data: imageExists } = useGetImageExistsQuery(
     { reference: selectedRef! },
-    { skip: !selectedRef },
+    { skip: !selectedRef, refetchOnMountOrArgChange: true },
   );
 
   // The mutation state is scoped to the reference it was started with,

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
@@ -42,7 +42,9 @@ const OfficialImageSource = () => {
   const hasOfficialSelection = useAppSelector(selectIsOfficialImage);
 
   const { data: authStatus, isLoading: isAuthLoading } =
-    useGetRegistryAuthStatusQuery();
+    useGetRegistryAuthStatusQuery(undefined, {
+      refetchOnMountOrArgChange: true,
+    });
   const isAuthenticated = authStatus?.status === 'authenticated';
 
   const images = useMemo(() => {

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
@@ -8,6 +8,7 @@ import {
   HelperText,
   HelperTextItem,
   Spinner,
+  Tooltip,
 } from '@patternfly/react-core';
 
 import {
@@ -16,7 +17,10 @@ import {
   usePullImageMutation,
 } from '@/store/api/backend';
 import { Distributions } from '@/store/api/backend/hosted';
-import { KNOWN_IMAGES } from '@/store/api/backend/onprem/constants';
+import {
+  IMAGE_REGISTRY_HOST,
+  KNOWN_IMAGES,
+} from '@/store/api/backend/onprem/constants';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeDistribution,
@@ -33,6 +37,42 @@ import {
 import ImageSelect from './ImageSelect';
 import RegistryAuth from './RegistryAuth';
 
+type PullButtonProps = {
+  onPull: () => void;
+  isPulling: boolean;
+  isAuthenticated: boolean;
+  isDisabled?: boolean;
+};
+
+const PullButton = ({
+  onPull,
+  isPulling,
+  isAuthenticated,
+  isDisabled,
+}: PullButtonProps) => {
+  const button = (
+    <Button
+      variant='secondary'
+      onClick={onPull}
+      isDisabled={isDisabled || isPulling}
+      isAriaDisabled={!isAuthenticated}
+      icon={isPulling ? <Spinner size='sm' /> : undefined}
+    >
+      {isPulling ? 'Pulling image...' : 'Pull latest image'}
+    </Button>
+  );
+
+  if (isAuthenticated) {
+    return button;
+  }
+
+  return (
+    <Tooltip content={`Log in to ${IMAGE_REGISTRY_HOST} to pull images.`}>
+      {button}
+    </Tooltip>
+  );
+};
+
 const OfficialImageSource = () => {
   const dispatch = useAppDispatch();
   const arch = useAppSelector(selectArchitecture);
@@ -47,13 +87,10 @@ const OfficialImageSource = () => {
     });
   const isAuthenticated = authStatus?.status === 'authenticated';
 
-  const images = useMemo(() => {
-    if (!isAuthenticated) {
-      return [];
-    }
-
-    return KNOWN_IMAGES.map((known) => ({ ...known, arch }));
-  }, [isAuthenticated, arch]);
+  const images = useMemo(
+    () => KNOWN_IMAGES.map((known) => ({ ...known, arch })),
+    [arch],
+  );
 
   // Local images can be removed outside the wizard (e.g. podman rmi),
   // so bypass the cache and re-check whenever this section mounts.
@@ -86,48 +123,42 @@ const OfficialImageSource = () => {
   return (
     <>
       <RegistryAuth />
-      {isAuthenticated && (
-        <Flex
-          spaceItems={{ default: 'spaceItemsMd' }}
-          alignItems={{ default: 'alignItemsFlexStart' }}
-        >
-          <FlexItem>
-            <ImageSelect
-              items={images}
-              selectedRef={selectedRef}
-              ariaDescribedBy={errorId}
-              onSelect={(_event, selection) => {
-                const selected = images.find(
-                  (img) => img.reference === selection,
+      <Flex
+        spaceItems={{ default: 'spaceItemsMd' }}
+        alignItems={{ default: 'alignItemsFlexStart' }}
+      >
+        <FlexItem>
+          <ImageSelect
+            items={images}
+            selectedRef={selectedRef}
+            ariaDescribedBy={errorId}
+            onSelect={(_event, selection) => {
+              const selected = images.find(
+                (img) => img.reference === selection,
+              );
+              if (selected) {
+                dispatch(changeImageSource(selected.reference));
+                dispatch(changeDistribution(selected.distro as Distributions));
+                dispatch(
+                  changeImageTypes([selected.type as SupportedImageTypes]),
                 );
-                if (selected) {
-                  dispatch(changeImageSource(selected.reference));
-                  dispatch(
-                    changeDistribution(selected.distro as Distributions),
-                  );
-                  dispatch(
-                    changeImageTypes([selected.type as SupportedImageTypes]),
-                  );
-                }
-              }}
-              getLabel={(item) => item.name}
-              placeholder={'Select an official image'}
+              }
+            }}
+            getLabel={(item) => item.name}
+            placeholder={'Select an official image'}
+          />
+        </FlexItem>
+        {hasOfficialSelection && (
+          <FlexItem className='pf-v6-u-mt-md'>
+            <PullButton
+              onPull={() => pullImage({ reference: selectedRef! })}
+              isPulling={isPulling}
+              isAuthenticated={isAuthenticated}
+              isDisabled={isAuthLoading}
             />
           </FlexItem>
-          {hasOfficialSelection && (
-            <FlexItem className='pf-v6-u-mt-md'>
-              <Button
-                variant='secondary'
-                onClick={() => pullImage({ reference: selectedRef! })}
-                isDisabled={isAuthLoading || isPulling}
-                icon={isPulling ? <Spinner size='sm' /> : undefined}
-              >
-                {isPulling ? 'Pulling image...' : 'Pull latest image'}
-              </Button>
-            </FlexItem>
-          )}
-        </Flex>
-      )}
+        )}
+      </Flex>
       {showSelectionError && (
         <FormHelperText>
           <HelperText>
@@ -143,7 +174,9 @@ const OfficialImageSource = () => {
             <HelperTextItem variant='error' id='official-image-pull-error'>
               {isPullError
                 ? 'Failed to pull image. Please try again.'
-                : 'Image must be pulled before proceeding.'}
+                : isAuthenticated
+                  ? 'Bootc container must be pulled before proceeding.'
+                  : `Bootc container is not in local storage. Log in to ${IMAGE_REGISTRY_HOST} to pull it.`}
             </HelperTextItem>
           </HelperText>
         </FormHelperText>

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/RegistryAuth.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/RegistryAuth.tsx
@@ -210,7 +210,11 @@ const RegistryStatus = ({ username }: { username: string }) => {
 const RegistryAuth = () => {
   const [isFormVisible, setIsFormVisible] = useState(false);
 
-  const { data, isLoading } = useGetRegistryAuthStatusQuery();
+  // The login can change outside the wizard (e.g. podman logout), so
+  // bypass the cache and re-check whenever this section mounts.
+  const { data, isLoading } = useGetRegistryAuthStatusQuery(undefined, {
+    refetchOnMountOrArgChange: true,
+  });
 
   if (isLoading) {
     return (

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/RegistryAuth.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/RegistryAuth.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 
 import {
+  Alert,
+  AlertActionLink,
   Button,
   Card,
   CardBody,
@@ -9,10 +11,6 @@ import {
   CardTitle,
   Content,
   ContentVariants,
-  EmptyState,
-  EmptyStateActions,
-  EmptyStateBody,
-  EmptyStateFooter,
   Flex,
   FlexItem,
   FormGroup,
@@ -31,23 +29,21 @@ import {
 import { IMAGE_REGISTRY_HOST } from '@/store/api/backend/onprem/constants';
 import { OnPremError } from '@/store/api/shared';
 
-const EmptyCard = ({ openForm }: { openForm: (arg0: boolean) => void }) => {
+const LoginPrompt = ({ openForm }: { openForm: (arg0: boolean) => void }) => {
   return (
-    <Card variant='secondary' className='pf-v6-u-mt-md pf-v6-u-py-md'>
-      <EmptyState titleText='Login to select an image' headingLevel='h4'>
-        <EmptyStateBody>
-          <Content>Registry images come from {IMAGE_REGISTRY_HOST}.</Content>
-          <Content>
-            Sign in to browse available images for this release.
-          </Content>
-        </EmptyStateBody>
-        <EmptyStateFooter>
-          <EmptyStateActions>
-            <Button onClick={() => openForm(true)}>Login</Button>
-          </EmptyStateActions>
-        </EmptyStateFooter>
-      </EmptyState>
-    </Card>
+    <Alert
+      variant='info'
+      isInline
+      title='Log in to pull the latest images'
+      className='pf-v6-u-mt-md'
+      actionLinks={
+        <AlertActionLink onClick={() => openForm(true)}>Log in</AlertActionLink>
+      }
+    >
+      You can build from images already on this system without logging in.
+      Pulling the latest images from {IMAGE_REGISTRY_HOST} requires a Red Hat
+      login.
+    </Alert>
   );
 };
 
@@ -230,7 +226,7 @@ const RegistryAuth = () => {
   }
 
   if (!isFormVisible) {
-    return <EmptyCard openForm={setIsFormVisible} />;
+    return <LoginPrompt openForm={setIsFormVisible} />;
   }
 
   return <LoginCard closeForm={setIsFormVisible} />;

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/index.tsx
@@ -7,7 +7,6 @@ import {
   CardTitle,
   FormGroup,
   Gallery,
-  Label,
 } from '@patternfly/react-core';
 
 import { IMAGE_REGISTRY_HOST } from '@/store/api/backend/onprem/constants';
@@ -47,7 +46,7 @@ const OnPremImageSourceSelect = () => {
             }}
           >
             <CardTitle id='official-card-title'>
-              Official Red Hat images <Label isCompact>Login required</Label>
+              Official Red Hat images
             </CardTitle>
           </CardHeader>
           <CardBody>Remote images from {IMAGE_REGISTRY_HOST}</CardBody>

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -108,6 +108,7 @@ describe('ImageSourceSelect', () => {
       expect(screen.getByText('Local images')).toBeInTheDocument();
       expect(screen.queryByText('Custom images')).not.toBeInTheDocument();
       expect(screen.queryByText('No login')).not.toBeInTheDocument();
+      expect(screen.queryByText('Login required')).not.toBeInTheDocument();
     });
 
     test('does not auto-select an image on-prem', async () => {
@@ -175,6 +176,87 @@ describe('ImageSourceSelect', () => {
       expect(
         screen.queryByRole('button', { name: /pulling image/i }),
       ).not.toBeInTheDocument();
+    });
+
+    test('requires the bootc container to be pulled', async () => {
+      mockUseGetImageExistsQuery.mockReturnValue({
+        data: false,
+        isLoading: false,
+        isError: false,
+      });
+
+      renderWithGuestImage();
+
+      expect(
+        await screen.findByText(
+          /bootc container must be pulled before proceeding/i,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Not logged in', () => {
+    beforeEach(() => {
+      mockUseGetRegistryAuthStatusQuery.mockReturnValue({
+        data: { status: 'unauthenticated' },
+        isLoading: false,
+        isError: false,
+        error: undefined,
+      });
+    });
+
+    test('displays the login prompt instead of an empty state', async () => {
+      renderImageSourceSelect();
+
+      expect(
+        await screen.findByText(/log in to pull the latest images/i),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/login to select an image/i),
+      ).not.toBeInTheDocument();
+    });
+
+    test('disables the pull button', async () => {
+      renderWithGuestImage();
+      const user = createUser();
+
+      const pullButton = await screen.findByRole('button', {
+        name: /pull latest image/i,
+      });
+      expect(pullButton).toHaveAttribute('aria-disabled', 'true');
+
+      await clickWithWait(user, pullButton);
+      expect(mockPullImage).not.toHaveBeenCalled();
+    });
+
+    test('points at the login when a missing image cannot be pulled', async () => {
+      mockUseGetImageExistsQuery.mockReturnValue({
+        data: false,
+        isLoading: false,
+        isError: false,
+      });
+
+      renderWithGuestImage();
+
+      expect(
+        await screen.findByText(/log in to registry\.redhat\.io to pull it/i),
+      ).toBeInTheDocument();
+    });
+
+    test('login action opens the login form', async () => {
+      renderImageSourceSelect();
+      const user = createUser();
+
+      const loginButton = await screen.findByRole('button', {
+        name: /log in/i,
+      });
+      await clickWithWait(user, loginButton);
+
+      expect(
+        await screen.findByText(/log in to registry\.redhat\.io/i),
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -16,6 +16,9 @@ import {
 
 import ImageSourceSelect from '../components/ImageSourceSelect';
 
+const KVM_REF = 'registry.redhat.io/rhel10/rhel-bootc-kvm:latest';
+const AWS_REF = 'registry.redhat.io/rhel10/rhel-bootc-aws:latest';
+
 const mockRefetch = vi.fn();
 const mockUseGetDistributionsQuery = vi.fn();
 const mockUseGetImageExistsQuery = vi.fn();
@@ -43,6 +46,19 @@ const renderHostedImageSourceSelect = () => {
     details: {
       ...initialState.details,
       blueprint: { ...initialState.details.blueprint, mode: 'image' },
+    },
+  });
+};
+
+// Tests preset the selected image in state rather than driving the
+// dropdown: the dropdown is on its way out as a selection mechanism.
+const renderWithGuestImage = () => {
+  return renderImageSourceSelect({
+    output: {
+      ...initialState.output,
+      imageSourceType: 'official',
+      imageTypes: ['guest-image'],
+      imageSource: KVM_REF,
     },
   });
 };
@@ -100,6 +116,65 @@ describe('ImageSourceSelect', () => {
       await screen.findByText('Image source');
 
       expect(selectImageSource(store.getState())).toBeUndefined();
+    });
+  });
+
+  describe('Official images', () => {
+    test('pulls the selected container', async () => {
+      renderWithGuestImage();
+      const user = createUser();
+
+      const pullButton = await screen.findByRole('button', {
+        name: /pull latest image/i,
+      });
+      await clickWithWait(user, pullButton);
+
+      expect(mockPullImage).toHaveBeenCalledWith({ reference: KVM_REF });
+    });
+
+    test('shows the pulling state for the selected image', async () => {
+      mockUsePullImageMutation.mockReturnValue([
+        mockPullImage,
+        {
+          isLoading: true,
+          isError: false,
+          originalArgs: { reference: KVM_REF },
+        },
+      ]);
+
+      renderWithGuestImage();
+
+      expect(
+        await screen.findByRole('button', { name: /pulling image/i }),
+      ).toBeInTheDocument();
+    });
+
+    test("does not show another image's pull as busy", async () => {
+      // A pull of the guest image is in flight while AWS is selected
+      mockUsePullImageMutation.mockReturnValue([
+        mockPullImage,
+        {
+          isLoading: true,
+          isError: false,
+          originalArgs: { reference: KVM_REF },
+        },
+      ]);
+
+      renderImageSourceSelect({
+        output: {
+          ...initialState.output,
+          imageSourceType: 'official',
+          imageTypes: ['aws'],
+          imageSource: AWS_REF,
+        },
+      });
+
+      expect(
+        await screen.findByRole('button', { name: /pull latest image/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /pulling image/i }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -12,8 +12,10 @@ import {
   BlueprintsResponse,
   useGetImageExistsQuery,
   useGetOscapCustomizationsQuery,
+  useGetRegistryAuthStatusQuery,
   useLazyGetBlueprintsQuery,
 } from '@/store/api/backend';
+import { IMAGE_REGISTRY_HOST } from '@/store/api/backend/onprem/constants';
 import { useShowActivationKeyQuery } from '@/store/api/rhsm';
 import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
@@ -1281,6 +1283,10 @@ export const useImagePullValidation = (): StepValidation => {
     { reference: imageSource! },
     { skip: !isOnPremise || !isOfficialImage },
   );
+  const { data: authStatus } = useGetRegistryAuthStatusQuery(undefined, {
+    skip: !isOnPremise || !isOfficialImage,
+  });
+  const isAuthenticated = authStatus?.status === 'authenticated';
 
   if (!isOnPremise || !isOfficialImage) {
     return { errors: {}, disabledNext: false };
@@ -1292,7 +1298,11 @@ export const useImagePullValidation = (): StepValidation => {
 
   if (imageExists !== true) {
     return {
-      errors: { imagePull: 'Image must be pulled before proceeding' },
+      errors: {
+        imagePull: isAuthenticated
+          ? 'Bootc container must be pulled before proceeding'
+          : `Bootc container is not in local storage. Log in to ${IMAGE_REGISTRY_HOST} to pull it.`,
+      },
       disabledNext: true,
     };
   }

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -109,7 +109,6 @@ export {
   getHostArch,
   getHostDistro,
   useExportBlueprintCockpitQuery,
-  useGetRegistryAuthStatusQuery,
   useLazyGetImageExistsQuery,
   useGetUploadConfigQuery,
   useLazyExportBlueprintCockpitQuery,
@@ -132,6 +131,18 @@ export const useGetImageExistsQuery = (
         isFetching: false,
       })
 ) as typeof composerQueries.useGetImageExistsQuery;
+
+// Same conditional export, for the same caller.
+export const useGetRegistryAuthStatusQuery = (
+  process.env.IS_ON_PREMISE
+    ? composerQueries.useGetRegistryAuthStatusQuery
+    : () => ({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        isFetching: false,
+      })
+) as typeof composerQueries.useGetRegistryAuthStatusQuery;
 
 export { composerApi, errorMessage, imageBuilderApi };
 


### PR DESCRIPTION
Registry login is no longer required to browse official images — logged-out users see the dropdown with pull disabled, and existence/auth checks stop going stale.
- Drop the login-gated empty state and "Login required" label; the image dropdown is always shown
- Logged-out users get an inline info alert offering registry login; pull buttons disabled with an explanatory tooltip
- Re-check image existence (refetchOnMountOrArgChange) on mount, so a podman rmi outside the wizard is noticed
- Re-check registry login on mount for the same staleness reason
- Scope the pull button's busy/error state to the selected image, so switching images doesn't show a stale pulling state
- Pull validation copy now tells the user how to resolve a missing image based on login state

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>