### PR TITLE
Wizard: add the container installer official image (HMS-11165)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/OfficialImageSource.tsx
@@ -5,6 +5,7 @@ import { useAppSelector } from '@/store/hooks';
 import {
   selectImageSource,
   selectImageSourceType,
+  selectIsoPayloadReference,
 } from '@/store/slices/wizard';
 
 import ContainerSection from './ContainerSection';
@@ -17,6 +18,8 @@ import RegistryAuth from './RegistryAuth';
 const OfficialImageSource = () => {
   const selectedRef = useAppSelector(selectImageSource);
   const imageSourceType = useAppSelector(selectImageSourceType);
+  // Only set while the container installer is selected
+  const isoPayloadReference = useAppSelector(selectIsoPayloadReference);
 
   const selected = KNOWN_IMAGES.find((img) => img.reference === selectedRef);
 
@@ -32,6 +35,14 @@ const OfficialImageSource = () => {
         reference={selected?.reference}
         name={selected?.name}
       />
+      {selected && isoPayloadReference && (
+        <ContainerSection
+          label='Payload container'
+          reference={isoPayloadReference}
+          name={selected.name}
+          helperText='The installer deploys this base image.'
+        />
+      )}
     </>
   );
 };

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/ImageSourceSelect.test.tsx
@@ -53,6 +53,22 @@ const renderHostedImageSourceSelect = () => {
 // The image is implied by the selected target environment; these tests
 // preset the resulting state (the radio interaction itself is covered
 // by the TargetEnvironment and output slice tests).
+const INSTALLER_REF = 'registry.redhat.io/rhel10/rhel-bootc-installer:latest';
+// The installer's payload: a distinct, non-cloud-specific base image
+const PLAIN_REF = 'registry.redhat.io/rhel10/rhel-bootc:latest';
+
+const renderWithInstaller = () => {
+  return renderImageSourceSelect({
+    output: {
+      ...initialState.output,
+      imageSourceType: 'official',
+      imageTypes: ['bootable-container-iso'],
+      imageSource: INSTALLER_REF,
+      isoPayloadReference: PLAIN_REF,
+    },
+  });
+};
+
 const renderWithGuestImage = () => {
   return renderImageSourceSelect({
     output: {
@@ -200,6 +216,58 @@ describe('ImageSourceSelect', () => {
       expect(
         screen.queryByRole('button', { name: /pulling image/i }),
       ).not.toBeInTheDocument();
+    });
+
+    test('shows the payload container for the installer', async () => {
+      renderWithInstaller();
+
+      expect(await screen.findByText('Payload container')).toBeInTheDocument();
+      expect(screen.getByDisplayValue(INSTALLER_REF)).toBeInTheDocument();
+      expect(screen.getByDisplayValue(PLAIN_REF)).toBeInTheDocument();
+      expect(
+        screen.getByText(/the installer deploys this base image/i),
+      ).toBeInTheDocument();
+    });
+
+    test('does not show the payload container for disk images', async () => {
+      renderWithGuestImage();
+
+      await screen.findByDisplayValue(KVM_REF);
+
+      expect(screen.queryByText('Payload container')).not.toBeInTheDocument();
+    });
+
+    test('pulls the payload container with its own pull button', async () => {
+      renderWithInstaller();
+      const user = createUser();
+
+      const pullButtons = await screen.findAllByRole('button', {
+        name: /pull latest image/i,
+      });
+      expect(pullButtons).toHaveLength(2);
+
+      await clickWithWait(user, pullButtons[1]);
+
+      expect(mockPullImage).toHaveBeenCalledWith({ reference: PLAIN_REF });
+    });
+
+    test('requires the payload container to be pulled', async () => {
+      // The installer image exists locally but its payload does not
+      mockUseGetImageExistsQuery.mockImplementation(
+        (arg: { reference: string }) => ({
+          data: arg.reference !== PLAIN_REF,
+          isLoading: false,
+          isError: false,
+        }),
+      );
+
+      renderWithInstaller();
+
+      expect(
+        await screen.findByText(
+          /payload container must be pulled before proceeding/i,
+        ),
+      ).toBeInTheDocument();
     });
 
     test('requires the bootc container to be pulled', async () => {

--- a/src/Components/CreateImageWizard/steps/ImageOutput/tests/TargetEnvironment.test.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/tests/TargetEnvironment.test.tsx
@@ -379,6 +379,9 @@ describe('TargetEnvironment', () => {
       expect(
         screen.getByRole('radio', { name: /Amazon Web Services/i }),
       ).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', { name: /Container installer/i }),
+      ).toBeInTheDocument();
     });
 
     test('offers the same environments when no image is selected', async () => {

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -53,6 +53,7 @@ import {
   selectImageSource,
   selectImageTypes,
   selectIsOfficialImage,
+  selectIsoPayloadReference,
   selectKernel,
   selectKeyboard,
   selectLanguages,
@@ -1279,10 +1280,19 @@ export const useImagePullValidation = (): StepValidation => {
   const isOnPremise = useAppSelector(selectIsOnPremise);
   const isOfficialImage = useAppSelector(selectIsOfficialImage);
   const imageSource = useAppSelector(selectImageSource);
+  // Only set when the container installer is selected; the installer
+  // needs its payload container in local storage too.
+  const isoPayloadReference = useAppSelector(selectIsoPayloadReference);
+
   const { data: imageExists, isLoading } = useGetImageExistsQuery(
     { reference: imageSource! },
     { skip: !isOnPremise || !isOfficialImage },
   );
+  const { data: payloadExists, isLoading: isPayloadLoading } =
+    useGetImageExistsQuery(
+      { reference: isoPayloadReference! },
+      { skip: !isOnPremise || !isOfficialImage || !isoPayloadReference },
+    );
   const { data: authStatus } = useGetRegistryAuthStatusQuery(undefined, {
     skip: !isOnPremise || !isOfficialImage,
   });
@@ -1292,7 +1302,9 @@ export const useImagePullValidation = (): StepValidation => {
     return { errors: {}, disabledNext: false };
   }
 
-  if (isLoading) {
+  const needsPayload = !!isoPayloadReference;
+
+  if (isLoading || (needsPayload && isPayloadLoading)) {
     return { errors: {}, disabledNext: true };
   }
 
@@ -1302,6 +1314,17 @@ export const useImagePullValidation = (): StepValidation => {
         imagePull: isAuthenticated
           ? 'Bootc container must be pulled before proceeding'
           : `Bootc container is not in local storage. Log in to ${IMAGE_REGISTRY_HOST} to pull it.`,
+      },
+      disabledNext: true,
+    };
+  }
+
+  if (needsPayload && payloadExists !== true) {
+    return {
+      errors: {
+        imagePull: isAuthenticated
+          ? 'Payload container must be pulled before proceeding'
+          : `Payload container is not in local storage. Log in to ${IMAGE_REGISTRY_HOST} to pull it.`,
       },
       disabledNext: true,
     };

--- a/src/store/api/backend/onprem/composerApi/helpers/podman/filters.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podman/filters.ts
@@ -12,6 +12,7 @@ import { inferDistro } from './inferDistro';
 export const backendToFrontendType: Record<string, string> = {
   qcow2: 'guest-image',
   ami: 'aws',
+  'bootc-generic-iso': 'bootable-container-iso',
 };
 
 const normalizeImageType = (type: string): string =>
@@ -23,6 +24,7 @@ const normalizeImageType = (type: string): string =>
 export const frontendToBackendType: Record<string, string> = {
   'guest-image': 'qcow2',
   aws: 'ami',
+  'bootable-container-iso': 'bootc-generic-iso',
 };
 
 export const toBackendImageType = (type: string): string =>

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/toBackendImageType.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/toBackendImageType.test.ts
@@ -10,6 +10,9 @@ describe('toBackendImageType', () => {
   it('maps frontend aliases back to backend type names', () => {
     expect(toBackendImageType('guest-image')).toBe('qcow2');
     expect(toBackendImageType('aws')).toBe('ami');
+    expect(toBackendImageType('bootable-container-iso')).toBe(
+      'bootc-generic-iso',
+    );
   });
 
   it('passes through types without an alias', () => {

--- a/src/store/api/backend/onprem/constants.ts
+++ b/src/store/api/backend/onprem/constants.ts
@@ -30,6 +30,15 @@ export const KNOWN_IMAGES: KnownImage[] = [
     name: 'Red Hat Enterprise Linux (RHEL) 10.3',
     type: 'aws',
   },
+  {
+    reference: `${IMAGE_REGISTRY}/rhel-bootc-installer:latest`,
+    distro: 'rhel-10.3',
+    name: 'Red Hat Enterprise Linux (RHEL) 10.3',
+    type: 'bootable-container-iso',
+    // The installer targets bare-metal deployments, so its payload is
+    // the plain base image rather than a cloud/VM-specific one.
+    iso_payload_references: [`${IMAGE_REGISTRY}/rhel-bootc:latest`],
+  },
 ];
 
 export const isKnownImageRef = (ref: string) => {

--- a/src/store/api/distributions/tests/hooks.test.tsx
+++ b/src/store/api/distributions/tests/hooks.test.tsx
@@ -103,6 +103,17 @@ describe('useCustomizationRestrictions hook logic', () => {
       expect(result.registration.shouldHide).toBe(false);
     });
 
+    it('should hide registration for the container installer', () => {
+      const result = computeRestrictions({
+        imageTypes: {
+          'bootable-container-iso': DISTRO_DETAILS['bootable-container-iso'],
+        },
+        context: onPremImageMode,
+      });
+
+      expect(result.registration.shouldHide).toBe(true);
+    });
+
     it('should show registration for non-RHEL custom images', () => {
       const result = computeRestrictions({
         imageTypes: { 'guest-image': DISTRO_DETAILS['guest-image'] },

--- a/src/store/slices/wizard/listeners.ts
+++ b/src/store/slices/wizard/listeners.ts
@@ -7,12 +7,14 @@ import {
   changeDistribution,
   changeImageSource,
   changeImageTypes,
+  changeIsoPayloadReference,
   isRhel,
   selectArchitecture,
   selectDistribution,
   selectImageSource,
   selectImageSourceType,
   selectImageTypes,
+  selectIsoPayloadReference,
 } from './output';
 import {
   changeAapEnabled,
@@ -149,5 +151,16 @@ export const resolveOfficialImage: WizardListenerEffect = (
   if (selected !== current) {
     listenerApi.dispatch(changeImageSource(selected.reference));
     listenerApi.dispatch(changeDistribution(selected.distro as Distributions));
+  }
+
+  // The container installer needs a payload container; default to the
+  // one the selected official image ships with.
+  const payloadRef = selected.iso_payload_references?.[0];
+  if (
+    targetType === 'bootable-container-iso' &&
+    payloadRef &&
+    !selectIsoPayloadReference(state)
+  ) {
+    listenerApi.dispatch(changeIsoPayloadReference(payloadRef));
   }
 };

--- a/src/store/slices/wizard/tests/resolveOfficialImage.test.ts
+++ b/src/store/slices/wizard/tests/resolveOfficialImage.test.ts
@@ -76,6 +76,46 @@ describe('resolveOfficialImage', () => {
     expect(listenerApi.dispatch).not.toHaveBeenCalled();
   });
 
+  it('defaults the payload container for the container installer', () => {
+    const listenerApi = createListenerApi(
+      imageModeState({
+        imageSource: KVM_REF,
+        imageTypes: ['bootable-container-iso'],
+      }),
+    );
+
+    resolveOfficialImage(
+      changeImageTypes(['bootable-container-iso']),
+      listenerApi,
+    );
+
+    expect(listenerApi.dispatch).toHaveBeenCalledWith({
+      type: 'wizard/output/changeImageSource',
+      payload: 'registry.redhat.io/rhel10/rhel-bootc-installer:latest',
+    });
+    expect(listenerApi.dispatch).toHaveBeenCalledWith({
+      type: 'wizard/output/changeIsoPayloadReference',
+      payload: 'registry.redhat.io/rhel10/rhel-bootc:latest',
+    });
+  });
+
+  it('keeps an explicit payload container reference', () => {
+    const listenerApi = createListenerApi(
+      imageModeState({
+        imageSource: 'registry.redhat.io/rhel10/rhel-bootc-installer:latest',
+        imageTypes: ['bootable-container-iso'],
+        isoPayloadReference: 'registry.example.org/payload:latest',
+      }),
+    );
+
+    resolveOfficialImage(
+      changeImageTypes(['bootable-container-iso']),
+      listenerApi,
+    );
+
+    expect(listenerApi.dispatch).not.toHaveBeenCalled();
+  });
+
   it('does not change an unknown image reference', () => {
     const listenerApi = createListenerApi(
       imageModeState({


### PR DESCRIPTION
Adds the RHEL 10.3 container installer ISO as a selectable official image, with a second read-only container section for its payload.
- Add the container installer (bootable-container-iso) to the official on-prem images
- Selecting its target environment shows a second read-only container section for the payload image, with its own pull button
- Default the payload reference via resolveOfficialImage; flow it to the CLI through the existing bootc argument helper
- Require both installer and payload images pulled before building
- Hide the registration step and reset registration type when the installer is selected — subscriptions aren't supported for it
- Translate the installer type to the CLI's name (bootc-generic-iso, not bootable-container-iso) so the build unit doesn't fail
- Resolves #4714

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>