### PR TITLE
wizard: remove basic partitioning for image mode

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemPartition.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemPartition.tsx
@@ -19,6 +19,7 @@ import {
   FilesystemMode,
   selectComplianceProfileID,
   selectFscMode,
+  selectIsImageMode,
 } from '@/store/slices/wizard';
 
 const fscModeOptions = [
@@ -46,7 +47,14 @@ const FileSystemPartition = () => {
   const dispatch = useAppDispatch();
   const fscMode = useAppSelector(selectFscMode);
   const hasOscapProfile = useAppSelector(selectComplianceProfileID);
+  const isImageMode = useAppSelector(selectIsImageMode);
   const [isOpen, setIsOpen] = useState(false);
+
+  // Basic partitioning maps to customizations.filesystem, which image mode
+  // images don't support
+  const availableOptions = isImageMode
+    ? fscModeOptions.filter((opt) => opt.value !== 'basic')
+    : fscModeOptions;
 
   if (hasOscapProfile) {
     return undefined;
@@ -88,7 +96,7 @@ const FileSystemPartition = () => {
         style={{ width: '60%' }}
       >
         <SelectList>
-          {fscModeOptions.map((option) => (
+          {availableOptions.map((option) => (
             <SelectOption
               key={option.value}
               value={option.value}

--- a/src/Components/CreateImageWizard/steps/FileSystem/tests/FileSystem.test.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/tests/FileSystem.test.tsx
@@ -80,6 +80,44 @@ describe('FileSystem Component', () => {
         }),
       ).toBeInTheDocument();
     });
+
+    test('offers basic filesystem partitioning in package mode', async () => {
+      const user = createUser();
+      renderFileSystemStep();
+
+      await clickWithWait(
+        user,
+        await screen.findByRole('button', { name: /Automatic partitioning/i }),
+      );
+
+      expect(
+        screen.getByRole('option', { name: /Basic filesystem partitioning/i }),
+      ).toBeInTheDocument();
+    });
+
+    test('does not offer basic filesystem partitioning in image mode', async () => {
+      const user = createUser();
+      renderFileSystemStep({
+        details: {
+          ...initialState.details,
+          blueprint: { ...initialState.details.blueprint, mode: 'image' },
+        },
+      });
+
+      await clickWithWait(
+        user,
+        await screen.findByRole('button', { name: /Automatic partitioning/i }),
+      );
+
+      expect(
+        screen.queryByRole('option', {
+          name: /Basic filesystem partitioning/i,
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('option', { name: /Advanced disk partitioning/i }),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('Validation', () => {

--- a/src/store/middleware/listeners.ts
+++ b/src/store/middleware/listeners.ts
@@ -11,6 +11,7 @@ import {
 // export from slices/wizard/listeners rather than slices/wizard
 // this is needed to avoid circular dependencies
 import {
+  clearUnsupportedFilesystem,
   clearUnsupportedRegistration,
   filterImageTypes,
   registerLater,
@@ -40,6 +41,11 @@ startListening({
 startListening({
   actionCreator: changeBlueprintMode,
   effect: clearUnsupportedRegistration,
+});
+
+startListening({
+  actionCreator: changeBlueprintMode,
+  effect: clearUnsupportedFilesystem,
 });
 
 startListening({

--- a/src/store/slices/wizard/listeners.ts
+++ b/src/store/slices/wizard/listeners.ts
@@ -3,6 +3,7 @@ import { KNOWN_IMAGES } from '@/store/api/backend/onprem/constants';
 import type { WizardListenerEffect } from '@/store/middleware/types';
 
 import { selectIsImageMode } from './details';
+import { changeFscMode, selectFscMode } from './filesystem';
 import {
   changeDistribution,
   changeImageSource,
@@ -95,6 +96,24 @@ export const clearUnsupportedRegistration: WizardListenerEffect = (
 
   if (selectAapEnabled(state)) {
     listenerApi.dispatch(changeAapEnabled(false));
+  }
+};
+
+// Basic partitioning maps to customizations.filesystem, which image mode
+// images don't support, so a selection made in package mode must not carry
+// over into the blueprint when the user switches modes.
+export const clearUnsupportedFilesystem: WizardListenerEffect = (
+  _action,
+  listenerApi,
+) => {
+  const state = listenerApi.getState();
+
+  if (!selectIsImageMode(state)) {
+    return;
+  }
+
+  if (selectFscMode(state) === 'basic') {
+    listenerApi.dispatch(changeFscMode('automatic'));
   }
 };
 

--- a/src/store/slices/wizard/tests/clearUnsupportedFilesystem.test.ts
+++ b/src/store/slices/wizard/tests/clearUnsupportedFilesystem.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  changeFscMode,
+  type FilesystemMode,
+  initialState,
+} from '@/store/slices/wizard';
+import {
+  createListenerApi,
+  createMockState,
+} from '@/store/slices/wizard/tests/mockWizardState';
+
+import { clearUnsupportedFilesystem } from '../listeners';
+
+const createState = (mode: 'image' | 'package', fscMode: FilesystemMode) =>
+  createMockState({
+    details: {
+      ...initialState.details,
+      blueprint: { ...initialState.details.blueprint, mode },
+    },
+    filesystem: { ...initialState.filesystem, mode: fscMode },
+  });
+
+describe('clearUnsupportedFilesystem', () => {
+  it('resets basic partitioning when switching to image mode', () => {
+    const listenerApi = createListenerApi(createState('image', 'basic'));
+
+    clearUnsupportedFilesystem({} as never, listenerApi as never);
+
+    expect(listenerApi.dispatch).toHaveBeenCalledWith(
+      changeFscMode('automatic'),
+    );
+  });
+
+  it('leaves basic partitioning untouched in package mode', () => {
+    const listenerApi = createListenerApi(createState('package', 'basic'));
+
+    clearUnsupportedFilesystem({} as never, listenerApi as never);
+
+    expect(listenerApi.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not reset advanced partitioning in image mode', () => {
+    const listenerApi = createListenerApi(createState('image', 'advanced'));
+
+    clearUnsupportedFilesystem({} as never, listenerApi as never);
+
+    expect(listenerApi.dispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
resolves #4710

Image mode images don't support customizations.filesystem, which
we use for basic partitioning. Remove it for Image Mode.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>